### PR TITLE
Tag docker images with testnet name

### DIFF
--- a/dockerize_testnet.sh
+++ b/dockerize_testnet.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-PROJECT_NAME=false
+PROJECT_ID=false
 TESTNET_NAME=false
 
 while getopts 'p:t:' flag; do
   case "${flag}" in
-    p) PROJECT_NAME="${OPTARG}" ;;
+    p) PROJECT_ID="${OPTARG}" ;;
     t) TESTNET_NAME="${OPTARG}" ;;
     *) error "Unexpected option ${flag}" ;;
   esac
@@ -12,9 +12,9 @@ done
 
 docker build . -t testnet-geth
 docker build . -f Dockerfile.kubeboot -t testnet-boot
-docker tag testnet-geth:latest gcr.io/$PROJECT_NAME/testnet-geth:$TESTNET_NAME
-docker tag testnet-boot:latest gcr.io/$PROJECT_NAME/testnet-boot:$TESTNET_NAME
-docker push gcr.io/$PROJECT_NAME/testnet-geth:$TESTNET_NAME
-docker push gcr.io/$PROJECT_NAME/testnet-boot:$TESTNET_NAME
+docker tag testnet-geth:latest gcr.io/$PROJECT_ID/testnet-geth:$TESTNET_NAME
+docker tag testnet-boot:latest gcr.io/$PROJECT_ID/testnet-boot:$TESTNET_NAME
+docker push gcr.io/$PROJECT_ID/testnet-geth:$TESTNET_NAME
+docker push gcr.io/$PROJECT_ID/testnet-boot:$TESTNET_NAME
 
 


### PR DESCRIPTION
### Description

This is a sibling PR to https://github.com/celo-org/kuberneteth/pull/18, allowing multiple testnets to run on the same GCP project.

### Tested

By pushing images to the container registry and running a testnet on the "celo-bootnode" project.

### Other changes

None
