### PR TITLE
Reset p2p intervals to original values

### DIFF
--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -32,7 +32,7 @@ import (
 const (
 	// This is the amount of time spent waiting in between
 	// redialing a certain node.
-	dialHistoryExpiration = 10 * time.Second
+	dialHistoryExpiration = 30 * time.Second
 
 	// Discovery lookups are throttled and can only run
 	// once every few seconds.
@@ -40,7 +40,7 @@ const (
 
 	// If no peers are found for this amount of time, the initial bootnodes are
 	// attempted to be connected.
-	fallbackInterval = 6 * time.Second
+	fallbackInterval = 20 * time.Second
 
 	// Endpoint resolution is throttled with bounded backoff.
 	initialResolveDelay = 60 * time.Second

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -70,8 +70,8 @@ func runDialTest(t *testing.T, test dialtest) {
 				i, spew.Sdump(new), spew.Sdump(round.new), spew.Sdump(test.init), spew.Sdump(running))
 		}
 
-		// Time advances by 6 seconds on every round.
-		vtime = vtime.Add(6 * time.Second)
+		// Time advances by 16 seconds on every round.
+		vtime = vtime.Add(16 * time.Second)
 		running += len(new)
 	}
 }
@@ -151,7 +151,7 @@ func TestDialStateDynDial(t *testing.T) {
 					&dialTask{flags: dynDialedConn, dest: &discover.Node{ID: uintID(5)}},
 				},
 				new: []task{
-					&waitExpireTask{Duration: 4 * time.Second},
+					&waitExpireTask{Duration: 14 * time.Second},
 				},
 			},
 			// In this round, the peer with id 2 drops off. The query
@@ -485,7 +485,7 @@ func TestDialStateStaticDial(t *testing.T) {
 					&dialTask{flags: staticDialedConn, dest: &discover.Node{ID: uintID(5)}},
 				},
 				new: []task{
-					&waitExpireTask{Duration: 4 * time.Second},
+					&waitExpireTask{Duration: 14 * time.Second},
 				},
 			},
 			// Wait a round for dial history to expire, no new tasks should spawn.
@@ -542,7 +542,7 @@ func TestDialStaticAfterReset(t *testing.T) {
 				&dialTask{flags: staticDialedConn, dest: &discover.Node{ID: uintID(2)}},
 			},
 			new: []task{
-				&waitExpireTask{Duration: 10 * time.Second},
+				&waitExpireTask{Duration: 30 * time.Second},
 			},
 		},
 	}
@@ -603,7 +603,7 @@ func TestDialStateCache(t *testing.T) {
 					&dialTask{flags: staticDialedConn, dest: &discover.Node{ID: uintID(3)}},
 				},
 				new: []task{
-					&waitExpireTask{Duration: 4 * time.Second},
+					&waitExpireTask{Duration: 14 * time.Second},
 				},
 			},
 			// Still waiting for node 3's entry to expire in the cache.


### PR DESCRIPTION
### Description

These values were reduced as they were setting a floor on the block time when our testnet nodes would continually drop and reconnect.  Resetting these values to be consistent with upstream.

### Tested

With unit tests.

### Other changes

None
### Related issues

- Fixes #22 