### PR TITLE
Lookup peers in the client pool by ID instead of by IP address

### DIFF
--- a/les/handler.go
+++ b/les/handler.go
@@ -263,20 +263,14 @@ func (pm *ProtocolManager) handle(p *peer) error {
 	}
 
 	if !pm.lightSync && !p.Peer.Info().Network.Trusted {
-		// addr, ok := p.RemoteAddr().(*net.TCPAddr)
-		// // test peer address is not a tcp address, don't use client pool if can not typecast
-		// if ok {
-		// id := addr.IP.String()
 		// geth upstream uses the IP address for the client pool to protect against malicious clients, in here we'll just use the peer's ID which can be changed but allows us to circumvent:
 		// 1. Kubernetes internal networking putting clients on the "same IP"
 		// 2. Light clients being on the same Wifi network
-		id := p.id
-		if !pm.clientPool.connect(id, func() { go pm.removePeer(p.id) }) {
+		if !pm.clientPool.connect(p.id, func() { go pm.removePeer(p.id) }) {
 			p.Log().Debug(fmt.Sprintf("Unable to connect peer to client pool"))
 			return p2p.DiscTooManyPeers
 		}
-		defer pm.clientPool.disconnect(id)
-		// }
+		defer pm.clientPool.disconnect(p.id)
 	}
 
 	if rw, ok := p.rw.(*meteredMsgReadWriter); ok {


### PR DESCRIPTION
Upstream geth uses a client pool to determine which peers to allow
and stay connected to and which not. It is supposed to reward good
peers who only stay connected as little as necessary and punish
peers who hog the connection. However, since there is nothing that
can truly uniquely identify clients (enode addresses are trivially
changable), upstream geth uses IP addresses as a proxyy. However this
breaks light clients with the same IP addresss, as well as setups like
Kubernetes that appear to geth under the same IP address due to their
networking.

Thus this change is a short term hack to stabilizes connections for us
by doing the lookup by the enode ID. Longer-term we need to figure out
a solution to this. Check out https://github.com/celo-org/celo-monorepo/issues/522
and https://github.com/ethereum/go-ethereum/pull/16899#issuecomment-418513423

## Testing

This is currently deployed to `testnet-dev` on which syncing headers now works continuously without the peer getting booted while other clients are also connected. However, @cmcewen noted that submitting transactions has not worked end to end

Related to #40.