### PR TITLE
Encode verification code with base64

### DIFF
--- a/abe/abe.go
+++ b/abe/abe.go
@@ -18,6 +18,7 @@ package abe
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -53,7 +53,7 @@ func createVerificationMessage(request types.VerificationRequest, account accoun
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("Celo verification code: %s:%d", hexutil.Encode(signature), request.VerificationIndex), nil
+	return fmt.Sprintf("Celo verification code: %s:%d", base64.URLEncoding.EncodeToString(signature), request.VerificationIndex), nil
 }
 
 func sendSms(phoneNumber string, message string) error {


### PR DESCRIPTION
### Description

This decreases the size of the verification code by 1/3, which will allow us to avoid the bug we've seen in the mobile wallet app where the full verification code was not being read.

### Tested

By running a single geth mining node and completing the verification process.

