### PR TITLE
Add Circle CI status badge to geth repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/6874
 [![Travis](https://travis-ci.org/ethereum/go-ethereum.svg?branch=master)](https://travis-ci.org/ethereum/go-ethereum)
 [![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://discord.gg/nthXNEv)
 
-Celo geth fork: [![CircleCI](https://circleci.com/gh/celo-org/geth.svg?style=svg)](https://circleci.com/gh/celo-org/geth)
+Celo geth fork: [![CircleCI](https://circleci.com/gh/celo-org/geth.svg?style=svg&circle-token=c0d6224076b9b9f7a6cf270c156d2e1d9f6e1263)](https://circleci.com/gh/celo-org/geth)
 
 Automated builds are available for stable releases and the unstable master branch.
 Binary archives are published at https://geth.ethereum.org/downloads/.


### PR DESCRIPTION
### Description

Our current set of badges reflect the status of open-source geth repository and not the status of our fork. Add the status badge from CircleCI for our fork as well/.

### Tested

Just a README change. No other test.