### PR TITLE
Add "celolatest" to syncmode error message

### DIFF
--- a/eth/downloader/modes.go
+++ b/eth/downloader/modes.go
@@ -74,7 +74,7 @@ func (mode *SyncMode) UnmarshalText(text []byte) error {
 	case "celolatest":
 		*mode = CeloLatestSync
 	default:
-		return fmt.Errorf(`unknown sync mode %q, want "full", "fast" or "light"`, text)
+		return fmt.Errorf(`unknown sync mode %q, want "full", "fast", "light", or "celolatest"`, text)
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

Add "celolatest" sync mode as a potential sync mode when an incorrect
sync mode is passed to geth.

### Tested

Manually tested by passing incorrect sync mode to geth

### Other changes

None

### Related issues

- https://github.com/celo-org/celo-monorepo/issues/320
