### PR TITLE
Support geth logging to stdout and in JSON format

### DIFF
--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -52,7 +52,7 @@ func main() {
 	)
 	flag.Parse()
 
-	glogger := log.NewGlogHandler(log.StreamHandler(os.Stderr, log.TerminalFormat(false)))
+	glogger := log.NewGlogHandler(log.StreamHandler(os.Stdout, log.JSONFormat()))
 	glogger.Verbosity(log.Lvl(*verbosity))
 	glogger.Vmodule(*vmodule)
 	log.Root().SetHandler(glogger)


### PR DESCRIPTION

Geth by default logs everything in terminal format to stderr.   This breaks stack driver logging integration -- it assumes every line is at error level, and cannot interpret the structure. This should fix this by adding two flags. Eg.  --consoleformat json --stdout.  Tested locally.