### PR TITLE
Set gasprice floor for miner and tx pool to zero

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -145,7 +145,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 1,
+	PriceLimit: 0,
 	PriceBump:  10,
 
 	AccountSlots: 16,
@@ -164,7 +164,7 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 		log.Warn("Sanitizing invalid txpool journal time", "provided", conf.Rejournal, "updated", time.Second)
 		conf.Rejournal = time.Second
 	}
-	if conf.PriceLimit < 1 {
+	if conf.PriceLimit < 0 {
 		log.Warn("Sanitizing invalid txpool price limit", "provided", conf.PriceLimit, "updated", DefaultTxPoolConfig.PriceLimit)
 		conf.PriceLimit = DefaultTxPoolConfig.PriceLimit
 	}

--- a/eth/config.go
+++ b/eth/config.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
-	"github.com/ethereum/go-ethereum/params"
 )
 
 // DefaultConfig contains default settings for use on the Ethereum main net.
@@ -50,7 +49,7 @@ var DefaultConfig = Config{
 	TrieTimeout:                 60 * time.Minute,
 	MinerGasFloor:               8000000,
 	MinerGasCeil:                8000000,
-	MinerGasPrice:               big.NewInt(params.GWei),
+	MinerGasPrice:               big.NewInt(0), // params.GWei
 	MinerRecommit:               3 * time.Second,
 	MinerVerificationServiceUrl: "https://mining-pool.celo.org/v0.1/sms",
 


### PR DESCRIPTION
### Description

* Allow transactions that specify a gas price of zero to be admitted and forwarded between nodes. 
* Set default miner gas price to zero so that the gas price oracle doesn't erroneously default to a non-zero value.

### Tested

* Locally and on a full network, where we connect as an additional node to that network. Transactions with zero gas price are seen to succeed and effect a state change.

