### PR TITLE
Add Google Cloud SDK to our Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+# How to test changes to this file
+# docker build -f Dockerfile -t gcr.io/celo-testnet/geth:$USER .
+# To locally run that image
+# docker run gcr.io/celo-testnet/geth:$USER
+# Then connect to it by first getting its container ID via docker ps
+# and then docker exec -t -i <containerID>  /bin/sh
+# Once you are satisfied, push the image to the cloud
+# docker push gcr.io/celo-testnet/geth:$USER
+# To use this image for testing, modify GETH_NODE_DOCKER_IMAGE_TAG in celo-monorepo/.env file
+
 # Build Geth in a stock Go builder container
 FROM golang:1.11-alpine as builder
 
@@ -11,6 +21,15 @@ FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
+
+# Uncomment this if you want to edit a file inside this docker image via vim
+# RUN apk add vim
+
+# For google-cloud-sdk
+RUN apk add bash
+RUN apk add curl
+RUN apk add python
+RUN curl -sSL https://sdk.cloud.google.com | bash
 
 EXPOSE 8545 8546 30303 30303/udp
 ENTRYPOINT ["geth"]


### PR DESCRIPTION
### Description
Add Google Cloud SDK to our Docker container

Required for 
https://github.com/celo-org/celo-monorepo/issues/1765

Building instructions are in the docker file itself.