### PR TITLE
Handle crash during rollback in CeloLatestSync mode

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -729,7 +729,7 @@ const (
 
 // Rollback is designed to remove a chain of links from the database that aren't
 // certain enough to be valid.
-func (bc *BlockChain) Rollback(chain []common.Hash) {
+func (bc *BlockChain) Rollback(chain []common.Hash, fullHeaderChainAvailable bool) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -729,7 +729,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	defer archive.Stop()
 
 	assert(t, "archive", archive, height, height, height)
-	archive.Rollback(remove)
+	archive.Rollback(remove, true)
 	assert(t, "archive", archive, height/2, height/2, height/2)
 
 	// Import the chain as a non-archive node and ensure all pointers are updated
@@ -749,7 +749,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 		t.Fatalf("failed to insert receipt %d: %v", n, err)
 	}
 	assert(t, "fast", fast, height, height, 0)
-	fast.Rollback(remove)
+	fast.Rollback(remove, true)
 	assert(t, "fast", fast, height/2, height/2, 0)
 
 	// Import the chain as a light node and ensure all pointers are updated
@@ -763,7 +763,7 @@ func TestLightVsFastVsFullChainHeads(t *testing.T) {
 	defer light.Stop()
 
 	assert(t, "light", light, height, 0, 0)
-	light.Rollback(remove)
+	light.Rollback(remove, true)
 	assert(t, "light", light, height/2, 0, 0)
 }
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -171,7 +171,7 @@ type LightChain interface {
 	InsertHeaderChain([]*types.Header, int) (int, error)
 
 	// Rollback removes a few recently added elements from the local chain.
-	Rollback([]common.Hash)
+	Rollback([]common.Hash, bool)
 }
 
 // BlockChain encapsulates functions required to sync a (full or fast) blockchain.
@@ -1226,7 +1226,7 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 				lastFastBlock = d.blockchain.CurrentFastBlock().Number()
 				lastBlock = d.blockchain.CurrentBlock().Number()
 			}
-			d.lightchain.Rollback(hashes)
+			d.lightchain.Rollback(hashes, d.Mode != CeloLatestSync)
 			curFastBlock, curBlock := common.Big0, common.Big0
 			if d.Mode != LightSync && d.Mode != CeloLatestSync {
 				curFastBlock = d.blockchain.CurrentFastBlock().Number()

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -371,7 +371,7 @@ func (dl *downloadTester) InsertReceiptChain(blocks types.Blocks, receipts []typ
 }
 
 // Rollback removes some recently added elements from the chain.
-func (dl *downloadTester) Rollback(hashes []common.Hash) {
+func (dl *downloadTester) Rollback(hashes []common.Hash, fullHeaderChainAvailable bool) {
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
 

--- a/les/handler.go
+++ b/les/handler.go
@@ -75,7 +75,7 @@ type BlockChain interface {
 	GetTd(hash common.Hash, number uint64) *big.Int
 	State() (*state.StateDB, error)
 	InsertHeaderChain(chain []*types.Header, checkFreq int) (int, error)
-	Rollback(chain []common.Hash)
+	Rollback(chain []common.Hash, fullHeaderChainAvailable bool)
 	GetHeaderByNumber(number uint64) *types.Header
 	GetAncestor(hash common.Hash, number, ancestor uint64, maxNonCanonical *uint64) (common.Hash, uint64)
 	Genesis() *types.Block


### PR DESCRIPTION
### Description

We don't have the full header chain in the CeloLatestSync mode,
therefore, a rollback beyond oldest fetched block will lead to a crash.
An example is described in https://github.com/celo-org/celo-monorepo/issues/1728#issuecomment-447154687

To prevent that, in CeloLatestSync mode, we do not roll back beyond the
oldest block. Note that since we fetch last 128 blocks, this will
interfere with a large scale re-org of the chain. In a PoA network, we
should not be expecting a re-org greater than 128 blocks anyways.

### Tested

Install the app, disable background data (via system settings -> app info), open the app, choose the language, and before the sync finishes press the home button, crash occurs.

It is hard to reproduce and test as I was able to reproduce this only a few times.

### Related issues

- Addresses one cause of #1728
