### PR TITLE
No more free gas

### DIFF
--- a/eth/config.go
+++ b/eth/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // DefaultConfig contains default settings for use on the Ethereum main net.
@@ -48,7 +49,7 @@ var DefaultConfig = Config{
 	TrieTimeout:                 60 * time.Minute,
 	MinerGasFloor:               8000000,
 	MinerGasCeil:                8000000,
-	MinerGasPrice:               big.NewInt(0), // Always free gas
+	MinerGasPrice:               big.NewInt(params.GWei),
 	MinerRecommit:               3 * time.Second,
 	MinerVerificationServiceUrl: "https://mining-pool.celo.org/v0.1/sms",
 
@@ -56,7 +57,7 @@ var DefaultConfig = Config{
 	GPO: gasprice.Config{
 		Blocks:     20,
 		Percentile: 60,
-		AlwaysZero: true, // Always free gas
+		AlwaysZero: false,
 	},
 }
 


### PR DESCRIPTION
### Description

No more free gas

### Tested

Build and run geth. Check the gas price

Before

`celotool geth build` 
`/Users/ashishb/celo/celo-monorepo/packages/celotool/../../packages/celotool/bin/celotooljs.sh --celo-env=random --geth-dir=/Users/ashishb/celo/geth --data-dir=/tmp/tmp2 --sync-mode=full --mining=true --minerGasPrice=999 --miner-address=0xfeE1a22F43BeeCB912B5a4912ba87527682ef0fC --genesis=/Users/ashishb/celo/celo-monorepo/packages/celotool/../../packages/celotool/src/genesis_poa_from_mobile_but_with_single_signer.json geth run`

```
 $ celotool get gas price  --datadir /tmp/tmp2
0 wei (0 wei)
```

After,

```
celotool get gas price  --datadir /tmp/tmp2
999 wei (999 wei)
```

Required for #63