### PR TITLE
Fetch Exchange rate from medianator

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -18,13 +18,14 @@ package core
 
 import (
 	"errors"
+	"math"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-	"math"
-	"math/big"
 )
 
 var (
@@ -197,15 +198,6 @@ func (st *StateTransition) canBuyGas(
 	return balanceOf.Cmp(gasNeeded) > 0, gasUsed
 }
 
-type ZeroAddress int64
-
-func (ZeroAddress) Address() common.Address {
-	var address common.Address
-	// Not required since address is, by default, initialized to 0
-	// copy(address[:], "0000000000000000000000000000000000000000")
-	return address
-}
-
 // contractAddress must have a function  with following signature
 // "function balanceOf(address _owner) public view returns (uint256)"
 func (st *StateTransition) getBalanceOf(accountOwner common.Address, contractAddress *common.Address) (
@@ -213,7 +205,7 @@ func (st *StateTransition) getBalanceOf(accountOwner common.Address, contractAdd
 	evm := st.evm
 	functionSelector := getBalanceOfFunctionSelector()
 	transactionData := getEncodedAbiWithOneArg(functionSelector, addressToAbi(accountOwner))
-	anyCaller := ZeroAddress(0) // any caller will work
+	anyCaller := vm.AccountRef(common.HexToAddress("0x0")) // any caller will work
 	log.Trace("getBalanceOf", "caller", anyCaller, "customTokenContractAddress",
 		*contractAddress, "gas", st.gas, "transactionData", hexutil.Encode(transactionData))
 	ret, leftoverGas, err := evm.StaticCall(anyCaller, *contractAddress, transactionData, st.gas+st.msg.Gas())
@@ -241,7 +233,7 @@ func (st *StateTransition) debitOrCreditErc20Balance(
 	evm := st.evm
 	transactionData := getEncodedAbiWithTwoArgs(functionSelector, addressToAbi(address), amountToAbi(amount))
 
-	rootCaller := ZeroAddress(0)
+	rootCaller := vm.AccountRef(common.HexToAddress("0x0"))
 	maxGasForCall := st.gas
 	// Limit the gas used by these calls to prevent a gas stealing attack.
 	if maxGasForCall > maxGasForDebitAndCreditTransactions {
@@ -320,6 +312,15 @@ func getBalanceOfFunctionSelector() []byte {
 	return hexutil.MustDecode("0x70a08231")
 }
 
+func getExchangeRateFunctionSelector() []byte {
+	// Function is "function getExchangeRate(address makerToken, address takerToken)"
+	// selector is first 4 bytes of keccak256 of "getExchangeRate(address,address)"
+	// Source:
+	// pip3 install pyethereum
+	// python3 -c 'from ethereum.utils import sha3; print(sha3("getExchangeRate(address,address)")[0:4].hex())'
+	return hexutil.MustDecode("0xbaaa61be")
+}
+
 func addressToAbi(address common.Address) []byte {
 	// Now convert address and amount to 32 byte (256-bit) chunks.
 	return common.LeftPadBytes(address.Bytes(), 32)
@@ -345,6 +346,40 @@ func getEncodedAbiWithTwoArgs(methodSelector []byte, var1Abi []byte, var2Abi []b
 	copy(encodedAbi[len(methodSelector):len(methodSelector)+len(var1Abi)], var1Abi[:])
 	copy(encodedAbi[len(methodSelector)+len(var1Abi):], var2Abi[:])
 	return encodedAbi
+}
+
+// Medianator contractAddress must have a function  with following signature
+// "function getExchangeRate(address makerToken, address takerToken)"
+// Note that if the Medianator is not initialized with a relevant Oracle then this
+// function will fail with a generic "execution reverted" error.
+func getExchangeRate(evm *vm.EVM, medianatorContractAddress common.Address, baseToken common.Address, counterToken common.Address) (
+	baseAmount *big.Int, counterAmount *big.Int, err error) {
+	log.Trace("getExchangeRate",
+		"medianatorContractAddress", medianatorContractAddress,
+		"baseToken", baseToken,
+		"counterToken", counterToken)
+	functionSelector := getExchangeRateFunctionSelector()
+	transactionData := getEncodedAbiWithTwoArgs(
+		functionSelector, addressToAbi(baseToken), addressToAbi(counterToken))
+	anyCaller := vm.AccountRef(common.HexToAddress("0x0")) // any caller will work
+	// Some reasonable gas limit to avoid a potentially bad Oracle from running expensive computations.
+	gas := uint64(10 * 1000)
+	log.Trace("getExchangeRate", "caller", anyCaller, "customTokenContractAddress",
+		medianatorContractAddress, "gas", gas, "transactionData", hexutil.Encode(transactionData))
+	ret, leftoverGas, err := evm.StaticCall(anyCaller, medianatorContractAddress, transactionData, gas)
+	if err != nil {
+		log.Debug("getExchangeRate error occurred", "Error", err, "leftoverGas", leftoverGas)
+		return nil, nil, err
+	}
+	if len(ret) != 2*32 {
+		log.Debug("getExchangeRate error occurred: unexpected return value", "ret", hexutil.Encode(ret))
+		return nil, nil, errors.New("unexpected return value")
+	}
+	log.Trace("getExchangeRate", "ret", ret, "leftoverGas", leftoverGas, "err", err)
+	baseAmount = new(big.Int).SetBytes(ret[0:32])
+	counterAmount = new(big.Int).SetBytes(ret[32:64])
+	log.Trace("getExchangeRate", "baseAmount", baseAmount, "counterAmount", counterAmount)
+	return baseAmount, counterAmount, nil
 }
 
 func (st *StateTransition) preCheck() error {


### PR DESCRIPTION
### Description

Add a function to fetch the exchange rate from medianator. A follow-on PR will add a call from currcy.go to this function.

### Tested

The Oracles are not configured by default, therefore, I have to add the following patch for testing

```
 $ git diff packages/protocol/contracts/tability/Medianator.sol
diff --git i/packages/protocol/contracts/stability/Medianator.sol w/packages/protocol/contracts/stability/Medianator.sol
index c152b552..445283a6 100644
--- i/packages/protocol/contracts/stability/Medianator.sol
+++ w/packages/protocol/contracts/stability/Medianator.sol
@@ -86,9 +86,10 @@ contract Medianator is IMedianator, Ownable, Initializable {
     view
     returns (uint256, uint256)
   {
+    return (35, 45);  // ;tTODO(ashishb): testing only
     require((base != 0) || (counter != 0));
```

### Related issues

- Basis for https://github.com/celo-org/celo-monorepo/issues/2706
