### PR TITLE
disabled goimport lint checks for now.  also updated core/blockchain.…

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -361,7 +361,9 @@ func doLint(cmdline []string) {
 		"--tests",
 		"--deadline=2m",
 		"--disable-all",
-		"--enable=goimports",
+		// TODO (kevjue) - The goimports lint check is disabled since it was raising false errors.  Changes should be made
+		//                 so that this check can be re-enabled without raising false errors.
+		// "--enable=goimports",
 		"--enable=varcheck",
 		"--enable=vet",
 		"--enable=gofmt",

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -43,7 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 var (


### PR DESCRIPTION
disabled goimport lint checks for now. also updated core/blockchain.go imports to reflect ethereum's geth version

### Description

This PR disables the goimports lint test for geth.  Originally, that lint test was raising false positives of unused imported packages.

### Tested

Ran the geth lint test as well as the regular tests on my local computer.

### Other changes

core/blockchain.go import code block is also updated to mirror ethereum's geth repo's code block (https://github.com/ethereum/go-ethereum/blob/master/core/blockchain.go#L46).

### Related issues

- Fixes #3057
