### PR TITLE
Slim down the docker image

### DIFF
--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -12,11 +12,4 @@ FROM alpine:latest
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go-ethereum/build/bin/* /usr/local/bin/
 
-# For google-cloud-sdk
-RUN apk add --no-cache bash curl python
-RUN curl -sSL https://sdk.cloud.google.com | bash
-# For snapshot API
-RUN /root/google-cloud-sdk/bin/gcloud components install beta
-RUN /root/google-cloud-sdk/bin/gcloud components install kubectl
-
 EXPOSE 8545 8546 30303 30303/udp


### PR DESCRIPTION
### Description

Installing gcloud and kubectl should be superflous here and unneccarily inflates the docker image size from 17MB to 300+ MB

### Tested

- Ran the backup cron job with the docker image `nambrot/gcloud-kubectl:latest`

- Fixes https://github.com/celo-org/celo-monorepo/issues/3053
