### PR TITLE
Protect against null result in Seal

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -431,9 +431,10 @@ func (sb *Backend) Seal(chain consensus.ChainReader, block *types.Block, results
 		for {
 			select {
 			case result := <-sb.commitCh:
+				// Somehow, the block `result` coming from commitCh can be null
 				// if the block hash and the hash from channel are the same,
 				// return the result. Otherwise, keep waiting the next hash.
-				if block.Hash() == result.Hash() {
+				if result != nil && block.Hash() == result.Hash() {
 					results <- result
 					return
 				}


### PR DESCRIPTION
### Description

This is a tricky one. For whatever reason, the result coming from the `commitCh` can be `nil`, even though the only place I can see where we pass a block is https://github.com/celo-org/geth/blob/nambrot/istanbul-null-seal-result-block/consensus/istanbul/backend/backend.go#L193 which clearly looks like a non-nil block. For now, I'm just checking against that

### Tested

- Observed `gethminer1` on `yuryload1`getting into this problem predictively by trying to catch up, and then deploying this change which causes it to stop

### Related issues

- Fixes #156 
