### PR TITLE
changes for periodic exchange rate cache refresh, sufficient balance check in tx_pool

### DIFF
--- a/common/abi.go
+++ b/common/abi.go
@@ -1,0 +1,48 @@
+// Copyright 2014 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package common
+
+import (
+	"math/big"
+)
+
+func AddressToAbi(address Address) []byte {
+	// Now convert address and amount to 32 byte (256-bit) chunks.
+	return LeftPadBytes(address.Bytes(), 32)
+}
+
+func AmountToAbi(amount *big.Int) []byte {
+	// Get amount as 32 bytes
+	return LeftPadBytes(amount.Bytes(), 32)
+}
+
+// Generates ABI for a given method and its argument.
+func GetEncodedAbiWithOneArg(methodSelector []byte, var1Abi []byte) []byte {
+	encodedAbi := make([]byte, len(methodSelector)+len(var1Abi))
+	copy(encodedAbi[0:len(methodSelector)], methodSelector[:])
+	copy(encodedAbi[len(methodSelector):len(methodSelector)+len(var1Abi)], var1Abi[:])
+	return encodedAbi
+}
+
+// Generates ABI for a given method and its arguments.
+func GetEncodedAbiWithTwoArgs(methodSelector []byte, var1Abi []byte, var2Abi []byte) []byte {
+	encodedAbi := make([]byte, len(methodSelector)+len(var1Abi)+len(var2Abi))
+	copy(encodedAbi[0:len(methodSelector)], methodSelector[:])
+	copy(encodedAbi[len(methodSelector):len(methodSelector)+len(var1Abi)], var1Abi[:])
+	copy(encodedAbi[len(methodSelector)+len(var1Abi):], var2Abi[:])
+	return encodedAbi
+}

--- a/core/currency.go
+++ b/core/currency.go
@@ -17,14 +17,38 @@
 package core
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 var (
 	cgExchangeRateNum = big.NewInt(1)
 	cgExchangeRateDen = big.NewInt(1)
+
+	// Function is "function getExchangeRate(address makerToken, address takerToken)"
+	// selector is first 4 bytes of keccak256 of "getExchangeRate(address,address)"
+	// Source:
+	// pip3 install pyethereum
+	// python3 -c 'from ethereum.utils import sha3; print(sha3("getExchangeRate(address,address)")[0:4].hex())'
+	getExchangeRateFuncABI = hexutil.MustDecode("0xbaaa61be")
+
+	// Function is "balanceOf(address _owner)"
+	// selector is first 4 bytes of keccak256 of "balanceOf(address)"
+	// Source:
+	// pip3 install pyethereum
+	// python3 -c 'from ethereum.utils import sha3; print(sha3("balanceOf(address)")[0:4].hex())'
+	getBalanceFuncABI = hexutil.MustDecode("0x70a08231")
+
+	errExchangeRateCacheMiss = errors.New("exchange rate cache miss")
 )
 
 type exchangeRate struct {
@@ -33,15 +57,21 @@ type exchangeRate struct {
 }
 
 type PriceComparator struct {
-	exchangeRates map[common.Address]*exchangeRate // indexedCurrency:CeloGold exchange rate
+	gasCurrencyAddresses *[]common.Address                // The set of currencies that will have their exchange rate monitored
+	exchangeRates        map[common.Address]*exchangeRate // indexedCurrency:CeloGold exchange rate
+	blockchain           *BlockChain                      // Used to construct the EVM object needed to make the call the medianator contract
+	chainConfig          *params.ChainConfig              // The config object of the eth object
 }
 
-func (pc *PriceComparator) getNumDenom(currency *common.Address) (*big.Int, *big.Int) {
+func (pc *PriceComparator) getNumDenom(currency *common.Address) (*big.Int, *big.Int, error) {
 	if currency == nil {
-		return cgExchangeRateNum, cgExchangeRateDen
+		return cgExchangeRateNum, cgExchangeRateDen, nil
 	} else {
-		exchangeRate := pc.exchangeRates[*currency]
-		return exchangeRate.Numerator, exchangeRate.Denominator
+		if exchangeRate, ok := pc.exchangeRates[*currency]; !ok {
+			return nil, nil, errExchangeRateCacheMiss
+		} else {
+			return exchangeRate.Numerator, exchangeRate.Denominator, nil
+		}
 	}
 }
 
@@ -50,8 +80,21 @@ func (pc *PriceComparator) Cmp(val1 *big.Int, currency1 *common.Address, val2 *b
 		return val1.Cmp(val2)
 	}
 
-	exchangeRate1Num, exchangeRate1Den := pc.getNumDenom(currency1)
-	exchangeRate2Num, exchangeRate2Den := pc.getNumDenom(currency2)
+	exchangeRate1Num, exchangeRate1Den, err1 := pc.getNumDenom(currency1)
+	exchangeRate2Num, exchangeRate2Den, err2 := pc.getNumDenom(currency2)
+
+	if err1 == nil || err2 == nil {
+		currency1Output := "nil"
+		if currency1 != nil {
+			currency1Output = currency1.Hex()
+		}
+		currency2Output := "nil"
+		if currency2 != nil {
+			currency2Output = currency2.Hex()
+		}
+		log.Warn("Error in retrieving cached exchange rate.  Will do comparison of two values without exchange rate conversion.", "currency1", currency1Output, "err1", err1, "currency2", currency2Output, "err2", err2)
+		return val1.Cmp(val2)
+	}
 
 	// Below code block is basically evaluating this comparison:
 	// val1 * exchangeRate1Num/exchangeRate1Den < val2 * exchangeRate2Num/exchangeRate2Den
@@ -62,16 +105,109 @@ func (pc *PriceComparator) Cmp(val1 *big.Int, currency1 *common.Address, val2 *b
 	return leftSide.Cmp(rightSide)
 }
 
-func NewPriceComparator() *PriceComparator {
-	// TODO(kevjue): Integrate implementation of issue https://github.com/celo-org/celo-monorepo/issues/2706, so that the
-	// exchange rate is retrieved from the smart contract.
-	// For now, hard coding in some exchange rates.  Will modify this to retrieve the
-	// exchange rates from the Celo's exchange smart contract.
-	// C$ will have a 2:1 exchange rate with CG
-	exchangeRates := make(map[common.Address]*exchangeRate)
-	exchangeRates[common.HexToAddress("0x0000000000000000000000000000000ce10d011a")] = &exchangeRate{Numerator: big.NewInt(2), Denominator: big.NewInt(1)}
+// This function will retrieve the exchange rates from the Medianator contract, and cache them.
+// Medianator contractAddress must have a function with following signature:
+// "function getExchangeRate(address makerToken, address takerToken)"
+func (pc *PriceComparator) retrieveExchangeRates() {
+	log.Trace("retrieveExchangeRates",
+		"gasCurrencyAddresses", fmt.Sprintf("%v", *pc.gasCurrencyAddresses))
 
-	return &PriceComparator{
-		exchangeRates: exchangeRates,
+	header := pc.blockchain.CurrentBlock().Header()
+	state, err := pc.blockchain.StateAt(header.Root)
+	if err != nil {
+		log.Error("PriceComparator.retrieveExchangeRates - Error it retrieving the state from the blockchain")
+		return
 	}
+
+	// The EVM Context requires a msg, but the actual field values don't really matter.  Putting in
+	// zero values.
+	msg := types.NewMessage(common.HexToAddress("0x0"), nil, 0, common.Big0, 0, common.Big0, []byte{}, false)
+	context := NewEVMContext(msg, header, pc.blockchain, nil)
+	evm := vm.NewEVM(context, state, pc.chainConfig, *pc.blockchain.GetVMConfig())
+
+	for _, gasCurrencyAddress := range *pc.gasCurrencyAddresses {
+		transactionData := common.GetEncodedAbiWithTwoArgs(
+			getExchangeRateFuncABI, common.AddressToAbi(params.AuthorizedTransferAddress), common.AddressToAbi(gasCurrencyAddress))
+		anyCaller := vm.AccountRef(common.HexToAddress("0x0")) // any caller will work
+
+		// Some reasonable gas limit to avoid a potentially bad Oracle from running expensive computations.
+		gas := uint64(20 * 1000)
+		log.Trace("PriceComparator.retrieveExchangeRates - Calling getExchangeRate", "caller", anyCaller, "customTokenContractAddress",
+			params.MedianatorAddress, "gas", gas, "transactionData", hexutil.Encode(transactionData))
+
+		ret, leftoverGas, err := evm.StaticCall(anyCaller, params.MedianatorAddress, transactionData, gas)
+
+		if err != nil {
+			log.Error("PriceComparator.retrieveExchangeRates - Error in retrieving exchange rate",
+				"base", params.AuthorizedTransferAddress, "counter", gasCurrencyAddress, "err", err)
+			continue
+		}
+
+		if len(ret) != 2*32 {
+			log.Error("PriceComparator.retrieveExchangeRates - Unexpected return value in retrieving exchange rate",
+				"base", params.AuthorizedTransferAddress, "counter", gasCurrencyAddress, "ret", hexutil.Encode(ret))
+			continue
+		}
+
+		log.Trace("getExchangeRate", "ret", ret, "leftoverGas", leftoverGas, "err", err)
+		baseAmount := new(big.Int).SetBytes(ret[0:32])
+		counterAmount := new(big.Int).SetBytes(ret[32:64])
+		log.Trace("getExchangeRate", "baseAmount", baseAmount, "counterAmount", counterAmount)
+
+		if _, ok := pc.exchangeRates[gasCurrencyAddress]; !ok {
+			pc.exchangeRates[gasCurrencyAddress] = &exchangeRate{}
+		}
+
+		pc.exchangeRates[gasCurrencyAddress].Numerator = baseAmount
+		pc.exchangeRates[gasCurrencyAddress].Denominator = counterAmount
+	}
+}
+
+func (pc *PriceComparator) mainLoop() {
+	pc.retrieveExchangeRates()
+	ticker := time.NewTicker(10 * time.Second)
+
+	for range ticker.C {
+		pc.retrieveExchangeRates()
+	}
+}
+
+func NewPriceComparator(gasCurrencyAddresses *[]common.Address, chainConfig *params.ChainConfig, blockchain *BlockChain) *PriceComparator {
+	exchangeRates := make(map[common.Address]*exchangeRate)
+
+	pc := &PriceComparator{
+		gasCurrencyAddresses: gasCurrencyAddresses,
+		exchangeRates:        exchangeRates,
+		blockchain:           blockchain,
+		chainConfig:          chainConfig,
+	}
+
+	if pc.gasCurrencyAddresses != nil && len(*pc.gasCurrencyAddresses) > 0 {
+		go pc.mainLoop()
+	}
+
+	return pc
+}
+
+// This function will retrieve the balance of an ERC20 token.  Specifically, the contract must have the
+// following function.
+// "function balanceOf(address _owner) public view returns (uint256)"
+func GetBalanceOf(accountOwner common.Address, contractAddress *common.Address, evm *vm.EVM, gas uint64) (
+	balance *big.Int, gasUsed uint64, err error) {
+
+	transactionData := common.GetEncodedAbiWithOneArg(getBalanceFuncABI, common.AddressToAbi(accountOwner))
+	anyCaller := vm.AccountRef(common.HexToAddress("0x0")) // any caller will work
+	log.Trace("getBalanceOf", "caller", anyCaller, "customTokenContractAddress",
+		*contractAddress, "gas", gas, "transactionData", hexutil.Encode(transactionData))
+	ret, leftoverGas, err := evm.StaticCall(anyCaller, *contractAddress, transactionData, gas)
+	gasUsed = gas - leftoverGas
+	if err != nil {
+		log.Debug("getBalanceOf error occurred", "Error", err)
+		return nil, gasUsed, err
+	}
+	result := big.NewInt(0)
+	result.SetBytes(ret)
+	log.Trace("getBalanceOf balance", "account", accountOwner.Hash(), "Balance", result.String(),
+		"gas used", gasUsed)
+	return result, gasUsed, nil
 }

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -302,7 +302,7 @@ func (l *txList) Filter(costLimit *big.Int, gasLimit uint64) (types.Transactions
 			return tx.Cost().Cmp(costLimit) > 0 || tx.Gas() > gasLimit
 		} else {
 			// If the gas is being paid in the non-native currency, ensure that the `tx.Value` is less than costLimit
-			// as the gas price will be dedudcted in the non-native currency.
+			// as the gas price will be deducted in the non-native currency.
 			log.Trace("Transaction Filter", "hash", tx.Hash(), "Gas currency", tx.GasCurrency(), "Value", tx.Value(), "Cost Limit", costLimit, "Gas", tx.Gas(), "Gas Limit", gasLimit)
 			return tx.Value().Cmp(costLimit) > 0 || tx.Gas() > gasLimit
 		}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -27,8 +27,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/prque"
+	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
@@ -122,6 +124,14 @@ type blockChain interface {
 	StateAt(root common.Hash) (*state.StateDB, error)
 
 	SubscribeChainHeadEvent(ch chan<- ChainHeadEvent) event.Subscription
+
+	// Engine retrieves the chain's consensus engine.
+	Engine() consensus.Engine
+
+	// GetHeader returns the header corresponding to their hash.
+	GetHeader(common.Hash, uint64) *types.Header
+
+	GetVMConfig() *vm.Config
 }
 
 // TxPoolConfig are the configuration parameters of the transaction pool.
@@ -646,6 +656,30 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		log.Debug("validateTx insufficient funds", "balance", pool.currentState.GetBalance(from).String(),
 			"txn cost", tx.Cost().String())
 		return ErrInsufficientFunds
+	} else if tx.GasCurrency() != nil {
+		header := pool.chain.CurrentBlock().Header()
+		state, err := pool.chain.StateAt(header.Root)
+
+		msg := types.NewMessage(common.HexToAddress("0x0"), nil, 0, common.Big0, 0, common.Big0, []byte{}, false)
+		context := NewEVMContext(msg, header, pool.chain, nil)
+		evm := vm.NewEVM(context, state, pool.chainconfig, *pool.chain.GetVMConfig())
+
+		gasCurrencyBalance, _, err := GetBalanceOf(from, tx.GasCurrency(), evm, 10 * 1000)
+
+		if err != nil {
+			log.Debug("validateTx error in getting gas currency balance", "gasCurrency", tx.GasCurrency(), "error", err)
+			return ErrInsufficientFunds
+		}
+
+		if gasCurrencyBalance.Cmp(new(big.Int).Mul(tx.GasPrice(), big.NewInt(int64(tx.Gas())))) < 0 {
+			log.Debug("validateTx insufficient gas currency", "gasCurrency", tx.GasCurrency(), "gasCurrencyBalance", gasCurrencyBalance)
+			return ErrInsufficientFunds
+		}
+
+		if pool.currentState.GetBalance(from).Cmp(tx.Value()) < 0 {
+			log.Debug("validateTx insufficient funds", "balance", pool.currentState.GetBalance(from).String())
+			return ErrInsufficientFunds
+		}
 	}
 	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, pool.homestead)
 	if err != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -181,7 +181,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if config.TxPool.Journal != "" {
 		config.TxPool.Journal = ctx.ResolvePath(config.TxPool.Journal)
 	}
-	pc := core.NewPriceComparator()
+	pc := core.NewPriceComparator(config.TxPool.CurrencyAddresses, eth.chainConfig, eth.blockchain)
 	eth.txPool = core.NewTxPool(config.TxPool, eth.chainConfig, eth.blockchain, pc)
 
 	if eth.protocolManager, err = NewProtocolManager(eth.chainConfig, config.SyncMode, config.NetworkId, eth.eventMux, eth.txPool, eth.engine, eth.blockchain, chainDb, config.Whitelist); err != nil {

--- a/les/handler_test.go
+++ b/les/handler_test.go
@@ -498,7 +498,7 @@ func TestTransactionStatusLes2(t *testing.T) {
 	chain := pm.blockchain.(*core.BlockChain)
 	config := core.DefaultTxPoolConfig
 	config.Journal = ""
-	pc := core.NewPriceComparator()
+	pc := core.NewPriceComparator(nil, nil, chain)
 	txpool := core.NewTxPool(config, params.TestChainConfig, chain, pc)
 	pm.txpool = txpool
 	peer, _ := newTestPeer(t, "peer", 2, pm, true)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -120,7 +120,7 @@ func newTestWorkerBackend(t *testing.T, chainConfig *params.ChainConfig, engine 
 	genesis := gspec.MustCommit(db)
 
 	chain, _ := core.NewBlockChain(db, nil, gspec.Config, engine, vm.Config{}, nil)
-	pc := core.NewPriceComparator()
+	pc := core.NewPriceComparator(nil, nil, nil)
 	txpool := core.NewTxPool(testTxPoolConfig, chainConfig, chain, pc)
 
 	// Generate a small n-block chain and an uncle block for it
@@ -163,7 +163,7 @@ func newTestWorker(t *testing.T, chainConfig *params.ChainConfig, engine consens
 	if shouldAddPendingTxs {
 		backend.txPool.AddLocals(pendingTxs)
 	}
-	pc := core.NewPriceComparator()
+	pc := core.NewPriceComparator(nil, nil, nil)
 	w := newWorker(chainConfig, engine, backend, new(event.TypeMux), time.Second, params.GenesisGasLimit, params.GenesisGasLimit, nil, testVerificationService, testVerificationRewardsAddress, pc)
 	w.setEtherbase(testBankAddress)
 	return w, backend

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -107,4 +107,5 @@ var (
 	AuthorizedTransferAddress            = common.HexToAddress("0x000000000000000000000000000000000000ce10") // Address of the contract authorized to call the transfer precompiled contract.
 	AuthorizedRequestVerificationAddress = common.HexToAddress("0x0000000000000000000000000000000000000ABE") // Address of the contract authorized to call the requestVerification precompiled contract.
 	ReserveAddress                       = common.HexToAddress("0x000000000000000000000000000000000000601d") // Address of the reserve proxy contract.
+	MedianatorAddress                    = common.HexToAddress("0x00000000000000000000000000000000044ed1a4") // Address of the medianator.
 )


### PR DESCRIPTION
### Description

This PR contains the following changes:

1) Periodic exchange rate cache refresh
2) Sufficient balance check in tx_pool


### Tested

Unit tests still need to be created (see issue# https://github.com/celo-org/celo-monorepo/issues/3107)

### Other changes

Added address for predeployed medianator smart contract

### Related issues

- Fixes #[3110] and #[2706] and #[2737]
