### PR TITLE
Add more logging for peers removal

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -193,7 +193,9 @@ func (pm *ProtocolManager) removePeer(id string) {
 	log.Debug("Removing Ethereum peer", "peer", id)
 
 	// Unregister the peer from the downloader and Ethereum peer set
-	pm.downloader.UnregisterPeer(id)
+	if err := pm.downloader.UnregisterPeer(id); err != nil {
+		log.Error("Peer removal from downloader failed", "peed", id, "err", err)
+	}
 	if err := pm.peers.Unregister(id); err != nil {
 		log.Error("Peer removal failed", "peer", id, "err", err)
 	}

--- a/les/handler.go
+++ b/les/handler.go
@@ -165,7 +165,16 @@ func NewProtocolManager(chainConfig *params.ChainConfig, indexerConfig *light.In
 
 // removePeer initiates disconnection from a peer by removing it from the peer set
 func (pm *ProtocolManager) removePeer(id string) {
-	pm.peers.Unregister(id)
+	log.Debug("Removing Ethereum Light peer", "peer", id)
+
+	if peer := pm.peers.Peer(id); peer == nil {
+		log.Debug("Attempt to remove light peer which has been already removed", "peer", id)
+		return
+	}
+
+	if err := pm.peers.Unregister(id); err != nil {
+		log.Error("Removing light peer failed", "peer", id, "err", err)
+	}
 }
 
 func (pm *ProtocolManager) Start(maxPeers int) {


### PR DESCRIPTION
### Description

More logging for peers removal. 

I have been investigating when the peers are connected and disconnected, therefore added a few log entries. It turned out that we have been receiving errors of removing an already removed peer. Therefore, I think, it would be informative to have such log messages in place. 

### Tested

Built and deployed on a testnet.
