### PR TITLE
Add codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default: 
+        threshold: null
+        target: auto
+    patch:
+      default: off


### PR DESCRIPTION
### Description

Default Codecov config seems to enforce a min threshold for coverage for a PR. Removing that.