### PR TITLE
Run Geth integration tests in Geth repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,3 +10,12 @@ jobs:
       - run: build/env.sh go run build/ci.go lint
       - run: build/env.sh go run build/ci.go test -coverage
       - run: bash <(curl -s https://codecov.io/bash)
+
+  end-to-end-test:
+    docker:
+      - image: circleci/golang:1.11
+
+    working_directory: /go/src/github.com/celo-org/geth
+    steps:
+      - checkout
+      - run: ./geth_end_to_end_test.sh checkout a2b5418ebf8f3eefea24323fadf0b9c3e47e3230 ${PWD}

--- a/geth_end_to_end_test.sh
+++ b/geth_end_to_end_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
+
+# For testing a particular commit hash of Celo monorepo repo (usually, on Circle CI)
+# Usage: ci_test.sh checkout <commit_hash_of_celo_monorepo_to_test>
+# For testing the local Celo monorepo dir (usually, for manual testing)
+# Usage: ci_test.sh local <location_of_local_celo_monorepo_dir>
+
+if [ "${1}" == "checkout" ]; then
+    export CELO_MONOREPO_DIR="/tmp/celo"
+    # Test master by default.
+    COMMIT_HASH_TO_TEST=${2:-"master"}
+    echo "Checking out celo monorepo at commit hash ${COMMIT_HASH_TO_TEST}..."
+    # Clone only up to depth 100 to save time. If COMMIT_HASH_TO_TEST is not in the
+    # last 100 commits then this will fail and that's fine since someone will be forced
+    # to upgrade the test to use a newer version of celo-monorepo to test against.
+    git clone --depth 100 git@github.com:celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} && cd ${CELO_MONOREPO_DIR} && git checkout ${COMMIT_HASH_TO_TEST} && cd -
+elif [ "${1}" == "local" ]; then
+    export CELO_MONOREPO_DIR="${2}"
+    echo "Testing using local celo monorepo dir ${CELO_MONOREPO_DIR}..."
+fi
+
+GETH_DIR=${3:-"$PWD"}
+cd ${CELO_MONOREPO_DIR}/packages/celotool
+./ci_test.sh local ${GETH_DIR}


### PR DESCRIPTION
### Description

Run Geth integration tests from celo-monorepo against the local Geth branch
and a fixed commit hash of the celo monorepo.

### Tested

`geth $ ./geth_end_to_end_test.sh checkout a2b5418ebf8f3eefea24323fadf0b9c3e47e3230 ${PWD}`