### PR TITLE
Ultralight sync mode

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -190,7 +190,7 @@ func initGenesis(ctx *cli.Context) error {
 	}
 	// Open an initialise both full and light databases
 	stack := makeFullNode(ctx)
-	for _, name := range []string{"chaindata", "lightchaindata", "celolatestchaindata"} {
+	for _, name := range []string{"chaindata", "lightchaindata", "celolatestchaindata", "ultralightchaindata"} {
 		chaindb, err := stack.OpenDatabase(name, 0, 0)
 		if err != nil {
 			utils.Fatalf("Failed to open database: %v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1380,7 +1380,7 @@ func SetDashboardConfig(ctx *cli.Context, cfg *dashboard.Config) {
 // RegisterEthService adds an Ethereum client to the stack.
 func RegisterEthService(stack *node.Node, cfg *eth.Config) {
 	var err error
-	if cfg.SyncMode == downloader.LightSync || cfg.SyncMode == downloader.CeloLatestSync {
+	if !cfg.SyncMode.SyncFullBlockChain() {
 		err = stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 			return les.New(ctx, cfg)
 		})
@@ -1481,6 +1481,8 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node) ethdb.Database {
 		name = "lightchaindata"
 	} else if ctx.GlobalString(SyncModeFlag.Name) == "celolatest" {
 		name = "celolatestchaindata"
+	} else if ctx.GlobalString(SyncModeFlag.Name) == "ultralight" {
+		name = "ultralightchaindata"
 	}
 	chainDb, err := stack.OpenDatabase(name, cache, handles)
 	if err != nil {

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -148,12 +148,10 @@ func (hc *HeaderChain) WriteHeader(header *types.Header) (status WriteStatus, er
 		if hc.config.FullHeaderChainAvailable {
 			return NonStatTy, consensus.ErrUnknownAncestor
 		} else {
-			// Ancestors would be missing if the full header chain is not available.
-			// Therefore, we cannot calculate the difficulty level, assume the difficulty of
-			// a block to be its block number for now. Later on, we will add some verification,
-			// so that, malicious blocks cannot be inserted.
-			totalDifficulty := big.NewInt(int64(number))
-			log.Debug(fmt.Sprintf("Previous header difficulty is not available, setting it to %v", totalDifficulty))
+			// In IBFT, it seems that the announced td (total difficulty) is 1 + block number.
+			totalDifficulty := big.NewInt(int64(number + 1))
+			log.Debug(fmt.Sprintf("Previous header for %d difficulty is not available, setting its difficulty to %v",
+				number, totalDifficulty))
 			localTd = big.NewInt(hc.CurrentHeader().Number.Int64())
 			externTd = externTd.Add(externTd, totalDifficulty)
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -109,8 +109,8 @@ func (s *Ethereum) AddLesServer(ls LesServer) {
 // initialisation of the common Ethereum object)
 func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	// Ensure configuration values are compatible and sane
-	if config.SyncMode == downloader.LightSync || config.SyncMode == downloader.CeloLatestSync {
-		return nil, errors.New("can't run eth.Ethereum in light sync mode or celolatest mode, use les.LightEthereum")
+	if !config.SyncMode.SyncFullBlockChain() {
+		return nil, errors.New("can't run eth.Ethereum in light sync mode, celolatest mode, or ultralight sync mode, use les.LightEthereum")
 	}
 	if !config.SyncMode.IsValid() {
 		return nil, fmt.Errorf("invalid sync mode %d", config.SyncMode)
@@ -129,6 +129,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		return nil, genesisErr
 	}
 	log.Info("Initialised chain configuration", "config", chainConfig)
+	fullHeaderChainAvailable := config.SyncMode.SyncFullHeaderChain()
 
 	eth := &Ethereum{
 		config:         config,
@@ -142,7 +143,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		gasPrice:       config.MinerGasPrice,
 		etherbase:      config.Etherbase,
 		bloomRequests:  make(chan chan *bloombits.Retrieval),
-		bloomIndexer:   NewBloomIndexer(chainDb, params.BloomBitsBlocks, params.BloomConfirms, config.SyncMode != downloader.CeloLatestSync),
+		bloomIndexer:   NewBloomIndexer(chainDb, params.BloomBitsBlocks, params.BloomConfirms, fullHeaderChainAvailable),
 	}
 
 	log.Info("Initialising Ethereum protocol", "versions", eth.engine.Protocol().Versions, "network", config.NetworkId)
@@ -247,10 +248,12 @@ func CreateDB(ctx *node.ServiceContext, config *Config, name string) (ethdb.Data
 func CreateConsensusEngine(ctx *node.ServiceContext, chainConfig *params.ChainConfig, config *Config, notify []string, noverify bool, db ethdb.Database) consensus.Engine {
 	// If proof-of-authority is requested, set it up
 	if chainConfig.Clique != nil {
+		log.Debug("Setting up clique consensus engine")
 		return clique.New(chainConfig.Clique, db)
 	}
 	// If Istanbul is requested, set it up
 	if chainConfig.Istanbul != nil {
+		log.Debug("Setting up Istanbul consensus engine")
 		if chainConfig.Istanbul.Epoch != 0 {
 			config.Istanbul.Epoch = chainConfig.Istanbul.Epoch
 		}
@@ -259,6 +262,7 @@ func CreateConsensusEngine(ctx *node.ServiceContext, chainConfig *params.ChainCo
 	}
 
 	// Otherwise assume proof-of-work
+	log.Debug("Setting up proof-of-work (pow) consensus engine")
 	switch config.Ethash.PowMode {
 	case ethash.ModeFake:
 		log.Warn("Ethash used in fake mode")

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -20,6 +20,7 @@ package downloader
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -37,13 +38,14 @@ import (
 )
 
 var (
-	MaxHashFetch    = 512 // Amount of hashes to be fetched per retrieval request
-	MaxBlockFetch   = 128 // Amount of blocks to be fetched per retrieval request
-	MaxHeaderFetch  = 192 // Amount of block headers to be fetched per retrieval request
-	MaxSkeletonSize = 128 // Number of header fetches to need for a skeleton assembly
-	MaxBodyFetch    = 128 // Amount of block bodies to be fetched per retrieval request
-	MaxReceiptFetch = 256 // Amount of transaction receipts to allow fetching per request
-	MaxStateFetch   = 384 // Amount of node state values to allow fetching per request
+	MaxHashFetch        = 512 // Amount of hashes to be fetched per retrieval request
+	MaxBlockFetch       = 128 // Amount of blocks to be fetched per retrieval request
+	MaxHeaderFetch      = 192 // Amount of block headers to be fetched per retrieval request
+	MaxEpochHeaderFetch = 192 // Number of epoch block headers to fetch (only used in IBFT consensus + UltraLight sync mode)
+	MaxSkeletonSize     = 128 // Number of header fetches to need for a skeleton assembly
+	MaxBodyFetch        = 128 // Amount of block bodies to be fetched per retrieval request
+	MaxReceiptFetch     = 256 // Amount of transaction receipts to allow fetching per request
+	MaxStateFetch       = 384 // Amount of node state values to allow fetching per request
 
 	MaxForkAncestry  = 3 * params.EpochDuration // Maximum chain reorganisation
 	rttMinEstimate   = 2 * time.Second          // Minimum round-trip time to target for download requests
@@ -99,10 +101,12 @@ type Downloader struct {
 	Mode SyncMode       // Synchronisation mode defining the strategy used (per sync cycle)
 	mux  *event.TypeMux // Event multiplexer to announce sync operation events
 
-	genesis uint64   // Genesis block number to limit sync to (e.g. light client CHT)
-	queue   *queue   // Scheduler for selecting the hashes to download
-	peers   *peerSet // Set of active peers from which download can proceed
-	stateDB ethdb.Database
+	genesis       uint64   // Genesis block number to limit sync to (e.g. light client CHT)
+	queue         *queue   // Scheduler for selecting the hashes to download
+	peers         *peerSet // Set of active peers from which download can proceed
+	stateDB       ethdb.Database
+	ibftConsensus bool   // True if we are in IBFT consensus mode
+	epoch         uint64 // Epoch value is useful in IBFT consensus
 
 	rttEstimate   uint64 // Round trip time to target for download requests
 	rttConfidence uint64 // Confidence in the estimated RTT (unit: millionths to allow atomic ops)
@@ -173,6 +177,8 @@ type LightChain interface {
 
 	// Rollback removes a few recently added elements from the local chain.
 	Rollback([]common.Hash, bool)
+
+	Config() *params.ChainConfig
 }
 
 // BlockChain encapsulates functions required to sync a (full or fast) blockchain.
@@ -205,9 +211,22 @@ type BlockChain interface {
 }
 
 // New creates a new downloader to fetch hashes and blocks from remote peers.
-func New(mode SyncMode, stateDb ethdb.Database, mux *event.TypeMux, chain BlockChain, lightchain LightChain, dropPeer peerDropFn) *Downloader {
+func New(mode SyncMode, stateDb ethdb.Database, mux *event.TypeMux, chain BlockChain, lightchain LightChain,
+	dropPeer peerDropFn) *Downloader {
 	if lightchain == nil {
 		lightchain = chain
+	}
+	ibftConsensus := false
+	epoch := uint64(0)
+	if chain != nil && chain.Config() != nil && chain.Config().Istanbul != nil {
+		epoch = chain.Config().Istanbul.Epoch
+		ibftConsensus = true
+	} else if lightchain != nil && lightchain.Config() != nil && lightchain.Config().Istanbul != nil {
+		epoch = lightchain.Config().Istanbul.Epoch
+		ibftConsensus = true
+	}
+	if epoch > math.MaxInt32 {
+		panic(fmt.Sprintf("epoch is too big(%d), the code to fetch epoch headers casts epoch to an int to calculate value for skip variable", epoch))
 	}
 
 	dl := &Downloader{
@@ -234,6 +253,8 @@ func New(mode SyncMode, stateDb ethdb.Database, mux *event.TypeMux, chain BlockC
 			processed: rawdb.ReadFastTrieProgress(stateDb),
 		},
 		trackStateReq: make(chan *stateReq),
+		ibftConsensus: ibftConsensus,
+		epoch:         epoch,
 	}
 	go dl.qosTuner()
 	go dl.stateFetcher()
@@ -261,6 +282,8 @@ func (d *Downloader) Progress() ethereum.SyncProgress {
 	case LightSync:
 		fallthrough
 	case CeloLatestSync:
+		fallthrough
+	case UltraLightSync:
 		current = d.lightchain.CurrentHeader().Number.Uint64()
 	}
 	log.Debug(fmt.Sprintf("Current head is %v", current))
@@ -447,7 +470,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 		// which requires multiple blocks to calculate the gas price and if the blocks are missing
 		// then the code panics. Therefore, we have to fetch more than one block.
 		// Anecodotally, 128 seems to be large enough.
-		origin = height - 128 // Download just the latest block
+		origin = height - 128 // Download just the latest set of blocks
 		log.Info(fmt.Sprintf("Mode is CeloLatestSync, latest block is %d, new origin is %d", height, origin))
 	}
 	d.syncStatsLock.Lock()
@@ -481,9 +504,9 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 	}
 
 	fetchers := []func() error{
-		func() error { return d.fetchHeaders(p, origin+1, pivot) }, // Headers are always retrieved
-		func() error { return d.fetchBodies(origin + 1) },          // Bodies are retrieved during normal and fast sync
-		func() error { return d.fetchReceipts(origin + 1) },        // Receipts are retrieved during fast sync
+		func() error { return d.fetchHeaders(p, origin+1, pivot, height) }, // Headers are always retrieved
+		func() error { return d.fetchBodies(origin + 1) },                  // Bodies are retrieved during normal and fast sync
+		func() error { return d.fetchReceipts(origin + 1) },                // Receipts are retrieved during fast sync
 		func() error { return d.processHeaders(origin+1, pivot, td) },
 	}
 	if d.Mode == FastSync {
@@ -683,7 +706,7 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 
 		// If we're doing a light sync, ensure the floor doesn't go below the CHT, as
 		// all headers before that point will be missing.
-		if d.Mode == LightSync || d.Mode == CeloLatestSync {
+		if !d.Mode.SyncFullBlockChain() {
 			// If we dont know the current CHT position, find it
 			if d.genesis == 0 {
 				header := d.lightchain.CurrentHeader()
@@ -869,8 +892,9 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 // other peers are only accepted if they map cleanly to the skeleton. If no one
 // can fill in the skeleton - not even the origin peer - it's assumed invalid and
 // the origin is dropped.
-func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64) error {
-	p.log.Debug("Directing header downloads", "origin", from)
+// height = latest block announced by the peers.
+func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64, height uint64) error {
+	p.log.Debug("fetchHeaders", "origin", from, "pivot", pivot, "height", height)
 	defer p.log.Debug("Header download terminated")
 
 	// Create a timeout timer, and the associated header fetcher
@@ -879,6 +903,7 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64) 
 	timeout := time.NewTimer(0) // timer to dump a non-responsive active peer
 	<-timeout.C                 // timeout channel should be initially empty
 	defer timeout.Stop()
+	epoch := d.epoch
 
 	var ttl time.Duration
 	getHeaders := func(from uint64) {
@@ -891,12 +916,73 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64) 
 			p.log.Trace("Fetching skeleton headers", "count", MaxHeaderFetch, "from", from)
 			go p.peer.RequestHeadersByNumber(from+uint64(MaxHeaderFetch)-1, MaxSkeletonSize, MaxHeaderFetch-1, false)
 		} else {
-			p.log.Trace("Fetching full headers", "count", MaxHeaderFetch, "from", from)
-			go p.peer.RequestHeadersByNumber(from, MaxHeaderFetch, 0, false)
+			count := MaxHeaderFetch
+			skip := 0
+			p.log.Trace("Fetching full headers", "count", count, "from", from)
+			go p.peer.RequestHeadersByNumber(from, MaxHeaderFetch, skip, false)
 		}
 	}
-	// Start pulling the header chain skeleton until all is done
-	getHeaders(from)
+
+	getEpochHeaders := func(fromEpochBlock uint64) {
+		if d.Mode != UltraLightSync {
+			panic("This method should be called only in UltraLightSync mode")
+		}
+		if fromEpochBlock%epoch != 0 {
+			panic(fmt.Sprintf(
+				"Logic error: getEpochHeaders received a request to fetch non-epoch block %d with epoch %d",
+				fromEpochBlock, epoch))
+		}
+
+		request = time.Now()
+
+		ttl = d.requestTTL()
+		timeout.Reset(ttl)
+
+		// if epoch is 100 and we fetch from=1000 and skip=100 then we will get
+		// 1000, 1101, 1202, 1303 ...
+		// So, skip has to be epoch - 1 to get the right set of blocks.
+		skip := int(epoch - 1)
+		count := MaxEpochHeaderFetch
+		log.Trace("getEpochHeaders", "from", fromEpochBlock, "count", count, "skip", skip)
+		p.log.Trace("Fetching full headers", "count", count, "from", fromEpochBlock)
+		go p.peer.RequestHeadersByNumber(fromEpochBlock, count, skip, false)
+	}
+
+	// Returns true if a header(s) fetch request was made, false if the syncing is finished.
+	getEpochOrNormalHeaders := func(from uint64) bool {
+		// Download the epoch headers including and beyond the current head.
+		nextEpochBlock := (from-1)/epoch*epoch + epoch
+		// If we're still not synced up to the latest epoch, sync only epoch headers.
+		// Otherwise, sync block headers as we would normally in light sync.
+		if nextEpochBlock < height {
+			log.Trace("getHeaders#epochDownload", "from", from, "nextEpochBlock", nextEpochBlock, "epoch", epoch)
+			getEpochHeaders(nextEpochBlock)
+			return true
+		} else if from < height {
+			log.Trace("getHeaders, all epoch blocks have been fetched, now fetch the last block", "from", height, "epoch", epoch)
+			getHeaders(height)
+			return true
+		} else {
+			// During repeated invocations, "from" can be more than height since the blocks could have
+			// created after this method was invoked and in that case, the from which is one beyond the
+			// last fetched header number can be more than the height.
+			// If we have already fetched a block header >= height block header then we declare that the sync
+			// is finished and stop.
+			return false
+		}
+	}
+
+	if d.Mode == UltraLightSync {
+		if epoch == 0 {
+			panic("Epoch cannot be 0 in IBFT + UltraLightSync")
+		}
+		// Don't fetch skeleton, only fetch the headers.
+		skeleton = false
+		getEpochOrNormalHeaders(from)
+	} else {
+		log.Trace("getHeaders#initialHeaderDownload", "from", from)
+		getHeaders(from)
+	}
 
 	for {
 		select {
@@ -915,6 +1001,7 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64) 
 			// If the skeleton's finished, pull any remaining head headers directly from the origin
 			if packet.Items() == 0 && skeleton {
 				skeleton = false
+				log.Trace("getHeaders, skeleton finished, download remaining headers")
 				getHeaders(from)
 				continue
 			}
@@ -940,6 +1027,7 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64) 
 					return errCancelHeaderFetch
 				}
 			}
+			// Received headers
 			headers := packet.(*headerPack).headers
 
 			// If we received a skeleton batch, resolve internals concurrently
@@ -955,24 +1043,28 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64) 
 				// If we're closing in on the chain head, but haven't yet reached it, delay
 				// the last few headers so mini reorgs on the head don't cause invalid hash
 				// chain errors.
-				if n := len(headers); n > 0 {
-					// Retrieve the current head we're at
-					head := uint64(0)
-					if d.Mode == LightSync || d.Mode == CeloLatestSync {
-						head = d.lightchain.CurrentHeader().Number.Uint64()
-					} else {
-						head = d.blockchain.CurrentFastBlock().NumberU64()
-						if full := d.blockchain.CurrentBlock().NumberU64(); head < full {
-							head = full
+				// Don't delay last few headers in IBFT since we are not expecting chain reorgs in IBFT
+				if !d.ibftConsensus {
+					if n := len(headers); n > 0 {
+						// Retrieve the current head we're at
+						head := uint64(0)
+						if !d.Mode.SyncFullBlockChain() {
+							head = d.lightchain.CurrentHeader().Number.Uint64()
+						} else {
+							head = d.blockchain.CurrentFastBlock().NumberU64()
+							if full := d.blockchain.CurrentBlock().NumberU64(); head < full {
+								head = full
+							}
 						}
-					}
-					// If the head is way older than this batch, delay the last few headers
-					if head+uint64(reorgProtThreshold) < headers[n-1].Number.Uint64() {
-						delay := reorgProtHeaderDelay
-						if delay > n {
-							delay = n
+						// If the head is way older than this batch, delay the last few headers
+						if head+uint64(reorgProtThreshold) < headers[n-1].Number.Uint64() {
+							delay := reorgProtHeaderDelay
+							if delay > n {
+								delay = n
+							}
+							log.Trace("Headers received", "received", len(headers), "kept from", 0, "kept till", n-delay)
+							headers = headers[:n-delay]
 						}
-						headers = headers[:n-delay]
 					}
 				}
 			}
@@ -984,14 +1076,35 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64) 
 				case <-d.cancelCh:
 					return errCancelHeaderFetch
 				}
-				from += uint64(len(headers))
-				getHeaders(from)
+				// In all other sync modes, we fetch the block immediately after the current block.
+				// In the ultralight sync mode, increment the value by epoch instead.
+				if d.Mode == UltraLightSync {
+					lastFetchedHeaderNumber := headers[len(headers)-1].Number.Uint64()
+					moreHeaderFetchesPending := getEpochOrNormalHeaders(lastFetchedHeaderNumber + 1)
+					if !moreHeaderFetchesPending {
+						p.log.Debug("No more headers available")
+						select {
+						case d.headerProcCh <- nil:
+							return nil
+						case <-d.cancelCh:
+							return errCancelHeaderFetch
+						}
+					}
+				} else {
+					from += uint64(len(headers))
+					log.Trace("getHeaders#downloadMoreHeaders", "from", from)
+					getHeaders(from)
+				}
 			} else {
 				// No headers delivered, or all of them being delayed, sleep a bit and retry
 				p.log.Trace("All headers delayed, waiting")
 				select {
 				case <-time.After(fsHeaderContCheck):
-					getHeaders(from)
+					if d.Mode == UltraLightSync {
+						getEpochOrNormalHeaders(from)
+					} else {
+						getHeaders(from)
+					}
 					continue
 				case <-d.cancelCh:
 					return errCancelHeaderFetch
@@ -1310,13 +1423,13 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 				hashes[i] = header.Hash()
 			}
 			lastHeader, lastFastBlock, lastBlock := d.lightchain.CurrentHeader().Number, common.Big0, common.Big0
-			if d.Mode != LightSync && d.Mode != CeloLatestSync {
+			if d.Mode.SyncFullBlockChain() {
 				lastFastBlock = d.blockchain.CurrentFastBlock().Number()
 				lastBlock = d.blockchain.CurrentBlock().Number()
 			}
-			d.lightchain.Rollback(hashes, d.Mode != CeloLatestSync)
+			d.lightchain.Rollback(hashes, d.Mode.SyncFullHeaderChain())
 			curFastBlock, curBlock := common.Big0, common.Big0
-			if d.Mode != LightSync && d.Mode != CeloLatestSync {
+			if d.Mode.SyncFullBlockChain() {
 				curFastBlock = d.blockchain.CurrentFastBlock().Number()
 				curBlock = d.blockchain.CurrentBlock().Number()
 			}
@@ -1357,7 +1470,7 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 				// L: Sync begins, and finds common ancestor at 11
 				// L: Request new headers up from 11 (R's TD was higher, it must have something)
 				// R: Nothing to give
-				if d.Mode != LightSync && d.Mode != CeloLatestSync {
+				if d.Mode.SyncFullBlockChain() {
 					head := d.blockchain.CurrentBlock()
 					if !gotHeaders && td.Cmp(d.blockchain.GetTd(head.Hash(), head.NumberU64())) > 0 {
 						return errStallingPeer
@@ -1400,7 +1513,7 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 				chunk := headers[:limit]
 
 				// In case of header only syncing, validate the chunk immediately
-				if d.Mode == FastSync || d.Mode == LightSync || d.Mode == CeloLatestSync {
+				if d.Mode == FastSync || !d.Mode.SyncFullBlockChain() {
 					// Collect the yet unknown headers to mark them as uncertain
 					unknown := make([]*types.Header, 0, len(headers))
 					for _, header := range chunk {
@@ -1413,16 +1526,33 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 					if chunk[len(chunk)-1].Number.Uint64()+uint64(fsHeaderForceVerify) > pivot {
 						frequency = 1
 					}
-					if n, err := d.lightchain.InsertHeaderChain(chunk, frequency); err != nil {
-						// If some headers were inserted, add them too to the rollback list
-						if n > 0 {
-							rollback = append(rollback, chunk[:n]...)
+					if d.Mode == UltraLightSync {
+						// `InsertHeaderChain` only permits the insertion of a continuous set of headers.
+						// See ValidateHeaderChain in core/headerchain.go for the check which rejects
+						// non-contiguous blocks. In UltraLightSync, we will be getting discontinuous epoch
+						// headers and a set of continuous headers around the last block number at the end.
+						for i := 0; i < len(chunk); i++ {
+							if n, err := d.lightchain.InsertHeaderChain(chunk[i:i+1], frequency); err != nil {
+								// If some headers were inserted, add them too to the rollback list
+								if n > 0 {
+									rollback = append(rollback, chunk[i:i+n]...)
+								}
+								log.Debug("Invalid header encountered", "number", chunk[n].Number, "hash", chunk[n].Hash(), "err", err)
+								return errInvalidChain
+							}
 						}
-						log.Debug("Invalid header encountered", "number", chunk[n].Number, "hash", chunk[n].Hash(), "err", err)
-						return errInvalidChain
+					} else {
+						if n, err := d.lightchain.InsertHeaderChain(chunk, frequency); err != nil {
+							// If some headers were inserted, add them too to the rollback list
+							if n > 0 {
+								rollback = append(rollback, chunk[:n]...)
+							}
+							log.Debug("Invalid header encountered", "number", chunk[n].Number, "hash", chunk[n].Hash(), "err", err)
+							return errInvalidChain
+						}
 					}
 					// All verifications passed, store newly found uncertain headers
-					log.Debug(fmt.Sprintf("Adding headers for rollback: %v", headersToNumbers(unknown)))
+					log.Trace(fmt.Sprintf("Adding headers for potential rollback: %v", headersToNumbers(unknown)))
 					rollback = append(rollback, unknown...)
 					if len(rollback) > fsHeaderSafetyNet {
 						log.Debug("Adding some headers for rollback")
@@ -1430,7 +1560,7 @@ func (d *Downloader) processHeaders(origin uint64, pivot uint64, td *big.Int) er
 					}
 				}
 				// Unless we're doing light chains, schedule the headers for associated content retrieval
-				if d.Mode == FullSync || d.Mode == FastSync {
+				if d.Mode.SyncFullBlockChain() {
 					// If we've reached the allowed number of pending headers, stall a bit
 					for d.queue.PendingBlocks() >= maxQueuedHeaders || d.queue.PendingReceipts() >= maxQueuedHeaders {
 						select {

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -19,6 +19,7 @@ package downloader
 import (
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/params"
 	"math/big"
 	"strings"
 	"sync"
@@ -62,6 +63,10 @@ type downloadTester struct {
 	ownChainTd  map[common.Hash]*big.Int       // Total difficulties of the blocks in the local chain
 
 	lock sync.RWMutex
+}
+
+func (dl *downloadTester) Config() *params.ChainConfig {
+	return nil
 }
 
 // newTester creates a new downloader test mocker.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -106,7 +106,9 @@ type ProtocolManager struct {
 
 // NewProtocolManager returns a new Ethereum sub protocol manager. The Ethereum sub protocol manages peers capable
 // with the Ethereum network.
-func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, networkID uint64, mux *event.TypeMux, txpool txPool, engine consensus.Engine, blockchain *core.BlockChain, chaindb ethdb.Database, whitelist map[uint64]common.Hash) (*ProtocolManager, error) {
+func NewProtocolManager(config *params.ChainConfig, mode downloader.SyncMode, networkID uint64, mux *event.TypeMux,
+	txpool txPool, engine consensus.Engine, blockchain *core.BlockChain, chaindb ethdb.Database,
+	whitelist map[uint64]common.Hash) (*ProtocolManager, error) {
 	// Create the protocol manager with the base fields
 	manager := &ProtocolManager{
 		networkID:   networkID,

--- a/les/backend.go
+++ b/les/backend.go
@@ -90,6 +90,9 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 	} else if syncMode == downloader.CeloLatestSync {
 		chainName = "celolatestchaindata"
 		fullChainAvailable = false
+	} else if syncMode == downloader.UltraLightSync {
+		chainName = "ultralightchaindata"
+		fullChainAvailable = false
 	} else {
 		panic("Unexpected sync mode: " + syncMode.String())
 	}
@@ -122,6 +125,12 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		networkId:      config.NetworkId,
 		bloomRequests:  make(chan chan *bloombits.Retrieval),
 		bloomIndexer:   eth.NewBloomIndexer(chainDb, params.BloomBitsBlocksClient, params.HelperTrieConfirmations, fullChainAvailable),
+	}
+
+	if syncMode == downloader.UltraLightSync && chainConfig.Istanbul == nil {
+		msg := fmt.Sprintf(
+			"To use UltraLightSync sync mode, run the node with Istanbul BFT consensus %v", chainConfig)
+		panic(msg)
 	}
 
 	leth.relay = NewLesTxRelay(peers, leth.reqDist)

--- a/les/handler.go
+++ b/les/handler.go
@@ -125,8 +125,12 @@ type ProtocolManager struct {
 
 // NewProtocolManager returns a new ethereum sub protocol manager. The Ethereum sub protocol manages peers capable
 // with the ethereum network.
-func NewProtocolManager(chainConfig *params.ChainConfig, indexerConfig *light.IndexerConfig, syncMode downloader.SyncMode, networkId uint64, mux *event.TypeMux, engine consensus.Engine, peers *peerSet, blockchain BlockChain, txpool txPool, chainDb ethdb.Database, odr *LesOdr, txrelay *LesTxRelay, serverPool *serverPool, quitSync chan struct{}, wg *sync.WaitGroup, etherbase common.Address) (*ProtocolManager, error) {
-	lightSync := syncMode == downloader.LightSync || syncMode == downloader.CeloLatestSync
+func NewProtocolManager(chainConfig *params.ChainConfig, indexerConfig *light.IndexerConfig,
+	syncMode downloader.SyncMode, networkId uint64, mux *event.TypeMux, engine consensus.Engine,
+	peers *peerSet, blockchain BlockChain, txpool txPool, chainDb ethdb.Database,
+	odr *LesOdr, txrelay *LesTxRelay, serverPool *serverPool, quitSync chan struct{},
+	wg *sync.WaitGroup, etherbase common.Address) (*ProtocolManager, error) {
+	lightSync := !syncMode.SyncFullBlockChain()
 	// Create the protocol manager with the base fields
 	manager := &ProtocolManager{
 		lightSync:   lightSync,
@@ -157,7 +161,7 @@ func NewProtocolManager(chainConfig *params.ChainConfig, indexerConfig *light.In
 		removePeer = func(id string) {}
 	}
 
-	if syncMode == downloader.LightSync || syncMode == downloader.CeloLatestSync {
+	if lightSync {
 		manager.downloader = downloader.New(syncMode, chainDb, manager.eventMux, nil, blockchain, removePeer)
 		manager.peers.notify((*downloaderPeerNotify)(manager))
 		manager.fetcher = newLightFetcher(manager)

--- a/les/helper_test.go
+++ b/les/helper_test.go
@@ -161,8 +161,8 @@ func newTestProtocolManager(syncmode downloader.SyncMode, blocks int, generator 
 	if peers == nil {
 		peers = newPeerSet()
 	}
+	lightSync := !syncmode.SyncFullBlockChain()
 
-	lightSync := syncmode == downloader.LightSync || syncmode == downloader.CeloLatestSync
 	if lightSync {
 		chain, _ = light.NewLightChain(odr, gspec.Config, engine)
 	} else {

--- a/les/sync.go
+++ b/les/sync.go
@@ -57,9 +57,12 @@ func (pm *ProtocolManager) syncer() {
 
 func (pm *ProtocolManager) needToSync(peerHead blockInfo, mode downloader.SyncMode) bool {
 	head := pm.blockchain.CurrentHeader()
-	if mode == downloader.CeloLatestSync {
-		// In the celolatest mode, the difficulty calculation is meaningless, so, we rely on the block
-		// numbers.
+	if !mode.SyncFullHeaderChain() {
+		// There are two modes where this holds, celolatest and ultralight.
+		// In the celolatest mode, the difficulty calculation cannot be done since we don't have all the blocks,
+		// so, we rely on the block numbers.
+		// In the ultralight mode used for IBFT, each block has a difficulty of 1, so, block number
+		// corresponds to the difficulty level.
 		currentHead := head.Number.Uint64()
 		log.Debug("needToSync", "currentHead", currentHead, "peerHead", peerHead.Number)
 		return peerHead.Number > currentHead

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -326,7 +326,7 @@ func (self *LightChain) Rollback(chain []common.Hash, fullHeaderChainAvailable b
 
 		if head := self.hc.CurrentHeader(); head.Hash() == hash {
 			parentHeader := self.GetHeader(head.ParentHash, head.Number.Uint64()-1)
-			// In all sync modes except CeloLatestSync, a complete header chain is available.
+			// In all sync modes except CeloLatestSync and UltraLightSync, a complete header chain is available.
 			// Maintain the old behavior in those cases.
 			if fullHeaderChainAvailable || parentHeader != nil {
 				self.hc.SetCurrentHeader(parentHeader)

--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -45,6 +45,7 @@ const SyncModeFullSync = 1
 const SyncModeFastSync = 2
 const SyncModeLightSync = 3
 const SyncModeCeloLatestSync = 4
+const UltraLightSync = 5
 
 // NodeConfig represents the collection of configuration values to fine tune the Geth
 // node embedded into a mobile process. The available values are a subset of the
@@ -217,6 +218,8 @@ func getSyncMode(syncMode int) downloader.SyncMode {
 		return downloader.LightSync
 	case SyncModeCeloLatestSync:
 		return downloader.CeloLatestSync
+	case UltraLightSync:
+		return downloader.UltraLightSync
 	default:
 		panic(fmt.Sprintf("Unexpected sync mode value: %d", syncMode))
 	}


### PR DESCRIPTION
### Description

Add a new ultralight sync mode. This mode only works for IBFT. The way it works is that it downloads all epoch blocks and validates all of them. So, for example, if the epoch size is 100 and the current head is 653 then this will download block 100, 200, 300, 400, 500, 600, and 653. The blocks are validated and inserted.



### Tested

#### First test ([Logs](https://github.com/celo-org/geth/files/3271233/tmp15_ultralight.txt)), Geth was run and was syncing to `valset` in `ultralight` mode. 
In this case, epoch size is 300.
Now, run `grep -E "(height is|Inserted new header)" <filename>` this shows that the height (latest block header) is 990240 and that only headers which are multiples of 300 are fetched till 990000 (last epoch) then a batch of headers which includes 990240 is fetched. From their onwards, single headers are fetched.

When we do `grep "getHeaders#"` which shows that a single request is fetching ~190 headers which are similar to how light mode works as well.

```
getHeaders#0                             from=1      startDownloadFrom=300 epoch=300
getHeaders#5                             from=57300
getHeaders#5                             from=114300
getHeaders#5                             from=171300
getHeaders#5                             from=228300
getHeaders#5                             from=285300
getHeaders#5                             from=342300
getHeaders#5                             from=399300
getHeaders#5                             from=456300
getHeaders#5                             from=513300
getHeaders#5                             from=570300
getHeaders#5                             from=627300
getHeaders#5                             from=684300
getHeaders#5                             from=741300
getHeaders#5                             from=798300
getHeaders#5                             from=855300
getHeaders#5                             from=912300
getHeaders#5                             from=969300
getHeaders#5                             from=989700
getHeaders#5                             from=990000
```

#### Second test
```
packages/celotool $ ./geth_tests/integration_network_sync_test.sh valset ultralight
This test will start a local node in 'ultralight' sync mode which will connect to network 'valset' and verify that syncing works
Setting constants...
Geth has been built successfully!
Running geth in the background...
Latest block number is 384600
```

`valset` is a network with low epoch value (300) for testing.

packages/celotool $ ./geth_tests/integration_network_sync_test.sh integration ultralight
This test will start a local node in 'ultralight' sync mode which will connect to network 'integration' and verify that syncing works
Setting constants...
Geth has been built successfully!
Running geth in the background...
Latest block number is 39998

packages/celotool $ ./geth_tests/integration_network_sync_test.sh appintegration ultralight
This test will start a local node in 'ultralight' sync mode which will connect to network 'appintegration' and verify that syncing works
Setting constants...
Geth has been built successfully!
Running geth in the background...
Latest block number is 81920


#### Third test - restart of Geth from an existing sync state

```
packages/celotool $ ./geth_tests/integration_network_sync_test.sh integration ultralight
This test will start a local node in 'ultralight' sync mode which will connect to network 'integration' and verify that syncing works
...
Latest block number is 68937
```

Now, run
```
./geth_tests/integration_network_sync_test.sh_2 integration ultralight | tee tmp17_restart_ultralight
This file does not delete existing Geth data dir and restarts geth from its previous state


cat ./geth_tests/integration_network_sync_test.sh_2
#!/usr/bin/env bash
set -euo pipefail

# Usage: geth_tests/integration_network_sync_test.sh [network name] [sync mode]
# Default to testing the integration network
NETWORK_NAME=${1:-"integration"}
# Default to testing the full sync mode
SYNCMODE=${2:-"full"}

echo "This test will start a local node in '${SYNCMODE}' sync mode which will connect to network '${NETWORK_NAME}' and verify that syncing works"

echo "Setting constants..."
# For now, the script assumes that it runs from a sub-dir of sub-dir of monorepo directory.
CELO_MONOREPO_DIR="${PWD}/../.."

DATA_DIR="/tmp/tmp1"
GENESIS_FILE_PATH="/tmp/genesis_ibft.json"

GETH_BINARY="${GETH_DIR}/build/bin/geth --datadir ${DATA_DIR}"
CELOTOOLJS="${CELO_MONOREPO_DIR}/packages/celotool/bin/celotooljs.sh"

echo "Building Geth..."
${CELOTOOLJS} geth build --geth-dir ${GETH_DIR}

echo "Reusing Geth data dir {$DATA_DIR}..."

cp ${CELO_MONOREPO_DIR}/packages/celotool/geth_tests/${NETWORK_NAME}_static-nodes.json ${DATA_DIR}/static-nodes.json

echo "Running geth in the background..."
# Run geth in the background
${CELOTOOLJS} geth run \
    --geth-dir ${GETH_DIR} \
    --data-dir ${DATA_DIR} \
    --sync-mode ${SYNCMODE} \ 
```

Checks the log file to confirm a few things
1. Geth started from the last reported origin 68937
2. Only the blocks starting from the newly reported latest block, "height", are fetched.

```
DEBUG[06-11|17:44:25.179|eth/downloader/downloader.go:480]   After the check origin is 68937 height is 68952 
284:DEBUG[06-11|17:44:25.207|light/lightchain.go:393]                  Inserted new header                      number=68952 hash=8afc7d…17b1f9
327:DEBUG[06-11|17:44:26.113|light/lightchain.go:393]                  Inserted new header                      number=68953 hash=5c3216…4135e5
377:DEBUG[06-11|17:44:31.130|light/lightchain.go:393]                  Inserted new header                      number=68954 hash=f067fe…ce3123
```


### Related issues

- Fixes https://github.com/celo-org/geth/issues/187

### Backwards compatibility

This change is backward-compatible. It adds a new sync mode while keep existing sync modes intact.