### PR TITLE
Use existing validator set when static call to get new one fails

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -382,7 +382,7 @@ func (sb *Backend) UpdateValSetDiff(chain consensus.ChainReader, header *types.H
 			// Get the new epoch's validator set
 			var newValSet []common.Address
 
-			maxGasForGetValidators := 1000000
+			maxGasForGetValidators := uint64(1000000)
 			// TODO(kevjue) - Once the validator election smart contract is completed, then a more accurate gas value should be used.
 			leftoverGas, err := sb.iEvmH.MakeStaticCall(*validatorAddress, getValidatorsFuncABI, "getValidators", []interface{}{}, &newValSet, maxGasForGetValidators, header, state)
 			if err != nil {


### PR DESCRIPTION
### Description

This PR enables keeping the current validator set when fetching the new set fails.

This PR is a sibling to https://github.com/celo-org/celo-monorepo/pull/3636

### Tested

Not tested

### Other changes

Promotes log level of validator set diff message from `Trace` to `Info`

### Related issues

- https://github.com/celo-org/celo-monorepo/issues/3281

### Backwards compatibility

Not backwards compatible