### PR TITLE
Repoint geth end-to-end tests to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,7 @@ jobs:
             mkdir -p ~/.ssh/
             echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
             export CELO_MONOREPO_DIR="./celo-monorepo"
-            # TODO(nguo) change this back to master
-            git clone --depth 1 https://${GH_AUTH_USERNAME}:${GH_AUTH_TOKEN}@github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b nguo/total-supply-goldtoken
+            git clone --depth 1 https://${GH_AUTH_USERNAME}:${GH_AUTH_TOKEN}@github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b master
             # Change these paths to use https login since the SSH key does not have access to these repositories.
             # Once we open source this code, these modifications can be eliminated.
             # These environment variables are configured at https://circleci.com/gh/celo-org/geth/edit#env-vars


### PR DESCRIPTION
Description
This PR is a followup to #261 in which we needed to point the monorepo end-to-end tests to a specific commit, which was merged in celo-org/celo-monorepo#3652, in order for them to pass. Now that celo-org/celo-monorepo#3652 is merged, we can run the tests with monorepo master again.

Tested
CircleCI