### PR TITLE
Trianglesphere/oom fix

### DIFF
--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -93,7 +93,7 @@ type NodeConfig struct {
 
 	// UseLightweightKDF lowers the memory and CPU requirements of the key store
 	// scrypt KDF at the expense of security.
-  // See https://geth.ethereum.org/doc/Mobile_Account-management for reference
+	// See https://geth.ethereum.org/doc/Mobile_Account-management for reference
 	UseLightweightKDF bool
 }
 
@@ -137,12 +137,12 @@ func NewNode(datadir string, config *NodeConfig) (stack *Node, _ error) {
 
 	// Create the empty networking stack
 	nodeConf := &node.Config{
-		Name:        clientIdentifier,
-		Version:     params.VersionWithMeta,
-		DataDir:     datadir,
-		KeyStoreDir: filepath.Join(datadir, "keystore"), // Mobile should never use internal keystores!
+		Name:              clientIdentifier,
+		Version:           params.VersionWithMeta,
+		DataDir:           datadir,
+		KeyStoreDir:       filepath.Join(datadir, "keystore"), // Mobile should never use internal keystores!
 		UseLightweightKDF: config.UseLightweightKDF,
-		IPCPath:     "geth.ipc",
+		IPCPath:           "geth.ipc",
 		P2P: p2p.Config{
 			NoDiscovery:      true,
 			DiscoveryV5:      false,


### PR DESCRIPTION
### Description

Adds the options for a `UseLightweightKDF` on Geth's mobile config. This then uses 4MB of RAM rather than 256 MB of RAM with `scrypt` to secure the private key of the account.

This should be able to be merged without dependency issues, and needs to merged before the other PRs.

### Tested

This PR along with the PRs in the other two repos was tested on both failing phones, and the phones no longer crashed on inputting the invite key (which causes a store of a private key which invokes scrypt wit hthe standard parameters). Syncing not working, but that seemed to be an issue with test networks.


### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/3254 and https://github.com/celo-org/celo-monorepo/issues/3693

### Backwards compatibility

Yes.
