### PR TITLE
Reset monorepo e2e test branch back to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
             mkdir -p ~/.ssh/
             echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
             export CELO_MONOREPO_DIR="./celo-monorepo"
-            git clone --depth 1 https://${GH_AUTH_USERNAME}:${GH_AUTH_TOKEN}@github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b nitya/stability-fee
+            git clone --depth 1 https://${GH_AUTH_USERNAME}:${GH_AUTH_TOKEN}@github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b master
             # Change these paths to use https login since the SSH key does not have access to these repositories.
             # Once we open source this code, these modifications can be eliminated.
             # These environment variables are configured at https://circleci.com/gh/celo-org/geth/edit#env-vars


### PR DESCRIPTION
### Description

Resets e2e's to run off master again once https://github.com/celo-org/celo-monorepo/pull/3258 is merged

### Tested

e2e tests pass on the branch in https://github.com/celo-org/celo-monorepo/pull/3258

### Other changes

n/a

### Backwards compatibility

Backwards compatible, e2e is green at all points