### PR TITLE
Check for an empty heap when getting the cheapest transactions

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -564,8 +564,13 @@ func (l *txPricedList) Discard(count int, local *accountSet) types.Transactions 
 // Retrieves the heap with the lowest normalized price at it's head
 func (l *txPricedList) getHeapWithMinHead() (*priceHeap, *types.Transaction) {
 	// Initialize it to the nilCurrencyHeap
-	var cheapestHeap *priceHeap = l.nilCurrencyHeap
-	var cheapestTxn *types.Transaction = []*types.Transaction(*l.nilCurrencyHeap)[0]
+	var cheapestHeap *priceHeap
+	var cheapestTxn *types.Transaction
+
+	if len(*l.nilCurrencyHeap) > 0 {
+		cheapestHeap = l.nilCurrencyHeap
+		cheapestTxn = []*types.Transaction(*l.nilCurrencyHeap)[0]
+	}
 
 	for _, priceHeap := range l.nonNilCurrencyHeaps {
 		if len(*priceHeap) > 0 {


### PR DESCRIPTION
### Description

This PR fixes a bug that caused geth to crash when started with a non-empty tx pool but no txs in the pool paying for gas in Celo Gold, by checking that the heap of txs paying for gas in Celo Gold is non-empty before popping from it.


### Tested

Bringing up a local network of one node with the end-to-end tests, making an underpriced transaction that wouldn't get mined, killing the node, and restarting the node. The node crashes before the changes, and runs smoothly after.

### Other changes

None
