### PR TITLE
Provide 10M gas for fetching the validator set

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -428,7 +428,7 @@ func (sb *Backend) getValSet(header *types.Header, state *state.StateDB) ([]comm
 		return newValSet, err
 	} else {
 		// Get the new epoch's validator set
-		maxGasForGetValidators := uint64(1000000)
+		maxGasForGetValidators := uint64(10000000)
 		// TODO(asa) - Once the validator election smart contract is completed, then a more accurate gas value should be used.
 		_, err := sb.iEvmH.MakeStaticCall(*validatorsAddress, getValidatorsFuncABI, "getValidators", []interface{}{}, &newValSet, maxGasForGetValidators, header, state)
 		return newValSet, err


### PR DESCRIPTION
### Description

1M wasn't enough. 1.75M seemed to do it but we should test this with more validator groups at some point.

