### PR TITLE
Fix docs.celo.org link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Celo project comes with several wrappers/executables found in the `cmd` director
 
 ## Running Celo
 
-Please see the [docs page](docs.celo.org) for more instructions on how to run a Celo node conencted to the Alfajores testnet.
+Please see the [docs page](https://docs.celo.org) for more instructions on how to run a Celo node conencted to the Alfajores testnet.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Celo project comes with several wrappers/executables found in the `cmd` director
 
 ## Running Celo
 
-Please see the [docs page](https://docs.celo.org) for more instructions on how to run a Celo node conencted to the Alfajores testnet.
+Please see the [docs page](https://docs.celo.org) for more instructions on how to run a Celo node connected to the Alfajores testnet.
 
 ### Configuration
 


### PR DESCRIPTION
### Description

The link wasn't properly formatted

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Other changes

_Describe any minor or "drive-by" changes here._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible. Feel free to remove for trivial, backwards compatible changes._
