### PR TITLE
Separate phone number decryption to a separate key

### DIFF
--- a/abe/abe.go
+++ b/abe/abe.go
@@ -73,8 +73,8 @@ func sendSms(phoneNumber string, message string, account common.Address, issuer 
 	return err
 }
 
-func SendAttestationMessages(receipts []*types.Receipt, block *types.Block, coinbase common.Address, accountManager *accounts.Manager, verificationServiceURL string) {
-	account := accounts.Account{Address: coinbase}
+func SendAttestationMessages(receipts []*types.Receipt, block *types.Block, decryptionAccount common.Address, accountManager *accounts.Manager, verificationServiceURL string) {
+	account := accounts.Account{Address: decryptionAccount}
 	var wallet accounts.Wallet
 	var err error
 	for _, receipt := range receipts {
@@ -87,7 +87,7 @@ func SendAttestationMessages(receipts []*types.Receipt, block *types.Block, coin
 				}
 			}
 
-			if !bytes.Equal(coinbase.Bytes(), request.Verifier.Bytes()) {
+			if !bytes.Equal(decryptionAccount.Bytes(), request.Verifier.Bytes()) {
 				continue
 			}
 			phoneNumber, err := decryptPhoneNumber(request, account, wallet)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -111,6 +111,7 @@ var (
 		utils.MinerRecommitIntervalFlag,
 		utils.MinerNoVerfiyFlag,
 		utils.MinerVerificationServiceUrlFlag,
+		utils.AttestationsDecryptionAccount,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV5Flag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -201,6 +201,12 @@ var AppHelpFlagGroups = []flagGroup{
 		},
 	},
 	{
+		Name: "ATTESTATIONS",
+		Flags: []cli.Flag{
+			utils.AttestationsDecryptionAccount,
+		},
+	},
+	{
 		Name: "VIRTUAL MACHINE",
 		Flags: []cli.Flag{
 			utils.VMEnableDebugFlag,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -215,7 +215,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		istanbul.SetGasPriceMinimum(eth.gpm)
 	}
 
-	eth.miner = miner.New(eth, eth.chainConfig, eth.EventMux(), eth.engine, config.MinerRecommit, config.MinerGasFloor, config.MinerGasCeil, eth.isLocalBlock, config.MinerVerificationServiceUrl, co, random, &chainDb)
+	eth.miner = miner.New(eth, eth.chainConfig, eth.EventMux(), eth.engine, config.MinerRecommit, config.MinerGasFloor, config.MinerGasCeil, eth.isLocalBlock, config.MinerVerificationServiceUrl, config.AttestationDecryptionAccount, co, random, &chainDb)
 	eth.miner.SetExtra(makeExtraData(config.MinerExtraData))
 
 	eth.APIBackend = &EthAPIBackend{eth}

--- a/eth/config.go
+++ b/eth/config.go
@@ -42,15 +42,16 @@ var DefaultConfig = Config{
 		DatasetsInMem:  1,
 		DatasetsOnDisk: 2,
 	},
-	NetworkId:                   1,
-	LightPeers:                  100,
-	DatabaseCache:               768,
-	TrieTimeout:                 60 * time.Minute,
-	MinerGasFloor:               8000000,
-	MinerGasCeil:                8000000,
-	MinerGasPrice:               big.NewInt(1),
-	MinerRecommit:               3 * time.Second,
-	MinerVerificationServiceUrl: "https://mining-pool.celo.org/v0.1/sms",
+	NetworkId:                    1,
+	LightPeers:                   100,
+	DatabaseCache:                768,
+	TrieTimeout:                  60 * time.Minute,
+	MinerGasFloor:                8000000,
+	MinerGasCeil:                 8000000,
+	MinerGasPrice:                big.NewInt(1),
+	MinerRecommit:                3 * time.Second,
+	MinerVerificationServiceUrl:  "https://mining-pool.celo.org/v0.1/sms",
+	AttestationDecryptionAccount: common.Address{},
 
 	TxPool: core.DefaultTxPoolConfig,
 
@@ -110,6 +111,8 @@ type Config struct {
 	MinerRecommit               time.Duration
 	MinerNoverify               bool
 	MinerVerificationServiceUrl string
+
+	AttestationDecryptionAccount common.Address
 
 	// Ethash options
 	Ethash ethash.Config

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -59,13 +59,13 @@ type Miner struct {
 	shouldStart int32 // should start indicates whether we should start after sync
 }
 
-func New(eth Backend, config *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, recommit time.Duration, gasFloor, gasCeil uint64, isLocalBlock func(block *types.Block) bool, verificationService string, co *core.CurrencyOperator, random *core.Random, db *ethdb.Database) *Miner {
+func New(eth Backend, config *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, recommit time.Duration, gasFloor, gasCeil uint64, isLocalBlock func(block *types.Block) bool, verificationService string, attestationDecryptionKey common.Address, co *core.CurrencyOperator, random *core.Random, db *ethdb.Database) *Miner {
 	miner := &Miner{
 		eth:      eth,
 		mux:      mux,
 		engine:   engine,
 		exitCh:   make(chan struct{}),
-		worker:   newWorker(config, engine, eth, mux, recommit, gasFloor, gasCeil, isLocalBlock, verificationService, co, random, db),
+		worker:   newWorker(config, engine, eth, mux, recommit, gasFloor, gasCeil, isLocalBlock, verificationService, attestationDecryptionKey, co, random, db),
 		canStart: 1,
 	}
 	go miner.update()


### PR DESCRIPTION
### Description

This change allows validators to specify the account with which phone numbers in reveal transactions should be decrypted.

### Tested

- [ ] On a testnet
- [ ] TOFIX: I didn't actually change the decryption, i changed the account to identify if the attestation request goes to our miner. I should actually pass through the decryption

### Related issues

- Fixes #321 

### Backwards compatibility

- We will no longer decrypt phone numbers with the coinbase account