### PR TITLE
Add locks to lastAnnounceGossiped

### DIFF
--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -328,6 +328,8 @@ func (sb *Backend) handleIstAnnounce(payload []byte) error {
 	sb.logger.Trace("Regossiping the istanbul announce message", "AnnounceMsg", msg)
 	sb.Gossip(nil, payload, istanbulAnnounceMsg, true)
 
+	sb.lastAnnounceGossipedMu.Lock()
+	defer sb.lastAnnounceGossipedMu.Unlock()
 	sb.lastAnnounceGossiped[msg.Address] = &AnnounceGossipTimestamp{enodeURL: enodeUrl, timestamp: time.Now()}
 
 	// prune non registered validator entries in the valEnodeTable, reverseValEnodeTable, and lastAnnounceGossiped tables about 5% of the times that an announce msg is handled

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -318,12 +318,15 @@ func (sb *Backend) handleIstAnnounce(payload []byte) error {
 	}
 
 	// If we gossiped this address/enodeURL within the last 60 seconds, then don't regossip
+	sb.lastAnnounceGossipedMu.RLock()
 	if lastGossipTs, ok := sb.lastAnnounceGossiped[msg.Address]; ok {
 		if lastGossipTs.enodeURL == enodeUrl && time.Since(lastGossipTs.timestamp) < time.Minute {
 			sb.logger.Trace("Already regossiped the msg within the last minute, so not regossiping.", "AnnounceMsg", msg)
+			sb.lastAnnounceGossipedMu.RUnlock()
 			return nil
 		}
 	}
+	sb.lastAnnounceGossipedMu.RUnlock()
 
 	sb.logger.Trace("Regossiping the istanbul announce message", "AnnounceMsg", msg)
 	sb.Gossip(nil, payload, istanbulAnnounceMsg, true)

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -118,7 +118,8 @@ type Backend struct {
 	recentMessages *lru.ARCCache // the cache of peer's messages
 	knownMessages  *lru.ARCCache // the cache of self messages
 
-	lastAnnounceGossiped map[common.Address]*AnnounceGossipTimestamp
+	lastAnnounceGossiped   map[common.Address]*AnnounceGossipTimestamp
+	lastAnnounceGossipedMu sync.RWMutex
 
 	valEnodeTable *validatorEnodeTable
 


### PR DESCRIPTION
### Description

During `handleIstAnnounce`, a `lastAnnounceGossiped` map is used to only regossip messages from a sender after some time from their previous message. However, since there were no locks used, concurrent map writes occurred.

This pr adds rw locks around map reads and writes.

### Tested


### Other changes


### Related issues

- Fixes #368 

### Backwards compatibility

Yes, since just added locks
