### PR TITLE
Points CI back to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           command: |
             set -euo pipefail
             export CELO_MONOREPO_DIR="$HOME/geth/celo-monorepo"
-            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b kobigurk/bls
+            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b master
             cd ${CELO_MONOREPO_DIR}/packages
             # TODO(ashishb): Delete unnecessary packages to speed up build time.
             # It would be better whitelist certain packages and delete the rest.


### PR DESCRIPTION
The BLS PR https://github.com/celo-org/celo-blockchain/pull/326 pointed the CI to a specific branch in order to pass tests.