### PR TITLE
fix: build contractkit & celotool from monorepo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,14 +81,15 @@ jobs:
             set -euo pipefail
             export CELO_MONOREPO_DIR="$HOME/geth/celo-monorepo"
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b master
-            cd ${CELO_MONOREPO_DIR}/packages
             # TODO(ashishb): Delete unnecessary packages to speed up build time.
             # It would be better whitelist certain packages and delete the rest.
             # Deletion does not work right now and yarn fails with weird errors.
             # This will be enabled and resolved later.
             # rm -rf analytics blockchain-api cli docs faucet helm-charts mobile notification-service react-components transaction-metrics-exporter verification-pool-api verifier web
-            cd ${CELO_MONOREPO_DIR}/packages/celotool
-            yarn || yarn
+            # cd ${CELO_MONOREPO_DIR}/packages/celotool
+            cd ${CELO_MONOREPO_DIR}            
+            yarn install || yarn install
+            yarn build --scope @celo/contractkit --scope @celo/celotool
       - persist_to_workspace:
           root: .
           paths: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
             # cd ${CELO_MONOREPO_DIR}/packages/celotool
             cd ${CELO_MONOREPO_DIR}            
             yarn install || yarn install
-            yarn build --scope @celo/contractkit --scope @celo/celotool
+            yarn build --scope @celo/util --scope @celo/contractkit --scope @celo/verification-pool-api --scope @celo/celotool
       - persist_to_workspace:
           root: .
           paths: .


### PR DESCRIPTION
### Description

CircleCI needs to build monorepo, now that postinstall doesn't build

### Tested

CI

