### PR TITLE
Only rebuild rust in Docker with vendor changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@
 
 FROM ubuntu:16.04 as rustbuilder
 RUN apt update && apt install -y curl musl-tools
-ADD . /go-ethereum
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH=$PATH:~/.cargo/bin
 RUN $HOME/.cargo/bin/rustup install 1.36.0 && $HOME/.cargo/bin/rustup default 1.36.0 && $HOME/.cargo/bin/rustup target add x86_64-unknown-linux-musl
+ADD ./vendor /go-ethereum/vendor
 RUN cd /go-ethereum/vendor/github.com/celo-org/bls-zexe/bls && $HOME/.cargo/bin/cargo build --target x86_64-unknown-linux-musl --release
 
 # Build Geth in a stock Go builder container


### PR DESCRIPTION
### Description

Using layer caching, whenever a non-`vendor/` change is made, Docker builds are sped up from ~8.5 minutes to ~1.5 minutes. This only recompiles rust dependencies when there's a change in the `vendor` directory

### Tested

Built with & without, `geth attach`'d on both versions that were built
