### PR TITLE
[cleanup]Remove references to Celo latest sync mode

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -190,7 +190,7 @@ func initGenesis(ctx *cli.Context) error {
 	}
 	// Open an initialise both full and light databases
 	stack := makeFullNode(ctx)
-	for _, name := range []string{"chaindata", "lightchaindata", "celolatestchaindata", "ultralightchaindata"} {
+	for _, name := range []string{"chaindata", "lightchaindata", "ultralightchaindata"} {
 		chaindb, err := stack.OpenDatabase(name, 0, 0)
 		if err != nil {
 			utils.Fatalf("Failed to open database: %v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -171,7 +171,7 @@ var (
 	defaultSyncMode = eth.DefaultConfig.SyncMode
 	SyncModeFlag    = TextMarshalerFlag{
 		Name:  "syncmode",
-		Usage: `Blockchain sync mode ("fast", "full", "light", or "celolatest")`,
+		Usage: `Blockchain sync mode ("fast", "full", "light", or "ultralight")`,
 		Value: &defaultSyncMode,
 	}
 	GCModeFlag = cli.StringFlag{
@@ -1456,8 +1456,6 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node) ethdb.Database {
 	name := "chaindata"
 	if ctx.GlobalString(SyncModeFlag.Name) == "light" {
 		name = "lightchaindata"
-	} else if ctx.GlobalString(SyncModeFlag.Name) == "celolatest" {
-		name = "celolatestchaindata"
 	} else if ctx.GlobalString(SyncModeFlag.Name) == "ultralight" {
 		name = "ultralightchaindata"
 	}
@@ -1490,7 +1488,7 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 	var err error
 	chainDb = MakeChainDatabase(ctx, stack)
 	config, _, err := core.SetupGenesisBlock(chainDb, MakeGenesis(ctx))
-	if ctx.GlobalString(SyncModeFlag.Name) == "celolatest" {
+	if ctx.GlobalString(SyncModeFlag.Name) == "ultralight" {
 		config.FullHeaderChainAvailable = false
 	}
 	if err != nil {

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -378,7 +378,7 @@ func (c *Clique) verifyCascadingFields(chain consensus.ChainReader, header *type
 		parent = chain.GetHeader(header.ParentHash, number-1)
 	}
 
-	// Added to bypass the situation when the parent is missing in celolatest mode
+	// Added to bypass the situation when the parent is missing in ultralight mode
 	if chain.Config().FullHeaderChainAvailable {
 		if parent == nil || parent.Number.Uint64() != number-1 || parent.Hash() != header.ParentHash {
 			return consensus.ErrUnknownAncestor

--- a/core/chain_indexer.go
+++ b/core/chain_indexer.go
@@ -92,7 +92,7 @@ type ChainIndexer struct {
 
 	log  log.Logger
 	lock sync.RWMutex
-	// True in all sync modes except CeloLatestSync and UltraLightSync
+	// True in all sync modes except UltraLightSync
 	fullHeaderChainDownloaded bool
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -107,7 +107,7 @@ func (s *Ethereum) AddLesServer(ls LesServer) {
 func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	// Ensure configuration values are compatible and sane
 	if !config.SyncMode.SyncFullBlockChain() {
-		return nil, errors.New("can't run eth.Ethereum in light sync mode, celolatest mode, or ultralight sync mode, use les.LightEthereum")
+		return nil, errors.New("can't run eth.Ethereum in light sync mode or ultralight sync mode, use les.LightEthereum")
 	}
 	if !config.SyncMode.IsValid() {
 		return nil, fmt.Errorf("invalid sync mode %d", config.SyncMode)

--- a/eth/downloader/modes.go
+++ b/eth/downloader/modes.go
@@ -25,7 +25,6 @@ const (
 	FullSync       SyncMode = iota // Synchronise the entire blockchain history from full blocks
 	FastSync                       // Quickly download the headers, full sync only at the chain head
 	LightSync                      // Download only the headers and terminate afterwards
-	CeloLatestSync                 // Latest block only (Celo-specific mode)
 	UltraLightSync                 // Synchronise one block per Epoch (Celo-specific mode)
 )
 
@@ -44,8 +43,6 @@ func (mode SyncMode) String() string {
 		return "fast"
 	case LightSync:
 		return "light"
-	case CeloLatestSync:
-		return "celolatest"
 	case UltraLightSync:
 		return ultraLightSyncModeAsString
 	default:
@@ -61,8 +58,6 @@ func (mode SyncMode) MarshalText() ([]byte, error) {
 		return []byte("fast"), nil
 	case LightSync:
 		return []byte("light"), nil
-	case CeloLatestSync:
-		return []byte("celolatest"), nil
 	case UltraLightSync:
 		return []byte(ultraLightSyncModeAsString), nil
 	default:
@@ -78,12 +73,10 @@ func (mode *SyncMode) UnmarshalText(text []byte) error {
 		*mode = FastSync
 	case "light":
 		*mode = LightSync
-	case "celolatest":
-		*mode = CeloLatestSync
 	case ultraLightSyncModeAsString:
 		*mode = UltraLightSync
 	default:
-		return fmt.Errorf(`unknown sync mode %q, want "full", "fast", "light", "celolatest", or "%s"`,
+		return fmt.Errorf(`unknown sync mode %q, want "full", "fast", "light", or "%s"`,
 			text, ultraLightSyncModeAsString)
 	}
 	return nil
@@ -98,8 +91,6 @@ func (mode SyncMode) SyncFullHeaderChain() bool {
 		return true
 	case LightSync:
 		return true
-	case CeloLatestSync:
-		return false
 	case UltraLightSync:
 		return false
 	default:
@@ -116,8 +107,6 @@ func (mode SyncMode) SyncFullBlockChain() bool {
 	case FastSync:
 		return true
 	case LightSync:
-		return false
-	case CeloLatestSync:
 		return false
 	case UltraLightSync:
 		return false

--- a/les/backend.go
+++ b/les/backend.go
@@ -84,9 +84,6 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 	if syncMode == downloader.LightSync {
 		chainName = "lightchaindata"
 		fullChainAvailable = true
-	} else if syncMode == downloader.CeloLatestSync {
-		chainName = "celolatestchaindata"
-		fullChainAvailable = false
 	} else if syncMode == downloader.UltraLightSync {
 		chainName = "ultralightchaindata"
 		fullChainAvailable = false

--- a/les/fetcher.go
+++ b/les/fetcher.go
@@ -28,7 +28,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/light"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -654,20 +653,13 @@ func (f *lightFetcher) checkSyncedHeaders(p *peer) {
 	var td *big.Int
 
 	log.Debug(fmt.Sprintf("Last announced block is %v", n.number))
-	// Disable this in Latest block only mode since we are not fetching the full chain now n is the
-	// latest downloaded header after syncing.
-	// Ultralightsync mode handles this behavior properly because it will download the latest
-	// announced header before completing the sync.
-	//
 	// Check for the latest announced header in our chain. If it is present, then move on, otherwise,
 	// move through the parents until we find a header that we have downloaded.
-	if f.pm.downloader.Mode != downloader.CeloLatestSync {
-		for n != nil {
-			if td = f.chain.GetTd(n.hash, n.number); td != nil {
-				break
-			}
-			n = n.parent
+	for n != nil {
+		if td = f.chain.GetTd(n.hash, n.number); td != nil {
+			break
 		}
+		n = n.parent
 	}
 	// Now n is the latest announced block by this peer that exists in our chain.
 	if n == nil {

--- a/les/sync.go
+++ b/les/sync.go
@@ -58,9 +58,7 @@ func (pm *ProtocolManager) syncer() {
 func (pm *ProtocolManager) needToSync(peerHead blockInfo, mode downloader.SyncMode) bool {
 	head := pm.blockchain.CurrentHeader()
 	if !mode.SyncFullHeaderChain() {
-		// There are two modes where this holds, celolatest and ultralight.
-		// In the celolatest mode, the difficulty calculation cannot be done since we don't have all the blocks,
-		// so, we rely on the block numbers.
+		// This is true only for the ultralight sync mode.
 		// In the ultralight mode used for IBFT, each block has a difficulty of 1, so, block number
 		// corresponds to the difficulty level.
 		currentHead := head.Number.Uint64()

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -326,7 +326,7 @@ func (self *LightChain) Rollback(chain []common.Hash, fullHeaderChainAvailable b
 
 		if head := self.hc.CurrentHeader(); head.Hash() == hash {
 			parentHeader := self.GetHeader(head.ParentHash, head.Number.Uint64()-1)
-			// In all sync modes except CeloLatestSync and UltraLightSync, a complete header chain is available.
+			// In all sync modes except UltraLightSync, a complete header chain is available.
 			// Maintain the old behavior in those cases.
 			if fullHeaderChainAvailable || parentHeader != nil {
 				self.hc.SetCurrentHeader(parentHeader)

--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -44,7 +44,10 @@ const SyncModeUnset = 0 // will be treated as SyncModeLightSync
 const SyncModeFullSync = 1
 const SyncModeFastSync = 2
 const SyncModeLightSync = 3
-const SyncModeCeloLatestSync = 4
+
+// Deprecated: This used to be SyncModeCeloLatestSync. Geth will panic if started in this mode.
+// Use UltraLightSync instead.
+const DeprecatedSyncMode = 4
 const UltraLightSync = 5
 
 // NodeConfig represents the collection of configuration values to fine tune the Geth
@@ -222,8 +225,8 @@ func getSyncMode(syncMode int) downloader.SyncMode {
 		// This maintains backward compatibility.
 	case SyncModeLightSync:
 		return downloader.LightSync
-	case SyncModeCeloLatestSync:
-		return downloader.CeloLatestSync
+	case DeprecatedSyncMode:
+		panic("CeloLatestSync mode is no longer supported. Use UltraLightSync instead")
 	case UltraLightSync:
 		return downloader.UltraLightSync
 	default:

--- a/params/config.go
+++ b/params/config.go
@@ -218,7 +218,7 @@ type ChainConfig struct {
 	Istanbul *IstanbulConfig `json:"istanbul,omitempty"`
 	// This does not belong here but passing it to every function is not possible since that breaks
 	// some implemented interfaces and introduces churn across the geth codebase.
-	FullHeaderChainAvailable bool // False for celolatest Sync mode, true otherwise
+	FullHeaderChainAvailable bool // False for ultralight Sync mode, true otherwise
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.


### PR DESCRIPTION
### Description

Remove references to Celo latest sync mode

### Tested

`make -j geth && make -j lint`

### Related issues

- Addresses https://github.com/celo-org/celo-monorepo/issues/596

### Backwards compatibility

Removes `CeloLatestsync` mode.