### PR TITLE
[CircleCI]Build walletkit explicitly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,9 @@ jobs:
             # rm -rf analytics blockchain-api cli docs faucet helm-charts mobile notification-service react-components transaction-metrics-exporter verification-pool-api verifier web
             cd ${CELO_MONOREPO_DIR}/packages/celotool
             yarn || yarn
+            yarn --cwd=${CELO_MONOREPO_DIR}/packages/utils build
+            yarn --cwd=${CELO_MONOREPO_DIR}/packages/walletkit build
+            yarn --cwd=${CELO_MONOREPO_DIR}/packages/celotool build
       - persist_to_workspace:
           root: .
           paths: .


### PR DESCRIPTION
### Description

Earlier, `yarn` would build walletkit in the post install step.
That has been removed in celo-monorepo, therefore, build walletkit and some other packages
explicitly to avoid https://circleci.com/gh/celo-org/celo-blockchain/7304

### Tested

Circle CI execution will test this

Fixes https://github.com/celo-org/celo-monorepo/issues/616