### PR TITLE
Istanbul: adds minimum quorum violation logging

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -352,6 +352,7 @@ func (sb *Backend) verifyCommittedSeals(chain consensus.ChainReader, header *typ
 
 	// The length of validSeal should be larger than number of faulty node + 1
 	if len(publicKeys) < snap.ValSet.MinQuorumSize() {
+		sb.logger.Error("not enough signatures to form a quorum", "public keys", len(publicKeys), "minimum quorum size", snap.ValSet.MinQuorumSize())
 		return errInvalidCommittedSeals
 	}
 	err = blscrypto.VerifyAggregatedSignature(publicKeys, proposalSeal, []byte{}, extra.CommittedSeal, false)


### PR DESCRIPTION
### Description

Currently, the Istanbul engine only fails with a generic error. Added logging for the specific case where the quorum size is not big enough.

### Tested

Tested against integration which had an older quorum size logic and currently the local node fails to sync with integration.