### PR TITLE
[CircleCI] Build walletkit explicitly & fix test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,9 @@ jobs:
             # rm -rf analytics blockchain-api cli docs faucet helm-charts mobile notification-service react-components transaction-metrics-exporter verification-pool-api verifier web
             cd ${CELO_MONOREPO_DIR}/packages/celotool
             yarn || yarn
+            yarn --cwd=${CELO_MONOREPO_DIR}/packages/utils build
+            yarn --cwd=${CELO_MONOREPO_DIR}/packages/walletkit build
+            yarn --cwd=${CELO_MONOREPO_DIR}/packages/celotool build
       - persist_to_workspace:
           root: .
           paths: .

--- a/p2p/discv5/node_test.go
+++ b/p2p/discv5/node_test.go
@@ -71,8 +71,9 @@ var parseNodeTests = []struct {
 		wantError: `invalid IP address`,
 	},
 	{
-		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:foo",
-		wantError: `invalid port`,
+		rawurl: "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:foo",
+		// net/url.Parse(rawurl) returns an error with rawurl and why the parse failed.
+		wantError: `parse enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:foo: invalid port ":foo" after host`,
 	},
 	{
 		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:3?discport=foo",

--- a/p2p/enode/urlv4_test.go
+++ b/p2p/enode/urlv4_test.go
@@ -46,8 +46,9 @@ var parseNodeTests = []struct {
 		wantError: `invalid IP address`,
 	},
 	{
+		// net/url.Parse(rawurl) returns an error with rawurl and why the parse failed.
 		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:foo",
-		wantError: `invalid port`,
+		wantError: `parse enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:foo: invalid port ":foo" after host`,
 	},
 	{
 		rawurl:    "enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:3?discport=foo",


### PR DESCRIPTION
### Description

Earlier, `yarn` would build walletkit in the post install step.
That has been removed in celo-monorepo, therefore, build walletkit and some other packages
explicitly to avoid https://circleci.com/gh/celo-org/celo-blockchain/7304
Also fixes a failing unit test (cause due to change in error string from golang).

### Tested

Circle CI execution will test this

Fixes https://github.com/celo-org/celo-monorepo/issues/616
