### PR TITLE
Fixes LightPeers equal to MaxPeers

### DIFF
--- a/eth/config.go
+++ b/eth/config.go
@@ -43,7 +43,7 @@ var DefaultConfig = Config{
 		DatasetsOnDisk: 2,
 	},
 	NetworkId:                   1,
-	LightPeers:                  100,
+	LightPeers:                  99,
 	LightServ:                   50,
 	DatabaseCache:               768,
 	TrieTimeout:                 60 * time.Minute,


### PR DESCRIPTION
### Description

`eth/backend.go` rejects configs where `LightPeers >= MaxPeers`.
https://github.com/celo-org/celo-blockchain/pull/395 broke our tests/maybe geth and this fixes it.

### Tested

Tests should be passing now.

### Other changes

N/A

### Related issues

N/A

### Backwards compatibility

N/A
