### PR TITLE
Double contract bytecode limit

### DIFF
--- a/cmd/puppeth/genesis_test.go
+++ b/cmd/puppeth/genesis_test.go
@@ -82,6 +82,7 @@ func TestParitySturebyConverter(t *testing.T) {
 		t.Fatalf("failed creating chainspec: %v", err)
 	}
 
+	// Note: this file has been edited to reflect Celo's larger maxCodeSize
 	expBlob, err := ioutil.ReadFile("testdata/stureby_parity.json")
 	if err != nil {
 		t.Fatalf("could not read file: %v", err)

--- a/cmd/puppeth/testdata/stureby_parity.json
+++ b/cmd/puppeth/testdata/stureby_parity.json
@@ -28,7 +28,7 @@
     "minGasLimit":"0x1388",
     "networkID":"0x4cb2e",
     "chainID":"0x4cb2e",
-    "maxCodeSize":"0x6000",
+    "maxCodeSize":"0xc000",
     "maxCodeSizeTransition":"0x0",
     "eip98Transition": "0x7fffffffffffffff",
     "eip150Transition":"0x3a98",

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -73,7 +73,7 @@ const (
 	MemoryGas        uint64 = 3     // Times the address of the (highest referenced byte in memory + 1). NOTE: referencing happens on read, write and in instructions such as RETURN and CALL.
 	TxDataNonZeroGas uint64 = 68    // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions.
 
-	MaxCodeSize = 24576 // Maximum bytecode to permit for a contract
+	MaxCodeSize = 49152 // Maximum bytecode to permit for a contract
 
 	// Precompiled contract gas prices
 


### PR DESCRIPTION
### Description

As per [EIP-170](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md), the size of deployed contracts is limited by a constant parameter to avoid a quadratic vulnerability.

We can increase the constant without reintroducing the vulnerability - all that matters is that the constant remains reasonably small.

We've been running into bytecode limits while developing the core Celo contracts that implement on-chain governance. This PR doubles the limit to ease smart contract development.

### Tested

Deployed a smart contract that I'm working on on a separate branch that went over the old bytecode limit.

### Related issues

- Fixes celo-monorepo#378, obviates celo-monorepo#379

### Backwards compatibility

Could potentially be backwards incompatible on a network on which there appeared a transaction attempting to deploy a contract that was too large for the old bytecode limit - a new node syncing would accept that contract, arriving at a different chain state.