### PR TITLE
fixed geth's reading of exchange rates

### DIFF
--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -140,9 +140,9 @@ func Convert(val *big.Int, currencyFrom *common.Address, currencyTo *common.Addr
 	}
 
 	// Given value of val and rates n1/d1 and n2/d2 the function below does
-	// (val * n1 * d2) / (d1 * n2)
-	numerator := new(big.Int).Mul(val, new(big.Int).Mul(exchangeRateFrom.Numerator, exchangeRateTo.Denominator))
-	denominator := new(big.Int).Mul(exchangeRateFrom.Denominator, exchangeRateTo.Numerator)
+	// (val * d1 * n2) / (n1 * d2)
+	numerator := new(big.Int).Mul(val, new(big.Int).Mul(exchangeRateFrom.Denominator, exchangeRateTo.Numerator))
+	denominator := new(big.Int).Mul(exchangeRateFrom.Numerator, exchangeRateTo.Denominator)
 	return new(big.Int).Div(numerator, denominator), nil
 }
 
@@ -168,11 +168,11 @@ func Cmp(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *com
 	}
 
 	// Below code block is basically evaluating this comparison:
-	// val1 * exchangeRate1.Numerator/exchangeRate1.Denominator < val2 * exchangeRate2.Numerator/exchangeRate2.Denominator
+	// val1 * exchangeRate1.Denominator/exchangeRate1.Numerator < val2 * exchangeRate2.Denominator/exchangeRate2.Numerator
 	// It will transform that comparison to this, to remove having to deal with fractional values.
-	// val1 * exchangeRate1.Numerator * exchangeRate2.Denominator < val2 * exchangeRate2.Numerator * exchangeRate1.Denominator
-	leftSide := new(big.Int).Mul(val1, new(big.Int).Mul(exchangeRate1.Numerator, exchangeRate2.Denominator))
-	rightSide := new(big.Int).Mul(val2, new(big.Int).Mul(exchangeRate2.Numerator, exchangeRate1.Denominator))
+	// val1 * exchangeRate1.Denominator * exchangeRate2.Numerator < val2 * exchangeRate2.Denominator * exchangeRate1.Numerator
+	leftSide := new(big.Int).Mul(val1, new(big.Int).Mul(exchangeRate1.Denominator, exchangeRate2.Numerator))
+	rightSide := new(big.Int).Mul(val2, new(big.Int).Mul(exchangeRate2.Denominator, exchangeRate1.Numerator))
 	return leftSide.Cmp(rightSide)
 }
 


### PR DESCRIPTION
### Description

There is an existing bug in the logic around converting and comparing two denominations of different currencies within geth.  Basically, when geth was reading the exchange rates from the smart contracts, it erroneously switched the numerator and denominator around.

Specifically, it should be using this format:

<asset we’re pegging to> / Celo Gold 

instead of 

Celo Gold / <asset we’re pegging to> 

### Tested

Ran celo dollar gas currency e2e tests.
Ran geth's unit tests.

### Other changes


### Related issues

### Backwards compatibility

Is backward compatible.