### PR TITLE
increased MaxGasToReadErc20Balance

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -132,7 +132,7 @@ const (
 	MaxGasForDebitFromTransactions      uint64 = 50 * 1000
 	ExpectedGasForDebitFromTransactions uint64 = 35 * 1000
 	MaxGasForCreditToTransactions       uint64 = 30 * 1000
-	MaxGasToReadErc20Balance            uint64 = 10 * 1000
+	MaxGasToReadErc20Balance            uint64 = 35 * 1000
 	MaxGasToReadTobinTax                uint64 = 50 * 1000
 	// We charge for reading the balance, 1 debit, and 3 credits (refunding gas, paying the gas fee recipient, sending to the infrastructure fund)
 	AdditionalGasForNonGoldCurrencies uint64 = 3*MaxGasForCreditToTransactions + ExpectedGasForDebitFromTransactions + MaxGasToReadErc20Balance


### PR DESCRIPTION
### Description

This PR increases the max gas used for an erc20 balanceOf evm call.

### Tested

Will be testing in the "pilot staging" testnet. 

### Other changes

None

### Related issues

- Fixes https://github.com/celo-org/celo-labs/issues/106

### Backwards compatibility

Is backwards compatible.
