### PR TITLE
set max gas to double of the charged gas for the 'intrinsic' smart contract calls

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -212,7 +212,7 @@ func (st *StateTransition) canBuyGas(accountOwner common.Address, gasNeeded *big
 		return st.state.GetBalance(accountOwner).Cmp(gasNeeded) > 0
 	}
 	balanceOf, gasUsed, err := currency.GetBalanceOf(accountOwner, *gasCurrency, params.MaxGasToReadErc20Balance, st.evm.GetHeader(), st.evm.GetStateDB())
-	log.Debug("canBuyGas called", "gasCurrency", *gasCurrency, "gasUsed", gasUsed)
+	log.Debug("balanceOf called", "gasCurrency", *gasCurrency, "gasUsed", gasUsed)
 
 	if err != nil {
 		return false

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -211,7 +211,9 @@ func (st *StateTransition) canBuyGas(accountOwner common.Address, gasNeeded *big
 	if gasCurrency == nil {
 		return st.state.GetBalance(accountOwner).Cmp(gasNeeded) > 0
 	}
-	balanceOf, _, err := currency.GetBalanceOf(accountOwner, *gasCurrency, params.MaxGasToReadErc20Balance, st.evm.GetHeader(), st.evm.GetStateDB())
+	balanceOf, gasUsed, err := currency.GetBalanceOf(accountOwner, *gasCurrency, params.MaxGasToReadErc20Balance, st.evm.GetHeader(), st.evm.GetStateDB())
+	log.Debug("canBuyGas called", "gasCurrency", *gasCurrency, "gasUsed", gasUsed)
+
 	if err != nil {
 		return false
 	}
@@ -233,7 +235,9 @@ func (st *StateTransition) debitFrom(address common.Address, amount *big.Int, ga
 
 	rootCaller := vm.AccountRef(common.HexToAddress("0x0"))
 	// The caller was already charged for the cost of this operation via IntrinsicGas.
-	_, _, err := evm.Call(rootCaller, *gasCurrency, transactionData, params.MaxGasForDebitFromTransactions, big.NewInt(0))
+	_, leftoverGas, err := evm.Call(rootCaller, *gasCurrency, transactionData, params.MaxGasForDebitFromTransactions, big.NewInt(0))
+	gasUsed := params.MaxGasForDebitFromTransactions - leftoverGas
+	log.Debug("debitFrom called", "gasCurrency", *gasCurrency, "gasUsed", gasUsed)
 	return err
 }
 
@@ -251,7 +255,9 @@ func (st *StateTransition) creditTo(address common.Address, amount *big.Int, gas
 	transactionData := common.GetEncodedAbi(functionSelector, [][]byte{common.AddressToAbi(address), common.AmountToAbi(amount)})
 	rootCaller := vm.AccountRef(common.HexToAddress("0x0"))
 	// The caller was already charged for the cost of this operation via IntrinsicGas.
-	_, _, err := evm.Call(rootCaller, *gasCurrency, transactionData, params.MaxGasForCreditToTransactions, big.NewInt(0))
+	_, leftoverGas, err := evm.Call(rootCaller, *gasCurrency, transactionData, params.MaxGasForCreditToTransactions, big.NewInt(0))
+	gasUsed := params.MaxGasForCreditToTransactions - leftoverGas
+	log.Debug("creditTo called", "gasCurrency", *gasCurrency, "gasUsed", gasUsed)
 	return err
 }
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -139,6 +139,10 @@ const (
 	// TODO(asa): Make these operations less expensive by charging only what is used.
 	// The problem is we don't know how much to refund until the refund is complete.
 	// If these values are changed, "setDefaults" will need updating.
+
+	// The plan is to have these values set within a system smart contract,
+	// and that they are read during runtime.  They could then be changed via
+	// governance.
 	ExpectedGasForDebitFromTransactions uint64 = 23 * 1000
 	MaxGasForDebitFromTransactions      uint64 = 46 * 1000
 

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -139,11 +139,16 @@ const (
 	// TODO(asa): Make these operations less expensive by charging only what is used.
 	// The problem is we don't know how much to refund until the refund is complete.
 	// If these values are changed, "setDefaults" will need updating.
-	MaxGasForDebitFromTransactions      uint64 = 38 * 1000
 	ExpectedGasForDebitFromTransactions uint64 = 23 * 1000
-	MaxGasForCreditToTransactions       uint64 = 32 * 1000
-	MaxGasToReadErc20Balance            uint64 = 15 * 1000
-	MaxGasToReadTobinTax                uint64 = 50 * 1000
+	MaxGasForDebitFromTransactions      uint64 = 46 * 1000
+
+	ExpectedGasForCreditToTransactions uint64 = 32 * 1000
+	MaxGasForCreditToTransactions      uint64 = 64 * 1000
+
+	ExpectedGasToReadErc20Balance uint64 = 15 * 1000
+	MaxGasToReadErc20Balance      uint64 = 30 * 1000
+
+	MaxGasToReadTobinTax uint64 = 50 * 1000
 	// We charge for reading the balance, 1 debit, and 3 credits (refunding gas, paying the gas fee recipient, sending to the infrastructure fund)
-	AdditionalGasForNonGoldCurrencies uint64 = 3*MaxGasForCreditToTransactions + ExpectedGasForDebitFromTransactions + MaxGasToReadErc20Balance
+	AdditionalGasForNonGoldCurrencies uint64 = 3*ExpectedGasForCreditToTransactions + ExpectedGasForDebitFromTransactions + ExpectedGasToReadErc20Balance
 )


### PR DESCRIPTION
# Description

Set the max gas for intrinsic smart contracts calls to double the charged gas.

Note that we plan to modify geth to read these values from a smart contract.

### Tested

Ran the unit tests.

### Other changes

### Related issues

### Backwards compatibility

Is backward compatible.  Specifically, the charged intrinsic gas is not changed.