### PR TITLE
Reduce istanbul default timeout, cap exp backoff

### DIFF
--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -31,7 +31,7 @@ type Config struct {
 }
 
 var DefaultConfig = &Config{
-	RequestTimeout: 10000,
+	RequestTimeout: 3000,
 	BlockPeriod:    1,
 	ProposerPolicy: RoundRobin,
 	Epoch:          30000,

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -342,11 +342,11 @@ func (c *core) stopTimer() {
 func (c *core) newRoundChangeTimer() {
 	c.stopTimer()
 
-	// set timeout based on the round number
+	// timeout for subsequent rounds adds an exponential backup, capped at 2**4 = 16s
 	timeout := time.Duration(c.config.RequestTimeout) * time.Millisecond
 	round := c.current.Round().Uint64()
 	if round > 0 {
-		timeout += time.Duration(math.Pow(2, float64(round))) * time.Second
+		timeout += time.Duration(math.Pow(2, math.Min(float64(round), 4.))) * time.Second
 	}
 
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {


### PR DESCRIPTION
### Description

* reduce default istanbul round change timeout from 10s to 3s 
* limit exponential backoff to 5 rounds, so backoff at round=5 is 3+2**4 = 35 secs
* add the blockperiod on to the timeout for the first round of every sequence 

### Tested

By running a testnet and e2e tests.

### Backwards compatibility

Yes