### PR TITLE
Check message address against signature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,18 +70,12 @@ jobs:
             set -euo pipefail
             export CELO_MONOREPO_DIR="$PWD"
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b master
-            cd ${CELO_MONOREPO_DIR}/packages
-            # TODO(ashishb): Delete unnecessary packages to speed up build time.
-            # It would be better whitelist certain packages and delete the rest.
-            # Deletion does not work right now and yarn fails with weird errors.
-            # This will be enabled and resolved later.
-            # rm -rf analytics blockchain-api cli docs faucet helm-charts mobile notification-service react-components transaction-metrics-exporter verification-pool-api verifier web
-            cd ${CELO_MONOREPO_DIR}/packages/celotool
-            yarn || yarn
-            yarn --cwd=${CELO_MONOREPO_DIR}/packages/utils build
-            yarn --cwd=${CELO_MONOREPO_DIR}/packages/walletkit build
-            yarn --cwd=${CELO_MONOREPO_DIR}/packages/celotool build
-
+            # separate build to avoid ENOMEM in CI :(
+            yarn build --scope @celo/utils
+            yarn build --scope @celo/protocol
+            yarn build --scope docs
+            yarn build --scope @celo/walletkit
+            yarn build --ignore @celo/protocol --ignore docs --ignore @celo/walletkit --ignore @celo/web --ignore @celo/mobile --ignore @celo/react-components
       - run:
           name: Setup Go language
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ jobs:
             set -euo pipefail
             export CELO_MONOREPO_DIR="$PWD"
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b master
+            yarn install || yarn install
             # separate build to avoid ENOMEM in CI :(
             yarn build --scope @celo/utils
             yarn build --scope @celo/protocol

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -129,6 +129,7 @@ func (self *testSystemBackend) Verify(proposal istanbul.Proposal, src istanbul.V
 }
 
 func (self *testSystemBackend) Sign(data []byte) ([]byte, error) {
+	// We overload the signature with the signer address so we can return the latter from CheckValidatorSignature.
 	return self.Address().Bytes(), nil
 }
 
@@ -137,6 +138,7 @@ func (self *testSystemBackend) CheckSignature([]byte, common.Address, []byte) er
 }
 
 func (self *testSystemBackend) CheckValidatorSignature(data []byte, sig []byte) (common.Address, error) {
+	// Return the actual signature data as the signer address here.
 	return common.BytesToAddress(sig), nil
 }
 

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -97,7 +97,6 @@ func (self *testSystemBackend) Broadcast(valSet istanbul.ValidatorSet, message [
 	return nil
 }
 func (self *testSystemBackend) Gossip(valSet istanbul.ValidatorSet, message []byte, msgCode uint64, ignoreCache bool) error {
-	testLogger.Warn("not sign any data")
 	return nil
 }
 
@@ -130,8 +129,7 @@ func (self *testSystemBackend) Verify(proposal istanbul.Proposal, src istanbul.V
 }
 
 func (self *testSystemBackend) Sign(data []byte) ([]byte, error) {
-	testLogger.Warn("not sign any data")
-	return data, nil
+	return self.Address().Bytes(), nil
 }
 
 func (self *testSystemBackend) CheckSignature([]byte, common.Address, []byte) error {
@@ -139,7 +137,7 @@ func (self *testSystemBackend) CheckSignature([]byte, common.Address, []byte) er
 }
 
 func (self *testSystemBackend) CheckValidatorSignature(data []byte, sig []byte) (common.Address, error) {
-	return common.Address{}, nil
+	return common.BytesToAddress(sig), nil
 }
 
 func (self *testSystemBackend) Hash(b interface{}) common.Hash {

--- a/consensus/istanbul/errors.go
+++ b/consensus/istanbul/errors.go
@@ -22,6 +22,8 @@ var (
 	// ErrUnauthorizedAddress is returned when given address cannot be found in
 	// current validator set.
 	ErrUnauthorizedAddress = errors.New("unauthorized address")
+	// ErrInvalidSigner is returned if a message's signature does not correspond to the address in msg.Address
+	ErrInvalidSigner = errors.New("signed by incorrect validator")
 	// ErrStoppedEngine is returned if the engine is stopped
 	ErrStoppedEngine = errors.New("stopped engine")
 	// ErrStartedEngine is returned if the engine is already started

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -204,10 +204,15 @@ func (m *Message) FromPayload(b []byte, validateFn func([]byte, []byte) (common.
 			return err
 		}
 
-		_, err = validateFn(payload, m.Signature)
+		signed_val_addr, err := validateFn(payload, m.Signature)
+		if err != nil {
+			return err
+		}
+		if signed_val_addr != m.Address {
+			return ErrInvalidSigner
+		}
 	}
-	// Still return the message even the err is not nil
-	return err
+	return nil
 }
 
 func (m *Message) Payload() ([]byte, error) {


### PR DESCRIPTION
### Description

Ensure we check the address of the validator signing a message with the value at `msg.Address` 

### Tested

New unit tests.

### Related issues

- Fixes celo-labs#107

### Backwards compatibility

Yes