### PR TITLE
added new option --use-in-memory-discovery-table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,18 +70,13 @@ jobs:
             set -euo pipefail
             export CELO_MONOREPO_DIR="$PWD"
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b master
-            cd ${CELO_MONOREPO_DIR}/packages
-            # TODO(ashishb): Delete unnecessary packages to speed up build time.
-            # It would be better whitelist certain packages and delete the rest.
-            # Deletion does not work right now and yarn fails with weird errors.
-            # This will be enabled and resolved later.
-            # rm -rf analytics blockchain-api cli docs faucet helm-charts mobile notification-service react-components transaction-metrics-exporter verification-pool-api verifier web
-            cd ${CELO_MONOREPO_DIR}/packages/celotool
-            yarn || yarn
-            yarn --cwd=${CELO_MONOREPO_DIR}/packages/utils build
-            yarn --cwd=${CELO_MONOREPO_DIR}/packages/walletkit build
-            yarn --cwd=${CELO_MONOREPO_DIR}/packages/celotool build
-
+            yarn install || yarn install
+            # separate build to avoid ENOMEM in CI :(
+            yarn build --scope @celo/utils
+            yarn build --scope @celo/protocol
+            yarn build --scope docs
+            yarn build --scope @celo/walletkit
+            yarn build --ignore @celo/protocol --ignore docs --ignore @celo/walletkit --ignore @celo/web --ignore @celo/mobile --ignore @celo/react-components
       - run:
           name: Setup Go language
           command: |

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -139,6 +139,7 @@ var (
 		utils.IstanbulRequestTimeoutFlag,
 		utils.IstanbulBlockPeriodFlag,
 		utils.PingIPFromPacketFlag,
+		utils.UseInMemoryDiscoverTable,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -183,6 +183,8 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.NetrestrictFlag,
 			utils.NodeKeyFileFlag,
 			utils.NodeKeyHexFlag,
+			utils.PingIPFromPacketFlag,
+			utils.UseInMemoryDiscoverTable,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -563,6 +563,10 @@ var (
 		Name:  "ping-ip-from-packet",
 		Usage: "Has the discovery protocol use the IP address given by a ping packet",
 	}
+	UseInMemoryDiscoverTable = cli.BoolFlag{
+		Name:  "use-in-memory-discovery-table",
+		Usage: "Specifies whether to use an in memory discovery table",
+	}
 
 	// ATM the url is left to the user and deployment to
 	JSpathFlag = cli.StringFlag{
@@ -994,6 +998,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	}
 	if ctx.GlobalIsSet(PingIPFromPacketFlag.Name) {
 		cfg.PingIPFromPacket = true
+	}
+	if ctx.GlobalIsSet(UseInMemoryDiscoverTable.Name) {
+		cfg.UseInMemoryNodeDatabase = true
 	}
 
 	// if we're running a light client or server, force enable the v5 peer discovery

--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -60,7 +60,7 @@ type Backend interface {
 
 	// Verify verifies the proposal. If a consensus.ErrFutureBlock error is returned,
 	// the time difference of the proposal and current time is also returned.
-	Verify(Proposal, Validator) (time.Duration, error)
+	Verify(Proposal) (time.Duration, error)
 
 	// Sign signs input data with the backend's private key
 	Sign([]byte) ([]byte, error)

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -279,7 +279,7 @@ func (sb *Backend) EventMux() *event.TypeMux {
 }
 
 // Verify implements istanbul.Backend.Verify
-func (sb *Backend) Verify(proposal istanbul.Proposal, src istanbul.Validator) (time.Duration, error) {
+func (sb *Backend) Verify(proposal istanbul.Proposal) (time.Duration, error) {
 	// Check if the proposal is a valid block
 	block := &types.Block{}
 	block, ok := proposal.(*types.Block)
@@ -303,11 +303,17 @@ func (sb *Backend) Verify(proposal istanbul.Proposal, src istanbul.Validator) (t
 		return 0, errInvalidUncleHash
 	}
 
-	// verify the header of proposed block
-	if block.Header().Coinbase != src.Address() {
+	// The author should be the first person to propose the block to ensure that randomness matches up.
+	addr, err := sb.Author(block.Header())
+	if err != nil {
+		sb.logger.Error("Could not recover orignal author of the block to verify the randomness", "err", err, "func", "Verify")
+		return 0, errInvalidProposal
+	} else if addr != block.Header().Coinbase {
+		sb.logger.Error("Original author of the block does not match the coinbase", "addr", addr, "coinbase", block.Header().Coinbase, "func", "Verify")
 		return 0, errInvalidCoinbase
 	}
-	err := sb.VerifyHeader(sb.chain, block.Header(), false)
+
+	err = sb.VerifyHeader(sb.chain, block.Header(), false)
 
 	// ignore errEmptyCommittedSeals error because we don't have the committed seals yet
 	if err != nil && err != errEmptyCommittedSeals {

--- a/consensus/istanbul/core/backlog_test.go
+++ b/consensus/istanbul/core/backlog_test.go
@@ -28,16 +28,18 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/log"
+	elog "github.com/ethereum/go-ethereum/log"
 )
 
 func TestCheckMessage(t *testing.T) {
+	testLogger.SetHandler(elog.StdoutHandler)
 	c := &core{
-		state: StateAcceptRequest,
+		logger: testLogger,
+		state:  StateAcceptRequest,
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4), common.Hash{}, nil, nil, nil),
+		}, newTestValidatorSet(4), nil, nil, istanbul.EmptyPreparedCertificate(), nil),
 	}
 
 	// invalid view format
@@ -46,7 +48,7 @@ func TestCheckMessage(t *testing.T) {
 		t.Errorf("error mismatch: have %v, want %v", err, errInvalidMessage)
 	}
 
-	testStates := []State{StateAcceptRequest, StatePreprepared, StatePrepared, StateCommitted}
+	testStates := []State{StateAcceptRequest, StatePreprepared, StatePrepared, StateCommitted, StateWaitingForNewRound}
 	testCode := []uint64{istanbul.MsgPreprepare, istanbul.MsgPrepare, istanbul.MsgCommit, istanbul.MsgRoundChange}
 
 	// future sequence
@@ -82,27 +84,6 @@ func TestCheckMessage(t *testing.T) {
 			}
 		}
 	}
-
-	// current view but waiting for round change
-	v = &istanbul.View{
-		Sequence: big.NewInt(1),
-		Round:    big.NewInt(0),
-	}
-	c.waitingForRoundChange = true
-	for i := 0; i < len(testStates); i++ {
-		c.state = testStates[i]
-		for j := 0; j < len(testCode); j++ {
-			err := c.checkMessage(testCode[j], v)
-			if testCode[j] == istanbul.MsgRoundChange {
-				if err != nil {
-					t.Errorf("error mismatch: have %v, want nil", err)
-				}
-			} else if err != errFutureMessage {
-				t.Errorf("error mismatch: have %v, want %v", err, errFutureMessage)
-			}
-		}
-	}
-	c.waitingForRoundChange = false
 
 	v = c.currentView()
 	// current view, state = StateAcceptRequest
@@ -163,11 +144,25 @@ func TestCheckMessage(t *testing.T) {
 		}
 	}
 
+	// current view, state = StateWaitingForNewRound
+	c.state = StateWaitingForNewRound
+	for i := 0; i < len(testCode); i++ {
+		err := c.checkMessage(testCode[i], v)
+		if testCode[i] == istanbul.MsgRoundChange {
+			if err != nil {
+				t.Errorf("error mismatch: have %v, want nil", err)
+			}
+		} else if err != errFutureMessage {
+			t.Errorf("error mismatch: have %v, want %v", err, errFutureMessage)
+		}
+	}
+
 }
 
 func TestStoreBacklog(t *testing.T) {
+	testLogger.SetHandler(elog.StdoutHandler)
 	c := &core{
-		logger:     log.New("backend", "test", "id", 0),
+		logger:     testLogger,
 		backlogs:   make(map[istanbul.Validator]*prque.Prque),
 		backlogsMu: new(sync.Mutex),
 	}
@@ -183,8 +178,9 @@ func TestStoreBacklog(t *testing.T) {
 	}
 	prepreparePayload, _ := Encode(preprepare)
 	m := &istanbul.Message{
-		Code: istanbul.MsgPreprepare,
-		Msg:  prepreparePayload,
+		Code:    istanbul.MsgPreprepare,
+		Msg:     prepreparePayload,
+		Address: p.Address(),
 	}
 	c.storeBacklog(m, p)
 	msg := c.backlogs[p].PopItem()
@@ -200,8 +196,9 @@ func TestStoreBacklog(t *testing.T) {
 	subjectPayload, _ := Encode(subject)
 
 	m = &istanbul.Message{
-		Code: istanbul.MsgPrepare,
-		Msg:  subjectPayload,
+		Code:    istanbul.MsgPrepare,
+		Msg:     subjectPayload,
+		Address: p.Address(),
 	}
 	c.storeBacklog(m, p)
 	msg = c.backlogs[p].PopItem()
@@ -211,8 +208,9 @@ func TestStoreBacklog(t *testing.T) {
 
 	// push commit msg
 	m = &istanbul.Message{
-		Code: istanbul.MsgCommit,
-		Msg:  subjectPayload,
+		Code:    istanbul.MsgCommit,
+		Msg:     subjectPayload,
+		Address: p.Address(),
 	}
 	c.storeBacklog(m, p)
 	msg = c.backlogs[p].PopItem()
@@ -221,9 +219,16 @@ func TestStoreBacklog(t *testing.T) {
 	}
 
 	// push roundChange msg
+	rc := &istanbul.RoundChange{
+		View:                v,
+		PreparedCertificate: istanbul.EmptyPreparedCertificate(),
+	}
+	rcPayload, _ := Encode(rc)
+
 	m = &istanbul.Message{
-		Code: istanbul.MsgRoundChange,
-		Msg:  subjectPayload,
+		Code:    istanbul.MsgRoundChange,
+		Msg:     rcPayload,
+		Address: p.Address(),
 	}
 	c.storeBacklog(m, p)
 	msg = c.backlogs[p].PopItem()
@@ -236,15 +241,16 @@ func TestProcessFutureBacklog(t *testing.T) {
 	backend := &testSystemBackend{
 		events: new(event.TypeMux),
 	}
+	testLogger.SetHandler(elog.StdoutHandler)
 	c := &core{
-		logger:     log.New("backend", "test", "id", 0),
+		logger:     testLogger,
 		backlogs:   make(map[istanbul.Validator]*prque.Prque),
 		backlogsMu: new(sync.Mutex),
 		backend:    backend,
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4), common.Hash{}, nil, nil, nil),
+		}, newTestValidatorSet(4), nil, nil, istanbul.EmptyPreparedCertificate(), nil),
 		state: StateAcceptRequest,
 	}
 	c.subscribeEvents()
@@ -298,22 +304,34 @@ func TestProcessBacklog(t *testing.T) {
 	}
 	subjectPayload, _ := Encode(subject)
 
+	rc := &istanbul.RoundChange{
+		View:                v,
+		PreparedCertificate: istanbul.EmptyPreparedCertificate(),
+	}
+	rcPayload, _ := Encode(rc)
+
+	address := common.BytesToAddress([]byte("0xce10ce10"))
+
 	msgs := []*istanbul.Message{
 		{
-			Code: istanbul.MsgPreprepare,
-			Msg:  prepreparePayload,
+			Code:    istanbul.MsgPreprepare,
+			Msg:     prepreparePayload,
+			Address: address,
 		},
 		{
-			Code: istanbul.MsgPrepare,
-			Msg:  subjectPayload,
+			Code:    istanbul.MsgPrepare,
+			Msg:     subjectPayload,
+			Address: address,
 		},
 		{
-			Code: istanbul.MsgCommit,
-			Msg:  subjectPayload,
+			Code:    istanbul.MsgCommit,
+			Msg:     subjectPayload,
+			Address: address,
 		},
 		{
-			Code: istanbul.MsgRoundChange,
-			Msg:  subjectPayload,
+			Code:    istanbul.MsgRoundChange,
+			Msg:     rcPayload,
+			Address: address,
 		},
 	}
 	for i := 0; i < len(msgs); i++ {
@@ -327,8 +345,9 @@ func testProcessBacklog(t *testing.T, msg *istanbul.Message) {
 		events: new(event.TypeMux),
 		peers:  vset,
 	}
+	testLogger.SetHandler(elog.StdoutHandler)
 	c := &core{
-		logger:     log.New("backend", "test", "id", 0),
+		logger:     testLogger,
 		backlogs:   make(map[istanbul.Validator]*prque.Prque),
 		backlogsMu: new(sync.Mutex),
 		backend:    backend,
@@ -336,7 +355,7 @@ func testProcessBacklog(t *testing.T, msg *istanbul.Message) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4), common.Hash{}, nil, nil, nil),
+		}, newTestValidatorSet(4), nil, nil, istanbul.EmptyPreparedCertificate(), nil),
 	}
 	c.subscribeEvents()
 	defer c.unsubscribeEvents()

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -25,6 +25,8 @@ import (
 )
 
 func (c *core) sendCommit() {
+	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "sendCommit")
+	logger.Trace("Sending commit")
 	sub := c.current.Subject()
 	c.broadcastCommit(sub)
 }
@@ -38,7 +40,7 @@ func (c *core) sendCommitForOldBlock(view *istanbul.View, digest common.Hash) {
 }
 
 func (c *core) broadcastCommit(sub *istanbul.Subject) {
-	logger := c.logger.New("state", c.state)
+	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence())
 
 	encodedSubject, err := Encode(sub)
 	if err != nil {
@@ -51,7 +53,8 @@ func (c *core) broadcastCommit(sub *istanbul.Subject) {
 	})
 }
 
-func (c *core) handleCommit(msg *istanbul.Message, src istanbul.Validator) error {
+func (c *core) handleCommit(msg *istanbul.Message) error {
+	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "handleCommit", "tag", "handleMsg")
 	// Decode COMMIT message
 	var commit *istanbul.Subject
 	err := msg.Decode(&commit)
@@ -63,7 +66,7 @@ func (c *core) handleCommit(msg *istanbul.Message, src istanbul.Validator) error
 		return err
 	}
 
-	if err := c.verifyCommit(commit, src); err != nil {
+	if err := c.verifyCommit(commit); err != nil {
 		return err
 	}
 
@@ -72,30 +75,37 @@ func (c *core) handleCommit(msg *istanbul.Message, src istanbul.Validator) error
 		return errInvalidValidatorAddress
 	}
 
-	seal := PrepareCommittedSeal(c.current.Proposal().Hash())
-	err = blscrypto.VerifySignature(validator.BLSPublicKey(), seal, []byte{}, msg.CommittedSeal, false)
-	if err != nil {
-		return err
+	if err := c.verifyCommittedSeal(commit.Digest, msg.CommittedSeal, validator); err != nil {
+		return errInvalidCommittedSeal
 	}
 
-	c.acceptCommit(msg, src)
+	c.acceptCommit(msg)
+	numberOfCommits := c.current.Commits.Size()
+	minQuorumSize := c.valSet.MinQuorumSize()
+	logger.Trace("Accepted commit", "Number of commits", numberOfCommits)
 
 	// Commit the proposal once we have enough COMMIT messages and we are not in the Committed state.
 	//
 	// If we already have a proposal, we may have chance to speed up the consensus process
 	// by committing the proposal without PREPARE messages.
-	if c.current.Commits.Size() >= c.valSet.MinQuorumSize() && c.state.Cmp(StateCommitted) < 0 {
-		// Still need to call LockHash here since state can skip Prepared state and jump directly to the Committed state.
-		c.current.LockHash()
+	// TODO(joshua): Remove state comparisons (or change the cmp function)
+	if numberOfCommits >= minQuorumSize && c.state.Cmp(StateCommitted) < 0 {
+		logger.Trace("Got a quorum of commits", "tag", "stateTransition", "commits", c.current.Commits)
 		c.commit()
+	} else if c.current.GetPrepareOrCommitSize() >= minQuorumSize && c.state.Cmp(StatePrepared) < 0 {
+		logger.Trace("Got enough prepares and commits to generate a PreparedCertificate")
+		if err := c.current.CreateAndSetPreparedCertificate(minQuorumSize); err != nil {
+			logger.Error("Failed to create and set preprared certificate", "err", err)
+			return err
+		}
 	}
 
 	return nil
 }
 
 // verifyCommit verifies if the received COMMIT message is equivalent to our subject
-func (c *core) verifyCommit(commit *istanbul.Subject, src istanbul.Validator) error {
-	logger := c.logger.New("from", src, "state", c.state)
+func (c *core) verifyCommit(commit *istanbul.Subject) error {
+	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "verifyCommit")
 
 	sub := c.current.Subject()
 	if !reflect.DeepEqual(commit, sub) {
@@ -106,8 +116,14 @@ func (c *core) verifyCommit(commit *istanbul.Subject, src istanbul.Validator) er
 	return nil
 }
 
-func (c *core) acceptCommit(msg *istanbul.Message, src istanbul.Validator) error {
-	logger := c.logger.New("from", src, "state", c.state)
+// verifyCommittedSeal verifies the commit seal in the received COMMIT message
+func (c *core) verifyCommittedSeal(digest common.Hash, committedSeal []byte, src istanbul.Validator) error {
+	seal := PrepareCommittedSeal(digest)
+	return blscrypto.VerifySignature(src.BLSPublicKey(), seal, []byte{}, committedSeal, false)
+}
+
+func (c *core) acceptCommit(msg *istanbul.Message) error {
+	logger := c.logger.New("from", msg.Address, "state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "acceptCommit")
 
 	// Add the COMMIT message to current round state
 	if err := c.current.Commits.Add(msg); err != nil {

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -168,7 +168,6 @@ OUTER:
 
 		for i, v := range test.system.backends {
 			validator := r0.valSet.GetByIndex(uint64(i))
-
 			privateKey, _ := bls.DeserializePrivateKey(test.system.validatorsKeys[i])
 			defer privateKey.Destroy()
 
@@ -183,12 +182,9 @@ OUTER:
 				Address:       validator.Address(),
 				Signature:     []byte{},
 				CommittedSeal: signatureBytes,
-			}, validator); err != nil {
+			}); err != nil {
 				if err != test.expectedErr {
 					t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
-				}
-				if r0.current.IsHashLocked() {
-					t.Errorf("block should not be locked")
 				}
 				continue OUTER
 			}
@@ -202,9 +198,6 @@ OUTER:
 			}
 			if r0.current.Commits.Size() > r0.valSet.MinQuorumSize() {
 				t.Errorf("the size of commit messages should be less than %v", r0.valSet.MinQuorumSize())
-			}
-			if r0.current.IsHashLocked() {
-				t.Errorf("block should not be locked")
 			}
 			continue
 		}
@@ -223,9 +216,6 @@ OUTER:
 		}
 		if signedCount < r0.valSet.MinQuorumSize() {
 			t.Errorf("the expected signed count should be greater than or equal to %v, but got %v", r0.valSet.MinQuorumSize(), signedCount)
-		}
-		if !r0.current.IsHashLocked() {
-			t.Errorf("block should be locked")
 		}
 	}
 }
@@ -328,7 +318,7 @@ func TestVerifyCommit(t *testing.T) {
 		c := sys.backends[0].engine.(*core)
 		c.current = test.roundState
 
-		if err := c.verifyCommit(test.commit, peer); err != nil {
+		if err := c.verifyCommit(test.commit); err != nil {
 			if err != test.expected {
 				t.Errorf("result %d: error mismatch: have %v, want %v", i, err, test.expected)
 			}

--- a/consensus/istanbul/core/core_test.go
+++ b/consensus/istanbul/core/core_test.go
@@ -38,6 +38,19 @@ func makeBlock(number int64) *types.Block {
 	return types.NewBlock(header, nil, nil, nil, nil)
 }
 
+func makeBlockWithDifficulty(number, difficulty int64) *types.Block {
+	header := &types.Header{
+		Difficulty: big.NewInt(difficulty),
+		Number:     big.NewInt(number),
+		GasLimit:   0,
+		GasUsed:    0,
+		Time:       big.NewInt(0),
+	}
+	block := &types.Block{}
+	block = block.WithRandomness(&types.EmptyRandomness)
+	return block.WithSeal(header)
+}
+
 func newTestProposal() istanbul.Proposal {
 	return makeBlock(1)
 }

--- a/consensus/istanbul/core/errors.go
+++ b/consensus/istanbul/core/errors.go
@@ -25,8 +25,6 @@ var (
 	// errNotFromProposer is returned when received message is supposed to be from
 	// proposer.
 	errNotFromProposer = errors.New("message does not come from proposer")
-	// errIgnored is returned when a message was ignored.
-	errIgnored = errors.New("message is ignored")
 	// errFutureMessage is returned when current view is earlier than the
 	// view of the received message.
 	errFutureMessage = errors.New("future message")
@@ -41,6 +39,44 @@ var (
 	errFailedDecodePrepare = errors.New("failed to decode PREPARE")
 	// errFailedDecodeCommit is returned when the COMMIT message is malformed.
 	errFailedDecodeCommit = errors.New("failed to decode COMMIT")
+	// errInvalidPreparedCertificateProposal is returned when the PREPARED certificate has an invalid proposal.
+	errInvalidPreparedCertificateProposal = errors.New("invalid proposal in PREPARED certificate")
+	// errInvalidPreparedCertificateNumMsgs is returned when the PREPARED certificate has an incorrect number of messages.
+	errInvalidPreparedCertificateNumMsgs = errors.New("invalid number of PREPARE messages in certificate")
+	// errInvalidPreparedCertificateMsgSignature is returned when the PREPARED certificate has a message with an invalid signature.
+	errInvalidPreparedCertificateMsgSignature = errors.New("invalid signature in PREPARED certificate")
+	// errInvalidPreparedCertificateDuplicate is returned when the PREPARED certificate has multiple messages from the same validator.
+	errInvalidPreparedCertificateDuplicate = errors.New("duplicate message in PREPARED certificate")
+	// errInvalidPreparedCertificateMsgCode is returned when the PREPARED certificate contains a non-PREPARE/COMMIT message.
+	errInvalidPreparedCertificateMsgCode = errors.New("non-PREPARE message in PREPARED certificate")
+	// errInvalidPreparedCertificateMsgView is returned when the PREPARED certificate contains a message for the wrong view
+	errInvalidPreparedCertificateMsgView = errors.New("message in PREPARED certificate for wrong view")
+	// errInvalidPreparedCertificateDigestMismatch is returned when the PREPARED certificate proposal doesn't match one of the messages.
+	errInvalidPreparedCertificateDigestMismatch = errors.New("message in PREPARED certificate for different digest than proposal")
+	// errInvalidRoundChangeViewMismatch is returned when the PREPARED certificate view is greater than the round change view
+	errInvalidRoundChangeViewMismatch = errors.New("View for PREPARED certificate is greater than the view in the round change message")
+
+	// errInvalidRoundChangeCertificateNumMsgs is returned when the ROUND CHANGE certificate has an incorrect number of ROUND CHANGE messages.
+	errInvalidRoundChangeCertificateNumMsgs = errors.New("invalid number of ROUND CHANGE messages in certificate")
+	// errInvalidRoundChangeCertificateMsgSignature is returned when the ROUND CHANGE certificate has a ROUND CHANGE message with an invalid signature.
+	errInvalidRoundChangeCertificateMsgSignature = errors.New("invalid signature in ROUND CHANGE certificate")
+	// errInvalidRoundChangeCertificateDuplicate is returned when the ROUND CHANGE certificate has multiple ROUND CHANGE messages from the same validator.
+	errInvalidRoundChangeCertificateDuplicate = errors.New("duplicate message in ROUND CHANGE certificate")
+	// errInvalidRoundChangeCertificateMsgCode is returned when the ROUND CHANGE certificate contains a message with the wrong code.
+	errInvalidRoundChangeCertificateMsgCode = errors.New("non-ROUND CHANGE message in ROUND CHANGE certificate")
+	// errInvalidRoundChangeCertificateMsgView is returned when the ROUND CHANGE certificate contains a message for the wrong view
+	errInvalidRoundChangeCertificateMsgView = errors.New("message in ROUND CHANGE certificate for wrong view")
+
+	// errInvalidCommittedSeal is returned when a COMMIT message has an invalid committed seal.
+	errInvalidCommittedSeal = errors.New("invalid committed seal in COMMIT message")
+	// errMissingRoundChangeCertificate is returned when ROUND CHANGE certificate is missing from a PREPREPARE for round > 0.
+	errMissingRoundChangeCertificate = errors.New("missing ROUND CHANGE certificate in PREPREPARE")
+	// errFailedCreatePreparedCertificate is returned when there aren't enough PREPARE messages to create a PREPARED certificate.
+	errFailedCreatePreparedCertificate = errors.New("failed to create PREPARED certficate")
+	// errFailedCreateRoundChangeCertificate is returned when there aren't enough ROUND CHANGE messages to create a ROUND CHANGE certificate.
+	errFailedCreateRoundChangeCertificate = errors.New("failed to create ROUND CHANGE certficate")
+	// errInvalidProposal is returned when a PREPARED certificate exists for proposal A in the ROUND CHANGE certificate for a PREPREPARE with proposal B.
+	errInvalidProposal = errors.New("invalid proposal in PREPREPARE")
 	// errInvalidValidatorAddress is returned when the COMMIT message address doesn't
 	// correspond to a validator in the current set.
 	errInvalidValidatorAddress = errors.New("failed to find an existing validator by address")

--- a/consensus/istanbul/core/events.go
+++ b/consensus/istanbul/core/events.go
@@ -25,4 +25,6 @@ type backlogEvent struct {
 	msg *istanbul.Message
 }
 
-type timeoutEvent struct{}
+type timeoutEvent struct {
+	view *istanbul.View
+}

--- a/consensus/istanbul/core/final_committed.go
+++ b/consensus/istanbul/core/final_committed.go
@@ -19,7 +19,7 @@ package core
 import "github.com/ethereum/go-ethereum/common"
 
 func (c *core) handleFinalCommitted() error {
-	logger := c.logger.New("state", c.state)
+	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence())
 	logger.Trace("Received a final committed proposal")
 	c.startNewRound(common.Big0)
 	return nil

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -19,25 +19,27 @@ package core
 import (
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
-func (c *core) sendPreprepare(request *istanbul.Request) {
-	logger := c.logger.New("state", c.state)
+func (c *core) sendPreprepare(request *istanbul.Request, roundChangeCertificate istanbul.RoundChangeCertificate) {
+	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "sendPreprepare")
 
 	// If I'm the proposer and I have the same sequence with the proposal
 	if c.current.Sequence().Cmp(request.Proposal.Number()) == 0 && c.isProposer() {
 		curView := c.currentView()
 		preprepare, err := Encode(&istanbul.Preprepare{
-			View:     curView,
-			Proposal: request.Proposal,
+			View:                   curView,
+			Proposal:               request.Proposal,
+			RoundChangeCertificate: roundChangeCertificate,
 		})
 		if err != nil {
 			logger.Error("Failed to encode", "view", curView)
 			return
 		}
-
+		logger.Trace("Sending preprepare")
 		c.broadcast(&istanbul.Message{
 			Code: istanbul.MsgPreprepare,
 			Msg:  preprepare,
@@ -45,14 +47,36 @@ func (c *core) sendPreprepare(request *istanbul.Request) {
 	}
 }
 
-func (c *core) handlePreprepare(msg *istanbul.Message, src istanbul.Validator) error {
-	logger := c.logger.New("from", src, "state", c.state)
+func (c *core) handlePreprepare(msg *istanbul.Message) error {
+	logger := c.logger.New("from", msg.Address, "state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "handlePreprepare", "tag", "handleMsg")
+	logger.Trace("Got pre-prepare message")
 
 	// Decode PRE-PREPARE
 	var preprepare *istanbul.Preprepare
 	err := msg.Decode(&preprepare)
 	if err != nil {
 		return errFailedDecodePreprepare
+	}
+
+	// If round > 0, handle the ROUND CHANGE certificate. If round = 0, it should not have a ROUND CHANGE certificate
+	if preprepare.View.Round.Cmp(common.Big0) > 0 {
+		if !preprepare.HasRoundChangeCertificate() {
+			logger.Error("Preprepare for non-zero round did not contain a round change certificate.")
+			return errMissingRoundChangeCertificate
+		}
+		subject := istanbul.Subject{
+			View:   preprepare.View,
+			Digest: preprepare.Proposal.Hash(),
+		}
+		// This also moves us to the next round if the certificate is valid.
+		err := c.handleRoundChangeCertificate(subject, preprepare.RoundChangeCertificate)
+		if err != nil {
+			logger.Warn("Invalid round change certificate with preprepare.", "err", err)
+			return err
+		}
+	} else if preprepare.HasRoundChangeCertificate() {
+		logger.Error("Preprepare for round 0 has a round change certificate.")
+		return errInvalidProposal
 	}
 
 	// Ensure we have the same view with the PRE-PREPARE message
@@ -66,59 +90,43 @@ func (c *core) handlePreprepare(msg *istanbul.Message, src istanbul.Validator) e
 			// Broadcast COMMIT if it is an existing block
 			// 1. The proposer needs to be a proposer matches the given (Sequence + Round)
 			// 2. The given block must exist
-			if valSet.IsProposer(src.Address()) && c.backend.HasProposal(preprepare.Proposal.Hash(), preprepare.Proposal.Number()) {
+			if valSet.IsProposer(msg.Address) && c.backend.HasProposal(preprepare.Proposal.Hash(), preprepare.Proposal.Number()) {
+				logger.Trace("Sending a commit message for an old block", "view", preprepare.View, "block hash", preprepare.Proposal.Hash())
 				c.sendCommitForOldBlock(preprepare.View, preprepare.Proposal.Hash())
 				return nil
 			}
 		}
+		// Probably shouldn't errFutureMessage as we should have moved to that round in handleRoundChangeCertificate
+		logger.Trace("Check pre-prepare failed", "cur_round", c.current.Round(), "err", err)
 		return err
 	}
 
 	// Check if the message comes from current proposer
-	if !c.valSet.IsProposer(src.Address()) {
+	if !c.valSet.IsProposer(msg.Address) {
 		logger.Warn("Ignore preprepare messages from non-proposer")
 		return errNotFromProposer
 	}
 
 	// Verify the proposal we received
-	if duration, err := c.backend.Verify(preprepare.Proposal, src); err != nil {
+	if duration, err := c.backend.Verify(preprepare.Proposal); err != nil {
 		logger.Warn("Failed to verify proposal", "err", err, "duration", duration)
 		// if it's a future block, we will handle it again after the duration
 		if err == consensus.ErrFutureBlock {
 			c.stopFuturePreprepareTimer()
 			c.futurePreprepareTimer = time.AfterFunc(duration, func() {
 				c.sendEvent(backlogEvent{
-					src: src,
 					msg: msg,
 				})
 			})
-		} else {
-			c.sendNextRoundChange()
 		}
 		return err
 	}
 
-	// Here is about to accept the PRE-PREPARE
 	if c.state == StateAcceptRequest {
-		// Send ROUND CHANGE if the locked proposal and the received proposal are different
-		if c.current.IsHashLocked() {
-			if preprepare.Proposal.Hash() == c.current.GetLockedHash() {
-				// Broadcast COMMIT and enters Prepared state directly
-				c.acceptPreprepare(preprepare)
-				c.setState(StatePrepared)
-				c.sendCommit()
-			} else {
-				// Send round change
-				c.sendNextRoundChange()
-			}
-		} else {
-			// Either
-			//   1. the locked proposal and the received proposal match
-			//   2. we have no locked proposal
-			c.acceptPreprepare(preprepare)
-			c.setState(StatePreprepared)
-			c.sendPrepare()
-		}
+		logger.Trace("Accepted preprepare", "tag", "stateTransition")
+		c.acceptPreprepare(preprepare)
+		c.setState(StatePreprepared)
+		c.sendPrepare()
 	}
 
 	return nil

--- a/consensus/istanbul/core/request_test.go
+++ b/consensus/istanbul/core/request_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/event"
@@ -36,7 +35,7 @@ func TestCheckRequestMsg(t *testing.T) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4), common.Hash{}, nil, nil, nil),
+		}, newTestValidatorSet(4), nil, nil, istanbul.EmptyPreparedCertificate(), nil),
 	}
 
 	// invalid request
@@ -91,7 +90,7 @@ func TestStoreRequestMsg(t *testing.T) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4), common.Hash{}, nil, nil, nil),
+		}, newTestValidatorSet(4), nil, nil, istanbul.EmptyPreparedCertificate(), nil),
 		pendingRequests:   prque.New(nil),
 		pendingRequestsMu: new(sync.Mutex),
 	}

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -32,25 +32,23 @@ func (c *core) sendNextRoundChange() {
 
 // sendRoundChange sends the ROUND CHANGE message with the given round
 func (c *core) sendRoundChange(round *big.Int) {
-	logger := c.logger.New("state", c.state)
+	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "sendRoundChange", "target round", round)
 
 	cv := c.currentView()
 	if cv.Round.Cmp(round) >= 0 {
-		logger.Error("Cannot send out the round change", "current round", cv.Round, "target round", round)
+		logger.Error("Cannot send out the round change")
 		return
 	}
 
-	c.catchUpRound(&istanbul.View{
+	nextView := &istanbul.View{
 		// The round number we'd like to transfer to.
 		Round:    new(big.Int).Set(round),
 		Sequence: new(big.Int).Set(cv.Sequence),
-	})
+	}
 
-	// Now we have the new round number and sequence number
-	cv = c.currentView()
-	rc := &istanbul.Subject{
-		View:   cv,
-		Digest: common.Hash{},
+	rc := &istanbul.RoundChange{
+		View:                nextView,
+		PreparedCertificate: c.current.preparedCertificate,
 	}
 
 	payload, err := Encode(rc)
@@ -58,53 +56,144 @@ func (c *core) sendRoundChange(round *big.Int) {
 		logger.Error("Failed to encode ROUND CHANGE", "rc", rc, "err", err)
 		return
 	}
-
+	logger.Trace("Sending round change message", "rcs", c.roundChangeSet)
 	c.broadcast(&istanbul.Message{
 		Code: istanbul.MsgRoundChange,
 		Msg:  payload,
 	})
 }
 
-func (c *core) handleRoundChange(msg *istanbul.Message, src istanbul.Validator) error {
-	logger := c.logger.New("state", c.state, "from", src.Address().Hex())
+func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChangeCertificate istanbul.RoundChangeCertificate) error {
+	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "handleRoundChangeCertificate")
+
+	if len(roundChangeCertificate.RoundChangeMessages) > c.valSet.Size() || len(roundChangeCertificate.RoundChangeMessages) < c.valSet.MinQuorumSize() {
+		return errInvalidRoundChangeCertificateNumMsgs
+	}
+
+	maxRound := big.NewInt(-1)
+	preferredDigest := common.Hash{}
+	seen := make(map[common.Address]bool)
+	decodedMessages := make([]istanbul.RoundChange, len(roundChangeCertificate.RoundChangeMessages))
+	for i, message := range roundChangeCertificate.RoundChangeMessages {
+		// Verify message signed by a validator
+		data, err := message.PayloadNoSig()
+		if err != nil {
+			return err
+		}
+
+		signer, err := c.validateFn(data, message.Signature)
+		if err != nil {
+			return err
+		}
+
+		if signer != message.Address {
+			return errInvalidRoundChangeCertificateMsgSignature
+		}
+
+		// Check for duplicate ROUND CHANGE messages
+		if seen[signer] {
+			return errInvalidRoundChangeCertificateDuplicate
+		}
+		seen[signer] = true
+
+		// Check that the message is a ROUND CHANGE message
+		if istanbul.MsgRoundChange != message.Code {
+			return errInvalidRoundChangeCertificateMsgCode
+		}
+
+		var roundChange *istanbul.RoundChange
+		if err := message.Decode(&roundChange); err != nil {
+			logger.Error("Failed to decode ROUND CHANGE in certificate", "err", err)
+			return err
+		}
+
+		// Verify ROUND CHANGE message is for a proper view
+		if roundChange.View.Cmp(proposal.View) != 0 || roundChange.View.Round.Cmp(c.current.DesiredRound()) < 0 {
+			return errInvalidRoundChangeCertificateMsgView
+		}
+
+		if roundChange.HasPreparedCertificate() {
+			if err := c.verifyPreparedCertificate(roundChange.PreparedCertificate); err != nil {
+				return err
+			}
+			// We must use the proposal in the prepared certificate with the highest round number. (See OSDI 99, Section 4.4)
+			// Older prepared certificates may be generated, but if no node committed, there is no guarantee that
+			// it will be the next pre-prepare. If one node committed, that block is guaranteed (by quorum intersection)
+			// to be the next pre-prepare. That (higher view) prepared cert should override older perpared certs for
+			// blocks that were not committed.
+			// Also reject round change messages where the prepared view is greater than the round change view.
+			preparedView := roundChange.PreparedCertificate.View()
+			if preparedView == nil || preparedView.Round.Cmp(proposal.View.Round) > 0 {
+				return errInvalidRoundChangeViewMismatch
+			} else if preparedView.Round.Cmp(maxRound) > 0 {
+				maxRound = preparedView.Round
+				preferredDigest = roundChange.PreparedCertificate.Proposal.Hash()
+			}
+		}
+
+		decodedMessages[i] = *roundChange
+		// TODO(joshua): startNewRound needs these round change messages to generate a
+		// round change certificate even if this node is not the next proposer
+		c.roundChangeSet.Add(roundChange.View.Round, &message)
+	}
+
+	if maxRound.Cmp(big.NewInt(-1)) > 0 && proposal.Digest != preferredDigest {
+		return errInvalidPreparedCertificateDigestMismatch
+	}
+
+	// May have already moved to this round based on quorum round change messages.
+	logger.Trace("Trying to move to round change certificate's round", "target round", proposal.View.Round)
+	c.startNewRound(proposal.View.Round)
+
+	return nil
+}
+
+func (c *core) handleRoundChange(msg *istanbul.Message) error {
+	logger := c.logger.New("state", c.state, "from", msg.Address, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "handleRoundChange", "tag", "handleMsg")
 
 	// Decode ROUND CHANGE message
-	var rc *istanbul.Subject
+	var rc *istanbul.RoundChange
 	if err := msg.Decode(&rc); err != nil {
 		logger.Error("Failed to decode ROUND CHANGE", "err", err)
 		return errInvalidMessage
 	}
 
+	// Must be same sequence and future round.
 	if err := c.checkMessage(istanbul.MsgRoundChange, rc.View); err != nil {
+		logger.Info("Check round change message failed", "err", err)
 		return err
 	}
 
-	cv := c.currentView()
+	// Verify the PREPARED certificate if present.
+	if rc.HasPreparedCertificate() {
+		if err := c.verifyPreparedCertificate(rc.PreparedCertificate); err != nil {
+			return err
+		}
+		preparedCertView := rc.PreparedCertificate.View()
+		if preparedCertView == nil || preparedCertView.Round.Cmp(rc.View.Round) > 0 {
+			return errInvalidRoundChangeViewMismatch
+		}
+	}
+
 	roundView := rc.View
 
 	// Add the ROUND CHANGE message to its message set and return how many
 	// messages we've got with the same round number and sequence number.
 	num, err := c.roundChangeSet.Add(roundView.Round, msg)
 	if err != nil {
-		logger.Warn("Failed to add round change message", "from", src, "msg", msg, "err", err)
+		logger.Warn("Failed to add round change message", "message", msg, "err", err)
 		return err
 	}
+	logger.Trace("Got round change message", "num", num, "message_round", roundView.Round)
 
-	// Once we received f+1 ROUND CHANGE messages, those messages form a weak certificate.
-	// If our round number is smaller than the certificate's round number, we would
-	// try to catch up the round number.
-	if c.waitingForRoundChange && num == c.valSet.F()+1 {
-		if cv.Round.Cmp(roundView.Round) < 0 {
-			c.sendRoundChange(roundView.Round)
-		}
-		return nil
-	} else if num == c.valSet.MinQuorumSize() && (c.waitingForRoundChange || cv.Round.Cmp(roundView.Round) < 0) {
-		// We've received the minimum quorum size ROUND CHANGE messages, start a new round immediately.
+	// On f+1 round changes we send a round change and wait for the next round if we haven't done so already
+	// On quorum round change messages we go to the next round immediately.
+	if num == c.valSet.F()+1 {
+		logger.Trace("Got f+1 round change messages, sending own round change message and waiting for next round.")
+		c.waitForDesiredRound(roundView.Round)
+	} else if num == c.valSet.MinQuorumSize() {
+		logger.Trace("Got quorum round change messages, starting new round.")
 		c.startNewRound(roundView.Round)
-		return nil
-	} else if cv.Round.Cmp(roundView.Round) < 0 {
-		// Only gossip the message with current round to other validators.
-		return errIgnored
 	}
 	return nil
 }
@@ -169,4 +258,22 @@ func (rcs *roundChangeSet) MaxRound(num int) *big.Int {
 		}
 	}
 	return maxRound
+}
+
+func (rcs *roundChangeSet) getCertificate(r *big.Int, quorumSize int) (istanbul.RoundChangeCertificate, error) {
+	rcs.mu.Lock()
+	defer rcs.mu.Unlock()
+
+	round := r.Uint64()
+	if rcs.roundChanges[round] != nil && rcs.roundChanges[round].Size() >= quorumSize {
+		messages := make([]istanbul.Message, rcs.roundChanges[round].Size())
+		for i, message := range rcs.roundChanges[round].Values() {
+			messages[i] = *message
+		}
+		return istanbul.RoundChangeCertificate{
+			RoundChangeMessages: messages,
+		}, nil
+	} else {
+		return istanbul.RoundChangeCertificate{}, errFailedCreateRoundChangeCertificate
+	}
 }

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -19,6 +19,7 @@ package core
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
@@ -26,7 +27,7 @@ import (
 )
 
 func TestRoundChangeSet(t *testing.T) {
-	vals, _ := generateValidators(4)
+	vals, _, _ := generateValidators(4)
 	vset := validator.NewSet(vals, istanbul.RoundRobin)
 	rc := newRoundChangeSet(vset)
 
@@ -90,4 +91,384 @@ func TestRoundChangeSet(t *testing.T) {
 	if rc.roundChanges[view.Round.Uint64()] != nil {
 		t.Errorf("the change messages mismatch: have %v, want nil", rc.roundChanges[view.Round.Uint64()])
 	}
+}
+
+func TestHandleRoundChangeCertificate(t *testing.T) {
+	N := uint64(4) // replica 0 is the proposer, it will send messages to others
+	F := uint64(1)
+	view := istanbul.View{
+		Round:    big.NewInt(1),
+		Sequence: big.NewInt(1),
+	}
+
+	testCases := []struct {
+		getCertificate func(*testSystem) istanbul.RoundChangeCertificate
+		expectedErr    error
+	}{
+		{
+			// Valid round change certificate without PREPARED certificate
+			func(sys *testSystem) istanbul.RoundChangeCertificate {
+				return sys.getRoundChangeCertificate(t, view, istanbul.EmptyPreparedCertificate())
+			},
+			nil,
+		},
+		{
+			// Valid round change certificate with PREPARED certificate
+			func(sys *testSystem) istanbul.RoundChangeCertificate {
+				return sys.getRoundChangeCertificate(t, view, sys.getPreparedCertificate(t, view, makeBlock(0)))
+			},
+			nil,
+		},
+		{
+			// Invalid round change certificate, duplicate message
+			func(sys *testSystem) istanbul.RoundChangeCertificate {
+				roundChangeCertificate := sys.getRoundChangeCertificate(t, view, istanbul.EmptyPreparedCertificate())
+				roundChangeCertificate.RoundChangeMessages[1] = roundChangeCertificate.RoundChangeMessages[0]
+				return roundChangeCertificate
+			},
+			errInvalidRoundChangeCertificateDuplicate,
+		},
+		{
+			// Empty certificate
+			func(sys *testSystem) istanbul.RoundChangeCertificate {
+				return istanbul.RoundChangeCertificate{}
+			},
+			errInvalidRoundChangeCertificateNumMsgs,
+		},
+	}
+	for _, test := range testCases {
+		sys := NewTestSystemWithBackend(N, F)
+		for i, backend := range sys.backends {
+			c := backend.engine.(*core)
+			certificate := test.getCertificate(sys)
+			subject := istanbul.Subject{
+				View:   &view,
+				Digest: makeBlock(0).Hash(),
+			}
+			err := c.handleRoundChangeCertificate(subject, certificate)
+
+			if err != test.expectedErr {
+				t.Errorf("error mismatch for test case %v: have %v, want %v", i, err, test.expectedErr)
+			}
+			if err == nil && c.currentView().Cmp(&view) != 0 {
+				t.Errorf("view mismatch for test case %v: have %v, want %v", i, c.currentView(), view)
+			}
+		}
+	}
+}
+
+func TestHandleRoundChange(t *testing.T) {
+	N := uint64(4) // replica 0 is the proposer, it will send messages to others
+	F := uint64(1) // F does not affect tests
+
+	testCases := []struct {
+		system      *testSystem
+		getCert     func(*testSystem) istanbul.PreparedCertificate
+		expectedErr error
+	}{
+		{
+			// normal case
+			NewTestSystemWithBackend(N, F),
+			func(_ *testSystem) istanbul.PreparedCertificate {
+				return istanbul.EmptyPreparedCertificate()
+			},
+			nil,
+		},
+		{
+			// normal case with valid prepared certificate
+			NewTestSystemWithBackend(N, F),
+			func(sys *testSystem) istanbul.PreparedCertificate {
+				return sys.getPreparedCertificate(t, *sys.backends[0].engine.(*core).currentView(), makeBlock(1))
+			},
+			nil,
+		},
+		{
+			// normal case with invalid prepared certificate
+			NewTestSystemWithBackend(N, F),
+			func(sys *testSystem) istanbul.PreparedCertificate {
+				preparedCert := sys.getPreparedCertificate(t, *sys.backends[0].engine.(*core).currentView(), makeBlock(1))
+				preparedCert.PrepareOrCommitMessages[0] = preparedCert.PrepareOrCommitMessages[1]
+				return preparedCert
+			},
+			errInvalidPreparedCertificateDuplicate,
+		},
+		{
+			// valid message for future round
+			func() *testSystem {
+				sys := NewTestSystemWithBackend(N, F)
+				sys.backends[0].engine.(*core).current.SetRound(big.NewInt(10))
+				return sys
+			}(),
+			func(_ *testSystem) istanbul.PreparedCertificate {
+				return istanbul.EmptyPreparedCertificate()
+			},
+			nil,
+		},
+		{
+			// invalid message for future sequence
+			func() *testSystem {
+				sys := NewTestSystemWithBackend(N, F)
+				sys.backends[0].engine.(*core).current.SetSequence(big.NewInt(10))
+				return sys
+			}(),
+			func(_ *testSystem) istanbul.PreparedCertificate {
+				return istanbul.EmptyPreparedCertificate()
+			},
+			errFutureMessage,
+		},
+		{
+			// invalid message for previous round
+			func() *testSystem {
+				sys := NewTestSystemWithBackend(N, F)
+				sys.backends[0].engine.(*core).current.SetRound(big.NewInt(0))
+				return sys
+			}(),
+			func(_ *testSystem) istanbul.PreparedCertificate {
+				return istanbul.EmptyPreparedCertificate()
+			},
+			nil,
+		},
+	}
+
+OUTER:
+	for _, test := range testCases {
+		test.system.Run(false)
+
+		v0 := test.system.backends[0]
+		r0 := v0.engine.(*core)
+
+		curView := r0.currentView()
+		nextView := &istanbul.View{
+			Round:    new(big.Int).Add(curView.Round, common.Big1),
+			Sequence: curView.Sequence,
+		}
+
+		roundChange := &istanbul.RoundChange{
+			View:                nextView,
+			PreparedCertificate: test.getCert(test.system),
+		}
+
+		for i, v := range test.system.backends {
+			// i == 0 is primary backend, it is responsible for send ROUND CHANGE messages to others.
+			if i == 0 {
+				continue
+			}
+
+			c := v.engine.(*core)
+
+			m, _ := Encode(roundChange)
+
+			// run each backends and verify handlePreprepare function.
+			err := c.handleRoundChange(&istanbul.Message{
+				Code:    istanbul.MsgRoundChange,
+				Msg:     m,
+				Address: v0.Address(),
+			})
+			if err != test.expectedErr {
+				t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
+			}
+			continue OUTER
+		}
+	}
+}
+
+func (ts *testSystem) distributeIstMsgs(t *testing.T, sys *testSystem, istMsgDistribution map[uint64]map[int]bool) {
+	for {
+		select {
+		case <-ts.quit:
+			return
+		case event := <-ts.queuedMessage:
+			msg := new(istanbul.Message)
+			if err := msg.FromPayload(event.Payload, nil); err != nil {
+				t.Errorf("Could not decode payload")
+			}
+
+			targets := istMsgDistribution[msg.Code]
+			for index, b := range sys.backends {
+				if targets[index] || msg.Address == b.address {
+					go b.EventMux().Post(event)
+				} else {
+					testLogger.Info("ignoring message with code", "code", msg.Code)
+				}
+			}
+		}
+	}
+}
+
+var gossip = map[int]bool{
+	0: true,
+	1: true,
+	2: true,
+	3: true,
+}
+
+var sendTo2FPlus1 = map[int]bool{
+	0: true,
+	1: true,
+	2: true,
+	3: false,
+}
+
+var sendToF = map[int]bool{
+	0: false,
+	1: false,
+	2: false,
+	3: true,
+}
+
+var sendToFPlus1 = map[int]bool{
+	0: false,
+	1: false,
+	2: true,
+	3: true,
+}
+var noGossip = map[int]bool{
+	0: false,
+	1: false,
+	2: false,
+	3: false,
+}
+
+// This tests the liveness issue present in the initial implementation of Istanbul, described in
+// more detail here: https://arxiv.org/pdf/1901.07160.pdf
+// To test this, a block is proposed, for which 2F + 1 PREPARE messages are sent to F nodes.
+// In the original implementation, these F nodes would lock onto that block, and eventually everyone would
+// round change. If the next proposer was byzantine, they could send a PRE-PREPARED with a different block,
+// get the remaining 2F non-byzantine nodes to lock onto that new block, causing a deadlock.
+// In the new implementation, the PRE-PREPARE will include a ROUND CHANGE certificate,
+// and all nodes will accept the newly proposed block.
+func TestCommitsBlocksAfterRoundChange(t *testing.T) {
+	// Initialize the system with a nil round state so that we properly start round 0.
+	sys := NewTestSystemWithBackendAndCurrentRoundState(4, 1, func(vset istanbul.ValidatorSet) *roundState { return nil })
+
+	for i, b := range sys.backends {
+		b.engine.Start() // start Istanbul core
+		block := makeBlockWithDifficulty(1, int64(i))
+		sys.backends[i].NewRequest(block)
+	}
+
+	newBlocks := sys.backends[3].EventMux().Subscribe(istanbul.FinalCommittedEvent{})
+	defer newBlocks.Unsubscribe()
+
+	timeout := sys.backends[3].EventMux().Subscribe(timeoutEvent{})
+	defer timeout.Unsubscribe()
+
+	istMsgDistribution := map[uint64]map[int]bool{}
+
+	// Allow everyone to see the initial proposal
+	// Send all PREPARE messages to F nodes.
+	// Send COMMIT messages (we don't expect these to be sent in the first round anyway).
+	// Send ROUND CHANGE messages to the remaining 2F + 1 nodes.
+	istMsgDistribution[istanbul.MsgPreprepare] = gossip
+	istMsgDistribution[istanbul.MsgPrepare] = sendToF
+	istMsgDistribution[istanbul.MsgCommit] = gossip
+	istMsgDistribution[istanbul.MsgRoundChange] = sendTo2FPlus1
+
+	go sys.distributeIstMsgs(t, sys, istMsgDistribution)
+
+	// Turn PREPAREs back on for round 1.
+	<-time.After(1 * time.Second)
+	istMsgDistribution[istanbul.MsgPrepare] = gossip
+
+	// Wait for round 1 to start.
+	<-timeout.Chan()
+
+	// Eventually we should get a block again
+	select {
+	case <-timeout.Chan():
+		t.Error("Did not finalize a block in round 1")
+	case _, ok := <-newBlocks.Chan():
+		if !ok {
+			t.Error("Error reading block")
+		}
+		// Wait for all backends to finalize the block.
+		<-time.After(1 * time.Second)
+		expectedCommitted, _ := sys.backends[0].LastProposal()
+		for i, b := range sys.backends {
+			committed, _ := b.LastProposal()
+			// We don't expect any particular block to be committed here. We do expect them to be consistent.
+			if committed.Number().Cmp(common.Big1) != 0 {
+				t.Errorf("Backend %v got committed block with unexpected number: expected %v, got %v", i, 1, committed.Number())
+			}
+			if expectedCommitted.Hash() != committed.Hash() {
+				t.Errorf("Backend %v got committed block with unexpected hash: expected %v, got %v", i, expectedCommitted.Hash(), committed.Hash())
+			}
+		}
+	}
+
+	// Manually open and close b/c hijacking sys.listen
+	for _, b := range sys.backends {
+		b.engine.Stop() // stop Istanbul core
+	}
+	close(sys.quit)
+}
+
+// This tests that when F+1 nodes receive 2F+1 PREPARE messages for a particular proposal, the
+// system enforces that as the only valid proposal for this sequence.
+func TestPreparedCertificatePersistsThroughRoundChanges(t *testing.T) {
+	// Initialize the system with a nil round state so that we properly start round 0.
+	sys := NewTestSystemWithBackendAndCurrentRoundState(4, 1, func(vset istanbul.ValidatorSet) *roundState { return nil })
+
+	for i, b := range sys.backends {
+		b.engine.Start() // start Istanbul core
+		block := makeBlockWithDifficulty(1, int64(i))
+		sys.backends[i].NewRequest(block)
+	}
+
+	newBlocks := sys.backends[3].EventMux().Subscribe(istanbul.FinalCommittedEvent{})
+	defer newBlocks.Unsubscribe()
+
+	timeout := sys.backends[3].EventMux().Subscribe(timeoutEvent{})
+	defer timeout.Unsubscribe()
+
+	istMsgDistribution := map[uint64]map[int]bool{}
+
+	// Send PREPARE messages to F + 1 nodes so we guarantee a PREPARED certificate in the ROUND CHANGE certificate..
+	istMsgDistribution[istanbul.MsgPreprepare] = gossip
+	istMsgDistribution[istanbul.MsgPrepare] = sendToFPlus1
+	istMsgDistribution[istanbul.MsgCommit] = gossip
+	istMsgDistribution[istanbul.MsgRoundChange] = gossip
+
+	go sys.distributeIstMsgs(t, sys, istMsgDistribution)
+
+	// Turn PREPARE messages off for round 1 to force reuse of the PREPARED certificate.
+	<-time.After(1 * time.Second)
+	istMsgDistribution[istanbul.MsgPrepare] = noGossip
+
+	// Wait for round 1 to start.
+	<-timeout.Chan()
+	// Turn PREPARE messages back on in time for round 2.
+	<-time.After(1 * time.Second)
+	istMsgDistribution[istanbul.MsgPrepare] = gossip
+
+	// Wait for round 2 to start.
+	<-timeout.Chan()
+
+	select {
+	case <-timeout.Chan():
+		t.Error("Did not finalize a block in round 2.")
+	case _, ok := <-newBlocks.Chan():
+		if !ok {
+			t.Error("Error reading block")
+		}
+		// Wait for all backends to finalize the block.
+		<-time.After(2 * time.Second)
+		for i, b := range sys.backends {
+			committed, _ := b.LastProposal()
+			// We expect to commit the block proposed by the first proposer.
+			expectedCommitted := makeBlockWithDifficulty(1, 0)
+			if committed.Number().Cmp(common.Big1) != 0 {
+				t.Errorf("Backend %v got committed block with unexpected number: expected %v, got %v", i, 1, committed.Number())
+			}
+			if expectedCommitted.Hash() != committed.Hash() {
+				t.Errorf("Backend %v got committed block with unexpected hash: expected %v, got %v", i, expectedCommitted.Hash(), committed.Hash())
+			}
+		}
+	}
+
+	// Manually open and close b/c hijacking sys.listen
+	for _, b := range sys.backends {
+		b.engine.Stop() // start Istanbul core
+	}
+	close(sys.quit)
 }

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -27,31 +27,31 @@ import (
 )
 
 // newRoundState creates a new roundState instance with the given view and validatorSet
-// lockedHash and preprepare are for round change when lock exists,
-// we need to keep a reference of preprepare in order to propose locked proposal when there is a lock and itself is the proposer
-func newRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, lockedHash common.Hash, preprepare *istanbul.Preprepare, pendingRequest *istanbul.Request, hasBadProposal func(hash common.Hash) bool) *roundState {
+func newRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, preprepare *istanbul.Preprepare, pendingRequest *istanbul.Request, preparedCertificate istanbul.PreparedCertificate, hasBadProposal func(hash common.Hash) bool) *roundState {
 	return &roundState{
-		round:          view.Round,
-		sequence:       view.Sequence,
-		Preprepare:     preprepare,
-		Prepares:       newMessageSet(validatorSet),
-		Commits:        newMessageSet(validatorSet),
-		lockedHash:     lockedHash,
-		mu:             new(sync.RWMutex),
-		pendingRequest: pendingRequest,
-		hasBadProposal: hasBadProposal,
+		round:               view.Round,
+		desiredRound:        view.Round,
+		sequence:            view.Sequence,
+		Preprepare:          preprepare,
+		Prepares:            newMessageSet(validatorSet),
+		Commits:             newMessageSet(validatorSet),
+		mu:                  new(sync.RWMutex),
+		pendingRequest:      pendingRequest,
+		preparedCertificate: preparedCertificate,
+		hasBadProposal:      hasBadProposal,
 	}
 }
 
 // roundState stores the consensus state
 type roundState struct {
-	round          *big.Int
-	sequence       *big.Int
-	Preprepare     *istanbul.Preprepare
-	Prepares       *messageSet
-	Commits        *messageSet
-	lockedHash     common.Hash
-	pendingRequest *istanbul.Request
+	round               *big.Int
+	desiredRound        *big.Int
+	sequence            *big.Int
+	Preprepare          *istanbul.Preprepare
+	Prepares            *messageSet
+	Commits             *messageSet
+	pendingRequest      *istanbul.Request
+	preparedCertificate istanbul.PreparedCertificate
 
 	mu             *sync.RWMutex
 	hasBadProposal func(hash common.Hash) bool
@@ -61,15 +61,7 @@ func (s *roundState) GetPrepareOrCommitSize() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	result := s.Prepares.Size() + s.Commits.Size()
-
-	// find duplicate one
-	for _, m := range s.Prepares.Values() {
-		if s.Commits.Get(m.Address) != nil {
-			result--
-		}
-	}
-	return result
+	return s.getPrepareOrCommitSize()
 }
 
 func (s *roundState) Subject() *istanbul.Subject {
@@ -121,6 +113,20 @@ func (s *roundState) Round() *big.Int {
 	return s.round
 }
 
+func (s *roundState) SetDesiredRound(r *big.Int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.desiredRound = new(big.Int).Set(r)
+}
+
+func (s *roundState) DesiredRound() *big.Int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.desiredRound
+}
+
 func (s *roundState) SetSequence(seq *big.Int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -135,37 +141,51 @@ func (s *roundState) Sequence() *big.Int {
 	return s.sequence
 }
 
-func (s *roundState) LockHash() {
+func (s *roundState) SetPreparedCertificate(preparedCertificate istanbul.PreparedCertificate) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.Preprepare != nil {
-		s.lockedHash = s.Preprepare.Proposal.Hash()
-	}
+	s.preparedCertificate = preparedCertificate
 }
 
-func (s *roundState) UnlockHash() {
+func (s *roundState) CreateAndSetPreparedCertificate(quorumSize int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.lockedHash = common.Hash{}
-}
-
-func (s *roundState) IsHashLocked() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	if (s.lockedHash == common.Hash{}) {
-		return false
+	prepareOrCommitSize := s.getPrepareOrCommitSize()
+	if prepareOrCommitSize >= quorumSize {
+		messages := make([]istanbul.Message, prepareOrCommitSize)
+		i := 0
+		for _, message := range s.Prepares.Values() {
+			messages[i] = *message
+			i++
+		}
+		for _, message := range s.Commits.Values() {
+			if s.Prepares.Get(message.Address) == nil {
+				messages[i] = *message
+				i++
+			}
+		}
+		s.preparedCertificate = istanbul.PreparedCertificate{
+			Proposal:                s.Preprepare.Proposal,
+			PrepareOrCommitMessages: messages,
+		}
+		return nil
+	} else {
+		return errFailedCreatePreparedCertificate
 	}
-	return !s.hasBadProposal(s.GetLockedHash())
 }
 
-func (s *roundState) GetLockedHash() common.Hash {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (s *roundState) getPrepareOrCommitSize() int {
+	result := s.Prepares.Size() + s.Commits.Size()
 
-	return s.lockedHash
+	// find duplicate one
+	for _, m := range s.Prepares.Values() {
+		if s.Commits.Get(m.Address) != nil {
+			result--
+		}
+	}
+	return result
 }
 
 // The DecodeRLP method should read one value from the given
@@ -178,7 +198,6 @@ func (s *roundState) DecodeRLP(stream *rlp.Stream) error {
 		Preprepare     *istanbul.Preprepare
 		Prepares       *messageSet
 		Commits        *messageSet
-		lockedHash     common.Hash
 		pendingRequest *istanbul.Request
 	}
 
@@ -190,7 +209,6 @@ func (s *roundState) DecodeRLP(stream *rlp.Stream) error {
 	s.Preprepare = ss.Preprepare
 	s.Prepares = ss.Prepares
 	s.Commits = ss.Commits
-	s.lockedHash = ss.lockedHash
 	s.pendingRequest = ss.pendingRequest
 	s.mu = new(sync.RWMutex)
 
@@ -215,7 +233,6 @@ func (s *roundState) EncodeRLP(w io.Writer) error {
 		s.Preprepare,
 		s.Prepares,
 		s.Commits,
-		s.lockedHash,
 		s.pendingRequest,
 	})
 }

--- a/consensus/istanbul/core/roundstate_test.go
+++ b/consensus/istanbul/core/roundstate_test.go
@@ -17,9 +17,7 @@
 package core
 
 import (
-	"math/big"
 	"sync"
-	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
@@ -36,41 +34,5 @@ func newTestRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet) 
 		hasBadProposal: func(hash common.Hash) bool {
 			return false
 		},
-	}
-}
-
-func TestLockHash(t *testing.T) {
-	sys := NewTestSystemWithBackend(1, 0)
-	rs := newTestRoundState(
-		&istanbul.View{
-			Round:    big.NewInt(0),
-			Sequence: big.NewInt(0),
-		},
-		sys.backends[0].peers,
-	)
-	if (rs.GetLockedHash() != common.Hash{}) {
-		t.Errorf("error mismatch: have %v, want empty", rs.GetLockedHash())
-	}
-	if rs.IsHashLocked() {
-		t.Error("IsHashLocked should return false")
-	}
-
-	// Lock
-	expected := rs.Proposal().Hash()
-	rs.LockHash()
-	if expected != rs.GetLockedHash() {
-		t.Errorf("error mismatch: have %v, want %v", rs.GetLockedHash(), expected)
-	}
-	if !rs.IsHashLocked() {
-		t.Error("IsHashLocked should return true")
-	}
-
-	// Unlock
-	rs.UnlockHash()
-	if (rs.GetLockedHash() != common.Hash{}) {
-		t.Errorf("error mismatch: have %v, want empty", rs.GetLockedHash())
-	}
-	if rs.IsHashLocked() {
-		t.Error("IsHashLocked should return false")
 	}
 }

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -18,7 +18,9 @@ package core
 
 import (
 	"crypto/ecdsa"
+	"math"
 	"math/big"
+	"testing"
 	"time"
 
 	"github.com/celo-org/bls-zexe/go"
@@ -46,7 +48,8 @@ type testSystemBackend struct {
 	committedMsgs []testCommittedMsgs
 	sentMsgs      [][]byte // store the message when Send is called by core
 
-	key     []byte
+	key     ecdsa.PrivateKey
+	blsKey  []byte
 	address common.Address
 	db      ethdb.Database
 }
@@ -97,12 +100,11 @@ func (self *testSystemBackend) Broadcast(valSet istanbul.ValidatorSet, message [
 	return nil
 }
 func (self *testSystemBackend) Gossip(valSet istanbul.ValidatorSet, message []byte, msgCode uint64, ignoreCache bool) error {
-	testLogger.Warn("not sign any data")
 	return nil
 }
 
 func (self *testSystemBackend) SignBlockHeader(data []byte) ([]byte, error) {
-	privateKey, _ := bls.DeserializePrivateKey(self.key)
+	privateKey, _ := bls.DeserializePrivateKey(self.blsKey)
 	defer privateKey.Destroy()
 
 	signature, _ := privateKey.SignMessage(data, []byte{}, false)
@@ -125,13 +127,13 @@ func (self *testSystemBackend) Commit(proposal istanbul.Proposal, bitmap *big.In
 	return nil
 }
 
-func (self *testSystemBackend) Verify(proposal istanbul.Proposal, src istanbul.Validator) (time.Duration, error) {
+func (self *testSystemBackend) Verify(proposal istanbul.Proposal) (time.Duration, error) {
 	return 0, nil
 }
 
 func (self *testSystemBackend) Sign(data []byte) ([]byte, error) {
-	testLogger.Warn("not sign any data")
-	return data, nil
+	hashData := crypto.Keccak256(data)
+	return crypto.Sign(hashData, &self.key)
 }
 
 func (self *testSystemBackend) CheckSignature([]byte, common.Address, []byte) error {
@@ -139,7 +141,7 @@ func (self *testSystemBackend) CheckSignature([]byte, common.Address, []byte) er
 }
 
 func (self *testSystemBackend) CheckValidatorSignature(data []byte, sig []byte) (common.Address, error) {
-	return common.Address{}, nil
+	return istanbul.CheckValidatorSignature(self.peers, data, sig)
 }
 
 func (self *testSystemBackend) Hash(b interface{}) common.Hash {
@@ -159,8 +161,10 @@ func (self *testSystemBackend) HasBadProposal(hash common.Hash) bool {
 func (self *testSystemBackend) LastProposal() (istanbul.Proposal, common.Address) {
 	l := len(self.committedMsgs)
 	if l > 0 {
+		testLogger.Info("have proposal for block", "num", l)
 		return self.committedMsgs[l-1].commitProposal, common.Address{}
 	}
+	testLogger.Info("do not have proposal for block", "num", 0)
 	return makeBlock(0), common.Address{}
 }
 
@@ -175,6 +179,82 @@ func (self *testSystemBackend) GetProposer(number uint64) common.Address {
 
 func (self *testSystemBackend) ParentValidators(proposal istanbul.Proposal) istanbul.ValidatorSet {
 	return self.peers
+}
+
+func (self *testSystemBackend) finalizeAndReturnMessage(msg *istanbul.Message) (istanbul.Message, error) {
+	message := new(istanbul.Message)
+	data, err := self.engine.(*core).finalizeMessage(msg)
+	if err != nil {
+		return *message, err
+	}
+	err = message.FromPayload(data, self.engine.(*core).validateFn)
+	return *message, err
+}
+
+func (self *testSystemBackend) getPrepareMessage(view istanbul.View, digest common.Hash) (istanbul.Message, error) {
+	prepare := &istanbul.Subject{
+		View:   &view,
+		Digest: digest,
+	}
+
+	payload, err := Encode(prepare)
+	if err != nil {
+		return istanbul.Message{}, err
+	}
+
+	msg := &istanbul.Message{
+		Code: istanbul.MsgPrepare,
+		Msg:  payload,
+	}
+
+	return self.finalizeAndReturnMessage(msg)
+}
+
+func (self *testSystemBackend) getCommitMessage(view istanbul.View, proposal istanbul.Proposal) (istanbul.Message, error) {
+	commit := &istanbul.Subject{
+		View:   &view,
+		Digest: proposal.Hash(),
+	}
+
+	payload, err := Encode(commit)
+	if err != nil {
+		return istanbul.Message{}, err
+	}
+
+	msg := &istanbul.Message{
+		Code: istanbul.MsgCommit,
+		Msg:  payload,
+	}
+
+	// We swap in the provided proposal so that the message is finalized for the provided proposal
+	// and not for the current preprepare.
+	cachePreprepare := self.engine.(*core).current.Preprepare
+	self.engine.(*core).current.Preprepare = &istanbul.Preprepare{
+		View:     &view,
+		Proposal: proposal,
+	}
+	message, err := self.finalizeAndReturnMessage(msg)
+	self.engine.(*core).current.Preprepare = cachePreprepare
+	return message, err
+}
+
+func (self *testSystemBackend) getRoundChangeMessage(view istanbul.View, preparedCert istanbul.PreparedCertificate) (istanbul.Message, error) {
+	rc := &istanbul.RoundChange{
+		View:                &view,
+		PreparedCertificate: preparedCert,
+	}
+
+	payload, err := Encode(rc)
+	if err != nil {
+		return istanbul.Message{}, err
+	}
+
+	msg := &istanbul.Message{
+		Code: istanbul.MsgRoundChange,
+		Msg:  payload,
+	}
+
+	return self.finalizeAndReturnMessage(msg)
 }
 
 func (self *testSystemBackend) AddValidatorPeer(enodeURL string) {}
@@ -197,26 +277,31 @@ func (self *testSystemBackend) RefreshValPeers(valSet istanbul.ValidatorSet) {}
 
 type testSystem struct {
 	backends       []*testSystemBackend
+	f              uint64
+	n              uint64
 	validatorsKeys [][]byte
 
 	queuedMessage chan istanbul.MessageEvent
 	quit          chan struct{}
 }
 
-func newTestSystem(n uint64, keys [][]byte) *testSystem {
+func newTestSystem(n uint64, f uint64, keys [][]byte) *testSystem {
 	testLogger.SetHandler(elog.StdoutHandler)
 	return &testSystem{
 		backends:       make([]*testSystemBackend, n),
 		validatorsKeys: keys,
+		f:              f,
+		n:              n,
 
 		queuedMessage: make(chan istanbul.MessageEvent),
 		quit:          make(chan struct{}),
 	}
 }
 
-func generateValidators(n int) ([]istanbul.ValidatorData, [][]byte) {
+func generateValidators(n int) ([]istanbul.ValidatorData, [][]byte, []*ecdsa.PrivateKey) {
 	vals := make([]istanbul.ValidatorData, 0)
-	keys := make([][]byte, 0)
+	blsKeys := make([][]byte, 0)
+	keys := make([]*ecdsa.PrivateKey, 0)
 	for i := 0; i < n; i++ {
 		privateKey, _ := crypto.GenerateKey()
 		blsPrivateKey, _ := blscrypto.ECDSAToBLS(privateKey)
@@ -225,22 +310,34 @@ func generateValidators(n int) ([]istanbul.ValidatorData, [][]byte) {
 			crypto.PubkeyToAddress(privateKey.PublicKey),
 			blsPublicKey,
 		})
-		keys = append(keys, blsPrivateKey)
+		keys = append(keys, privateKey)
+		blsKeys = append(blsKeys, blsPrivateKey)
 	}
-	return vals, keys
+	return vals, blsKeys, keys
 }
 
 func newTestValidatorSet(n int) istanbul.ValidatorSet {
-	validators, _ := generateValidators(n)
+	validators, _, _ := generateValidators(n)
 	return validator.NewSet(validators, istanbul.RoundRobin)
 }
 
-// FIXME: int64 is needed for N and F
 func NewTestSystemWithBackend(n, f uint64) *testSystem {
+	return NewTestSystemWithBackendAndCurrentRoundState(n, f, func(vset istanbul.ValidatorSet) *roundState {
+		return newRoundState(&istanbul.View{
+			Round:    big.NewInt(0),
+			Sequence: big.NewInt(1),
+		}, vset, nil, nil, istanbul.EmptyPreparedCertificate(), func(hash common.Hash) bool {
+			return false
+		})
+	})
+}
+
+// FIXME: int64 is needed for N and F
+func NewTestSystemWithBackendAndCurrentRoundState(n, f uint64, getRoundState func(vset istanbul.ValidatorSet) *roundState) *testSystem {
 	testLogger.SetHandler(elog.StdoutHandler)
 
-	validators, keys := generateValidators(int(n))
-	sys := newTestSystem(n, keys)
+	validators, blsKeys, keys := generateValidators(int(n))
+	sys := newTestSystem(n, f, blsKeys)
 	config := istanbul.DefaultConfig
 
 	for i := uint64(0); i < n; i++ {
@@ -248,16 +345,13 @@ func NewTestSystemWithBackend(n, f uint64) *testSystem {
 		backend := sys.NewBackend(i)
 		backend.peers = vset
 		backend.address = vset.GetByIndex(i).Address()
-		backend.key = keys[i]
+		backend.key = *keys[i]
+		backend.blsKey = blsKeys[i]
 
 		core := New(backend, config).(*core)
 		core.state = StateAcceptRequest
-		core.current = newRoundState(&istanbul.View{
-			Round:    big.NewInt(0),
-			Sequence: big.NewInt(1),
-		}, vset, common.Hash{}, nil, nil, func(hash common.Hash) bool {
-			return false
-		})
+		core.current = getRoundState(vset)
+		core.roundChangeSet = newRoundChangeSet(vset)
 		core.valSet = vset
 		core.logger = testLogger
 		core.validateFn = backend.CheckValidatorSignature
@@ -321,6 +415,53 @@ func (t *testSystem) NewBackend(id uint64) *testSystemBackend {
 
 	t.backends[id] = backend
 	return backend
+}
+
+func (t *testSystem) F() uint64 {
+	return t.f
+}
+
+func (t *testSystem) MinQuorumSize() uint64 {
+	return uint64(math.Ceil(float64(2*t.n) / 3))
+}
+
+func (sys *testSystem) getPreparedCertificate(t *testing.T, view istanbul.View, proposal istanbul.Proposal) istanbul.PreparedCertificate {
+	preparedCertificate := istanbul.PreparedCertificate{
+		Proposal:                proposal,
+		PrepareOrCommitMessages: []istanbul.Message{},
+	}
+	for i, backend := range sys.backends {
+		if uint64(i) == sys.MinQuorumSize() {
+			break
+		}
+		var err error
+		var msg istanbul.Message
+		if i%2 == 0 {
+			msg, err = backend.getPrepareMessage(view, proposal.Hash())
+		} else {
+			msg, err = backend.getCommitMessage(view, proposal)
+		}
+		if err != nil {
+			t.Errorf("Failed to create message %v: %v", i, err)
+		}
+		preparedCertificate.PrepareOrCommitMessages = append(preparedCertificate.PrepareOrCommitMessages, msg)
+	}
+	return preparedCertificate
+}
+
+func (sys *testSystem) getRoundChangeCertificate(t *testing.T, view istanbul.View, preparedCertificate istanbul.PreparedCertificate) istanbul.RoundChangeCertificate {
+	var roundChangeCertificate istanbul.RoundChangeCertificate
+	for i, backend := range sys.backends {
+		if uint64(i) == sys.MinQuorumSize() {
+			break
+		}
+		msg, err := backend.getRoundChangeMessage(view, preparedCertificate)
+		if err != nil {
+			t.Errorf("Failed to create ROUND CHANGE message: %v", err)
+		}
+		roundChangeCertificate.RoundChangeMessages = append(roundChangeCertificate.RoundChangeMessages, msg)
+	}
+	return roundChangeCertificate
 }
 
 // ==============================================

--- a/consensus/istanbul/core/types.go
+++ b/consensus/istanbul/core/types.go
@@ -36,6 +36,7 @@ const (
 	StatePreprepared
 	StatePrepared
 	StateCommitted
+	StateWaitingForNewRound
 )
 
 func (s State) String() string {
@@ -47,6 +48,8 @@ func (s State) String() string {
 		return "Prepared"
 	} else if s == StateCommitted {
 		return "Committed"
+	} else if s == StateWaitingForNewRound {
+		return "Waiting for new round"
 	} else {
 		return "Unknown"
 	}

--- a/consensus/istanbul/errors.go
+++ b/consensus/istanbul/errors.go
@@ -22,6 +22,8 @@ var (
 	// ErrUnauthorizedAddress is returned when given address cannot be found in
 	// current validator set.
 	ErrUnauthorizedAddress = errors.New("unauthorized address")
+	// ErrInvalidSigner is returned if a message's signature does not correspond to the address in msg.Address
+	ErrInvalidSigner = errors.New("signed by incorrect validator")
 	// ErrStoppedEngine is returned if the engine is stopped
 	ErrStoppedEngine = errors.New("stopped engine")
 	// ErrStartedEngine is returned if the engine is already started

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -385,6 +385,17 @@ func (b *Block) WithSeal(header *Header) *Block {
 	}
 }
 
+// WithRandomness returns a new block with the given randomness.
+func (b *Block) WithRandomness(randomness *Randomness) *Block {
+	block := &Block{
+		header:       b.header,
+		transactions: b.transactions,
+		uncles:       b.uncles,
+		randomness:   randomness,
+	}
+	return block
+}
+
 // WithBody returns a new block with the given transaction and uncle contents.
 func (b *Block) WithBody(transactions []*Transaction, uncles []*Header, randomness *Randomness) *Block {
 	block := &Block{

--- a/node/config.go
+++ b/node/config.go
@@ -186,7 +186,7 @@ func (c *Config) IPCEndpoint() string {
 
 // NodeDB returns the path to the discovery node database.
 func (c *Config) NodeDB() string {
-	if c.DataDir == "" {
+	if c.DataDir == "" || c.P2P.UseInMemoryNodeDatabase {
 		return "" // ephemeral
 	}
 	return c.ResolvePath(datadirNodeDatabase)

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -122,6 +122,9 @@ type Config struct {
 	// live nodes in the network.
 	NodeDatabase string `toml:",omitempty"`
 
+	// UseInMemoryNodeDatabase specifies whether the node database should be in-memory or on-disk
+	UseInMemoryNodeDatabase bool
+
 	// Protocols should contain the protocols supported
 	// by the server. Matching protocols are launched for
 	// each peer.


### PR DESCRIPTION
### Description

Added an option for geth to use the in-memory discovery table (the same one that the bootnode uses).

When this option is used, then it wouldn't read or write to disk the discovery table.  This option can be used when we don't want to persist the discovery table for internal testnets when doing a `deploy upgrade`.

### Tested

* Ran a geth instance with and without the new option enabled, and verified that the persisted discovery table was not saved and saved to disk respectively.

### Other changes

Fixed the grouping of the command line arguments when outputted via geth --help.

### Related issues

- Fixes https://github.com/celo-org/celo-blockchain/issues/478
- Fixes https://github.com/celo-org/celo-blockchain/issues/437

### Backwards compatibility

is backward compatible
