### PR TITLE
Log validator result elections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,18 +70,13 @@ jobs:
             set -euo pipefail
             export CELO_MONOREPO_DIR="$PWD"
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b master
-            cd ${CELO_MONOREPO_DIR}/packages
-            # TODO(ashishb): Delete unnecessary packages to speed up build time.
-            # It would be better whitelist certain packages and delete the rest.
-            # Deletion does not work right now and yarn fails with weird errors.
-            # This will be enabled and resolved later.
-            # rm -rf analytics blockchain-api cli docs faucet helm-charts mobile notification-service react-components transaction-metrics-exporter verification-pool-api verifier web
-            cd ${CELO_MONOREPO_DIR}/packages/celotool
-            yarn || yarn
-            yarn --cwd=${CELO_MONOREPO_DIR}/packages/utils build
-            yarn --cwd=${CELO_MONOREPO_DIR}/packages/walletkit build
-            yarn --cwd=${CELO_MONOREPO_DIR}/packages/celotool build
-
+            yarn install || yarn install
+            # separate build to avoid ENOMEM in CI :(
+            yarn build --scope @celo/utils
+            yarn build --scope @celo/protocol
+            yarn build --scope docs
+            yarn build --scope @celo/walletkit
+            yarn build --ignore @celo/protocol --ignore docs --ignore @celo/walletkit --ignore @celo/web --ignore @celo/mobile --ignore @celo/react-components
       - run:
           name: Setup Go language
           command: |

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -1,8 +1,8 @@
 FROM ubuntu:16.04 as rustbuilder
 RUN apt update && apt install -y curl musl-tools
-ADD . /go-ethereum
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN $HOME/.cargo/bin/rustup install 1.36.0 && $HOME/.cargo/bin/rustup default 1.36.0 && $HOME/.cargo/bin/rustup target add x86_64-unknown-linux-musl
+ADD ./vendor /go-ethereum/vendor
 RUN cd /go-ethereum/vendor/github.com/celo-org/bls-zexe/bls && $HOME/.cargo/bin/cargo build --target x86_64-unknown-linux-musl --release
 
 # Build Geth in a stock Go builder container

--- a/cmd/bootnode/main.go
+++ b/cmd/bootnode/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/discover"
 	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -43,6 +44,7 @@ func main() {
 		nodeKeyHex       = flag.String("nodekeyhex", "", "private key as hex (for testing)")
 		natdesc          = flag.String("nat", "none", "port mapping mechanism (any|none|upnp|pmp|extip:<IP>)")
 		netrestrict      = flag.String("netrestrict", "", "restrict network communication to the given IP networks (CIDR masks)")
+		runv4            = flag.Bool("v4", true, "run a v4 topic discovery bootnode")
 		runv5            = flag.Bool("v5", false, "run a v5 topic discovery bootnode")
 		verbosity        = flag.Int("verbosity", int(log.LvlInfo), "log verbosity (0-9)")
 		vmodule          = flag.String("vmodule", "", "log verbosity pattern")
@@ -64,6 +66,8 @@ func main() {
 		utils.Fatalf("-nat: %v", err)
 	}
 	switch {
+	case !*runv4 && !*runv5:
+		utils.Fatalf("Must specify at least one discovery protocol (v4 or v5)")
 	case *genKey != "":
 		nodeKey, err = crypto.GenerateKey()
 		if err != nil {
@@ -124,19 +128,38 @@ func main() {
 		}
 	}
 
-	if *runv5 {
-		if _, err := discv5.ListenUDP(nodeKey, conn, "", restrictList); err != nil {
-			utils.Fatalf("%v", err)
+	// If v4 and v5 are both enabled, a packet is first tried as v4
+	// and then v5 if v4 decoding fails, following the same pattern as full
+	// nodes that use v4 and v5:
+	// https://github.com/celo-org/celo-blockchain/blob/7fbd6f3574f1c1c1e657c152fc63fb771adab3af/p2p/server.go#L588
+	var unhandled chan discover.ReadPacket
+	var sconn *p2p.SharedUDPConn
+	if *runv4 {
+		if *runv5 {
+			unhandled = make(chan discover.ReadPacket, 100)
+			sconn = &p2p.SharedUDPConn{conn, unhandled}
 		}
-	} else {
 		db, _ := enode.OpenDB("")
 		ln := enode.NewLocalNode(db, nodeKey, *networkId)
 		cfg := discover.Config{
 			PrivateKey:       nodeKey,
 			NetRestrict:      restrictList,
 			PingIPFromPacket: *pingIPFromPacket,
+			Unhandled:        unhandled,
 		}
 		if _, err := discover.ListenUDP(conn, ln, cfg); err != nil {
+			utils.Fatalf("%v", err)
+		}
+	}
+
+	if *runv5 {
+		var err error
+		if sconn != nil {
+			_, err = discv5.ListenUDP(nodeKey, sconn, "", restrictList)
+		} else {
+			_, err = discv5.ListenUDP(nodeKey, conn, "", restrictList)
+		}
+		if err != nil {
 			utils.Fatalf("%v", err)
 		}
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -139,6 +139,7 @@ var (
 		utils.IstanbulRequestTimeoutFlag,
 		utils.IstanbulBlockPeriodFlag,
 		utils.PingIPFromPacketFlag,
+		utils.UseInMemoryDiscoverTable,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -183,6 +183,8 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.NetrestrictFlag,
 			utils.NodeKeyFileFlag,
 			utils.NodeKeyHexFlag,
+			utils.PingIPFromPacketFlag,
+			utils.UseInMemoryDiscoverTable,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -563,6 +563,10 @@ var (
 		Name:  "ping-ip-from-packet",
 		Usage: "Has the discovery protocol use the IP address given by a ping packet",
 	}
+	UseInMemoryDiscoverTable = cli.BoolFlag{
+		Name:  "use-in-memory-discovery-table",
+		Usage: "Specifies whether to use an in memory discovery table",
+	}
 
 	// ATM the url is left to the user and deployment to
 	JSpathFlag = cli.StringFlag{
@@ -994,6 +998,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	}
 	if ctx.GlobalIsSet(PingIPFromPacketFlag.Name) {
 		cfg.PingIPFromPacket = true
+	}
+	if ctx.GlobalIsSet(UseInMemoryDiscoverTable.Name) {
+		cfg.UseInMemoryNodeDatabase = true
 	}
 
 	// if we're running a light client or server, force enable the v5 peer discovery

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -314,7 +314,7 @@ func (sb *Backend) handleIstAnnounce(payload []byte) error {
 
 		newValEnode := &validatorEnode{enodeURL: enodeUrl, view: msg.View}
 		if err := sb.valEnodeTable.upsert(msg.Address, newValEnode, valSet, sb.Address()); err != nil {
-			sb.logger.Error("Error in upserting a valenode entry", "AnnounceMsg", msg, "error", err)
+			sb.logger.Warn("Error in upserting a valenode entry", "AnnounceMsg", msg, "error", err)
 			return err
 		}
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -456,14 +456,15 @@ func (sb *Backend) IsLastBlockOfEpoch(header *types.Header) bool {
 func (sb *Backend) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, randomness *types.Randomness) (*types.Block, error) {
 	// Trigger an update to the gas price minimum in the GasPriceMinimum contract based on block congestion
 	updatedGasPriceMinimum, err := gpm.UpdateGasPriceMinimum(header, state)
-
-	if err != nil {
+	if err == contract_errors.ErrRegistryContractNotDeployed {
+		log.Debug("Error in updating gas price minimum", "error", err, "updatedGasPriceMinimum", updatedGasPriceMinimum)
+	} else if err != nil {
 		log.Error("Error in updating gas price minimum", "error", err, "updatedGasPriceMinimum", updatedGasPriceMinimum)
 	}
 
 	goldTokenAddress, err := contract_comm.GetRegisteredAddress(params.GoldTokenRegistryId, header, state)
-	if err == contract_errors.ErrSmartContractNotDeployed {
-		log.Warn("Registry address lookup failed", "err", err)
+	if err == contract_errors.ErrSmartContractNotDeployed || err == contract_errors.ErrRegistryContractNotDeployed {
+		log.Debug("Registry address lookup failed", "err", err)
 	} else if err != nil {
 		log.Error(err.Error())
 	}
@@ -474,7 +475,7 @@ func (sb *Backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 		infrastructureBlockReward := big.NewInt(params.Ether)
 		governanceAddress, err := contract_comm.GetRegisteredAddress(params.GovernanceRegistryId, header, state)
 		if err == contract_errors.ErrSmartContractNotDeployed {
-			log.Warn("Registry address lookup failed", "err", err)
+			log.Debug("Registry address lookup failed", "err", err)
 		} else if err != nil {
 			log.Error(err.Error())
 		}
@@ -487,7 +488,7 @@ func (sb *Backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 		stakerBlockReward := big.NewInt(params.Ether)
 		lockedGoldAddress, err := contract_comm.GetRegisteredAddress(params.LockedGoldRegistryId, header, state)
 		if err == contract_errors.ErrSmartContractNotDeployed {
-			log.Warn("Registry address lookup failed", "err", err, "contract id", params.LockedGoldRegistryId)
+			log.Debug("Registry address lookup failed", "err", err, "contract id", params.LockedGoldRegistryId)
 		} else if err != nil {
 			log.Error(err.Error())
 		}

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -111,7 +111,13 @@ func (sb *Backend) NewChainHead() error {
 	currentBlock := sb.currentBlock()
 	if istanbul.IsLastBlockOfEpoch(currentBlock.Number().Uint64(), sb.config.Epoch) {
 		sb.logger.Trace("At end of epoch and going to refresh validator peers", "current block number", currentBlock.Number().Uint64())
-		go sb.RefreshValPeers(sb.getValidators(currentBlock.Number().Uint64(), currentBlock.Hash()))
+		valset := sb.getValidators(currentBlock.Number().Uint64(), currentBlock.Hash())
+		if _, val := valset.GetByAddress(sb.Address()); val == nil {
+			sb.logger.Info("Validators Election Results: Node OUT ValidatorSet")
+		} else {
+			sb.logger.Info("Validators Election Results: Node IN ValidatorSet")
+		}
+		go sb.RefreshValPeers(valset)
 	}
 
 	go sb.istanbulEventMux.Post(istanbul.FinalCommittedEvent{})

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -31,7 +31,7 @@ type Config struct {
 }
 
 var DefaultConfig = &Config{
-	RequestTimeout: 10000,
+	RequestTimeout: 3000,
 	BlockPeriod:    1,
 	ProposerPolicy: RoundRobin,
 	Epoch:          30000,

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -108,7 +108,7 @@ func (c *core) handleEvents() {
 			case backlogEvent:
 				// No need to check signature for internal messages
 				if err := c.handleCheckedMsg(ev.msg, ev.src); err != nil {
-					c.logger.Error("Error in handling istanbul message that was sent from a backlog event", "err", err)
+					c.logger.Warn("Error in handling istanbul message that was sent from a backlog event", "err", err)
 				}
 			}
 		case event, ok := <-c.timeoutSub.Chan():

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -100,7 +100,6 @@ func (self *testSystemBackend) Broadcast(valSet istanbul.ValidatorSet, message [
 	return nil
 }
 func (self *testSystemBackend) Gossip(valSet istanbul.ValidatorSet, message []byte, msgCode uint64, ignoreCache bool) error {
-	testLogger.Warn("not sign any data")
 	return nil
 }
 

--- a/consensus/istanbul/errors.go
+++ b/consensus/istanbul/errors.go
@@ -22,6 +22,8 @@ var (
 	// ErrUnauthorizedAddress is returned when given address cannot be found in
 	// current validator set.
 	ErrUnauthorizedAddress = errors.New("unauthorized address")
+	// ErrInvalidSigner is returned if a message's signature does not correspond to the address in msg.Address
+	ErrInvalidSigner = errors.New("signed by incorrect validator")
 	// ErrStoppedEngine is returned if the engine is stopped
 	ErrStoppedEngine = errors.New("stopped engine")
 	// ErrStartedEngine is returned if the engine is already started

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -324,10 +324,15 @@ func (m *Message) FromPayload(b []byte, validateFn func([]byte, []byte) (common.
 			return err
 		}
 
-		_, err = validateFn(payload, m.Signature)
+		signed_val_addr, err := validateFn(payload, m.Signature)
+		if err != nil {
+			return err
+		}
+		if signed_val_addr != m.Address {
+			return ErrInvalidSigner
+		}
 	}
-	// Still return the message even the err is not nil
-	return err
+	return nil
 }
 
 func (m *Message) Payload() ([]byte, error) {

--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -224,7 +224,7 @@ func makeCallWithContractId(registryId [32]byte, abi abi.ABI, funcName string, a
 			log.Warn("Contract not yet deployed", "contractId", registryId)
 			return 0, err
 		} else if err == errors.ErrRegistryContractNotDeployed {
-			log.Warn("Contract Address Registry not yet deployed")
+			log.Debug("Contract Address Registry not yet deployed")
 			return 0, err
 		} else {
 			log.Error("Error in contract communication", "contract id", registryId, "error", err)

--- a/contract_comm/random/random.go
+++ b/contract_comm/random/random.go
@@ -101,8 +101,8 @@ func commitmentDbLocation(commitment common.Hash) []byte {
 
 func address() *common.Address {
 	randomAddress, err := contract_comm.GetRegisteredAddress(params.RandomRegistryId, nil, nil)
-	if err == errors.ErrSmartContractNotDeployed {
-		log.Warn("Registry address lookup failed", "err", err, "contract id", params.RandomRegistryId)
+	if err == errors.ErrSmartContractNotDeployed || err == errors.ErrRegistryContractNotDeployed {
+		log.Debug("Registry address lookup failed", "err", err, "contract id", params.RandomRegistryId)
 	} else if err != nil {
 		log.Error(err.Error())
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -381,7 +381,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		recipientTxFee = new(big.Int).Sub(totalTxFee, infraTxFee)
 		err = st.creditGas(*st.infrastructureAccountAddress, infraTxFee, msg.GasCurrency())
 	} else {
-		log.Error("no infrastructure account address found - sending entire txFee to fee recipient")
+		log.Debug("no infrastructure account address found - sending entire txFee to fee recipient")
 		recipientTxFee = totalTxFee
 	}
 

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -578,7 +578,7 @@ func (l *txPricedList) getHeapWithMinHead() (*priceHeap, *types.Transaction) {
 				cheapestTxn = []*types.Transaction(*cheapestHeap)[0]
 			} else {
 				txn := []*types.Transaction(*priceHeap)[0]
-				if currency.Cmp(cheapestTxn.GasPrice(), cheapestTxn.GasCurrency(), txn.GasPrice(), txn.GasCurrency()) < 0 {
+				if currency.Cmp(txn.GasPrice(), txn.GasCurrency(), cheapestTxn.GasPrice(), cheapestTxn.GasCurrency()) < 0 {
 					cheapestHeap = priceHeap
 				}
 			}

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -475,6 +475,15 @@ func (c *transfer) Run(input []byte, caller common.Address, evm *EVM, gas uint64
 		return nil, gas, err
 	}
 
+	// input is comprised of 3 arguments:
+	//   from:  32 bytes representing the address of the sender
+	//   to:    32 bytes representing the address of the recipient
+	//   value: 32 bytes, a 256 bit integer representing the amount of Celo Gold to transfer
+	// 3 arguments x 32 bytes each = 96 bytes total input
+	if len(input) < 96 {
+		return nil, gas, ErrInputLength
+	}
+
 	if caller != *celoGoldAddress {
 		return nil, gas, fmt.Errorf("Unable to call transfer from unpermissioned address")
 	}
@@ -506,6 +515,19 @@ func (c *fractionMulExp) Run(input []byte, caller common.Address, evm *EVM, gas 
 	gas, err := debitRequiredGas(c, input, gas)
 	if err != nil {
 		return nil, gas, err
+	}
+
+	// input is comprised of 6 arguments:
+	//   aNumerator:   32 bytes, 256 bit integer, numerator for the first fraction (a)
+	//   aDenominator: 32 bytes, 256 bit integer, denominator for the first fraction (a)
+	//   bNumerator:   32 bytes, 256 bit integer, numerator for the second fraction (b)
+	//   bDenominator: 32 bytes, 256 bit integer, denominator for the second fraction (b)
+	//   exponent:     32 bytes, 256 bit integer, exponent to raise the second fraction (b) to
+	//   decimals:     32 bytes, 256 bit integer, places of precision
+	//
+	// 6 args x 32 bytes each = 192 bytes total input length
+	if len(input) < 192 {
+		return nil, gas, ErrInputLength
 	}
 
 	parseErrorStr := "Error parsing input: unable to parse %s value from %s"
@@ -571,6 +593,14 @@ func (c *proofOfPossession) Run(input []byte, caller common.Address, evm *EVM, g
 		return nil, gas, err
 	}
 
+	// input is comprised of 2 arguments:
+	//   publicKey: 48 bytes, representing the public key (defined as a const in bls package)
+	//   signature: 96 bytes, representing the signature (defined as a const in bls package)
+	// the total length of input required is the sum of these constants
+	if len(input) < blscrypto.PUBLICKEYBYTES+blscrypto.SIGNATUREBYTES {
+		return nil, gas, ErrInputLength
+	}
+
 	publicKeyBytes := input[:blscrypto.PUBLICKEYBYTES]
 	publicKey, err := bls.DeserializePublicKey(publicKeyBytes)
 	if err != nil {
@@ -600,13 +630,20 @@ func (c *getValidator) RequiredGas(input []byte) uint64 {
 }
 
 func (c *getValidator) Run(input []byte, caller common.Address, evm *EVM, gas uint64) ([]byte, uint64, error) {
-	index := (&big.Int{}).SetBytes(input[0:32])
 	blockNumber := evm.Context.BlockNumber
 	validators := evm.Context.Engine.GetValidators(blockNumber, evm.Context.GetHash(blockNumber.Uint64()))
 	gas, err := debitRequiredGas(c, input, gas)
 	if err != nil {
 		return nil, gas, err
 	}
+
+	// input is comprised of a single argument:
+	//   index: 32 byte integer representing the index of the validator to get
+	if len(input) < 32 {
+		return nil, gas, ErrInputLength
+	}
+
+	index := (&big.Int{}).SetBytes(input[0:32])
 
 	if index.Cmp(big.NewInt(int64(len(validators)))) >= 0 {
 		return nil, gas, ErrValidatorsOutOfBounds

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -30,6 +30,7 @@ type precompiledTest struct {
 	gas             uint64
 	name            string
 	noBenchmark     bool // Benchmark primarily the worst-cases
+	errorExpected   bool
 }
 
 // modexpTests are the test and benchmark data for the modexp precompiled contract.
@@ -336,16 +337,53 @@ var bn256PairingTests = []precompiledTest{
 	},
 }
 
+var fractionMulExpTests = []precompiledTest{
+	{
+		input:    "0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000150000000000000000000000000000000000000000000000000000000000000f1000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000004",
+		expected: "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002710",
+		name:     "correct_input_length",
+	},
+	{ // extra input gets ignored and does not make an error occur
+		input:    "0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000150000000000000000000000000000000000000000000000000000000000000f100000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000400000000",
+		expected: "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002710",
+		name:     "input_too_long",
+	},
+	{
+		input:         "",
+		expected:      "invalid input length",
+		name:          "empty_input",
+		errorExpected: true,
+	},
+}
+
+var proofOfPossessionTests = []precompiledTest{
+	{
+		input:         "",
+		expected:      "invalid input length",
+		errorExpected: true,
+		name:          "empty_input",
+	},
+}
+
 func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
 	p := PrecompiledContractsByzantium[common.HexToAddress(addr)]
 	in := common.Hex2Bytes(test.input)
 	contract := NewContract(AccountRef(common.HexToAddress("1337")),
 		nil, new(big.Int), p.RequiredGas(in))
 	t.Run(fmt.Sprintf("%s-Gas=%d", test.name, contract.Gas), func(t *testing.T) {
-		if res, err := RunPrecompiledContract(p, in, contract, nil); err != nil {
-			t.Error(err)
-		} else if common.Bytes2Hex(res) != test.expected {
-			t.Errorf("Expected %v, got %v", test.expected, common.Bytes2Hex(res))
+		res, err := RunPrecompiledContract(p, in, contract, nil)
+		if test.errorExpected {
+			if err == nil {
+				t.Errorf("Expected error: %v, but no error occurred", test.expected)
+			} else if err.Error() != test.expected {
+				t.Errorf("Expected error: \"%v\", but got \"%v\"", test.expected, err.Error())
+			}
+		} else {
+			if err != nil {
+				t.Error(err)
+			} else if common.Bytes2Hex(res) != test.expected {
+				t.Errorf("Expected %v, got %v", test.expected, common.Bytes2Hex(res))
+			}
 		}
 	})
 }
@@ -475,9 +513,25 @@ func TestPrecompiledBn256Pairing(t *testing.T) {
 	}
 }
 
-// Behcnmarks the sample inputs from the elliptic curve pairing check EIP 197.
+// Benchmarks the sample inputs from the elliptic curve pairing check EIP 197.
 func BenchmarkPrecompiledBn256Pairing(bench *testing.B) {
 	for _, test := range bn256PairingTests {
 		benchmarkPrecompiled("08", test, bench)
+	}
+}
+
+// Tests sample inputs for fractionMulExp
+// NOTE: This currently only verifies that inputs of invalid length are rejected
+func TestPrecompiledFractionMulExp(t *testing.T) {
+	for _, test := range fractionMulExpTests {
+		testPrecompiled("fc", test, t)
+	}
+}
+
+// Tests sample inputs for proofOfPossession
+// NOTE: This currently only verifies that inputs of invalid length are rejected
+func TestPrecompiledProofOfPossession(t *testing.T) {
+	for _, test := range proofOfPossessionTests {
+		testPrecompiled("fb", test, t)
 	}
 }

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -28,4 +28,5 @@ var (
 	ErrContractAddressCollision = errors.New("contract address collision")
 	ErrNoCompatibleInterpreter  = errors.New("no compatible interpreter")
 	ErrValidatorsOutOfBounds    = errors.New("getValidators out of bounds")
+	ErrInputLength              = errors.New("invalid input length")
 )

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
+	abipkg "github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -546,7 +546,7 @@ func (evm *EVM) TobinTransfer(db StateDB, sender, recipient common.Address, gas 
 	return gas, nil
 }
 
-func (evm *EVM) StaticCallFromSystem(contractAddress common.Address, abi abi.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64) (uint64, error) {
+func (evm *EVM) StaticCallFromSystem(contractAddress common.Address, abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64) (uint64, error) {
 	staticCall := func(transactionData []byte) ([]byte, uint64, error) {
 		return evm.StaticCall(systemCaller, contractAddress, transactionData, gas)
 	}
@@ -554,14 +554,14 @@ func (evm *EVM) StaticCallFromSystem(contractAddress common.Address, abi abi.ABI
 	return evm.handleABICall(abi, funcName, args, returnObj, staticCall)
 }
 
-func (evm *EVM) CallFromSystem(contractAddress common.Address, abi abi.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int) (uint64, error) {
+func (evm *EVM) CallFromSystem(contractAddress common.Address, abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int) (uint64, error) {
 	call := func(transactionData []byte) ([]byte, uint64, error) {
 		return evm.Call(systemCaller, contractAddress, transactionData, gas, value)
 	}
 	return evm.handleABICall(abi, funcName, args, returnObj, call)
 }
 
-func (evm *EVM) handleABICall(abi abi.ABI, funcName string, args []interface{}, returnObj interface{}, call func([]byte) ([]byte, uint64, error)) (uint64, error) {
+func (evm *EVM) handleABICall(abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, call func([]byte) ([]byte, uint64, error)) (uint64, error) {
 	transactionData, err := abi.Pack(funcName, args...)
 	if err != nil {
 		log.Error("Error in generating the ABI encoding for the function call", "err", err, "funcName", funcName, "args", args)
@@ -579,7 +579,13 @@ func (evm *EVM) handleABICall(abi abi.ABI, funcName string, args []interface{}, 
 
 	if returnObj != nil {
 		if err := abi.Unpack(returnObj, funcName, ret); err != nil {
-			log.Error("Error in unpacking EVM call return bytes", "err", err)
+			// `ErrEmptyOutput` is expected when when syncing & importing blocks
+			// before a contract has been deployed
+			if err == abipkg.ErrEmptyOutput {
+				log.Debug("Error in unpacking EVM call return bytes", "err", err)
+			} else {
+				log.Error("Error in unpacking EVM call return bytes", "err", err)
+			}
 			return leftoverGas, err
 		}
 	}

--- a/node/config.go
+++ b/node/config.go
@@ -186,7 +186,7 @@ func (c *Config) IPCEndpoint() string {
 
 // NodeDB returns the path to the discovery node database.
 func (c *Config) NodeDB() string {
-	if c.DataDir == "" {
+	if c.DataDir == "" || c.P2P.UseInMemoryNodeDatabase {
 		return "" // ephemeral
 	}
 	return c.ResolvePath(datadirNodeDatabase)

--- a/p2p/discv5/udp.go
+++ b/p2p/discv5/udp.go
@@ -34,6 +34,8 @@ import (
 
 const Version = 4
 
+var celoClientSalt = []byte{0x63, 0x65, 0x6C, 0x6F}
+
 // Errors
 var (
 	errPacketTooSmall = errors.New("too small")
@@ -356,7 +358,7 @@ func encodePacket(priv *ecdsa.PrivateKey, ptype byte, req interface{}) (p, hash 
 		return nil, nil, err
 	}
 	packet := b.Bytes()
-	sig, err := crypto.Sign(crypto.Keccak256(packet[headSize:]), priv)
+	sig, err := crypto.Sign(crypto.Keccak256(packet[headSize:], celoClientSalt), priv)
 	if err != nil {
 		log.Error(fmt.Sprint("could not sign packet:", err))
 		return nil, nil, err
@@ -412,7 +414,7 @@ func decodePacket(buffer []byte, pkt *ingressPacket) error {
 	if !bytes.Equal(prefix, versionPrefix) {
 		return errBadPrefix
 	}
-	fromID, err := recoverNodeID(crypto.Keccak256(buf[headSize:]), sig)
+	fromID, err := recoverNodeID(crypto.Keccak256(buf[headSize:], celoClientSalt), sig)
 	if err != nil {
 		return err
 	}

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -122,6 +122,9 @@ type Config struct {
 	// live nodes in the network.
 	NodeDatabase string `toml:",omitempty"`
 
+	// UseInMemoryNodeDatabase specifies whether the node database should be in-memory or on-disk
+	UseInMemoryNodeDatabase bool
+
 	// Protocols should contain the protocols supported
 	// by the server. Matching protocols are launched for
 	// each peer.
@@ -425,16 +428,16 @@ func (srv *Server) Stop() {
 	srv.loopWG.Wait()
 }
 
-// sharedUDPConn implements a shared connection. Write sends messages to the underlying connection while read returns
+// SharedUDPConn implements a shared connection. Write sends messages to the underlying connection while read returns
 // messages that were found unprocessable and sent to the unhandled channel by the primary listener.
-type sharedUDPConn struct {
+type SharedUDPConn struct {
 	*net.UDPConn
-	unhandled chan discover.ReadPacket
+	Unhandled chan discover.ReadPacket
 }
 
 // ReadFromUDP implements discv5.conn
-func (s *sharedUDPConn) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error) {
-	packet, ok := <-s.unhandled
+func (s *SharedUDPConn) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err error) {
+	packet, ok := <-s.Unhandled
 	if !ok {
 		return 0, nil, errors.New("Connection was closed")
 	}
@@ -447,7 +450,7 @@ func (s *sharedUDPConn) ReadFromUDP(b []byte) (n int, addr *net.UDPAddr, err err
 }
 
 // Close implements discv5.conn
-func (s *sharedUDPConn) Close() error {
+func (s *SharedUDPConn) Close() error {
 	return nil
 }
 
@@ -586,11 +589,11 @@ func (srv *Server) setupDiscovery() error {
 
 	// Discovery V4
 	var unhandled chan discover.ReadPacket
-	var sconn *sharedUDPConn
+	var sconn *SharedUDPConn
 	if !srv.NoDiscovery {
 		if srv.DiscoveryV5 {
 			unhandled = make(chan discover.ReadPacket, 100)
-			sconn = &sharedUDPConn{conn, unhandled}
+			sconn = &SharedUDPConn{conn, unhandled}
 		}
 		cfg := discover.Config{
 			PingIPFromPacket: srv.PingIPFromPacket,

--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -18,63 +18,24 @@ package params
 
 // MainnetBootnodes are the enode URLs of the P2P bootstrap nodes running on
 // the main Ethereum network.
-var MainnetBootnodes = []string{
-	// Ethereum Foundation Go Bootnodes
-	"enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303", // IE
-	"enode://3f1d12044546b76342d59d4a05532c14b85aa669704bfe1f864fe079415aa2c02d743e03218e57a33fb94523adb54032871a6c51b2cc5514cb7c7e35b3ed0a99@13.93.211.84:30303",  // US-WEST
-	"enode://78de8a0916848093c73790ead81d1928bec737d565119932b98c6b100d944b7a95e94f847f689fc723399d2e31129d182f7ef3863f2b4c820abbf3ab2722344d@191.235.84.50:30303", // BR
-	"enode://158f8aab45f6d19c6cbf4a089c2670541a8da11978a2f90dbf6a502a4a3bab80d288afdbeb7ec0ef6d92de563767f3b1ea9e8e334ca711e9f8e2df5a0385e8e6@13.75.154.138:30303", // AU
-	"enode://1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082@52.74.57.123:30303",  // SG
-
-	// Ethereum Foundation C++ Bootnodes
-	"enode://979b7fa28feeb35a4741660a16076f1943202cb72b6af70d327f053e248bab9ba81760f39d0701ef1d8f89cc1fbd2cacba0710a12cd5314d5e0c9021aa3637f9@5.1.83.226:30303", // DE
-}
+var MainnetBootnodes = []string{}
 
 // TestnetBootnodes are the enode URLs of the P2P bootstrap nodes running on the
 // Ropsten test network.
-var TestnetBootnodes = []string{
-	"enode://30b7ab30a01c124a6cceca36863ece12c4f5fa68e3ba9b0b51407ccc002eeed3b3102d20a88f1c1d3c3154e2449317b8ef95090e77b312d5cc39354f86d5d606@52.176.7.10:30303",    // US-Azure geth
-	"enode://865a63255b3bb68023b6bffd5095118fcc13e79dcf014fe4e47e065c350c7cc72af2e53eff895f11ba1bbb6a2b33271c1116ee870f266618eadfc2e78aa7349c@52.176.100.77:30303",  // US-Azure parity
-	"enode://6332792c4a00e3e4ee0926ed89e0d27ef985424d97b6a45bf0f23e51f0dcb5e66b875777506458aea7af6f9e4ffb69f43f3778ee73c81ed9d34c51c4b16b0b0f@52.232.243.152:30303", // Parity
-	"enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09@192.81.208.223:30303", // @gpip
-}
+var TestnetBootnodes = []string{}
 
 // RinkebyBootnodes are the enode URLs of the P2P bootstrap nodes running on the
 // Rinkeby test network.
-var RinkebyBootnodes = []string{
-	"enode://a24ac7c5484ef4ed0c5eb2d36620ba4e4aa13b8c84684e1b4aab0cebea2ae45cb4d375b77eab56516d34bfbd3c1a833fc51296ff084b770b94fb9028c4d25ccf@52.169.42.101:30303", // IE
-	"enode://343149e4feefa15d882d9fe4ac7d88f885bd05ebb735e547f12e12080a9fa07c8014ca6fd7f373123488102fe5e34111f8509cf0b7de3f5b44339c9f25e87cb8@52.3.158.184:30303",  // INFURA
-	"enode://b6b28890b006743680c52e64e0d16db57f28124885595fa03a562be1d2bf0f3a1da297d56b13da25fb992888fd556d4c1a27b1f39d531bde7de1921c90061cc6@159.89.28.211:30303", // AKASHA
-}
+var RinkebyBootnodes = []string{}
 
 // GoerliBootnodes are the enode URLs of the P2P bootstrap nodes running on the
 // Görli test network.
-var GoerliBootnodes = []string{
-	// Upstrem bootnodes
-	"enode://011f758e6552d105183b1761c5e2dea0111bc20fd5f6422bc7f91e0fabbec9a6595caf6239b37feb773dddd3f87240d99d859431891e4a642cf2a0a9e6cbb98a@51.141.78.53:30303",
-	"enode://176b9417f511d05b6b2cf3e34b756cf0a7096b3094572a8f6ef4cdcb9d1f9d00683bf0f83347eebdf3b81c3521c2332086d9592802230bf528eaf606a1d9677b@13.93.54.137:30303",
-	"enode://46add44b9f13965f7b9875ac6b85f016f341012d84f975377573800a863526f4da19ae2c620ec73d11591fa9510e992ecc03ad0751f53cc02f7c7ed6d55c7291@94.237.54.114:30313",
-	"enode://c1f8b7c2ac4453271fa07d8e9ecf9a2e8285aa0bd0c07df0131f47153306b0736fd3db8924e7a9bf0bed6b1d8d4f87362a71b033dc7c64547728d953e43e59b2@52.64.155.147:30303",
-	"enode://f4a9c6ee28586009fb5a96c8af13a58ed6d8315a9eee4772212c1d4d9cebe5a8b8a78ea4434f318726317d04a3f531a1ef0420cf9752605a562cfe858c46e263@213.186.16.82:30303",
-
-	// Ethereum Foundation bootnode
-	"enode://573b6607cd59f241e30e4c4943fd50e99e2b6f42f9bd5ca111659d309c06741247f4f1e93843ad3e8c8c18b6e2d94c161b7ef67479b3938780a97134b618b5ce@52.56.136.200:30303",
-}
+var GoerliBootnodes = []string{}
 
 // Ottoman are the enode URLs of the P2P bootstrap nodes running on the
 // Ottoman test network.
-var OttomanBootnodes = []string{
-	"enode://851ceb576681cf1e0d46ee9f049d6c678f229d806d1b41afe5b6d3c99a43fbbb7271d60e4c43cc5535e125a61db4ea2424823a3ad2c5959e8125f546cd1a7969@13.76.136.158:30303",  //SG
-	"enode://e3b5624752b86b60aa492edd65bdc906f9861a5e9113abd8f908443d1f64395c0e2bdd2e1825154837fd72da9d2e55e4f231411d5ca99ba9c90e14ba2f5612f6@52.163.118.231:30303", //SG
-	"enode://3a1c96fe1fe9da5d4ea3b1a65bfecb4571101b519595cab6deb2eb029209353cdbc91c8d3751d0c6c00e5440657b678508e99bd9e934d4a0c1ad553fc1cb9155@13.76.140.250:30303",  //SG
-	"enode://aebe74e4ab7db8074d1cb9634dab3fd8c5745f8cc4868da2007ff754721085b189ffaf44b8041219de90b55df3ac515bbd0e1df7fde8d7684df0ecfb12534a73@52.187.45.126:30303",  //SG
-}
+var OttomanBootnodes = []string{}
 
 // DiscoveryV5Bootnodes are the enode URLs of the P2P bootstrap nodes for the
 // experimental RLPx v5 topic-discovery network.
-var DiscoveryV5Bootnodes = []string{
-	"enode://06051a5573c81934c9554ef2898eb13b33a34b94cf36b202b69fde139ca17a85051979867720d4bdae4323d4943ddf9aeeb6643633aa656e0be843659795007a@35.177.226.168:30303",
-	"enode://0cc5f5ffb5d9098c8b8c62325f3797f56509bff942704687b6530992ac706e2cb946b90a34f1f19548cd3c7baccbcaea354531e5983c7d1bc0dee16ce4b6440b@40.118.3.223:30304",
-	"enode://1c7a64d76c0334b0418c004af2f67c50e36a3be60b5e4790bdac0439d21603469a85fad36f2473c9a80eb043ae60936df905fa28f1ff614c3e5dc34f15dcd2dc@40.118.3.223:30306",
-	"enode://85c85d7143ae8bb96924f2b54f1b3e70d8c4d367af305325d30a61385a432f247d2c75c45c6b4a60335060d072d7f5b35dd1d4c45f76941f62a4f83b6e75daaf@40.118.3.223:30307",
-}
+var DiscoveryV5Bootnodes = []string{}


### PR DESCRIPTION
### Description

After a lengthly research; in order to detect the correct place where to  log, my findings were

1) Needs to be done **After** the block has been finalized. So, we react upon looking at the parent block, not the block that is being mined. That way we know it's finalized.

2) Needs to happen at the end/beginning of each epoch, that when the election is run

3) 
worker listens to newBlocks, and call the mainLoop (writes to newWorkCh),

mainLoop on `newWorkCh` call consensus `NewChainHead`

```go
		case req := <-w.newWorkCh:
			if h, ok := w.engine.(consensus.Handler); ok {
				h.NewChainHead()
			}
			w.commitNewWork(req.interrupt, req.noempty, req.timestamp)
```

`NewChainHead` checks if the last block (already mined) was the last epoch block; and that's where we can log

```go
func (sb *Backend) NewChainHead() error {
	sb.coreMu.RLock()
	defer sb.coreMu.RUnlock()
	if !sb.coreStarted {
		return istanbul.ErrStoppedEngine
	}

	// If the last block of the epoch has just been added to the blockchain, then
	// establish 'validator' type connections to all validators in the upcoming epoch
	// and disconnect from the ones that are no longer in the val set.
	currentBlock := sb.currentBlock()
	if istanbul.IsLastBlockOfEpoch(currentBlock.Number().Uint64(), sb.config.Epoch) {
		sb.logger.Trace("At end of epoch and going to refresh validator peers", "current block number", currentBlock.Number().Uint64())
		go sb.RefreshValPeers(sb.getValidators(currentBlock.Number().Uint64(), currentBlock.Hash()))
	}

	go sb.istanbulEventMux.Post(istanbul.FinalCommittedEvent{})
	return nil
}
```

### Tested

Run e2e tests

### Related issues

- Fixes #469 

