### PR TITLE
Send txFee to proposer not to infrastructure fund

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           command: |
             set -euo pipefail
             export CELO_MONOREPO_DIR="$PWD"
-            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b master
+            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b mc/proposer-fraction
             yarn install || yarn install
             # separate build to avoid ENOMEM in CI :(
             yarn build --scope @celo/utils

--- a/contract_comm/gasprice_minimum/gasprice_minimum.go
+++ b/contract_comm/gasprice_minimum/gasprice_minimum.go
@@ -100,10 +100,10 @@ const (
 const defaultGasAmount = 2000000
 
 var (
-	gasPriceMinimumABI, _                     = abi.JSON(strings.NewReader(gasPriceMinimumABIString))
-	FallbackInfraFraction   *ProposerFraction = &ProposerFraction{big.NewInt(0), big.NewInt(1)}
-	FallbackGasPriceMinimum *big.Int          = big.NewInt(0) // gasprice min to return if contracts are not found
-	suggestionMultiplier    *big.Int          = big.NewInt(5) // The multiplier that we apply to the minimum when suggesting gas price
+	gasPriceMinimumABI, _                      = abi.JSON(strings.NewReader(gasPriceMinimumABIString))
+	FallbackProposerFraction *ProposerFraction = &ProposerFraction{big.NewInt(0), big.NewInt(1)}
+	FallbackGasPriceMinimum  *big.Int          = big.NewInt(0) // gasprice min to return if contracts are not found
+	suggestionMultiplier     *big.Int          = big.NewInt(5) // The multiplier that we apply to the minimum when suggesting gas price
 )
 
 type ProposerFraction struct {
@@ -194,7 +194,7 @@ func GetProposerFraction(header *types.Header, state vm.StateDB) (*ProposerFract
 	)
 
 	if err != nil {
-		return FallbackInfraFraction, err
+		return FallbackProposerFraction, err
 	}
 
 	return &ProposerFraction{infraFraction[0], infraFraction[1]}, err

--- a/contract_comm/gasprice_minimum/gasprice_minimum.go
+++ b/contract_comm/gasprice_minimum/gasprice_minimum.go
@@ -36,7 +36,7 @@ const (
     {
       "constant": true,
       "inputs": [],
-      "name": "infrastructureFraction_",
+      "name": "proposerFraction_",
       "outputs": [
         {
           "name": "",
@@ -178,14 +178,14 @@ func UpdateGasPriceMinimum(header *types.Header, state vm.StateDB) (*big.Int, er
 	return updatedGasPriceMinimum, err
 }
 
-// Returns the fraction of the gasprice min that should be allocated to the infrastructure fund
+// Returns the fraction of the gasprice min that should be allocated to the proposer
 func GetProposerFraction(header *types.Header, state vm.StateDB) (*ProposerFraction, error) {
 	infraFraction := [2]*big.Int{big.NewInt(0), big.NewInt(1)} // Give everything to the miner as Fallback
 
 	_, err := contract_comm.MakeStaticCall(
 		params.GasPriceMinimumRegistryId,
 		gasPriceMinimumABI,
-		"infrastructureFraction_",
+		"proposerFraction_",
 		[]interface{}{},
 		&infraFraction,
 		200000,

--- a/contract_comm/gasprice_minimum/gasprice_minimum.go
+++ b/contract_comm/gasprice_minimum/gasprice_minimum.go
@@ -100,13 +100,13 @@ const (
 const defaultGasAmount = 2000000
 
 var (
-	gasPriceMinimumABI, _                           = abi.JSON(strings.NewReader(gasPriceMinimumABIString))
-	FallbackInfraFraction   *InfrastructureFraction = &InfrastructureFraction{big.NewInt(0), big.NewInt(1)}
-	FallbackGasPriceMinimum *big.Int                = big.NewInt(0) // gasprice min to return if contracts are not found
-	suggestionMultiplier    *big.Int                = big.NewInt(5) // The multiplier that we apply to the minimum when suggesting gas price
+	gasPriceMinimumABI, _                     = abi.JSON(strings.NewReader(gasPriceMinimumABIString))
+	FallbackInfraFraction   *ProposerFraction = &ProposerFraction{big.NewInt(0), big.NewInt(1)}
+	FallbackGasPriceMinimum *big.Int          = big.NewInt(0) // gasprice min to return if contracts are not found
+	suggestionMultiplier    *big.Int          = big.NewInt(5) // The multiplier that we apply to the minimum when suggesting gas price
 )
 
-type InfrastructureFraction struct {
+type ProposerFraction struct {
 	Numerator   *big.Int
 	Denominator *big.Int
 }
@@ -179,7 +179,7 @@ func UpdateGasPriceMinimum(header *types.Header, state vm.StateDB) (*big.Int, er
 }
 
 // Returns the fraction of the gasprice min that should be allocated to the infrastructure fund
-func GetInfrastructureFraction(header *types.Header, state vm.StateDB) (*InfrastructureFraction, error) {
+func GetProposerFraction(header *types.Header, state vm.StateDB) (*ProposerFraction, error) {
 	infraFraction := [2]*big.Int{big.NewInt(0), big.NewInt(1)} // Give everything to the miner as Fallback
 
 	_, err := contract_comm.MakeStaticCall(
@@ -197,5 +197,5 @@ func GetInfrastructureFraction(header *types.Header, state vm.StateDB) (*Infrast
 		return FallbackInfraFraction, err
 	}
 
-	return &InfrastructureFraction{infraFraction[0], infraFraction[1]}, err
+	return &ProposerFraction{infraFraction[0], infraFraction[1]}, err
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/contract_comm"
 	"github.com/ethereum/go-ethereum/contract_comm/currency"
 	gpm "github.com/ethereum/go-ethereum/contract_comm/gasprice_minimum"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -56,18 +55,17 @@ The state transitioning model does all the necessary work to work out a valid ne
 6) Derive new state root
 */
 type StateTransition struct {
-	gp                           *GasPool
-	msg                          Message
-	gas                          uint64
-	gasPrice                     *big.Int
-	initialGas                   uint64
-	value                        *big.Int
-	data                         []byte
-	state                        vm.StateDB
-	evm                          *vm.EVM
-	gasPriceMinimum              *big.Int
-	infraFraction                *gpm.InfrastructureFraction
-	infrastructureAccountAddress *common.Address
+	gp               *GasPool
+	msg              Message
+	gas              uint64
+	gasPrice         *big.Int
+	initialGas       uint64
+	value            *big.Int
+	data             []byte
+	state            vm.StateDB
+	evm              *vm.EVM
+	gasPriceMinimum  *big.Int
+	proposerFraction *gpm.ProposerFraction
 }
 
 // Message represents a message sent to a contract.
@@ -142,20 +140,18 @@ func IntrinsicGas(data []byte, contractCreation, homestead bool, gasCurrency *co
 // NewStateTransition initialises and returns a new state transition object.
 func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool) *StateTransition {
 	gasPriceMinimum, _ := gpm.GetGasPriceMinimum(msg.GasCurrency(), evm.GetHeader(), evm.GetStateDB())
-	infraFraction, _ := gpm.GetInfrastructureFraction(evm.GetHeader(), evm.GetStateDB())
-	infrastructureAccountAddress, _ := contract_comm.GetRegisteredAddress(params.GovernanceRegistryId, evm.GetHeader(), evm.GetStateDB())
+	proposerFraction, _ := gpm.GetProposerFraction(evm.GetHeader(), evm.GetStateDB())
 
 	return &StateTransition{
-		gp:                           gp,
-		evm:                          evm,
-		msg:                          msg,
-		gasPrice:                     msg.GasPrice(),
-		value:                        msg.Value(),
-		data:                         msg.Data(),
-		state:                        evm.StateDB,
-		gasPriceMinimum:              gasPriceMinimum,
-		infraFraction:                infraFraction,
-		infrastructureAccountAddress: infrastructureAccountAddress,
+		gp:               gp,
+		evm:              evm,
+		msg:              msg,
+		gasPrice:         msg.GasPrice(),
+		value:            msg.Value(),
+		data:             msg.Data(),
+		state:            evm.StateDB,
+		gasPriceMinimum:  gasPriceMinimum,
+		proposerFraction: proposerFraction,
 	}
 }
 
@@ -371,33 +367,24 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		log.Error("Failed to refund gas", "err", err)
 		return nil, 0, false, err
 	}
-	gasUsed := st.gasUsed()
 
-	// Pay tx fee to tx fee recipient and Infrastructure fund
-	totalTxFee := new(big.Int).Mul(new(big.Int).SetUint64(gasUsed), st.gasPrice)
-
-	var recipientTxFee *big.Int
-	if st.infrastructureAccountAddress != nil {
-		infraTxFee := new(big.Int).Div(new(big.Int).Mul(new(big.Int).SetUint64(gasUsed), new(big.Int).Mul(st.gasPriceMinimum, st.infraFraction.Numerator)), st.infraFraction.Denominator)
-		recipientTxFee = new(big.Int).Sub(totalTxFee, infraTxFee)
-		err = st.creditGas(*st.infrastructureAccountAddress, infraTxFee, msg.GasCurrency())
-	} else {
-		log.Debug("no infrastructure account address found - sending entire txFee to fee recipient")
-		recipientTxFee = totalTxFee
-	}
-
-	if err != nil {
-		return nil, 0, false, err
-	}
-
+	// Pay tx fee to tx fee recipient and the proposer (coinbase)
 	txFeeRecipient := msg.GasFeeRecipient()
 	if txFeeRecipient == nil {
 		sender := msg.From()
 		txFeeRecipient = &sender
 	}
-	err = st.creditGas(*txFeeRecipient, recipientTxFee, msg.GasCurrency())
 
-	if err != nil {
+	gasUsed := new(big.Int).SetUint64(st.gasUsed())
+	totalTxFee := new(big.Int).Mul(gasUsed, st.gasPrice)
+	// gasUsed * gasPriceMinimun * proposerFractionNumerator / proposerFractionDenominator
+	coinbaseTxFee := new(big.Int).Div(new(big.Int).Mul(gasUsed, new(big.Int).Mul(st.gasPriceMinimum, st.proposerFraction.Numerator)), st.proposerFraction.Denominator)
+	recipientTxFee := new(big.Int).Sub(totalTxFee, coinbaseTxFee)
+
+	if err = st.creditGas(st.evm.Coinbase, coinbaseTxFee, msg.GasCurrency()); err != nil {
+		return nil, 0, false, err
+	}
+	if err = st.creditGas(*txFeeRecipient, recipientTxFee, msg.GasCurrency()); err != nil {
 		return nil, 0, false, err
 	}
 

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -183,8 +183,8 @@ func (b *LesApiBackend) GetGasPriceMinimum(ctx context.Context, currencyAddress 
 	return gpm.GetGasPriceMinimum(currencyAddress, nil, nil)
 }
 
-func (b *LesApiBackend) InfrastructureFraction(ctx context.Context) (*gpm.InfrastructureFraction, error) {
-	return gpm.GetInfrastructureFraction(nil, nil)
+func (b *LesApiBackend) ProposerFraction(ctx context.Context) (*gpm.ProposerFraction, error) {
+	return gpm.GetProposerFraction(nil, nil)
 }
 
 func (b *LesApiBackend) ChainDb() ethdb.Database {


### PR DESCRIPTION
### Description

Instead of sending gas fees to "feeRecipient" and "infraestructureFund" we send them to "feeRecipient" and the "proposer".

The proposer, it's also the coinbase for the node.

### Tested

e2e

### Related issues

- Fixes #455
