### PR TITLE
Add NoDiscovery to mobile geth config

### DIFF
--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -86,6 +86,9 @@ type NodeConfig struct {
 	// WhisperEnabled specifies whether the node should run the Whisper protocol.
 	WhisperEnabled bool
 
+	// NoDiscovery indicates whether the node should not participate in p2p discovery
+	NoDiscovery bool
+
 	// Listening address of pprof server.
 	PprofAddress string
 
@@ -147,8 +150,8 @@ func NewNode(datadir string, config *NodeConfig) (stack *Node, _ error) {
 		UseLightweightKDF: config.UseLightweightKDF,
 		IPCPath:           "geth.ipc",
 		P2P: p2p.Config{
-			NoDiscovery:      true,
-			DiscoveryV5:      false,
+			NoDiscovery:      config.NoDiscovery,
+			DiscoveryV5:      !config.NoDiscovery,
 			BootstrapNodesV5: config.BootstrapNodes.nodes,
 			ListenAddr:       ":0",
 			NAT:              nat.Any(),


### PR DESCRIPTION
Don't merge this until the corresponding changes for `react-native-geth` & `celo-monorepo` have been merged

### Description

Pulled out of #454 

Allows a mobile client to enable/disable discovery

### Tested

Previously ran in junction with #454 to allow mobile clients to discovery full nodes

### Other changes

n/a

### Related issues

- Fixes celo-org/celo-monorepo#67

### Backwards compatibility

A new version of `@celo/client` will be needed, mobile should also set `NoDiscovery` using `react-native-geth` (PRs are open for both monorepo and react-native-geth)
