### PR TITLE
Sanitize logs

### DIFF
--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -314,7 +314,7 @@ func (sb *Backend) handleIstAnnounce(payload []byte) error {
 
 		newValEnode := &validatorEnode{enodeURL: enodeUrl, view: msg.View}
 		if err := sb.valEnodeTable.upsert(msg.Address, newValEnode, valSet, sb.Address()); err != nil {
-			sb.logger.Error("Error in upserting a valenode entry", "AnnounceMsg", msg, "error", err)
+			sb.logger.Warn("Error in upserting a valenode entry", "AnnounceMsg", msg, "error", err)
 			return err
 		}
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -463,7 +463,7 @@ func (sb *Backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 
 	goldTokenAddress, err := contract_comm.GetRegisteredAddress(params.GoldTokenRegistryId, header, state)
 	if err == contract_errors.ErrSmartContractNotDeployed {
-		log.Warn("Registry address lookup failed", "err", err)
+		log.Debug("Registry address lookup failed", "err", err)
 	} else if err != nil {
 		log.Error(err.Error())
 	}
@@ -474,7 +474,7 @@ func (sb *Backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 		infrastructureBlockReward := big.NewInt(params.Ether)
 		governanceAddress, err := contract_comm.GetRegisteredAddress(params.GovernanceRegistryId, header, state)
 		if err == contract_errors.ErrSmartContractNotDeployed {
-			log.Warn("Registry address lookup failed", "err", err)
+			log.Debug("Registry address lookup failed", "err", err)
 		} else if err != nil {
 			log.Error(err.Error())
 		}
@@ -487,7 +487,7 @@ func (sb *Backend) Finalize(chain consensus.ChainReader, header *types.Header, s
 		stakerBlockReward := big.NewInt(params.Ether)
 		lockedGoldAddress, err := contract_comm.GetRegisteredAddress(params.LockedGoldRegistryId, header, state)
 		if err == contract_errors.ErrSmartContractNotDeployed {
-			log.Warn("Registry address lookup failed", "err", err, "contract id", params.LockedGoldRegistryId)
+			log.Debug("Registry address lookup failed", "err", err, "contract id", params.LockedGoldRegistryId)
 		} else if err != nil {
 			log.Error(err.Error())
 		}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -456,13 +456,14 @@ func (sb *Backend) IsLastBlockOfEpoch(header *types.Header) bool {
 func (sb *Backend) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, randomness *types.Randomness) (*types.Block, error) {
 	// Trigger an update to the gas price minimum in the GasPriceMinimum contract based on block congestion
 	updatedGasPriceMinimum, err := gpm.UpdateGasPriceMinimum(header, state)
-
-	if err != nil {
+	if err == contract_errors.ErrRegistryContractNotDeployed {
+		log.Debug("Error in updating gas price minimum", "error", err, "updatedGasPriceMinimum", updatedGasPriceMinimum)
+	} else if err != nil {
 		log.Error("Error in updating gas price minimum", "error", err, "updatedGasPriceMinimum", updatedGasPriceMinimum)
 	}
 
 	goldTokenAddress, err := contract_comm.GetRegisteredAddress(params.GoldTokenRegistryId, header, state)
-	if err == contract_errors.ErrSmartContractNotDeployed {
+	if err == contract_errors.ErrSmartContractNotDeployed || err == contract_errors.ErrRegistryContractNotDeployed {
 		log.Debug("Registry address lookup failed", "err", err)
 	} else if err != nil {
 		log.Error(err.Error())

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -108,7 +108,7 @@ func (c *core) handleEvents() {
 			case backlogEvent:
 				// No need to check signature for internal messages
 				if err := c.handleCheckedMsg(ev.msg, ev.src); err != nil {
-					c.logger.Error("Error in handling istanbul message that was sent from a backlog event", "err", err)
+					c.logger.Warn("Error in handling istanbul message that was sent from a backlog event", "err", err)
 				}
 			}
 		case event, ok := <-c.timeoutSub.Chan():

--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -224,7 +224,7 @@ func makeCallWithContractId(registryId [32]byte, abi abi.ABI, funcName string, a
 			log.Warn("Contract not yet deployed", "contractId", registryId)
 			return 0, err
 		} else if err == errors.ErrRegistryContractNotDeployed {
-			log.Warn("Contract Address Registry not yet deployed")
+			log.Debug("Contract Address Registry not yet deployed")
 			return 0, err
 		} else {
 			log.Error("Error in contract communication", "contract id", registryId, "error", err)

--- a/contract_comm/random/random.go
+++ b/contract_comm/random/random.go
@@ -101,7 +101,7 @@ func commitmentDbLocation(commitment common.Hash) []byte {
 
 func address() *common.Address {
 	randomAddress, err := contract_comm.GetRegisteredAddress(params.RandomRegistryId, nil, nil)
-	if err == errors.ErrSmartContractNotDeployed {
+	if err == errors.ErrSmartContractNotDeployed || err == errors.ErrRegistryContractNotDeployed {
 		log.Debug("Registry address lookup failed", "err", err, "contract id", params.RandomRegistryId)
 	} else if err != nil {
 		log.Error(err.Error())

--- a/contract_comm/random/random.go
+++ b/contract_comm/random/random.go
@@ -102,7 +102,7 @@ func commitmentDbLocation(commitment common.Hash) []byte {
 func address() *common.Address {
 	randomAddress, err := contract_comm.GetRegisteredAddress(params.RandomRegistryId, nil, nil)
 	if err == errors.ErrSmartContractNotDeployed {
-		log.Warn("Registry address lookup failed", "err", err, "contract id", params.RandomRegistryId)
+		log.Debug("Registry address lookup failed", "err", err, "contract id", params.RandomRegistryId)
 	} else if err != nil {
 		log.Error(err.Error())
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -381,7 +381,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		recipientTxFee = new(big.Int).Sub(totalTxFee, infraTxFee)
 		err = st.creditGas(*st.infrastructureAccountAddress, infraTxFee, msg.GasCurrency())
 	} else {
-		log.Error("no infrastructure account address found - sending entire txFee to fee recipient")
+		log.Debug("no infrastructure account address found - sending entire txFee to fee recipient")
 		recipientTxFee = totalTxFee
 	}
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -579,13 +579,12 @@ func (evm *EVM) handleABICall(abi abipkg.ABI, funcName string, args []interface{
 
 	if returnObj != nil {
 		if err := abi.Unpack(returnObj, funcName, ret); err != nil {
-			// `ErrEmptyOutput` often occurs when when syncing & importing blocks
-			// before a contract has been deployed, creating expected warnings
-			logMsg := "Error in unpacking EVM call return bytes"
+			// `ErrEmptyOutput` is expected when when syncing & importing blocks
+			// before a contract has been deployed
 			if err == abipkg.ErrEmptyOutput {
-				log.Debug(logMsg, "err", err)
+				log.Debug("Error in unpacking EVM call return bytes", "err", err)
 			} else {
-				log.Warn(logMsg, "err", err)
+				log.Warn("Error in unpacking EVM call return bytes", "err", err)
 			}
 			return leftoverGas, err
 		}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -584,7 +584,7 @@ func (evm *EVM) handleABICall(abi abipkg.ABI, funcName string, args []interface{
 			if err == abipkg.ErrEmptyOutput {
 				log.Debug("Error in unpacking EVM call return bytes", "err", err)
 			} else {
-				log.Warn("Error in unpacking EVM call return bytes", "err", err)
+				log.Error("Error in unpacking EVM call return bytes", "err", err)
 			}
 			return leftoverGas, err
 		}


### PR DESCRIPTION
### Description

This decreases the logging intensity for a few expected situations. The first is when geth tries to get the the registry contract, but the contract is not yet deployed. This will output a lot of `error` level logs when a node begins syncing-- this is because geth will try to get the registry contract when processing a block, and there will always be a series of blocks that were mined before the registry contract was deployed. I decreased these logs the to `debug` level.

There were 2 other `error` level logs to do with Istanbul that I changed from `error` -> `warning`. The first is when an error occurs when upserting a validator enode entry (which can happen when an old announce message is received-- there was a comment on discord about this). The second is when handling an istanbul message that was sent from a backlog event (which can also happen from an old announce message).

Logs are now pretty clear & easy to read on log level 3

### Tested

Created my own testnet with the new logging

### Other changes

n/a

### Related issues

- Fixes #356 

### Backwards compatibility

The changes are backwards compatible
