### PR TITLE
Allow validators to add/remove/inspect sentries

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -138,6 +138,7 @@ var (
 		configFileFlag,
 		utils.IstanbulRequestTimeoutFlag,
 		utils.IstanbulBlockPeriodFlag,
+		utils.ProxiedFlag,
 		utils.PingIPFromPacketFlag,
 		utils.UseInMemoryDiscoverTable,
 	}

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -183,6 +183,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.NetrestrictFlag,
 			utils.NodeKeyFileFlag,
 			utils.NodeKeyHexFlag,
+			utils.ProxiedFlag,
 			utils.PingIPFromPacketFlag,
 			utils.UseInMemoryDiscoverTable,
 		},
@@ -234,6 +235,13 @@ var AppHelpFlagGroups = []flagGroup{
 		Flags: whisperFlags,
 	},
 	{
+		Name: "ISTANBUL",
+		Flags: []cli.Flag{
+			utils.IstanbulRequestTimeoutFlag,
+			utils.IstanbulBlockPeriodFlag,
+		},
+	},
+	{
 		Name: "DEPRECATED",
 		Flags: []cli.Flag{
 			utils.MinerLegacyThreadsFlag,
@@ -244,13 +252,6 @@ var AppHelpFlagGroups = []flagGroup{
 	},
 	{
 		Name: "MISC",
-	},
-	{
-		Name: "ISTANBUL",
-		Flags: []cli.Flag{
-			utils.IstanbulRequestTimeoutFlag,
-			utils.IstanbulBlockPeriodFlag,
-		},
 	},
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -997,19 +997,19 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	if ctx.GlobalIsSet(MaxPendingPeersFlag.Name) {
 		cfg.MaxPendingPeers = ctx.GlobalInt(MaxPendingPeersFlag.Name)
 	}
-	if ctx.GlobalIsSet(ProxiedFlag.Name) {
-		if !ctx.GlobalIsSet(MiningEnabledFlag.Name) {
+	if ctx.GlobalBool(ProxiedFlag.Name) {
+		if !ctx.GlobalBool(MiningEnabledFlag.Name) {
 			log.Warn("Node is proxied but is not configured to mine")
 		}
 		cfg.Proxied = true
 	}
-	if ctx.GlobalIsSet(NoDiscoverFlag.Name) || lightClient || cfg.Proxied {
+	if ctx.GlobalBool(NoDiscoverFlag.Name) || lightClient || cfg.Proxied {
 		cfg.NoDiscovery = true
 	}
-	if ctx.GlobalIsSet(PingIPFromPacketFlag.Name) {
+	if ctx.GlobalBool(PingIPFromPacketFlag.Name) {
 		cfg.PingIPFromPacket = true
 	}
-	if ctx.GlobalIsSet(UseInMemoryDiscoverTable.Name) {
+	if ctx.GlobalBool(UseInMemoryDiscoverTable.Name) {
 		cfg.UseInMemoryNodeDatabase = true
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -998,6 +998,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 		cfg.MaxPendingPeers = ctx.GlobalInt(MaxPendingPeersFlag.Name)
 	}
 	if ctx.GlobalIsSet(ProxiedFlag.Name) {
+		if !ctx.GlobalIsSet(MiningEnabledFlag.Name) {
+			log.Warn("Node is proxied but is not configured to mine")
+		}
 		cfg.Proxied = true
 	}
 	if ctx.GlobalIsSet(NoDiscoverFlag.Name) || lightClient || cfg.Proxied {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -559,6 +559,10 @@ var (
 		Name:  "netrestrict",
 		Usage: "Restricts network communication to the given IP networks (CIDR masks)",
 	}
+	ProxiedFlag = cli.BoolFlag{
+		Name:  "proxied",
+		Usage: "Indicates the node will be proxied by sentry nodes. Disables discovery.",
+	}
 	PingIPFromPacketFlag = cli.BoolFlag{
 		Name:  "ping-ip-from-packet",
 		Usage: "Has the discovery protocol use the IP address given by a ping packet",
@@ -993,7 +997,10 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	if ctx.GlobalIsSet(MaxPendingPeersFlag.Name) {
 		cfg.MaxPendingPeers = ctx.GlobalInt(MaxPendingPeersFlag.Name)
 	}
-	if ctx.GlobalIsSet(NoDiscoverFlag.Name) || lightClient {
+	if ctx.GlobalIsSet(ProxiedFlag.Name) {
+		cfg.Proxied = true
+	}
+	if ctx.GlobalIsSet(NoDiscoverFlag.Name) || lightClient || cfg.Proxied {
 		cfg.NoDiscovery = true
 	}
 	if ctx.GlobalIsSet(PingIPFromPacketFlag.Name) {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -281,9 +281,10 @@ func (pm *ProtocolManager) newPeer(pv int, p *p2p.Peer, rw p2p.MsgReadWriter) *p
 // this function terminates, the peer is disconnected.
 func (pm *ProtocolManager) handle(p *peer) error {
 	isValPeer := p.Validator()
+	isSentryPeer := p.Sentry()
 
-	// Ignore maxPeers if this is a trusted peer or a validator peer
-	if pm.peers.Len() >= (pm.maxPeers-len(pm.valPeers)) && !(p.Peer.Info().Network.Trusted || isValPeer) {
+	// Ignore maxPeers if this is a trusted, validator, or sentry peer
+	if pm.peers.Len() >= (pm.maxPeers-len(pm.valPeers)-pm.server.SentryCount()) && !(p.Peer.Info().Network.Trusted || isValPeer || isSentryPeer) {
 		return p2p.DiscTooManyPeers
 	}
 	p.Log().Debug("Ethereum peer connected", "name", p.Name())

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -479,7 +479,7 @@ func testDAOChallenge(t *testing.T, localForked, remoteForked bool, timeout bool
 	if err != nil {
 		t.Fatalf("failed to create new blockchain: %v", err)
 	}
-	pm, err := NewProtocolManager(config, downloader.FullSync, DefaultConfig.NetworkId, evmux, new(testTxPool), pow, blockchain, db, nil, nil)
+	pm, err := NewProtocolManager(config, downloader.FullSync, DefaultConfig.NetworkId, evmux, new(testTxPool), pow, blockchain, db, nil, newServer())
 	if err != nil {
 		t.Fatalf("failed to start test protocol manager: %v", err)
 	}
@@ -560,7 +560,7 @@ func testBroadcastBlock(t *testing.T, totalPeers, broadcastExpected int) {
 	if err != nil {
 		t.Fatalf("failed to create new blockchain: %v", err)
 	}
-	pm, err := NewProtocolManager(config, downloader.FullSync, DefaultConfig.NetworkId, evmux, new(testTxPool), pow, blockchain, db, nil, nil)
+	pm, err := NewProtocolManager(config, downloader.FullSync, DefaultConfig.NetworkId, evmux, new(testTxPool), pow, blockchain, db, nil, newServer())
 	if err != nil {
 		t.Fatalf("failed to start test protocol manager: %v", err)
 	}

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -65,13 +65,36 @@ func newTestProtocolManager(mode downloader.SyncMode, blocks int, generator func
 	if _, err := blockchain.InsertChain(chain); err != nil {
 		panic(err)
 	}
-
-	pm, err := NewProtocolManager(gspec.Config, mode, DefaultConfig.NetworkId, evmux, &testTxPool{added: newtx}, engine, blockchain, db, nil, nil)
+	pm, err := NewProtocolManager(gspec.Config, mode, DefaultConfig.NetworkId, evmux, &testTxPool{added: newtx}, engine, blockchain, db, nil, newServer())
 	if err != nil {
 		return nil, nil, err
 	}
 	pm.Start(1000)
 	return pm, db, nil
+}
+
+func newServer() *p2p.Server {
+	config := p2p.Config{
+		Name:       "test",
+		MaxPeers:   10,
+		ListenAddr: "127.0.0.1:0",
+		PrivateKey: newkey(),
+	}
+	server := &p2p.Server{
+		Config:       config,
+	}
+	if err := server.Start(); err != nil {
+		panic("Could not start server: " + err.Error())
+	}
+	return server
+}
+
+func newkey() *ecdsa.PrivateKey {
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		panic("couldn't generate key: " + err.Error())
+	}
+	return key
 }
 
 // newTestProtocolManagerMust creates a new protocol manager for testing purposes,

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -81,7 +81,7 @@ func newServer() *p2p.Server {
 		PrivateKey: newkey(),
 	}
 	server := &p2p.Server{
-		Config:       config,
+		Config: config,
 	}
 	if err := server.Start(); err != nil {
 		panic("Could not start server: " + err.Error())

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -221,6 +221,10 @@ web3._extend({
 			getter: 'admin_peers'
 		}),
 		new web3._extend.Property({
+			name: 'sentryInfo',
+			getter: 'admin_sentryInfo'
+		}),
+		new web3._extend.Property({
 			name: 'datadir',
 			getter: 'admin_datadir'
 		}),

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -160,6 +160,11 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'removeSentry',
+			call: 'admin_removeSentry',
+			params: 1
+		}),
+		new web3._extend.Method({
 			name: 'addTrustedPeer',
 			call: 'admin_addTrustedPeer',
 			params: 1

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -155,6 +155,11 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
+			name: 'addSentry',
+			call: 'admin_addSentry',
+			params: 1
+		}),
+		new web3._extend.Method({
 			name: 'addTrustedPeer',
 			call: 'admin_addTrustedPeer',
 			params: 1

--- a/node/api.go
+++ b/node/api.go
@@ -323,6 +323,16 @@ func (api *PublicAdminAPI) NodeInfo() (*p2p.NodeInfo, error) {
 	return server.NodeInfo(), nil
 }
 
+// SentryInfo retrieves all the information we know about each individual sentry
+// node at the protocol granularity.
+func (api *PublicAdminAPI) SentryInfo() ([]*p2p.PeerInfo, error) {
+	server := api.node.Server()
+	if server == nil {
+		return nil, ErrNodeStopped
+	}
+	return server.SentryInfo(), nil
+}
+
 // Datadir retrieves the current data directory the node is using.
 func (api *PublicAdminAPI) Datadir() string {
 	return api.node.DataDir()

--- a/node/api.go
+++ b/node/api.go
@@ -75,6 +75,21 @@ func (api *PrivateAdminAPI) RemovePeer(url string) (bool, error) {
 	return true, nil
 }
 
+// AddSentry peers with a remote node that acts as a sentry, even if slots are full
+func (api *PrivateAdminAPI) AddSentry(url string) (bool, error) {
+	// Make sure the server is running, fail otherwise
+	server := api.node.Server()
+	if server == nil {
+		return false, ErrNodeStopped
+	}
+	node, err := enode.ParseV4(url)
+	if err != nil {
+		return false, fmt.Errorf("invalid enode: %v", err)
+	}
+	server.AddSentryPeer(node)
+	return true, nil
+}
+
 // AddTrustedPeer allows a remote node to always connect, even if slots are full
 func (api *PrivateAdminAPI) AddTrustedPeer(url string) (bool, error) {
 	// Make sure the server is running, fail otherwise

--- a/node/api.go
+++ b/node/api.go
@@ -82,9 +82,6 @@ func (api *PrivateAdminAPI) AddSentry(url string) (bool, error) {
 	if server == nil {
 		return false, ErrNodeStopped
 	}
-	if !server.Proxied {
-		return false, fmt.Errorf("the node must be proxied to add a sentry")
-	}
 	node, err := enode.ParseV4(url)
 	if err != nil {
 		return false, fmt.Errorf("invalid enode: %v", err)
@@ -99,9 +96,6 @@ func (api *PrivateAdminAPI) RemoveSentry(url string) (bool, error) {
 	server := api.node.Server()
 	if server == nil {
 		return false, ErrNodeStopped
-	}
-	if !server.Proxied {
-		return false, fmt.Errorf("the node must be proxied to remove a sentry")
 	}
 	// Try to remove the url as a sentry and return
 	node, err := enode.ParseV4(url)

--- a/node/api.go
+++ b/node/api.go
@@ -90,6 +90,22 @@ func (api *PrivateAdminAPI) AddSentry(url string) (bool, error) {
 	return true, nil
 }
 
+// RemoveSentry removes a node from acting as a sentry
+func (api *PrivateAdminAPI) RemoveSentry(url string) (bool, error) {
+	// Make sure the server is running, fail otherwise
+	server := api.node.Server()
+	if server == nil {
+		return false, ErrNodeStopped
+	}
+	// Try to remove the url as a sentry and return
+	node, err := enode.ParseV4(url)
+	if err != nil {
+		return false, fmt.Errorf("invalid enode: %v", err)
+	}
+	server.RemoveSentryPeer(node)
+	return true, nil
+}
+
 // AddTrustedPeer allows a remote node to always connect, even if slots are full
 func (api *PrivateAdminAPI) AddTrustedPeer(url string) (bool, error) {
 	// Make sure the server is running, fail otherwise

--- a/node/api.go
+++ b/node/api.go
@@ -82,6 +82,9 @@ func (api *PrivateAdminAPI) AddSentry(url string) (bool, error) {
 	if server == nil {
 		return false, ErrNodeStopped
 	}
+	if !server.Proxied {
+		return false, fmt.Errorf("the node must be proxied to add a sentry")
+	}
 	node, err := enode.ParseV4(url)
 	if err != nil {
 		return false, fmt.Errorf("invalid enode: %v", err)
@@ -96,6 +99,9 @@ func (api *PrivateAdminAPI) RemoveSentry(url string) (bool, error) {
 	server := api.node.Server()
 	if server == nil {
 		return false, ErrNodeStopped
+	}
+	if !server.Proxied {
+		return false, fmt.Errorf("the node must be proxied to remove a sentry")
 	}
 	// Try to remove the url as a sentry and return
 	node, err := enode.ParseV4(url)

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -181,6 +181,11 @@ func (p *Peer) Validator() bool {
 	return p.rw.is(validatorConn)
 }
 
+// Sentry returns true if the peer is a sentry connection
+func (p *Peer) Sentry() bool {
+	return p.rw.is(sentryConn)
+}
+
 func newPeer(conn *conn, protocols []Protocol) *Peer {
 	protomap := matchProtocols(protocols, conn.caps, conn)
 	p := &Peer{

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -452,6 +452,7 @@ type PeerInfo struct {
 		Trusted       bool   `json:"trusted"`
 		Static        bool   `json:"static"`
 		Validator     bool   `json:"validator"`
+		Sentry        bool   `json:"sentry"`
 	} `json:"network"`
 	Protocols map[string]interface{} `json:"protocols"` // Sub-protocol specific metadata fields
 }
@@ -477,6 +478,7 @@ func (p *Peer) Info() *PeerInfo {
 	info.Network.Trusted = p.rw.is(trustedConn)
 	info.Network.Static = p.rw.is(staticDialedConn)
 	info.Network.Validator = p.rw.is(validatorConn)
+	info.Network.Sentry = p.rw.is(sentryConn)
 
 	// Gather all the running protocol infos
 	for _, proto := range p.running {

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -928,27 +928,30 @@ running:
 			// This channel is used by AddPeer to add to the
 			// ephemeral static peer list. Add it to the dialer,
 			// it will keep the node connected.
-
 			if isValNode(n.ID()) {
 				valNodes[n.ID()].atValRemoveSetStatic = true
-			} else if isSentryNode(n.ID()) {
-				sentryNodes[n.ID()].atSentryRemoveSetStatic = true
-			} else {
-				srv.log.Trace("Adding static node", "node", n)
-				addStatic(n)
+				break
 			}
+			if isSentryNode(n.ID()) {
+				sentryNodes[n.ID()].atSentryRemoveSetStatic = true
+				break
+			}
+			srv.log.Trace("Adding static node", "node", n)
+			addStatic(n)
 		case n := <-srv.removestatic:
 			// This channel is used by RemovePeer to send a
 			// disconnect request to a peer and begin the
 			// stop keeping the node connected.
 			if isValNode(n.ID()) {
 				valNodes[n.ID()].atValRemoveSetStatic = false
-			} else if isSentryNode(n.ID()) {
-				sentryNodes[n.ID()].atSentryRemoveSetStatic = false
-			} else {
-				srv.log.Trace("Removing static node", "node", n)
-				removeStatic(n)
+				break
 			}
+			if isSentryNode(n.ID()) {
+				sentryNodes[n.ID()].atSentryRemoveSetStatic = false
+				break
+			}
+			srv.log.Trace("Removing static node", "node", n)
+			removeStatic(n)
 		case n := <-srv.addtrusted:
 			// This channel is used by AddTrustedPeer to add an enode
 			// to the trusted node set.

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -114,6 +114,9 @@ type Config struct {
 	// IP networks contained in the list are considered.
 	NetRestrict *netutil.Netlist `toml:",omitempty"`
 
+	// Proxied indicates the node is proxied by sentry nodes.
+	Proxied bool
+
 	// PingIPFromPacket uses the IP address from p2p discovery ping packet
 	// rather than the UDP header. See https://github.com/celo-org/celo-blockchain/pull/301
 	PingIPFromPacket bool

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -889,7 +889,7 @@ running:
 				}
 			}
 		case n := <-srv.addsentry:
-			if !isSentryNode(n.ID()) {
+			if !isSentryNode(n.ID()) && srv.Proxied {
 				srv.log.Trace("Adding sentry node", "node", n)
 
 				// Save the previous state of the peer, so that when it's removed as a sentry node, it will be restored to that state
@@ -910,7 +910,7 @@ running:
 				}
 			}
 		case n := <-srv.removesentry:
-			if isSentryNode(n.ID()) {
+			if isSentryNode(n.ID()) && srv.Proxied {
 				srv.log.Trace("Removing sentry node", "node", n)
 
 				sentryNodeInfo := sentryNodes[n.ID()]

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -930,28 +930,24 @@ running:
 			// it will keep the node connected.
 			if isValNode(n.ID()) {
 				valNodes[n.ID()].atValRemoveSetStatic = true
-				break
-			}
-			if isSentryNode(n.ID()) {
+			} else if isSentryNode(n.ID()) {
 				sentryNodes[n.ID()].atSentryRemoveSetStatic = true
-				break
+			} else {
+				srv.log.Trace("Adding static node", "node", n)
+				addStatic(n)
 			}
-			srv.log.Trace("Adding static node", "node", n)
-			addStatic(n)
 		case n := <-srv.removestatic:
 			// This channel is used by RemovePeer to send a
 			// disconnect request to a peer and begin the
 			// stop keeping the node connected.
 			if isValNode(n.ID()) {
 				valNodes[n.ID()].atValRemoveSetStatic = false
-				break
-			}
-			if isSentryNode(n.ID()) {
+			} else if isSentryNode(n.ID()) {
 				sentryNodes[n.ID()].atSentryRemoveSetStatic = false
-				break
+			} else {
+				srv.log.Trace("Removing static node", "node", n)
+				removeStatic(n)
 			}
-			srv.log.Trace("Removing static node", "node", n)
-			removeStatic(n)
 		case n := <-srv.addtrusted:
 			// This channel is used by AddTrustedPeer to add an enode
 			// to the trusted node set.

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -893,7 +893,7 @@ running:
 				}
 			}
 		case n := <-srv.addsentry:
-			if !isSentryNode(n.ID()) && srv.Proxied {
+			if !isSentryNode(n.ID()) {
 				if !srv.Proxied {
 					srv.log.Error("Add sentry node failed: this node is not configured to be proxied")
 					break
@@ -923,10 +923,6 @@ running:
 			}
 		case n := <-srv.removesentry:
 			if isSentryNode(n.ID()) {
-				if !srv.Proxied {
-					srv.log.Error("Remove sentry node failed: this node is not configured to be proxied")
-					break
-				}
 				srv.log.Trace("Removing sentry node", "node", n)
 
 				sentryNodeInfo := sentryNodes[n.ID()]


### PR DESCRIPTION
### Description

Added the RPCs: `admin_addSentry`, `admin_removeSentry`, `admin_sentryInfo`, and the geth flag `--proxied` to indicate that the node will use sentries as a proxy. Sentry peers do not contribute to the max peer limit. `admin_sentryInfo` outputs the peer info that `admin_peers` prints out but only for sentry nodes

Example REPL output:

```
> admin.addSentry('enode://c5987f5df7d63aba328ecdf441437ec520e4dc42a17303aae17afc1b5f522d0655503f65f7179f62250fba3d6b94ed982f57cf9e79653c8620dbfd91587588f5@127.0.0.1:30304')
true
> admin.sentryInfo

[{
    caps: ["eth/63", "les/1", "les/2"],
    enode: "enode://c5987f5df7d63aba328ecdf441437ec520e4dc42a17303aae17afc1b5f522d0655503f65f7179f62250fba3d6b94ed982f57cf9e79653c8620dbfd91587588f5@127.0.0.1:30304",
    id: "141ffb9266bd56b0aa31bb97d1688822f4044531c4648a34ce142e00f8543864",
    name: "Geth/v1.8.23-stable-45ffb873/darwin-amd64/go1.11.13",
    network: {
      inbound: false,
      localAddress: "127.0.0.1:64114",
      remoteAddress: "127.0.0.1:30304",
      sentry: true,
      static: true,
      trusted: false,
      validator: false
    },
    protocols: {
      eth: {
        difficulty: 17179869184,
        head: "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
        version: 63
      }
    }
}]
> admin.removeSentry('enode://c5987f5df7d63aba328ecdf441437ec520e4dc42a17303aae17afc1b5f522d0655503f65f7179f62250fba3d6b94ed982f57cf9e79653c8620dbfd91587588f5@127.0.0.1:30304')
true
```

One thing to note is I've made the assumption that a peered sentry node will not be also a validator peer ( https://github.com/celo-org/celo-blockchain/pull/498/files#diff-40b2cd29997bbd3f578f9d537789b9bbR933 )-- I think this is a safe assumption but I wanted to highlight it in case that's not the case

Here's the help text for `--proxied`:
```
NETWORKING OPTIONS:
  --bootnodes value                Comma separated enode URLs for P2P discovery bootstrap (set v4+v5 instead for light servers)
  --bootnodesv4 value              Comma separated enode URLs for P2P v4 discovery bootstrap (light server, full nodes)
  --bootnodesv5 value              Comma separated enode URLs for P2P v5 discovery bootstrap (light server, light nodes)
  --port value                     Network listening port (default: 30303)
  --maxpeers value                 Maximum number of network peers (network disabled if set to 0) (default: 25)
  --maxpendpeers value             Maximum number of pending connection attempts (defaults used if set to 0) (default: 0)
  --nat value                      NAT port mapping mechanism (any|none|upnp|pmp|extip:<IP>) (default: "any")
  --nodiscover                     Disables the peer discovery mechanism (manual peer addition)
  --v5disc                         Enables the experimental RLPx V5 (Topic Discovery) mechanism
  --netrestrict value              Restricts network communication to the given IP networks (CIDR masks)
  --nodekey value                  P2P node key file
  --nodekeyhex value               P2P node key as hex (for testing)
  --proxied                        Indicates the node will be proxied by sentry nodes. Disables discovery.
  --ping-ip-from-packet            Has the discovery protocol use the IP address given by a ping packet
  --use-in-memory-discovery-table  Specifies whether to use an in memory discovery table
```

### Tested

Ran a few geth instances on my local computer. I was able to add other nodes as sentries, print info about sentries, and tested that they don't contribute to the max peer count.

### Other changes

Found a superfluous if statements ( https://github.com/celo-org/celo-blockchain/pull/498/files#diff-40b2cd29997bbd3f578f9d537789b9bbL790 ), so I removed those

I also moved the order of some groupings of flags on the help output-- I put `DEPRECATED OPTIONS` and `MISC OPTIONS` at the bottom, which felt a little more natural

I also noticed we use `GlobalIsSet` to check values of boolean flags, which should instead be `GlobalBool`

### Related 
- Fixes #484 

### Backwards compatibility

This is backwards compatible
