### PR TITLE
[wip] expose epochSize and blocks remaining

### DIFF
--- a/consensus/istanbul/utils.go
+++ b/consensus/istanbul/utils.go
@@ -67,7 +67,7 @@ func CheckValidatorSignature(valSet ValidatorSet, data []byte, sig []byte) (comm
 
 // Retrieves the block number within an epoch.  The return value will be 1-based.
 // There is a special case if the number == 0.  It is basically the last block of the 0th epoch, and should have a value of epochSize
-func getNumberWithinEpoch(number uint64, epochSize uint64) uint64 {
+func GetNumberWithinEpoch(number uint64, epochSize uint64) uint64 {
 	number = number % epochSize
 	if number == 0 {
 		return epochSize
@@ -77,7 +77,7 @@ func getNumberWithinEpoch(number uint64, epochSize uint64) uint64 {
 }
 
 func IsLastBlockOfEpoch(number uint64, epochSize uint64) bool {
-	return getNumberWithinEpoch(number, epochSize) == epochSize
+	return GetNumberWithinEpoch(number, epochSize) == epochSize
 }
 
 // Retrieves the epoch number given the block number.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -514,6 +514,7 @@ func (s *Ethereum) Miner() *miner.Miner { return s.miner }
 
 func (s *Ethereum) AccountManager() *accounts.Manager  { return s.accountManager }
 func (s *Ethereum) BlockChain() *core.BlockChain       { return s.blockchain }
+func (s *Ethereum) Config() *Config                    { return s.config }
 func (s *Ethereum) TxPool() *core.TxPool               { return s.txPool }
 func (s *Ethereum) EventMux() *event.TypeMux           { return s.eventMux }
 func (s *Ethereum) Engine() consensus.Engine           { return s.engine }

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth"
@@ -153,7 +154,7 @@ func (s *Service) loop() {
 	txEventCh := make(chan core.NewTxsEvent, txChanSize)
 	txSub := txpool.SubscribeNewTxsEvent(txEventCh)
 	defer txSub.Unsubscribe()
-
+	log.Info("test", "engine", istanbul.GetNumberWithinEpoch(2000, 123))
 	// Start a goroutine that exhausts the subsciptions to avoid events piling up
 	var (
 		quitCh = make(chan struct{})
@@ -469,19 +470,21 @@ func (s *Service) reportLatency(conn *websocket.Conn) error {
 
 // blockStats is the information to report about individual blocks.
 type blockStats struct {
-	Number     *big.Int       `json:"number"`
-	Hash       common.Hash    `json:"hash"`
-	ParentHash common.Hash    `json:"parentHash"`
-	Timestamp  *big.Int       `json:"timestamp"`
-	Miner      common.Address `json:"miner"`
-	GasUsed    uint64         `json:"gasUsed"`
-	GasLimit   uint64         `json:"gasLimit"`
-	Diff       string         `json:"difficulty"`
-	TotalDiff  string         `json:"totalDifficulty"`
-	Txs        []txStats      `json:"transactions"`
-	TxHash     common.Hash    `json:"transactionsRoot"`
-	Root       common.Hash    `json:"stateRoot"`
-	Uncles     uncleStats     `json:"uncles"`
+	Number      *big.Int       `json:"number"`
+	Hash        common.Hash    `json:"hash"`
+	ParentHash  common.Hash    `json:"parentHash"`
+	Timestamp   *big.Int       `json:"timestamp"`
+	Miner       common.Address `json:"miner"`
+	GasUsed     uint64         `json:"gasUsed"`
+	GasLimit    uint64         `json:"gasLimit"`
+	Diff        string         `json:"difficulty"`
+	TotalDiff   string         `json:"totalDifficulty"`
+	Txs         []txStats      `json:"transactions"`
+	TxHash      common.Hash    `json:"transactionsRoot"`
+	Root        common.Hash    `json:"stateRoot"`
+	Uncles      uncleStats     `json:"uncles"`
+	EpochSize   uint64         `json:"epochSize"`
+	BlockRemain uint64         `json:"blockRemain"`
 }
 
 // txStats is the information to report about individual transactions.
@@ -554,20 +557,26 @@ func (s *Service) assembleBlockStats(block *types.Block) *blockStats {
 	// Assemble and return the block stats
 	author, _ := s.engine.Author(header)
 
+	// Add epoch info
+	epochSize := s.eth.Config().Istanbul.Epoch
+	blockRemain := epochSize - istanbul.GetNumberWithinEpoch(header.Number.Uint64(), epochSize)
+
 	return &blockStats{
-		Number:     header.Number,
-		Hash:       header.Hash(),
-		ParentHash: header.ParentHash,
-		Timestamp:  header.Time,
-		Miner:      author,
-		GasUsed:    header.GasUsed,
-		GasLimit:   header.GasLimit,
-		Diff:       header.Difficulty.String(),
-		TotalDiff:  td.String(),
-		Txs:        txs,
-		TxHash:     header.TxHash,
-		Root:       header.Root,
-		Uncles:     uncles,
+		Number:      header.Number,
+		Hash:        header.Hash(),
+		ParentHash:  header.ParentHash,
+		Timestamp:   header.Time,
+		Miner:       author,
+		GasUsed:     header.GasUsed,
+		GasLimit:    header.GasLimit,
+		Diff:        header.Difficulty.String(),
+		TotalDiff:   td.String(),
+		Txs:         txs,
+		TxHash:      header.TxHash,
+		Root:        header.Root,
+		Uncles:      uncles,
+		EpochSize:   epochSize,
+		BlockRemain: blockRemain,
 	}
 }
 

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -154,7 +154,7 @@ func (s *Service) loop() {
 	txEventCh := make(chan core.NewTxsEvent, txChanSize)
 	txSub := txpool.SubscribeNewTxsEvent(txEventCh)
 	defer txSub.Unsubscribe()
-	log.Info("test", "engine", istanbul.GetNumberWithinEpoch(2000, 123))
+
 	// Start a goroutine that exhausts the subsciptions to avoid events piling up
 	var (
 		quitCh = make(chan struct{})


### PR DESCRIPTION
### Description

Export epoch information (size and blocks remaining) to celostats

### Tested

tested against integration testnet with https://github.com/diminator/ethstats-server/pull/1/files

### Other changes

Made `GetNumberWithinEpoch` public

### Related issues

- Fixes #463
