### PR TITLE
Fix discoverTableInfo when discovery is disabled

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -413,7 +413,10 @@ func (srv *Server) Self() *enode.Node {
 // DiscoverTableInfo gets information on all the buckets in the
 // discover table
 func (srv *Server) DiscoverTableInfo() *discover.TableInfo {
-	return srv.ntab.Info()
+	if srv.ntab != nil {
+		return srv.ntab.Info()
+	}
+	return nil
 }
 
 // Stop terminates the server and all active peer connections.


### PR DESCRIPTION
### Description

`ntab` is `nil` when `--nodiscover` is passed to geth, causing a seg fault

### Tested

Ran without the fix and `--nodiscover`, saw the error, then ran again with the fix to ensure the error went away

### Other changes

n/a

### Related issues

n/a

### Backwards compatibility

This is backwards compatible
