### PR TITLE
Sanitize more logs

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -456,7 +456,7 @@ func (sb *Backend) IsLastBlockOfEpoch(header *types.Header) bool {
 func (sb *Backend) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, randomness *types.Randomness) (*types.Block, error) {
 	// Trigger an update to the gas price minimum in the GasPriceMinimum contract based on block congestion
 	updatedGasPriceMinimum, err := gpm.UpdateGasPriceMinimum(header, state)
-	if err == contract_errors.ErrRegistryContractNotDeployed {
+	if err == contract_errors.ErrSmartContractNotDeployed || err == contract_errors.ErrRegistryContractNotDeployed {
 		log.Debug("Error in updating gas price minimum", "error", err, "updatedGasPriceMinimum", updatedGasPriceMinimum)
 	} else if err != nil {
 		log.Error("Error in updating gas price minimum", "error", err, "updatedGasPriceMinimum", updatedGasPriceMinimum)

--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -221,7 +221,7 @@ func makeCallWithContractId(registryId [32]byte, abi abi.ABI, funcName string, a
 
 	if err != nil {
 		if err == errors.ErrSmartContractNotDeployed {
-			log.Warn("Contract not yet deployed", "contractId", registryId)
+			log.Debug("Contract not yet deployed", "contractId", registryId)
 			return 0, err
 		} else if err == errors.ErrRegistryContractNotDeployed {
 			log.Debug("Contract Address Registry not yet deployed")


### PR DESCRIPTION
### Description

When syncing with alfajoresstaging from master I saw a couple more over-extreme errors/warnings when importing blocks before contracts had been deployed. I moved these down to the `Debug` level, just like in #495 

### Tested

Synced with the changes & saw the error/warnings go away

### Other changes

n/a

### Related issues

- Fixes #356 

### Backwards compatibility

This is backwards compatible