### PR TITLE
txpool invalidate txns for txs with gasPrice less than gpm

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -32,9 +32,10 @@ import (
 )
 
 var (
-	errInsufficientBalanceForGas    = errors.New("insufficient balance to pay for gas")
-	errNonWhitelistedGasCurrency    = errors.New("non-whitelisted gas currency address")
-	errGasPriceDoesNotExceedMinimum = errors.New("gasprice does not exceed gas price minimum")
+	ErrGasPriceDoesNotExceedMinimum = errors.New("gasprice does not exceed gas price minimum")
+
+	errInsufficientBalanceForGas = errors.New("insufficient balance to pay for gas")
+	errNonWhitelistedGasCurrency = errors.New("non-whitelisted gas currency address")
 )
 
 /*
@@ -297,7 +298,7 @@ func (st *StateTransition) preCheck() error {
 	// Make sure this transaction's gas price is valid.
 	if st.gasPrice.Cmp(st.gasPriceMinimum) < 0 {
 		log.Error("Tx gas price does not exceed minimum", "minimum", st.gasPriceMinimum, "price", st.gasPrice)
-		return errGasPriceDoesNotExceedMinimum
+		return ErrGasPriceDoesNotExceedMinimum
 	}
 
 	return nil

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/contract_comm/currency"
+	gpm "github.com/ethereum/go-ethereum/contract_comm/gasprice_minimum"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -667,6 +668,13 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		log.Debug("validateTx gas less than intrinsic gas", "tx.Gas", tx.Gas(), "intrinsic Gas", intrGas)
 		return ErrIntrinsicGas
 	}
+
+	gasPriceMinimum, _ := gpm.GetGasPriceMinimum(tx.GasCurrency(), nil, nil)
+	if tx.GasPrice().Cmp(gasPriceMinimum) == -1 {
+		log.Debug("gas price less than current gas price minimum", "gasPrice", tx.GasPrice(), "gasPriceMinimum", gasPriceMinimum)
+		return ErrGasPriceDoesNotExceedMinimum
+	}
+
 	return nil
 }
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/contract_comm/currency"
+	ccerrors "github.com/ethereum/go-ethereum/contract_comm/errors"
 	gpm "github.com/ethereum/go-ethereum/contract_comm/gasprice_minimum"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -670,7 +671,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 
 	gasPriceMinimum, err := gpm.GetGasPriceMinimum(tx.GasCurrency(), nil, nil)
-	if err != nil {
+	if err != nil && err != ccerrors.ErrSmartContractNotDeployed && err != ccerrors.ErrRegistryContractNotDeployed {
 		log.Debug("gas price less than current gas price minimum", "gasPriceMinimum", gasPriceMinimum, "err", err)
 		return err
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -669,7 +669,12 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrIntrinsicGas
 	}
 
-	gasPriceMinimum, _ := gpm.GetGasPriceMinimum(tx.GasCurrency(), nil, nil)
+	gasPriceMinimum, err := gpm.GetGasPriceMinimum(tx.GasCurrency(), nil, nil)
+	if err != nil {
+		log.Debug("gas price less than current gas price minimum", "gasPriceMinimum", gasPriceMinimum, "err", err)
+		return err
+	}
+
 	if tx.GasPrice().Cmp(gasPriceMinimum) == -1 {
 		log.Debug("gas price less than current gas price minimum", "gasPrice", tx.GasPrice(), "gasPriceMinimum", gasPriceMinimum)
 		return ErrGasPriceDoesNotExceedMinimum

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -812,6 +812,9 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 			break
 		}
 		// Check for valid gas currency and that the tx exceeds the gasPriceMinimum
+		// We will add any more txns from the `txns` parameter if `tx` is below the gas price minimum.
+		// All the other transactions after this will either also be below the gas price minimum or will have a
+		// nonce that is non sequential to the last mined txn for the account.
 		gasPriceMinimum, _ := gpm.GetGasPriceMinimum(tx.GasCurrency(), w.current.header, w.current.state)
 		if tx.GasPrice().Cmp(gasPriceMinimum) == -1 {
 			log.Info("Excluding transaction from block due to failure to exceed gasPriceMinimum", "gasPrice", tx.GasPrice(), "gasPriceMinimum", gasPriceMinimum)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -812,8 +812,8 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 			break
 		}
 		// Check for valid gas currency and that the tx exceeds the gasPriceMinimum
-		// We will add any more txns from the `txns` parameter if `tx` is below the gas price minimum.
-		// All the other transactions after this will either also be below the gas price minimum or will have a
+		// We will not add any more txns from the `txns` parameter if `tx`'s gasPrice is below the gas price minimum.
+		// All the other transactions after this `tx` will either also be below the gas price minimum or will have a
 		// nonce that is non sequential to the last mined txn for the account.
 		gasPriceMinimum, _ := gpm.GetGasPriceMinimum(tx.GasCurrency(), w.current.header, w.current.state)
 		if tx.GasPrice().Cmp(gasPriceMinimum) == -1 {


### PR DESCRIPTION
### Description

This PR modifies the tx pool so that it will verify that submitted txns' price is greater than or equal to the current gpm.

### Tested

* Unit tests ran
* Added an e2e test to verify that a txn w/ too low of a gasprice is invalidated by the txpool.

### Other changes

None

### Related issues

- Fixes #502 

### Backwards compatibility

Will not add txns that have a txn gas price < current gas price minimum