### PR TITLE
ci: use node 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ rust-defaults: &rust-defaults
 
 end-to-end-defaults: &end-to-end-defaults
   docker:
-    - image: celohq/node10:gcloud
+    - image: celohq/node10-gcloud
 
 jobs:
   unit-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ rust-defaults: &rust-defaults
 
 end-to-end-defaults: &end-to-end-defaults
   docker:
-    - image: celohq/node8:gcloud
+    - image: celohq/node10:gcloud
 
 jobs:
   unit-tests:


### PR DESCRIPTION


### Description

celo-monorepo now uses node 10

### Tested

CI

