### PR TITLE
Update celo-node dockerfile geth commit for alfajores/alfajoresstaging

### DIFF
--- a/Dockerfile.celo-node
+++ b/Dockerfile.celo-node
@@ -2,7 +2,7 @@
 # Takes a build arg called celo_env to pre-download genesis block and static nodes
 # docker build . -f Dockerfile.celo-node --build-arg celo_env=alfajoresstaging -t us.gcr.io/celo-testnet/celo-node:alfajoresstaging
 # docker push us.gcr.io/celo-testnet/celo-node:alfajoresstaging
-FROM us.gcr.io/celo-testnet/geth:f7095b78003062db9536e1d070772d20a3f81e93
+FROM us.gcr.io/celo-testnet/geth:027dba2e4584936cc5a8e8993e4e27d28d5247b8
 
 ARG celo_env
 


### PR DESCRIPTION
### Description

I pushed a new version of `us.gcr.io/celo-testnet/celo-node:alfajoresstaging` and `us.gcr.io/celo-testnet/celo-node:alfajores` that uses the correct geth version that's currently deployed

### Tested

The version is currently what's on alfajores/alfajoresstaging & they're working well

### Other changes

n/a

### Related 

n/a

### Backwards compatibility

not backwards compatible
