### PR TITLE
[WIP] Limit number of round change messages per validator

### DIFF
--- a/consensus/istanbul/core/message_set.go
+++ b/consensus/istanbul/core/message_set.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"fmt"
-	"math/big"
 	"strings"
 	"sync"
 
@@ -29,10 +28,6 @@ import (
 // Construct a new message set to accumulate messages for given sequence/view number.
 func newMessageSet(valSet istanbul.ValidatorSet) *messageSet {
 	return &messageSet{
-		view: &istanbul.View{
-			Round:    new(big.Int),
-			Sequence: new(big.Int),
-		},
 		messagesMu: new(sync.Mutex),
 		messages:   make(map[common.Address]*istanbul.Message),
 		valSet:     valSet,
@@ -42,14 +37,9 @@ func newMessageSet(valSet istanbul.ValidatorSet) *messageSet {
 // ----------------------------------------------------------------------------
 
 type messageSet struct {
-	view       *istanbul.View
 	valSet     istanbul.ValidatorSet
 	messagesMu *sync.Mutex
 	messages   map[common.Address]*istanbul.Message
-}
-
-func (ms *messageSet) View() *istanbul.View {
-	return ms.view
 }
 
 func (ms *messageSet) Add(msg *istanbul.Message) error {
@@ -121,9 +111,6 @@ func (ms *messageSet) verify(msg *istanbul.Message) error {
 	if _, v := ms.valSet.GetByAddress(msg.Address); v == nil {
 		return istanbul.ErrUnauthorizedAddress
 	}
-
-	// TODO: check view number and sequence number
-
 	return nil
 }
 

--- a/consensus/istanbul/core/message_set.go
+++ b/consensus/istanbul/core/message_set.go
@@ -81,6 +81,13 @@ func (ms *messageSet) ValSetSize() uint64 {
 	return uint64(ms.valSet.Size())
 }
 
+func (ms *messageSet) Remove(address common.Address) {
+	ms.messagesMu.Lock()
+	defer ms.messagesMu.Unlock()
+
+	delete(ms.messages, address)
+}
+
 func (ms *messageSet) Values() (result []*istanbul.Message) {
 	ms.messagesMu.Lock()
 	defer ms.messagesMu.Unlock()

--- a/consensus/istanbul/core/message_set.go
+++ b/consensus/istanbul/core/message_set.go
@@ -139,5 +139,5 @@ func (ms *messageSet) String() string {
 	for _, v := range ms.messages {
 		addresses = append(addresses, v.Address.String())
 	}
-	return fmt.Sprintf("[%v]", strings.Join(addresses, ", "))
+	return fmt.Sprintf("[<%v> %v]", len(ms.messages), strings.Join(addresses, ", "))
 }

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -275,10 +275,19 @@ func (rcs *roundChangeSet) MaxRound(num int) *big.Int {
 	rcs.mu.Lock()
 	defer rcs.mu.Unlock()
 
-	var maxRound *big.Int
-	for k, rms := range rcs.roundChanges {
-		if rms.Size() < num {
-			continue
+	// Sort rounds descending
+	var sortedRounds []uint64
+	for r := range rcs.msgsForRound {
+		sortedRounds = append(sortedRounds, r)
+	}
+	sort.Slice(sortedRounds, func(i, j int) bool { return sortedRounds[i] > sortedRounds[j] })
+
+	acc := 0
+	for _, r := range sortedRounds {
+		rms := rcs.msgsForRound[r]
+		acc += rms.Size()
+		if acc >= num {
+			return new(big.Int).SetUint64(r)
 		}
 	}
 

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -312,7 +312,29 @@ func (rcs *roundChangeSet) MaxOnOneRound(num int) *big.Int {
 			return new(big.Int).SetUint64(r)
 		}
 	}
-	return maxRound
+	return nil
+}
+
+func (rcs *roundChangeSet) String() string {
+	rcs.mu.Lock()
+	defer rcs.mu.Unlock()
+
+	msgsForRoundStr := make([]string, 0, len(rcs.msgsForRound))
+	for r, rms := range rcs.msgsForRound {
+		msgsForRoundStr = append(msgsForRoundStr, fmt.Sprintf("%v: %v", r, rms.String()))
+	}
+
+	latestRoundForValStr := make([]string, 0, len(rcs.latestRoundForVal))
+	for addr, r := range rcs.latestRoundForVal {
+		latestRoundForValStr = append(latestRoundForValStr, fmt.Sprintf("%v: %v", addr.String(), r))
+	}
+
+	return fmt.Sprintf("RCS len=%v  By round: {<%v> %v}  By val: {<%v> %v}",
+		len(rcs.latestRoundForVal),
+		len(rcs.msgsForRound),
+		strings.Join(msgsForRoundStr, ", "),
+		len(rcs.latestRoundForVal),
+		strings.Join(latestRoundForValStr, ", "))
 }
 
 func (rcs *roundChangeSet) getCertificate(r *big.Int, quorumSize int) (istanbul.RoundChangeCertificate, error) {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -252,9 +252,27 @@ func (rcs *roundChangeSet) MaxRound(num int) *big.Int {
 		if rms.Size() < num {
 			continue
 		}
-		r := big.NewInt(int64(k))
-		if maxRound == nil || maxRound.Cmp(r) < 0 {
-			maxRound = r
+	}
+
+	return nil
+}
+
+// MaxOnOneRound returns the max round which the number of messages is >= num
+func (rcs *roundChangeSet) MaxOnOneRound(num int) *big.Int {
+	rcs.mu.Lock()
+	defer rcs.mu.Unlock()
+
+	// Sort rounds descending
+	var sortedRounds []uint64
+	for r := range rcs.msgsForRound {
+		sortedRounds = append(sortedRounds, r)
+	}
+	sort.Slice(sortedRounds, func(i, j int) bool { return sortedRounds[i] > sortedRounds[j] })
+
+	for _, r := range sortedRounds {
+		rms := rcs.msgsForRound[r]
+		if rms.Size() >= num {
+			return new(big.Int).SetUint64(r)
 		}
 	}
 	return maxRound

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -202,16 +202,18 @@ func (c *core) handleRoundChange(msg *istanbul.Message) error {
 
 func newRoundChangeSet(valSet istanbul.ValidatorSet) *roundChangeSet {
 	return &roundChangeSet{
-		validatorSet: valSet,
-		roundChanges: make(map[uint64]*messageSet),
-		mu:           new(sync.Mutex),
+		validatorSet:      valSet,
+		msgsForRound:      make(map[uint64]*messageSet),
+		latestRoundForVal: make(map[common.Address]uint64),
+		mu:                new(sync.Mutex),
 	}
 }
 
 type roundChangeSet struct {
-	validatorSet istanbul.ValidatorSet
-	roundChanges map[uint64]*messageSet
-	mu           *sync.Mutex
+	validatorSet      istanbul.ValidatorSet
+	msgsForRound      map[uint64]*messageSet
+	latestRoundForVal map[common.Address]uint64
+	mu                *sync.Mutex
 }
 
 // Add adds the round and message into round change set

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -256,9 +256,16 @@ func (rcs *roundChangeSet) Clear(round *big.Int) {
 	rcs.mu.Lock()
 	defer rcs.mu.Unlock()
 
-	for k, rms := range rcs.roundChanges {
-		if len(rms.Values()) == 0 || k < round.Uint64() {
-			delete(rcs.roundChanges, k)
+	for k, rms := range rcs.msgsForRound {
+		if rms.Size() == 0 || k < round.Uint64() {
+			if rms != nil {
+				for _, msg := range rms.Values() {
+					if latestRound, ok := rcs.latestRoundForVal[msg.Address]; ok && k == latestRound {
+						delete(rcs.latestRoundForVal, msg.Address)
+					}
+				}
+			}
+			delete(rcs.msgsForRound, k)
 		}
 	}
 }

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -342,9 +342,11 @@ func (rcs *roundChangeSet) getCertificate(r *big.Int, quorumSize int) (istanbul.
 	defer rcs.mu.Unlock()
 
 	round := r.Uint64()
-	if rcs.roundChanges[round] != nil && rcs.roundChanges[round].Size() >= quorumSize {
-		messages := make([]istanbul.Message, rcs.roundChanges[round].Size())
-		for i, message := range rcs.roundChanges[round].Values() {
+	// TODO(Joshua): Think through if this is correct or if we need to include round change
+	// from messages from a larger round.
+	if rcs.msgsForRound[round] != nil && rcs.msgsForRound[round].Size() >= quorumSize {
+		messages := make([]istanbul.Message, rcs.msgsForRound[round].Size())
+		for i, message := range rcs.msgsForRound[round].Values() {
 			messages[i] = *message
 		}
 		return istanbul.RoundChangeCertificate{

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -50,8 +50,8 @@ func TestRoundChangeSet(t *testing.T) {
 			Address: v.Address(),
 		}
 		rc.Add(view.Round, msg)
-		if rc.roundChanges[view.Round.Uint64()].Size() != i+1 {
-			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.roundChanges[view.Round.Uint64()].Size(), i+1)
+		if rc.msgsForRound[view.Round.Uint64()].Size() != i+1 {
+			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.msgsForRound[view.Round.Uint64()].Size(), i+1)
 		}
 	}
 
@@ -63,8 +63,8 @@ func TestRoundChangeSet(t *testing.T) {
 			Address: v.Address(),
 		}
 		rc.Add(view.Round, msg)
-		if rc.roundChanges[view.Round.Uint64()].Size() != vset.Size() {
-			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.roundChanges[view.Round.Uint64()].Size(), vset.Size())
+		if rc.msgsForRound[view.Round.Uint64()].Size() != vset.Size() {
+			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.msgsForRound[view.Round.Uint64()].Size(), vset.Size())
 		}
 	}
 
@@ -73,23 +73,86 @@ func TestRoundChangeSet(t *testing.T) {
 		maxRound := rc.MaxRound(i)
 		if i <= vset.Size() {
 			if maxRound == nil || maxRound.Cmp(view.Round) != 0 {
-				t.Errorf("max round mismatch: have %v, want %v", maxRound, view.Round)
+				t.Errorf("MaxRound mismatch: have %v, want %v", maxRound, view.Round)
 			}
 		} else if maxRound != nil {
-			t.Errorf("max round mismatch: have %v, want nil", maxRound)
+			t.Errorf("MaxRound mismatch: have %v, want nil", maxRound)
 		}
 	}
 
 	// Test Clear()
 	for i := int64(0); i < 2; i++ {
 		rc.Clear(big.NewInt(i))
-		if rc.roundChanges[view.Round.Uint64()].Size() != vset.Size() {
-			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.roundChanges[view.Round.Uint64()].Size(), vset.Size())
+		if rc.msgsForRound[view.Round.Uint64()].Size() != vset.Size() {
+			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.msgsForRound[view.Round.Uint64()].Size(), vset.Size())
 		}
 	}
 	rc.Clear(big.NewInt(2))
-	if rc.roundChanges[view.Round.Uint64()] != nil {
-		t.Errorf("the change messages mismatch: have %v, want nil", rc.roundChanges[view.Round.Uint64()])
+	if rc.msgsForRound[view.Round.Uint64()] != nil {
+		t.Errorf("the change messages mismatch: have %v, want nil", rc.msgsForRound[view.Round.Uint64()])
+	}
+
+	// Test Add()
+	// Add message from all validators
+	for i, v := range vset.List() {
+		msg := &istanbul.Message{
+			Code:    istanbul.MsgRoundChange,
+			Msg:     m,
+			Address: v.Address(),
+		}
+		rc.Add(view.Round, msg)
+		if rc.msgsForRound[view.Round.Uint64()].Size() != i+1 {
+			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.msgsForRound[view.Round.Uint64()].Size(), i+1)
+		}
+	}
+
+	rc.Clear(big.NewInt(2))
+	if rc.msgsForRound[view.Round.Uint64()] != nil {
+		t.Errorf("the change messages mismatch: have %v, want nil", rc.msgsForRound[view.Round.Uint64()])
+	}
+
+	// Test that we only store the msg with the highest round for each validator
+	roundMultiplier := 1
+	for j := 1; j <= roundMultiplier; j++ {
+		for i, v := range vset.List() {
+			view := &istanbul.View{
+				Sequence: big.NewInt(1),
+				Round:    big.NewInt(int64(i * j)),
+			}
+			r := &istanbul.Subject{
+				View:   view,
+				Digest: common.Hash{},
+			}
+			m, _ := Encode(r)
+			msg := &istanbul.Message{
+				Code:    istanbul.MsgRoundChange,
+				Msg:     m,
+				Address: v.Address(),
+			}
+			err := rc.Add(view.Round, msg)
+			if err != nil {
+				t.Errorf("Round change message: unexpected error %v", err)
+			}
+		}
+	}
+
+	for i, v := range vset.List() {
+		lookingForValAtRound := uint64(roundMultiplier * i)
+		if rc.msgsForRound[lookingForValAtRound].Size() != 1 {
+			t.Errorf("Round change messages at unexpected rounds: %v", rc.msgsForRound)
+		}
+		if rc.latestRoundForVal[v.Address()] != lookingForValAtRound {
+			t.Errorf("Round change messages at unexpected rounds: for %v want %v have %v",
+				i, rc.latestRoundForVal[v.Address()], lookingForValAtRound)
+		}
+	}
+
+	for threshold := 1; threshold < vset.Size(); threshold++ {
+		r := rc.MaxRound(threshold).Uint64()
+		expectedR := uint64((vset.Size() - threshold) * roundMultiplier)
+		if r != expectedR {
+			t.Errorf("MaxRound: %v want %v have %v", rc.String(), expectedR, r)
+		}
 	}
 }
 


### PR DESCRIPTION
### Description

This limits the number of round change messages in a single sequence for a validator to one.

### Tested

Probably tested early September, but not since.

### Other changes

Removes `view `from message set.

### Related issues

- Fixes #183 

### Backwards compatibility

Theoretically should be backwards compatible in node behavior.