### PR TITLE
[IBFT]Prevent validator from double-signing

### DIFF
--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -74,7 +74,7 @@ func (c *core) getPreprepareMessage(
 		logger.Error("Failed to encode", "view", curView)
 		return nil, err
 	}
-	err2 := c.savePrepareMessageToDisk(messageType, roundNumber, sequenceNumber, preprepare)
+	err2 := c.savePreprepareMessageToDisk(messageType, roundNumber, sequenceNumber, preprepare)
 	if err2 != nil {
 		logger.Error("Failed to write prepare message to the disk", "msg", preprepare)
 		return nil, err2


### PR DESCRIPTION
### Description

 Validator before signing a message would check if it has already signed a message with same round and sequence number before. This prevents a malicious proposer from making a validator sign a different message after it has signed a message and rebooted.

### Tested

Verified that all the current tests and a deployment testnet work. So, this change does not break anything. I don't have a test to verify this new behavior.

### Related issues

- Fixes #396