### PR TITLE
Log provided gas if transaction fails due to low gas

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -322,7 +322,10 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 
 	// If the intrinsic gas is more than provided in the tx, return without failing.
 	if gas > st.msg.Gas() {
-		log.Error("Transaction failed provide intrinsic gas", "err", err, "gas", gas)
+		log.Error("Transaction failed provide intrinsic gas", "err", err,
+			"gas required", gas,
+			"gas provided", st.msg.Gas(),
+			"gas currency", st.msg.GasCurrency())
 		return nil, 0, false, vm.ErrOutOfGas
 	}
 


### PR DESCRIPTION
### Description

Log gas currency as well as the amount of gas provided in case a transaction
is failing due to the "out of gas" error.

### Tested

Trivial change, therefore, tested with `make lint && make -j geth`