### PR TITLE
Increase bytecode limit to 2^16

### DIFF
--- a/cmd/puppeth/testdata/stureby_parity.json
+++ b/cmd/puppeth/testdata/stureby_parity.json
@@ -28,7 +28,7 @@
     "minGasLimit":"0x1388",
     "networkID":"0x4cb2e",
     "chainID":"0x4cb2e",
-    "maxCodeSize":"0xc000",
+    "maxCodeSize":"0x10000",
     "maxCodeSizeTransition":"0x0",
     "eip98Transition": "0x7fffffffffffffff",
     "eip150Transition":"0x3a98",

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -74,7 +74,7 @@ const (
 	MemoryGas        uint64 = 3     // Times the address of the (highest referenced byte in memory + 1). NOTE: referencing happens on read, write and in instructions such as RETURN and CALL.
 	TxDataNonZeroGas uint64 = 68    // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions.
 
-	MaxCodeSize = 49152 // Maximum bytecode to permit for a contract
+	MaxCodeSize = 65536 // Maximum bytecode to permit for a contract (2^16)
 
 	// Precompiled contract gas prices
 


### PR DESCRIPTION
### Description

Follows lead of https://github.com/celo-org/celo-blockchain/pull/421 to allow for more Governance contract features.

### Related issues
Partner PR in mono: https://github.com/celo-org/celo-monorepo/pull/613

### Backwards compatibility

See #421 
