### PR TITLE
CI: brings back to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           command: |
             set -euo pipefail
             export CELO_MONOREPO_DIR="$PWD"
-            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b kobigurk/pop_eth_address
+            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b master
             yarn install || yarn install
             # separate build to avoid ENOMEM in CI :(
             yarn build --scope @celo/utils


### PR DESCRIPTION
### Description

CI was moved to a specific branch in https://github.com/celo-org/celo-blockchain/pull/556. This brings it back.