### PR TITLE
Atomically update p2p server validator peers on valEnodeTable change

### DIFF
--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -85,15 +85,6 @@ type Backend interface {
 	// HasBadProposal returns whether the block with the hash is a bad block
 	HasBadProposal(hash common.Hash) bool
 
-	// AddValidatorPeer adds a validator peer
-	AddValidatorPeer(enodeURL string)
-
-	// RemoveValidatorPeer removes a validator peer
-	RemoveValidatorPeer(enodeURL string)
-
-	// Get's all of the validator peers' enodeURL
-	GetValidatorPeers() []string
-
 	// RefreshValPeers will connect all all the validators in the valset and disconnect validator peers that are not in the set
 	RefreshValPeers(valset ValidatorSet)
 

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -322,25 +322,10 @@ func (sb *Backend) handleIstAnnounce(payload []byte) error {
 
 	// Save in the valEnodeTable if mining
 	if sb.coreStarted {
-		oldEnodeURL, err := sb.valEnodeTable.Upsert(msg.Address, enodeURL, msg.View)
+		err := sb.valEnodeTable.Upsert(msg.Address, enodeURL, msg.View)
 		if err != nil {
 			sb.logger.Warn("Error in upserting a valenode entry", "AnnounceMsg", msg, "error", err)
 			return err
-		}
-
-		// Disconnect from old peer
-		if oldEnodeURL != "" {
-			sb.RemoveValidatorPeer(oldEnodeURL)
-		}
-
-		// Connect to the remote peer if it's part of the current epoch's valset and
-		// if this node is also part of the current epoch's valset
-		block := sb.currentBlock()
-		valSet := sb.getValidators(block.Number().Uint64(), block.Hash())
-		if _, remoteNode := valSet.GetByAddress(msg.Address); remoteNode != nil {
-			if _, localNode := valSet.GetByAddress(sb.Address()); localNode != nil {
-				sb.AddValidatorPeer(enodeURL)
-			}
 		}
 	}
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -605,7 +605,7 @@ func (vpl *validatorPeerHandler) RemoveValidatorPeer(enodeURL string) {
 
 func (vpl *validatorPeerHandler) ReplaceValidatorPeers(newEnodeURLs []string) {
 	if vpl.sb.broadcaster != nil {
-		var enodeURLSet map[string]bool
+		enodeURLSet := make(map[string]bool)
 		for _, enodeURL := range newEnodeURLs {
 			enodeURLSet[enodeURL] = true
 		}

--- a/consensus/istanbul/backend/internal/enodes/val_enode_db_test.go
+++ b/consensus/istanbul/backend/internal/enodes/val_enode_db_test.go
@@ -22,13 +22,23 @@ func view(sequence, round int64) *istanbul.View {
 	}
 }
 
+type mockListener struct{}
+
+func (ml *mockListener) ValidatorPeerAdded(enodeURL string, address common.Address) {
+
+}
+
+func (ml *mockListener) ValidatorPeerRemoved(enodeURL string) {
+
+}
+
 func TestSimpleCase(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("")
+	vet, err := OpenValidatorEnodeDB("", &mockListener{})
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
 
-	_, err = vet.Upsert(addressA, "http://XXXX", view(0, 1))
+	err = vet.Upsert(addressA, "http://XXXX", view(0, 1))
 	if err != nil {
 		t.Fatal("Failed to upsert")
 	}
@@ -51,30 +61,30 @@ func TestSimpleCase(t *testing.T) {
 }
 
 func TestUpsertOldValue(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("")
+	vet, err := OpenValidatorEnodeDB("", &mockListener{})
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
 
-	_, err = vet.Upsert(addressA, "http://XXXX", view(0, 2))
+	err = vet.Upsert(addressA, "http://XXXX", view(0, 2))
 	if err != nil {
 		t.Fatal("Failed to upsert")
 	}
 
 	// trying to insert an old value
-	_, err = vet.Upsert(addressA, "http://YYYY", view(0, 1))
+	err = vet.Upsert(addressA, "http://YYYY", view(0, 1))
 	if err == nil {
 		t.Fatal("Upsert should have failed")
 	}
 }
 
 func TestDeleteEntry(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("")
+	vet, err := OpenValidatorEnodeDB("", &mockListener{})
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
 
-	_, err = vet.Upsert(addressA, "http://XXXX", view(0, 2))
+	err = vet.Upsert(addressA, "http://XXXX", view(0, 2))
 	if err != nil {
 		t.Fatal("Failed to upsert")
 	}
@@ -95,7 +105,7 @@ func TestDeleteEntry(t *testing.T) {
 }
 
 func TestPruneEntries(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("")
+	vet, err := OpenValidatorEnodeDB("", &mockListener{})
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
@@ -141,7 +151,7 @@ func TestRLPEntries(t *testing.T) {
 }
 
 func TestTableToString(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("")
+	vet, err := OpenValidatorEnodeDB("", &mockListener{})
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}

--- a/consensus/istanbul/backend/internal/enodes/val_enode_db_test.go
+++ b/consensus/istanbul/backend/internal/enodes/val_enode_db_test.go
@@ -24,13 +24,10 @@ func view(sequence, round int64) *istanbul.View {
 
 type mockListener struct{}
 
-func (ml *mockListener) ValidatorPeerAdded(enodeURL string, address common.Address) {
-
-}
-
-func (ml *mockListener) ValidatorPeerRemoved(enodeURL string) {
-
-}
+func (ml *mockListener) AddValidatorPeer(enodeURL string, address common.Address) {}
+func (ml *mockListener) RemoveValidatorPeer(enodeURL string)                      {}
+func (ml *mockListener) ReplaceValidatorPeers(newEnodeURLs []string)              {}
+func (ml *mockListener) ClearValidatorPeers()                                     {}
 
 func TestSimpleCase(t *testing.T) {
 	vet, err := OpenValidatorEnodeDB("", &mockListener{})

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -27,12 +27,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/celo-org/bls-zexe/go"
+	bls "github.com/celo-org/bls-zexe/go"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/bls"
+	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	elog "github.com/ethereum/go-ethereum/log"
@@ -267,14 +267,6 @@ func (self *testSystemBackend) getRoundChangeMessage(view istanbul.View, prepare
 	}
 
 	return self.finalizeAndReturnMessage(msg)
-}
-
-func (self *testSystemBackend) AddValidatorPeer(enodeURL string) {}
-
-func (self *testSystemBackend) RemoveValidatorPeer(enodeURL string) {}
-
-func (self *testSystemBackend) GetValidatorPeers() []string {
-	return nil
 }
 
 func (self *testSystemBackend) Enode() *enode.Node {

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -104,6 +104,8 @@ type ValidatorSet interface {
 	GetByIndex(i uint64) Validator
 	// Get validator by given address
 	GetByAddress(addr common.Address) (int, Validator)
+	// CointainByAddress indicates if a validator with the given address is present
+	ContainsByAddress(add common.Address) bool
 
 	// Add validators
 	AddValidators(validators []ValidatorData) bool

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -143,6 +143,15 @@ func (valSet *defaultSet) GetByAddress(addr common.Address) (int, istanbul.Valid
 	return -1, nil
 }
 
+func (valSet *defaultSet) ContainsByAddress(addr common.Address) bool {
+	for _, val := range valSet.List() {
+		if addr == val.Address() {
+			return true
+		}
+	}
+	return false
+}
+
 func (valSet *defaultSet) GetFilteredIndex(addr common.Address) int {
 	for i, val := range valSet.FilteredList() {
 		if addr == val.Address() {


### PR DESCRIPTION
### Description

Reinserts previous lock to ensure changes are atomic.

After a discussion with @kevjue; we think there's a small change of race condition when we are processing an announce message for the same node with different values. For it, we need to ensure that changes to the valEnodeTable and to the p2p server happen atomically. Hence the lock was reinserted.

### Tested

Unit tests

### Other changes

Extract interface to hide listener logic
