### PR TITLE
refactor istanbul message

### DIFF
--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -145,11 +145,10 @@ func (sb *Backend) generateIstAnnounce() (*istanbul.Message, error) {
 	}
 
 	msg := &istanbul.Message{
-		Code:          istanbulAnnounceMsg,
-		Msg:           announceBytes,
-		Address:       sb.Address(),
-		Signature:     []byte{},
-		CommittedSeal: []byte{},
+		Code:      istanbulAnnounceMsg,
+		Msg:       announceBytes,
+		Address:   sb.Address(),
+		Signature: []byte{},
 	}
 
 	sb.logger.Debug("Generated an announce message", "IstanbulMsg", msg.String(), "AnnounceMsg", announceMessage.String())

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -118,9 +118,16 @@ func (sb *Backend) HandleMsg(addr common.Address, msg p2p.Msg, peer consensus.Pe
 				return true, nil
 			}
 
-			fwdMsg := new(istanbul.Message)
-			if err := fwdMsg.FromPayload(data, nil); err != nil {
+			msg := new(istanbul.Message)
+			if err := msg.FromPayload(data, nil); err != nil {
 				sb.logger.Error("Failed to decode message from payload", "err", err)
+				return true, err
+			}
+
+			var fwdMsg *istanbul.ForwardMessage
+			err := msg.Decode(&fwdMsg)
+			if err != nil {
+				sb.logger.Error("Failed to decode a ForwardMessage", "err", err)
 				return true, err
 			}
 

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -118,14 +118,17 @@ func (sb *Backend) HandleMsg(addr common.Address, msg p2p.Msg, peer consensus.Pe
 				return true, nil
 			}
 
-			msg := new(istanbul.Message)
-			if err := msg.FromPayload(data, nil); err != nil {
+			istMsg := new(istanbul.Message)
+
+			// An Istanbul FwdMsg doesn't have a signature since it's coming from a trusted peer and
+			// the wrapped message is already signed by the proxied validator.
+			if err := istMsg.FromPayload(data, nil); err != nil {
 				sb.logger.Error("Failed to decode message from payload", "err", err)
 				return true, err
 			}
 
 			var fwdMsg *istanbul.ForwardMessage
-			err := msg.Decode(&fwdMsg)
+			err := istMsg.Decode(&fwdMsg)
 			if err != nil {
 				sb.logger.Error("Failed to decode a ForwardMessage", "err", err)
 				return true, err

--- a/consensus/istanbul/backend/val_enode_share.go
+++ b/consensus/istanbul/backend/val_enode_share.go
@@ -123,11 +123,10 @@ func (sb *Backend) generateValEnodeShareMsg() (*istanbul.Message, error) {
 	}
 
 	msg := &istanbul.Message{
-		Code:          istanbulValEnodeShareMsg,
-		Msg:           valEnodeShareBytes,
-		Address:       sb.Address(),
-		Signature:     []byte{},
-		CommittedSeal: []byte{},
+		Code:      istanbulValEnodeShareMsg,
+		Msg:       valEnodeShareBytes,
+		Address:   sb.Address(),
+		Signature: []byte{},
 	}
 
 	sb.logger.Trace("Generated a Istanbul Validator Enode Share message", "IstanbulMsg", msg.String(), "ValEnodeShareMsg", valEnodeShareMessage.String())

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -175,13 +175,16 @@ OUTER:
 			signature, _ := privateKey.SignMessage(hash, []byte{}, false)
 			defer signature.Destroy()
 			signatureBytes, _ := signature.Serialize()
-			m, _ := Encode(v.engine.(*core).current.Subject())
-			if err := r0.handleCommit(&istanbul.Message{
-				Code:          istanbul.MsgCommit,
-				Msg:           m,
-				Address:       validator.Address(),
-				Signature:     []byte{},
+			committedSubject := &istanbul.CommittedSubject{
+				Subject:       v.engine.(*core).current.Subject(),
 				CommittedSeal: signatureBytes,
+			}
+			m, _ := Encode(committedSubject)
+			if err := r0.handleCommit(&istanbul.Message{
+				Code:      istanbul.MsgCommit,
+				Msg:       m,
+				Address:   validator.Address(),
+				Signature: []byte{},
 			}); err != nil {
 				if err != test.expectedErr {
 					t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
@@ -238,15 +241,17 @@ func TestVerifyCommit(t *testing.T) {
 
 	testCases := []struct {
 		expected   error
-		commit     *istanbul.Subject
+		commit     *istanbul.CommittedSubject
 		roundState *roundState
 	}{
 		{
 			// normal case
 			expected: nil,
-			commit: &istanbul.Subject{
-				View:   &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(0)},
-				Digest: newTestProposal().Hash(),
+			commit: &istanbul.CommittedSubject{
+				Subject: &istanbul.Subject{
+					View:   &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(0)},
+					Digest: newTestProposal().Hash(),
+				},
 			},
 			roundState: newTestRoundState(
 				&istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(0)},
@@ -256,9 +261,11 @@ func TestVerifyCommit(t *testing.T) {
 		{
 			// old message
 			expected: errInconsistentSubject,
-			commit: &istanbul.Subject{
-				View:   &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(0)},
-				Digest: newTestProposal().Hash(),
+			commit: &istanbul.CommittedSubject{
+				Subject: &istanbul.Subject{
+					View:   &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(0)},
+					Digest: newTestProposal().Hash(),
+				},
 			},
 			roundState: newTestRoundState(
 				&istanbul.View{Round: big.NewInt(1), Sequence: big.NewInt(1)},
@@ -268,9 +275,11 @@ func TestVerifyCommit(t *testing.T) {
 		{
 			// different digest
 			expected: errInconsistentSubject,
-			commit: &istanbul.Subject{
-				View:   &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(0)},
-				Digest: common.BytesToHash([]byte("1234567890")),
+			commit: &istanbul.CommittedSubject{
+				Subject: &istanbul.Subject{
+					View:   &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(0)},
+					Digest: common.BytesToHash([]byte("1234567890")),
+				},
 			},
 			roundState: newTestRoundState(
 				&istanbul.View{Round: big.NewInt(1), Sequence: big.NewInt(1)},
@@ -280,9 +289,11 @@ func TestVerifyCommit(t *testing.T) {
 		{
 			// malicious package(lack of sequence)
 			expected: errInconsistentSubject,
-			commit: &istanbul.Subject{
-				View:   &istanbul.View{Round: big.NewInt(0), Sequence: nil},
-				Digest: newTestProposal().Hash(),
+			commit: &istanbul.CommittedSubject{
+				Subject: &istanbul.Subject{
+					View:   &istanbul.View{Round: big.NewInt(0), Sequence: nil},
+					Digest: newTestProposal().Hash(),
+				},
 			},
 			roundState: newTestRoundState(
 				&istanbul.View{Round: big.NewInt(1), Sequence: big.NewInt(1)},
@@ -292,9 +303,11 @@ func TestVerifyCommit(t *testing.T) {
 		{
 			// wrong prepare message with same sequence but different round
 			expected: errInconsistentSubject,
-			commit: &istanbul.Subject{
-				View:   &istanbul.View{Round: big.NewInt(1), Sequence: big.NewInt(0)},
-				Digest: newTestProposal().Hash(),
+			commit: &istanbul.CommittedSubject{
+				Subject: &istanbul.Subject{
+					View:   &istanbul.View{Round: big.NewInt(1), Sequence: big.NewInt(0)},
+					Digest: newTestProposal().Hash(),
+				},
 			},
 			roundState: newTestRoundState(
 				&istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(0)},
@@ -304,9 +317,11 @@ func TestVerifyCommit(t *testing.T) {
 		{
 			// wrong prepare message with same round but different sequence
 			expected: errInconsistentSubject,
-			commit: &istanbul.Subject{
-				View:   &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(1)},
-				Digest: newTestProposal().Hash(),
+			commit: &istanbul.CommittedSubject{
+				Subject: &istanbul.Subject{
+					View:   &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(1)},
+					Digest: newTestProposal().Hash(),
+				},
 			},
 			roundState: newTestRoundState(
 				&istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(0)},

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -173,7 +173,14 @@ func (c *core) commit() {
 		committedSeals := make([][]byte, c.current.Commits.Size())
 		for i, v := range c.current.Commits.Values() {
 			committedSeals[i] = make([]byte, types.IstanbulExtraCommittedSeal)
-			copy(committedSeals[i][:], v.CommittedSeal[:])
+
+			var commit *istanbul.CommittedSubject
+			err := v.Decode(&commit)
+			if err != nil {
+				panic(fmt.Sprintf("commit: error in decoding committed subject for address %s", hex.EncodeToString(v.Address[:])))
+			}
+
+			copy(committedSeals[i][:], commit.CommittedSeal[:])
 			j, err := c.current.Commits.GetAddressIndex(v.Address)
 			if err != nil {
 				panic(fmt.Sprintf("commit: couldn't get address index for address %s", hex.EncodeToString(v.Address[:])))

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -45,11 +45,10 @@ func TestHandleMsg(t *testing.T) {
 	})
 	// with a matched payload. istanbul.MsgPreprepare should match with *istanbul.Preprepare in normal case.
 	msg := &istanbul.Message{
-		Code:          istanbul.MsgPreprepare,
-		Msg:           m,
-		Address:       v0.Address(),
-		Signature:     []byte{},
-		CommittedSeal: []byte{},
+		Code:      istanbul.MsgPreprepare,
+		Msg:       m,
+		Address:   v0.Address(),
+		Signature: []byte{},
 	}
 
 	_, val := v0.Validators(nil).GetByAddress(v0.Address())
@@ -66,11 +65,10 @@ func TestHandleMsg(t *testing.T) {
 	})
 	// with a unmatched payload. istanbul.MsgPrepare should match with *istanbul.Subject in normal case.
 	msg = &istanbul.Message{
-		Code:          istanbul.MsgPrepare,
-		Msg:           m,
-		Address:       v0.Address(),
-		Signature:     []byte{},
-		CommittedSeal: []byte{},
+		Code:      istanbul.MsgPrepare,
+		Msg:       m,
+		Address:   v0.Address(),
+		Signature: []byte{},
 	}
 
 	_, val = v0.Validators(nil).GetByAddress(v0.Address())
@@ -87,11 +85,10 @@ func TestHandleMsg(t *testing.T) {
 	})
 	// with a unmatched payload. istanbul.MsgCommit should match with *istanbul.Subject in normal case.
 	msg = &istanbul.Message{
-		Code:          istanbul.MsgCommit,
-		Msg:           m,
-		Address:       v0.Address(),
-		Signature:     []byte{},
-		CommittedSeal: []byte{},
+		Code:      istanbul.MsgCommit,
+		Msg:       m,
+		Address:   v0.Address(),
+		Signature: []byte{},
 	}
 
 	_, val = v0.Validators(nil).GetByAddress(v0.Address())
@@ -108,11 +105,10 @@ func TestHandleMsg(t *testing.T) {
 	})
 	// invalid message code. message code is not exists in list
 	msg = &istanbul.Message{
-		Code:          uint64(99),
-		Msg:           m,
-		Address:       v0.Address(),
-		Signature:     []byte{},
-		CommittedSeal: []byte{},
+		Code:      uint64(99),
+		Msg:       m,
+		Address:   v0.Address(),
+		Signature: []byte{},
 	}
 
 	_, val = v0.Validators(nil).GetByAddress(v0.Address())

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -91,6 +91,14 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 			}
 			subject = committedSubject.Subject
 			committedSeal = committedSubject.CommittedSeal
+
+			// Verify the committedSeal
+			_, src := c.valSet.GetByAddress(signer)
+			err = c.verifyCommittedSeal(subject.Digest, committedSeal, src)
+			if err != nil {
+				logger.Error("Commit seal did not contain signature from message signer.", "err", err)
+				return err
+			}
 		} else {
 			if err := message.Decode(&subject); err != nil {
 				logger.Error("Failed to decode message in PREPARED certificate", "err", err)
@@ -108,16 +116,6 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 			return errInvalidPreparedCertificateDigestMismatch
 		}
 
-		// If COMMIT message, verify valid committed seal.
-		if message.Code == istanbul.MsgCommit {
-			_, src := c.valSet.GetByAddress(signer)
-
-			err := c.verifyCommittedSeal(subject.Digest, committedSeal, src)
-			if err != nil {
-				logger.Error("Commit seal did not contain signature from message signer.", "err", err)
-				return err
-			}
-		}
 	}
 	return nil
 }

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -53,7 +53,7 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 
 	seen := make(map[common.Address]bool)
 	for _, message := range preparedCertificate.PrepareOrCommitMessages {
-		data, err := message.PayloadNoSigAndDestAddrs()
+		data, err := message.PayloadNoSig()
 		if err != nil {
 			return err
 		}
@@ -80,9 +80,22 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 		}
 
 		var subject *istanbul.Subject
-		if err := message.Decode(&subject); err != nil {
-			logger.Error("Failed to decode message in PREPARED certificate", "err", err)
-			return err
+		var committedSeal []byte // This is set if the message.Code == MsgCommit
+
+		if message.Code == istanbul.MsgCommit {
+			var committedSubject *istanbul.CommittedSubject
+			err := message.Decode(&committedSubject)
+			if err != nil {
+				logger.Error("Failed to decode committedSubject in PREPARED certificate", "err", err)
+				return err
+			}
+			subject = committedSubject.Subject
+			committedSeal = committedSubject.CommittedSeal
+		} else {
+			if err := message.Decode(&subject); err != nil {
+				logger.Error("Failed to decode message in PREPARED certificate", "err", err)
+				return err
+			}
 		}
 
 		// Verify message for the proper sequence.
@@ -98,7 +111,8 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 		// If COMMIT message, verify valid committed seal.
 		if message.Code == istanbul.MsgCommit {
 			_, src := c.valSet.GetByAddress(signer)
-			err := c.verifyCommittedSeal(subject.Digest, message.CommittedSeal, src)
+
+			err := c.verifyCommittedSeal(subject.Digest, committedSeal, src)
 			if err != nil {
 				logger.Error("Commit seal did not contain signature from message signer.", "err", err)
 				return err

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -382,12 +382,12 @@ OUTER:
 		if decodedMsg.Code != istanbul.MsgCommit {
 			t.Errorf("message code mismatch: have %v, want %v", decodedMsg.Code, istanbul.MsgCommit)
 		}
-		var m *istanbul.Subject
+		var m *istanbul.CommittedSubject
 		err = decodedMsg.Decode(&m)
 		if err != nil {
 			t.Errorf("error mismatch: have %v, want nil", err)
 		}
-		if !reflect.DeepEqual(m, expectedSubject) {
+		if !reflect.DeepEqual(m.Subject, expectedSubject) {
 			t.Errorf("subject mismatch: have %v, want %v", m, expectedSubject)
 		}
 	}

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -76,7 +76,7 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 	decodedMessages := make([]istanbul.RoundChange, len(roundChangeCertificate.RoundChangeMessages))
 	for i, message := range roundChangeCertificate.RoundChangeMessages {
 		// Verify message signed by a validator
-		data, err := message.PayloadNoSigAndDestAddrs()
+		data, err := message.PayloadNoSig()
 		if err != nil {
 			return err
 		}

--- a/consensus/istanbul/core/types_test.go
+++ b/consensus/istanbul/core/types_test.go
@@ -128,11 +128,10 @@ func testSubjectWithSignature(t *testing.T) {
 	subjectPayload, _ := Encode(s)
 	// 1. Encode test
 	m := &istanbul.Message{
-		Code:          istanbul.MsgPreprepare,
-		Msg:           subjectPayload,
-		Address:       correctAddress,
-		Signature:     expectedSig,
-		CommittedSeal: []byte{},
+		Code:      istanbul.MsgPreprepare,
+		Msg:       subjectPayload,
+		Address:   correctAddress,
+		Signature: expectedSig,
 	}
 
 	msgPayload, err := m.Payload()


### PR DESCRIPTION
### Description

This is a follow up PR for this one:  https://github.com/celo-org/celo-blockchain/pull/515

It has the following changes:

1) Created a new subject type `CommittedSubject` that is used for commit messages.  This type contains a subject and a commitedSeal for it.  The `CommittedSeal` field that original was in the Istanbul `Message` type is moved to the new type.  @kobigurk - I would really appreciate it if you could take a glance at this.
2) Created a new istanbul submessage type `ForwardMessage` that is used by proxied validators to instruct the proxy forward it's consensus messages.

### Tested

* Ran geth unit tests
* Ran e2e proxy test


### Backwards compatibility

Is not backward compatible.