### PR TITLE
Panic on cache creation failure when creating a new backend for consensus

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -68,22 +68,23 @@ type AnnounceGossipTimestamp struct {
 // New creates an Ethereum backend for Istanbul core engine.
 func New(config *istanbul.Config, db ethdb.Database, dataDir string) consensus.Istanbul {
 	// Allocate the snapshot caches and create the engine
+	logger := log.New()
 	recentSnapshots, err := lru.NewARC(inmemorySnapshots)
 	if err != nil {
-		backend.logger.Crit("Failed to create recent snapshots cache", "err", err)
+		logger.Crit("Failed to create recent snapshots cache", "err", err)
 	}
 	recentMessages, err := lru.NewARC(inmemoryPeers)
 	if err != nil {
-		backend.logger.Crit("Failed to create recent messages cache", "err", err)
+		logger.Crit("Failed to create recent messages cache", "err", err)
 	}
 	knownMessages, err := lru.NewARC(inmemoryMessages)
 	if err != nil {
-		backend.logger.Crit("Failed to create known messages cache", "err", err)
+		logger.Crit("Failed to create known messages cache", "err", err)
 	}
 	backend := &Backend{
 		config:               config,
 		istanbulEventMux:     new(event.TypeMux),
-		logger:               log.New(),
+		logger:               logger,
 		db:                   db,
 		commitCh:             make(chan *types.Block, 1),
 		recentSnapshots:      recentSnapshots,
@@ -98,7 +99,7 @@ func New(config *istanbul.Config, db ethdb.Database, dataDir string) consensus.I
 	backend.core = istanbulCore.New(backend, backend.config)
 	table, err := enodes.OpenValidatorEnodeDB(config.ValidatorEnodeDBPath)
 	if err != nil {
-		backend.logger.Crit("Can't open ValidatorEnodeDB", "err", err, "dbpath", config.ValidatorEnodeDBPath)
+		logger.Crit("Can't open ValidatorEnodeDB", "err", err, "dbpath", config.ValidatorEnodeDBPath)
 	}
 	backend.valEnodeTable = table
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -607,7 +607,7 @@ func (sb *Backend) snapshot(chain consensus.ChainReader, number uint64, hash com
 	// Retrieve the most recent cached or on disk snapshot.
 	for ; ; numberIter = numberIter - sb.config.Epoch {
 		// If an in-memory snapshot was found, use that
-		if s, ok := sb.recents.Get(numberIter); ok {
+		if s, ok := sb.recentSnapshots.Get(numberIter); ok {
 			snap = s.(*Snapshot)
 			break
 		}
@@ -714,7 +714,7 @@ func (sb *Backend) snapshot(chain consensus.ChainReader, number uint64, hash com
 			return nil, err
 		}
 
-		sb.recents.Add(numberIter, snap)
+		sb.recentSnapshots.Add(numberIter, snap)
 	}
 	// Make a copy of the snapshot to return, since a few fields will be modified.
 	// The original snap is probably stored within the LRU cache, so we don't want to


### PR DESCRIPTION
### Description

If cache creation fails while creating a backend for the consensus engine, log and panic instead of continuing without error. The only failure condition based on the current code is if the cache size, which is constant, is changed to be less than zero, but it is always good practice to handle errors.

### Other changes

Rename `recents` to `recentSnapshots`

### Related issues

- Fixes https://github.com/celo-org/celo-blockchain/issues/586

### Backwards compatibility

Fully backwards compatible
