### PR TITLE
PrepareCert view consistency check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           command: |
             set -euo pipefail
             export CELO_MONOREPO_DIR="$PWD"
-            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b victor/gpm
+            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git ${CELO_MONOREPO_DIR} -b master 
             yarn install || yarn install
             # separate build to avoid ENOMEM in CI :(
             yarn build --scope @celo/utils

--- a/consensus/istanbul/core/errors.go
+++ b/consensus/istanbul/core/errors.go
@@ -55,6 +55,8 @@ var (
 	errInvalidPreparedCertificateDigestMismatch = errors.New("message in PREPARED certificate for different digest than proposal")
 	// errInvalidRoundChangeViewMismatch is returned when the PREPARED certificate view is greater than the round change view
 	errInvalidRoundChangeViewMismatch = errors.New("View for PREPARED certificate is greater than the view in the round change message")
+	// errInvalidPreparedCertificateInconsistentViews is returned when the PREPARED certificate view is inconsistent among it's messages
+	errInvalidPreparedCertificateInconsistentViews = errors.New("View is inconsistent among the PREPARED certificate messages")
 
 	// errInvalidRoundChangeCertificateNumMsgs is returned when the ROUND CHANGE certificate has an incorrect number of ROUND CHANGE messages.
 	errInvalidRoundChangeCertificateNumMsgs = errors.New("invalid number of ROUND CHANGE messages in certificate")

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -52,6 +52,8 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 	}
 
 	seen := make(map[common.Address]bool)
+
+	var view *istanbul.View
 	for _, message := range preparedCertificate.PrepareOrCommitMessages {
 		data, err := message.PayloadNoSig()
 		if err != nil {
@@ -93,6 +95,15 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 		// Verify message for the proper proposal.
 		if subject.Digest != preparedCertificate.Proposal.Hash() {
 			return errInvalidPreparedCertificateDigestMismatch
+		}
+
+		// Verify that the view is the same for all of the messages
+		if view == nil {
+			view = subject.View
+		} else {
+			if view.Cmp(subject.View) != 0 {
+				return errInvalidPreparedCertificateInconsistentViews
+			}
 		}
 
 		// If COMMIT message, verify valid committed seal.

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -180,6 +180,41 @@ func TestHandlePreprepare(t *testing.T) {
 			false,
 		},
 		{
+			// ROUND CHANGE certificate contains PREPARED certificate with inconsistent views among the cert's messages
+			func() *testSystem {
+				sys := NewTestSystemWithBackend(N, F)
+
+				for _, backend := range sys.backends {
+					c := backend.engine.(*core)
+					c.valSet = backend.peers
+					c.state = StatePreprepared
+					c.current.SetPreprepare(&istanbul.Preprepare{
+						View: &istanbul.View{
+							Round:    big.NewInt(1),
+							Sequence: big.NewInt(0),
+						},
+						Proposal:               makeBlock(2),
+						RoundChangeCertificate: istanbul.RoundChangeCertificate{},
+					})
+				}
+				return sys
+			}(),
+			func(sys *testSystem) istanbul.RoundChangeCertificate {
+				view1 := *(sys.backends[0].engine.(*core).currentView())
+
+				var view2 istanbul.View
+				view2.Sequence = big.NewInt(view1.Sequence.Int64())
+				view2.Round = big.NewInt(view1.Round.Int64() + 1)
+
+				preparedCertificate := sys.getPreparedCertificate(t, []istanbul.View{view1, view2}, makeBlock(2))
+				roundChangeCertificate := sys.getRoundChangeCertificate(t, *(sys.backends[0].engine.(*core).currentView()), preparedCertificate)
+				return roundChangeCertificate
+			},
+			makeBlock(2),
+			errInvalidPreparedCertificateInconsistentViews,
+			false,
+		},
+		{
 			// ROUND CHANGE certificate contains PREPARED certificate for a different block.
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
@@ -201,7 +236,7 @@ func TestHandlePreprepare(t *testing.T) {
 				return sys
 			}(),
 			func(sys *testSystem) istanbul.RoundChangeCertificate {
-				preparedCertificate := sys.getPreparedCertificate(t, *(sys.backends[0].engine.(*core).currentView()), makeBlock(2))
+				preparedCertificate := sys.getPreparedCertificate(t, []istanbul.View{*(sys.backends[0].engine.(*core).currentView())}, makeBlock(2))
 				roundChangeCertificate := sys.getRoundChangeCertificate(t, *(sys.backends[0].engine.(*core).currentView()), preparedCertificate)
 				return roundChangeCertificate
 			},
@@ -209,6 +244,7 @@ func TestHandlePreprepare(t *testing.T) {
 			errInvalidPreparedCertificateDigestMismatch,
 			false,
 		},
+
 		{
 			// ROUND CHANGE certificate for N+1 round with valid PREPARED certificates
 			// Round is N+1 to match the correct proposer.
@@ -226,7 +262,7 @@ func TestHandlePreprepare(t *testing.T) {
 				return sys
 			}(),
 			func(sys *testSystem) istanbul.RoundChangeCertificate {
-				preparedCertificate := sys.getPreparedCertificate(t, *(sys.backends[0].engine.(*core).currentView()), makeBlock(0))
+				preparedCertificate := sys.getPreparedCertificate(t, []istanbul.View{*(sys.backends[0].engine.(*core).currentView())}, makeBlock(0))
 				roundChangeCertificate := sys.getRoundChangeCertificate(t, *(sys.backends[0].engine.(*core).currentView()), preparedCertificate)
 				return roundChangeCertificate
 			},

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -188,10 +188,11 @@ func TestHandlePreprepare(t *testing.T) {
 					c := backend.engine.(*core)
 					c.valSet = backend.peers
 					c.state = StatePreprepared
+					c.current.SetRound(big.NewInt(1))
 					c.current.SetPreprepare(&istanbul.Preprepare{
 						View: &istanbul.View{
 							Round:    big.NewInt(1),
-							Sequence: big.NewInt(0),
+							Sequence: big.NewInt(2),
 						},
 						Proposal:               makeBlock(2),
 						RoundChangeCertificate: istanbul.RoundChangeCertificate{},

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -178,7 +178,7 @@ func TestHandleRoundChangeCertificate(t *testing.T) {
 		{
 			// Valid round change certificate with PREPARED certificate
 			func(sys *testSystem) istanbul.RoundChangeCertificate {
-				return sys.getRoundChangeCertificate(t, view, sys.getPreparedCertificate(t, view, makeBlock(0)))
+				return sys.getRoundChangeCertificate(t, view, sys.getPreparedCertificate(t, []istanbul.View{view}, makeBlock(0)))
 			},
 			nil,
 		},
@@ -241,7 +241,7 @@ func TestHandleRoundChange(t *testing.T) {
 			// normal case with valid prepared certificate
 			NewTestSystemWithBackend(N, F),
 			func(sys *testSystem) istanbul.PreparedCertificate {
-				return sys.getPreparedCertificate(t, *sys.backends[0].engine.(*core).currentView(), makeBlock(1))
+				return sys.getPreparedCertificate(t, []istanbul.View{*sys.backends[0].engine.(*core).currentView()}, makeBlock(1))
 			},
 			nil,
 		},
@@ -249,7 +249,7 @@ func TestHandleRoundChange(t *testing.T) {
 			// normal case with invalid prepared certificate
 			NewTestSystemWithBackend(N, F),
 			func(sys *testSystem) istanbul.PreparedCertificate {
-				preparedCert := sys.getPreparedCertificate(t, *sys.backends[0].engine.(*core).currentView(), makeBlock(1))
+				preparedCert := sys.getPreparedCertificate(t, []istanbul.View{*sys.backends[0].engine.(*core).currentView()}, makeBlock(1))
 				preparedCert.PrepareOrCommitMessages[0] = preparedCert.PrepareOrCommitMessages[1]
 				return preparedCert
 			},

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -463,7 +463,7 @@ func (t *testSystem) MinQuorumSize() uint64 {
 	return uint64(math.Ceil(float64(2*t.n) / 3))
 }
 
-func (sys *testSystem) getPreparedCertificate(t *testing.T, view istanbul.View, proposal istanbul.Proposal) istanbul.PreparedCertificate {
+func (sys *testSystem) getPreparedCertificate(t *testing.T, views []istanbul.View, proposal istanbul.Proposal) istanbul.PreparedCertificate {
 	preparedCertificate := istanbul.PreparedCertificate{
 		Proposal:                proposal,
 		PrepareOrCommitMessages: []istanbul.Message{},
@@ -475,9 +475,9 @@ func (sys *testSystem) getPreparedCertificate(t *testing.T, view istanbul.View, 
 		var err error
 		var msg istanbul.Message
 		if i%2 == 0 {
-			msg, err = backend.getPrepareMessage(view, proposal.Hash())
+			msg, err = backend.getPrepareMessage(views[i%len(views)], proposal.Hash())
 		} else {
-			msg, err = backend.getCommitMessage(view, proposal)
+			msg, err = backend.getCommitMessage(views[i%len(views)], proposal)
 		}
 		if err != nil {
 			t.Errorf("Failed to create message %v: %v", i, err)


### PR DESCRIPTION
### Description

This PR modifies the verifyPrepareCert function so that it will check that all of it's messages' views are the same.

### Tested

Added unit test cases and made sure they worked.

### Other changes


### Related issues

- Fixes https://github.com/celo-org/celo-blockchain/issues/587

### Backwards compatibility

Is not backward compatible
