### PR TITLE
Hide RoundState Implementation

### DIFF
--- a/consensus/istanbul/core/backlog.go
+++ b/consensus/istanbul/core/backlog.go
@@ -98,7 +98,7 @@ func (c *core) storeBacklog(msg *istanbul.Message, src istanbul.Validator) {
 		logger = logger.New("cur_seq", 0, "cur_round", -1)
 	}
 
-	if msg.Address == c.Address() {
+	if msg.Address == c.address {
 		logger.Warn("Backlog from self")
 		return
 	}

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -130,7 +130,7 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 	}
 
 	c.acceptCommit(msg)
-	numberOfCommits := c.current.Commits.Size()
+	numberOfCommits := c.current.Commits().Size()
 	minQuorumSize := c.valSet.MinQuorumSize()
 	logger.Trace("Accepted commit", "Number of commits", numberOfCommits)
 
@@ -178,7 +178,7 @@ func (c *core) acceptCommit(msg *istanbul.Message) error {
 	logger := c.logger.New("from", msg.Address, "state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "acceptCommit")
 
 	// Add the COMMIT message to current round state
-	if err := c.current.Commits.Add(msg); err != nil {
+	if err := c.current.Commits().Add(msg); err != nil {
 		logger.Error("Failed to record commit message", "msg", msg, "err", err)
 		return err
 	}
@@ -190,7 +190,7 @@ func (c *core) acceptParentCommit(msg *istanbul.Message, view *istanbul.View) er
 	logger := c.logger.New("from", msg.Address, "state", c.state, "parent_round", view.Round, "parent_seq", view.Sequence, "func", "acceptParentCommit")
 
 	// Add the ParentCommit to current round state
-	if err := c.current.ParentCommits.Add(msg); err != nil {
+	if err := c.current.ParentCommits().Add(msg); err != nil {
 		logger.Error("Failed to record parent seal", "msg", msg, "err", err)
 		return err
 	}

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -236,8 +236,8 @@ OUTER:
 		// how can we add our signature to the ParentCommit? Broadcast to ourselve
 		// does not make much sense
 		if test.checkParentCommits {
-			if r0.current.ParentCommits.Size() != r0.valSet.Size()-1 { // TODO: Maybe remove the -1?
-				t.Errorf("parent seals mismatch: have %v, want %v", r0.current.ParentCommits.Size(), r0.valSet.Size()-1)
+			if r0.current.ParentCommits().Size() != r0.valSet.Size()-1 { // TODO: Maybe remove the -1?
+				t.Errorf("parent seals mismatch: have %v, want %v", r0.current.ParentCommits().Size(), r0.valSet.Size()-1)
 			}
 		}
 
@@ -247,15 +247,15 @@ OUTER:
 			if r0.state != StatePrepared {
 				t.Errorf("state mismatch: have %v, want %v", r0.state, StatePrepared)
 			}
-			if r0.current.Commits.Size() > r0.valSet.MinQuorumSize() {
+			if r0.current.Commits().Size() > r0.valSet.MinQuorumSize() {
 				t.Errorf("the size of commit messages should be less than %v", r0.valSet.MinQuorumSize())
 			}
 			continue
 		}
 
 		// core should have min quorum size prepare messages
-		if r0.current.Commits.Size() < r0.valSet.MinQuorumSize() {
-			t.Errorf("the size of commit messages should be greater than or equal to minQuorumSize: size %v", r0.current.Commits.Size())
+		if r0.current.Commits().Size() < r0.valSet.MinQuorumSize() {
+			t.Errorf("the size of commit messages should be greater than or equal to minQuorumSize: size %v", r0.current.Commits().Size())
 		}
 
 		// check signatures large than MinQuorumSize
@@ -290,7 +290,7 @@ func TestVerifyCommit(t *testing.T) {
 	testCases := []struct {
 		expected   error
 		commit     *istanbul.Subject
-		roundState *roundState
+		roundState RoundState
 	}{
 		{
 			// normal case

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -118,7 +118,7 @@ func (c *core) SetAddress(address common.Address) {
 func (c *core) finalizeMessage(msg *istanbul.Message) ([]byte, error) {
 	var err error
 	// Add sender address
-	msg.Address = c.Address()
+	msg.Address = c.address
 
 	// Sign message
 	data, err := msg.PayloadNoSig()
@@ -163,11 +163,10 @@ func (c *core) currentView() *istanbul.View {
 }
 
 func (c *core) isProposer() bool {
-	v := c.valSet
-	if v == nil {
+	if c.valSet == nil {
 		return false
 	}
-	return v.IsProposer(c.backend.Address())
+	return c.valSet.IsProposer(c.address)
 }
 
 func (c *core) commit() {
@@ -416,10 +415,6 @@ func (c *core) setState(state State) {
 		c.processPendingRequests()
 	}
 	c.processBacklog()
-}
-
-func (c *core) Address() common.Address {
-	return c.address
 }
 
 func (c *core) stopFuturePreprepareTimer() {

--- a/consensus/istanbul/core/errors.go
+++ b/consensus/istanbul/core/errors.go
@@ -73,8 +73,6 @@ var (
 	errInvalidCommittedSeal = errors.New("invalid committed seal in COMMIT message")
 	// errMissingRoundChangeCertificate is returned when ROUND CHANGE certificate is missing from a PREPREPARE for round > 0.
 	errMissingRoundChangeCertificate = errors.New("missing ROUND CHANGE certificate in PREPREPARE")
-	// errFailedCreatePreparedCertificate is returned when there aren't enough PREPARE messages to create a PREPARED certificate.
-	errFailedCreatePreparedCertificate = errors.New("failed to create PREPARED certficate")
 	// errFailedCreateRoundChangeCertificate is returned when there aren't enough ROUND CHANGE messages to create a ROUND CHANGE certificate.
 	errFailedCreateRoundChangeCertificate = errors.New("failed to create ROUND CHANGE certficate")
 	// errInvalidProposal is returned when a PREPARED certificate exists for proposal A in the ROUND CHANGE certificate for a PREPREPARE with proposal B.

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -24,11 +24,10 @@ import (
 )
 
 func (c *core) ParentCommits() *messageSet {
-	if c.current != nil {
-		return c.current.ParentCommits
-	} else {
+	if c.current == nil {
 		return nil
 	}
+	return c.current.ParentCommits
 }
 
 // Start implements core.Engine.Start

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -23,11 +23,11 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
-func (c *core) ParentCommits() *messageSet {
+func (c *core) ParentCommits() MessageSet {
 	if c.current == nil {
 		return nil
 	}
-	return c.current.ParentCommits
+	return c.current.ParentCommits()
 }
 
 // Start implements core.Engine.Start

--- a/consensus/istanbul/core/message_set.go
+++ b/consensus/istanbul/core/message_set.go
@@ -46,7 +46,6 @@ type MessageSet interface {
 	Values() (result []*istanbul.Message)
 	Size() int
 	Get(addr common.Address) *istanbul.Message
-	// String() string
 }
 
 type messageSetImpl struct {

--- a/consensus/istanbul/core/message_set.go
+++ b/consensus/istanbul/core/message_set.go
@@ -26,8 +26,8 @@ import (
 )
 
 // Construct a new message set to accumulate messages for given sequence/view number.
-func newMessageSet(valSet istanbul.ValidatorSet) *messageSet {
-	return &messageSet{
+func newMessageSet(valSet istanbul.ValidatorSet) MessageSet {
+	return &messageSetImpl{
 		messagesMu: new(sync.Mutex),
 		messages:   make(map[common.Address]*istanbul.Message),
 		valSet:     valSet,
@@ -36,13 +36,26 @@ func newMessageSet(valSet istanbul.ValidatorSet) *messageSet {
 
 // ----------------------------------------------------------------------------
 
-type messageSet struct {
+type MessageSet interface {
+	fmt.Stringer
+	Add(msg *istanbul.Message) error
+	GetAddressIndex(addr common.Address) (uint64, error)
+	GetAddressPublicKey(addr common.Address) ([]byte, error)
+	ValSetSize() uint64
+	Remove(address common.Address)
+	Values() (result []*istanbul.Message)
+	Size() int
+	Get(addr common.Address) *istanbul.Message
+	// String() string
+}
+
+type messageSetImpl struct {
 	valSet     istanbul.ValidatorSet
 	messagesMu *sync.Mutex
 	messages   map[common.Address]*istanbul.Message
 }
 
-func (ms *messageSet) Add(msg *istanbul.Message) error {
+func (ms *messageSetImpl) Add(msg *istanbul.Message) error {
 	ms.messagesMu.Lock()
 	defer ms.messagesMu.Unlock()
 
@@ -53,7 +66,7 @@ func (ms *messageSet) Add(msg *istanbul.Message) error {
 	return ms.addVerifiedMessage(msg)
 }
 
-func (ms *messageSet) GetAddressIndex(addr common.Address) (uint64, error) {
+func (ms *messageSetImpl) GetAddressIndex(addr common.Address) (uint64, error) {
 	ms.messagesMu.Lock()
 	defer ms.messagesMu.Unlock()
 
@@ -65,7 +78,7 @@ func (ms *messageSet) GetAddressIndex(addr common.Address) (uint64, error) {
 	return uint64(i), nil
 }
 
-func (ms *messageSet) GetAddressPublicKey(addr common.Address) ([]byte, error) {
+func (ms *messageSetImpl) GetAddressPublicKey(addr common.Address) ([]byte, error) {
 	ms.messagesMu.Lock()
 	defer ms.messagesMu.Unlock()
 
@@ -77,18 +90,18 @@ func (ms *messageSet) GetAddressPublicKey(addr common.Address) ([]byte, error) {
 	return v.BLSPublicKey(), nil
 }
 
-func (ms *messageSet) ValSetSize() uint64 {
+func (ms *messageSetImpl) ValSetSize() uint64 {
 	return uint64(ms.valSet.Size())
 }
 
-func (ms *messageSet) Remove(address common.Address) {
+func (ms *messageSetImpl) Remove(address common.Address) {
 	ms.messagesMu.Lock()
 	defer ms.messagesMu.Unlock()
 
 	delete(ms.messages, address)
 }
 
-func (ms *messageSet) Values() (result []*istanbul.Message) {
+func (ms *messageSetImpl) Values() (result []*istanbul.Message) {
 	ms.messagesMu.Lock()
 	defer ms.messagesMu.Unlock()
 
@@ -99,13 +112,13 @@ func (ms *messageSet) Values() (result []*istanbul.Message) {
 	return result
 }
 
-func (ms *messageSet) Size() int {
+func (ms *messageSetImpl) Size() int {
 	ms.messagesMu.Lock()
 	defer ms.messagesMu.Unlock()
 	return len(ms.messages)
 }
 
-func (ms *messageSet) Get(addr common.Address) *istanbul.Message {
+func (ms *messageSetImpl) Get(addr common.Address) *istanbul.Message {
 	ms.messagesMu.Lock()
 	defer ms.messagesMu.Unlock()
 	return ms.messages[addr]
@@ -113,7 +126,7 @@ func (ms *messageSet) Get(addr common.Address) *istanbul.Message {
 
 // ----------------------------------------------------------------------------
 
-func (ms *messageSet) verify(msg *istanbul.Message) error {
+func (ms *messageSetImpl) verify(msg *istanbul.Message) error {
 	// verify if the message comes from one of the validators
 	if _, v := ms.valSet.GetByAddress(msg.Address); v == nil {
 		return istanbul.ErrUnauthorizedAddress
@@ -121,12 +134,12 @@ func (ms *messageSet) verify(msg *istanbul.Message) error {
 	return nil
 }
 
-func (ms *messageSet) addVerifiedMessage(msg *istanbul.Message) error {
+func (ms *messageSetImpl) addVerifiedMessage(msg *istanbul.Message) error {
 	ms.messages[msg.Address] = msg
 	return nil
 }
 
-func (ms *messageSet) String() string {
+func (ms *messageSetImpl) String() string {
 	ms.messagesMu.Lock()
 	defer ms.messagesMu.Unlock()
 	addresses := make([]string, 0, len(ms.messages))

--- a/consensus/istanbul/core/message_set_test.go
+++ b/consensus/istanbul/core/message_set_test.go
@@ -25,45 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-func TestMessageSetWithPreprepare(t *testing.T) {
-	valSet := newTestValidatorSet(4)
-
-	ms := newMessageSet(valSet)
-
-	view := &istanbul.View{
-		Round:    new(big.Int),
-		Sequence: new(big.Int),
-	}
-	pp := &istanbul.Preprepare{
-		View:     view,
-		Proposal: makeBlock(1),
-	}
-
-	rawPP, err := rlp.EncodeToBytes(pp)
-	if err != nil {
-		t.Errorf("error mismatch: have %v, want nil", err)
-	}
-	msg := &istanbul.Message{
-		Code:    istanbul.MsgPreprepare,
-		Msg:     rawPP,
-		Address: valSet.GetProposer().Address(),
-	}
-
-	err = ms.Add(msg)
-	if err != nil {
-		t.Errorf("error mismatch: have %v, want nil", err)
-	}
-
-	err = ms.Add(msg)
-	if err != nil {
-		t.Errorf("error mismatch: have %v, want nil", err)
-	}
-
-	if ms.Size() != 1 {
-		t.Errorf("the size of message set mismatch: have %v, want 1", ms.Size())
-	}
-}
-
 func TestMessageSetWithSubject(t *testing.T) {
 	valSet := newTestValidatorSet(4)
 

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -174,7 +174,7 @@ func (c *core) acceptPrepare(msg *istanbul.Message) error {
 	logger := c.logger.New("from", msg.Address, "state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "acceptPrepare")
 
 	// Add the PREPARE message to current round state
-	if err := c.current.Prepares.Add(msg); err != nil {
+	if err := c.current.Prepares().Add(msg); err != nil {
 		logger.Error("Failed to add PREPARE message to round state", "msg", msg, "err", err)
 		return err
 	}

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/bls"
+	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 )
 
 func TestVerifyPreparedCertificate(t *testing.T) {
@@ -182,7 +182,7 @@ func TestHandlePrepare(t *testing.T) {
 						},
 						c.valSet,
 					)
-					c.current.preparedCertificate = preparedCert
+					c.current.SetPreparedCertificate(preparedCert)
 
 					if i == 0 {
 						// replica 0 is the proposer
@@ -217,7 +217,7 @@ func TestHandlePrepare(t *testing.T) {
 						},
 						c.valSet,
 					)
-					c.current.preparedCertificate = preparedCert
+					c.current.SetPreparedCertificate(preparedCert)
 
 					if i == 0 {
 						// replica 0 is the proposer
@@ -370,7 +370,7 @@ OUTER:
 			if r0.state != StatePreprepared {
 				t.Errorf("state mismatch: have %v, want %v", r0.state, StatePreprepared)
 			}
-			if r0.current.Prepares.Size() >= r0.valSet.MinQuorumSize() {
+			if r0.current.Prepares().Size() >= r0.valSet.MinQuorumSize() {
 				t.Errorf("the size of PREPARE messages should be less than %v", 2*r0.valSet.MinQuorumSize()+1)
 			}
 
@@ -378,8 +378,8 @@ OUTER:
 		}
 
 		// core should have MinQuorumSize PREPARE messages
-		if r0.current.Prepares.Size() < r0.valSet.MinQuorumSize() {
-			t.Errorf("the size of PREPARE messages should be greater than or equal to MinQuorumSize: size %v", r0.current.Prepares.Size())
+		if r0.current.Prepares().Size() < r0.valSet.MinQuorumSize() {
+			t.Errorf("the size of PREPARE messages should be greater than or equal to MinQuorumSize: size %v", r0.current.Prepares().Size())
 		}
 
 		// a message will be delivered to backend if 2F+1
@@ -428,7 +428,7 @@ func TestVerifyPrepare(t *testing.T) {
 		expected error
 
 		prepare    *istanbul.Subject
-		roundState *roundState
+		roundState RoundState
 	}{
 		{
 			// normal case

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -182,7 +182,7 @@ func TestHandlePrepare(t *testing.T) {
 						},
 						c.valSet,
 					)
-					c.current.SetPreparedCertificate(preparedCert)
+					c.current.(*roundStateImpl).preparedCertificate = preparedCert
 
 					if i == 0 {
 						// replica 0 is the proposer
@@ -217,7 +217,7 @@ func TestHandlePrepare(t *testing.T) {
 						},
 						c.valSet,
 					)
-					c.current.SetPreparedCertificate(preparedCert)
+					c.current.(*roundStateImpl).preparedCertificate = preparedCert
 
 					if i == 0 {
 						// replica 0 is the proposer

--- a/consensus/istanbul/core/request.go
+++ b/consensus/istanbul/core/request.go
@@ -40,7 +40,7 @@ func (c *core) handleRequest(request *istanbul.Request) error {
 
 	logger.Trace("handleRequest", "number", request.Proposal.Number(), "hash", request.Proposal.Hash())
 
-	c.current.pendingRequest = request
+	c.current.SetPendingRequest(request)
 	// Must go through startNewRound to send proposals for round > 0 to ensure a round change certificate is generated.
 	if c.state == StateAcceptRequest && c.current.Round().Cmp(common.Big0) == 0 {
 		c.sendPreprepare(request, istanbul.RoundChangeCertificate{})
@@ -57,7 +57,7 @@ func (c *core) checkRequestMsg(request *istanbul.Request) error {
 		return errInvalidMessage
 	}
 
-	if c := c.current.sequence.Cmp(request.Proposal.Number()); c > 0 {
+	if c := c.current.Sequence().Cmp(request.Proposal.Number()); c > 0 {
 		return errOldMessage
 	} else if c < 0 {
 		return errFutureMessage

--- a/consensus/istanbul/core/request_test.go
+++ b/consensus/istanbul/core/request_test.go
@@ -113,7 +113,7 @@ func TestStoreRequestMsg(t *testing.T) {
 		t.Errorf("the size of pending requests mismatch: have %v, want %v", c.pendingRequests.Size(), len(requests))
 	}
 
-	c.current.sequence = big.NewInt(3)
+	c.current.SetSequence(big.NewInt(3))
 
 	c.subscribeEvents()
 	defer c.unsubscribeEvents()

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -18,12 +18,13 @@ package core
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"math/big"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
 // sendNextRoundChange sends the ROUND CHANGE message with current round + 1
@@ -50,7 +51,7 @@ func (c *core) sendRoundChange(round *big.Int) {
 
 	rc := &istanbul.RoundChange{
 		View:                nextView,
-		PreparedCertificate: c.current.preparedCertificate,
+		PreparedCertificate: c.current.PreparedCertificate(),
 	}
 
 	payload, err := Encode(rc)
@@ -209,7 +210,7 @@ func (c *core) handleRoundChange(msg *istanbul.Message) error {
 func newRoundChangeSet(valSet istanbul.ValidatorSet) *roundChangeSet {
 	return &roundChangeSet{
 		validatorSet:      valSet,
-		msgsForRound:      make(map[uint64]*messageSet),
+		msgsForRound:      make(map[uint64]MessageSet),
 		latestRoundForVal: make(map[common.Address]uint64),
 		mu:                new(sync.Mutex),
 	}
@@ -217,7 +218,7 @@ func newRoundChangeSet(valSet istanbul.ValidatorSet) *roundChangeSet {
 
 type roundChangeSet struct {
 	validatorSet      istanbul.ValidatorSet
-	msgsForRound      map[uint64]*messageSet
+	msgsForRound      map[uint64]MessageSet
 	latestRoundForVal map[common.Address]uint64
 	mu                *sync.Mutex
 }

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -402,7 +402,7 @@ var noGossip = map[int]bool{
 // and all nodes will accept the newly proposed block.
 func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 	// Initialize the system with a nil round state so that we properly start round 0.
-	sys := NewTestSystemWithBackendAndCurrentRoundState(4, 1, func(vset istanbul.ValidatorSet) *roundState { return nil })
+	sys := NewTestSystemWithBackendAndCurrentRoundState(4, 1, func(vset istanbul.ValidatorSet) RoundState { return nil })
 
 	for i, b := range sys.backends {
 		b.engine.Start() // start Istanbul core
@@ -470,7 +470,7 @@ func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 // system enforces that as the only valid proposal for this sequence.
 func TestPreparedCertificatePersistsThroughRoundChanges(t *testing.T) {
 	// Initialize the system with a nil round state so that we properly start round 0.
-	sys := NewTestSystemWithBackendAndCurrentRoundState(4, 1, func(vset istanbul.ValidatorSet) *roundState { return nil })
+	sys := NewTestSystemWithBackendAndCurrentRoundState(4, 1, func(vset istanbul.ValidatorSet) RoundState { return nil })
 
 	for i, b := range sys.backends {
 		b.engine.Start() // start Istanbul core

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -68,7 +68,6 @@ type RoundState interface {
 	Sequence() *big.Int
 	CreateAndSetPreparedCertificate(quorumSize int) error
 	PreparedCertificate() istanbul.PreparedCertificate
-	SetPreparedCertificate(preparedCertificate istanbul.PreparedCertificate)
 }
 
 // RoundState stores the consensus state
@@ -244,12 +243,6 @@ func (s *roundStateImpl) PreparedCertificate() istanbul.PreparedCertificate {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.preparedCertificate
-}
-
-func (s *roundStateImpl) SetPreparedCertificate(preparedCertificate istanbul.PreparedCertificate) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.preparedCertificate = preparedCertificate
 }
 
 // The DecodeRLP method should read one value from the given

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -245,13 +245,13 @@ func (self *testSystemBackend) getCommitMessage(view istanbul.View, proposal ist
 
 	// We swap in the provided proposal so that the message is finalized for the provided proposal
 	// and not for the current preprepare.
-	cachePreprepare := self.engine.(*core).current.Preprepare
-	self.engine.(*core).current.Preprepare = &istanbul.Preprepare{
+	cachePreprepare := self.engine.(*core).current.Preprepare()
+	self.engine.(*core).current.(*roundStateImpl).preprepare = &istanbul.Preprepare{
 		View:     &view,
 		Proposal: proposal,
 	}
 	message, err := self.finalizeAndReturnMessage(msg)
-	self.engine.(*core).current.Preprepare = cachePreprepare
+	self.engine.(*core).current.(*roundStateImpl).preprepare = cachePreprepare
 	return message, err
 }
 
@@ -335,7 +335,7 @@ func newTestValidatorSet(n int) istanbul.ValidatorSet {
 }
 
 func NewTestSystemWithBackend(n, f uint64) *testSystem {
-	return NewTestSystemWithBackendAndCurrentRoundState(n, f, func(vset istanbul.ValidatorSet) *roundState {
+	return NewTestSystemWithBackendAndCurrentRoundState(n, f, func(vset istanbul.ValidatorSet) RoundState {
 		return newRoundState(&istanbul.View{
 			Round:    big.NewInt(0),
 			Sequence: big.NewInt(1),
@@ -346,7 +346,7 @@ func NewTestSystemWithBackend(n, f uint64) *testSystem {
 }
 
 // FIXME: int64 is needed for N and F
-func NewTestSystemWithBackendAndCurrentRoundState(n, f uint64, getRoundState func(vset istanbul.ValidatorSet) *roundState) *testSystem {
+func NewTestSystemWithBackendAndCurrentRoundState(n, f uint64, getRoundState func(vset istanbul.ValidatorSet) RoundState) *testSystem {
 	testLogger.SetHandler(elog.StdoutHandler)
 
 	validators, blsKeys, keys := generateValidators(int(n))

--- a/consensus/istanbul/core/testutils_test.go
+++ b/consensus/istanbul/core/testutils_test.go
@@ -17,23 +17,31 @@
 package core
 
 import (
-	"sync"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
-func newTestRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet) *roundState {
-	return &roundState{
-		round:         view.Round,
-		sequence:      view.Sequence,
-		Preprepare:    newTestPreprepare(view),
-		Prepares:      newMessageSet(validatorSet),
-		ParentCommits: newMessageSet(validatorSet),
-		Commits:       newMessageSet(validatorSet),
-		mu:            new(sync.RWMutex),
-		hasBadProposal: func(hash common.Hash) bool {
+func newTestRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet) RoundState {
+	return newRoundState(
+		view,
+		validatorSet,
+		newTestPreprepare(view),
+		nil,
+		istanbul.PreparedCertificate{},
+		newMessageSet(validatorSet),
+		func(hash common.Hash) bool {
 			return false
 		},
-	}
+	)
+
+	// return &RoundState{
+	// 	round:         view.Round,
+	// 	sequence:      view.Sequence,
+	// 	Preprepare:    newTestPreprepare(view),
+	// 	Prepares:      newMessageSet(validatorSet),
+	// 	ParentCommits: newMessageSet(validatorSet),
+	// 	Commits:       newMessageSet(validatorSet),
+	// 	mu:            new(sync.RWMutex),
+	// 	hasBadProposal: ,
+	// }
 }

--- a/consensus/istanbul/core/types.go
+++ b/consensus/istanbul/core/types.go
@@ -28,7 +28,7 @@ type Engine interface {
 	CurrentView() *istanbul.View
 	SetAddress(common.Address)
 	// Validator -> CommittedSeal from Parent Block
-	ParentCommits() *messageSet
+	ParentCommits() MessageSet
 }
 
 type State uint64


### PR DESCRIPTION
### Description

Hide `RoundState` and `MessageSet` behind interface to avoid bad usage. For example, access data to read/write without the proper lock setup

### Tested

unit tests

### Other changes

minor lint issues
