### PR TITLE
Remove the set-node-key command

### DIFF
--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -609,19 +609,6 @@ func (ks *KeyStore) importKey(key *Key, passphrase string) (accounts.Account, er
 	return a, nil
 }
 
-func (ks *KeyStore) SetNodeKey(a accounts.Account, passphrase string, nodekeyPath string) error {
-	a, key, err := ks.getDecryptedKey(a, passphrase)
-
-	if err != nil {
-		fmt.Println(fmt.Sprintf("Failed to decyrpt node key: %v", err))
-	}
-
-	if err := crypto.SaveECDSA(nodekeyPath, key.PrivateKey); err != nil {
-		fmt.Println(fmt.Sprintf("Failed to persist node key: %v", err))
-	}
-	return nil
-}
-
 // Update changes the passphrase of an existing account.
 func (ks *KeyStore) Update(a accounts.Account, passphrase, newPassphrase string) error {
 	a, key, err := ks.getDecryptedKey(a, passphrase)

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -171,28 +171,6 @@ changing your password is only possible interactively.
 `,
 			},
 			{
-				Name:   "set-node-key",
-				Usage:  "Sets the nodekey used for Istanbul consensus",
-				Action: utils.MigrateFlags(setNodeKey),
-				Flags: []cli.Flag{
-					utils.DataDirFlag,
-					utils.KeyStoreDirFlag,
-					utils.PasswordFileFlag,
-					utils.LightKDFFlag,
-				},
-				ArgsUsage: "<address>",
-				Description: `
-    geth account set-node-key <address>
-
-Sets the nodekey with the given address. This is necessary to allow other validators to know that our node is a validator as well.
-
-For non-interactive use the passphrase can be specified with the --password flag:
-
-    geth account set-node-key [options] <address>
-
-`,
-			},
-			{
 				Name:   "import",
 				Usage:  "Import a private key into a new account",
 				Action: utils.MigrateFlags(accountImport),
@@ -387,31 +365,6 @@ func accountUpdate(ctx *cli.Context) error {
 		if err := ks.Update(account, oldPassword, newPassword); err != nil {
 			utils.Fatalf("Could not update the account: %v", err)
 		}
-	}
-	return nil
-}
-
-func setNodeKey(ctx *cli.Context) error {
-	if len(ctx.Args()) == 0 {
-		utils.Fatalf("No accounts specified to set the nodekey for")
-	}
-
-	stack, config := makeConfigNode(ctx)
-	ks := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
-
-	for _, addr := range ctx.Args() {
-		account, oldPassword := unlockAccount(ctx, ks, addr, 0, nil)
-		if (account == accounts.Account{}) {
-			utils.Fatalf("Could not unlock account")
-			continue
-		}
-
-		if err := ks.SetNodeKey(account, oldPassword, config.Node.ResolvePath("nodekey")); err != nil {
-			utils.Fatalf("Could not setNodeKey for the account: %v", err)
-		}
-
-		log.Info("Set nodekey", "address", account.Address)
-
 	}
 	return nil
 }


### PR DESCRIPTION
Reverts celo-org/celo-blockchain#348

## Description

After closing https://github.com/celo-org/celo-monorepo/issues/1268, it will no longer be necessary to set the node key to the validator private key. As such, this PR will remove the command introduced to accommodate this workaround.

## Issues

Related to https://github.com/celo-org/celo-monorepo/issues/1268
Depends on https://github.com/celo-org/celo-monorepo/pull/1922