### PR TITLE
Rename LastProposal/Proposer to Block/Author

### DIFF
--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -70,8 +70,8 @@ type Backend interface {
 	// GetCurrentHeadBlock retrieves the last block
 	GetCurrentHeadBlock() Proposal
 
-	// GetCurrentHeadBlockAndAuthorAndAuthor retrieves the last block alongside the author for that block
-	GetCurrentHeadBlockAndAuthorAndAuthor() (Proposal, common.Address)
+	// GetCurrentHeadBlockAndAuthor retrieves the last block alongside the author for that block
+	GetCurrentHeadBlockAndAuthor() (Proposal, common.Address)
 
 	// LastSubject retrieves latest committed subject (view and digest)
 	LastSubject() (Subject, error)

--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -67,17 +67,17 @@ type Backend interface {
 	// the given validator
 	CheckSignature(data []byte, addr common.Address, sig []byte) error
 
-	// LastBlock retrieves the last block
-	LastBlock() Proposal
+	// GetCurrentHeadBlock retrieves the last block
+	GetCurrentHeadBlock() Proposal
 
-	// LastBlockAndAuthor retrieves the last block alongside the author for that block
-	LastBlockAndAuthor() (Proposal, common.Address)
+	// GetCurrentHeadBlockAndAuthorAndAuthor retrieves the last block alongside the author for that block
+	GetCurrentHeadBlockAndAuthorAndAuthor() (Proposal, common.Address)
 
 	// LastSubject retrieves latest committed subject (view and digest)
 	LastSubject() (Subject, error)
 
-	// HasBlockMatching checks if the combination of the given hash and height matches any existing blocks
-	HasBlockMatching(hash common.Hash, number *big.Int) bool
+	// HasBlock checks if the combination of the given hash and height matches any existing blocks
+	HasBlock(hash common.Hash, number *big.Int) bool
 
 	// AuthorForBlock returns the proposer of the given block height
 	AuthorForBlock(number uint64) common.Address

--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -67,20 +67,23 @@ type Backend interface {
 	// the given validator
 	CheckSignature(data []byte, addr common.Address, sig []byte) error
 
-	// LastProposal retrieves latest committed proposal and the address of proposer
-	LastProposal() (Proposal, common.Address)
+	// LastBlock retrieves the last block
+	LastBlock() Proposal
+
+	// LastBlockAndAuthor retrieves the last block alongside the author for that block
+	LastBlockAndAuthor() (Proposal, common.Address)
 
 	// LastSubject retrieves latest committed subject (view and digest)
 	LastSubject() (Subject, error)
 
-	// HasProposal checks if the combination of the given hash and height matches any existing blocks
-	HasProposal(hash common.Hash, number *big.Int) bool
+	// HasBlockMatching checks if the combination of the given hash and height matches any existing blocks
+	HasBlockMatching(hash common.Hash, number *big.Int) bool
 
-	// GetProposer returns the proposer of the given block height
-	GetProposer(number uint64) common.Address
+	// AuthorForBlock returns the proposer of the given block height
+	AuthorForBlock(number uint64) common.Address
 
-	// ParentValidators returns the validator set of the given proposal's parent block
-	ParentValidators(proposal Proposal) ValidatorSet
+	// ParentBlockValidators returns the validator set of the given proposal's parent block
+	ParentBlockValidators(proposal Proposal) ValidatorSet
 
 	// RefreshValPeers will connect with all the validators in the valset and disconnect validator peers that are not in the set
 	RefreshValPeers(valset ValidatorSet)

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -538,8 +538,8 @@ func (sb *Backend) CheckSignature(data []byte, address common.Address, sig []byt
 	return nil
 }
 
-// HasBlockMatching implements istanbul.Backend.HasBlockMatching
-func (sb *Backend) HasBlockMatching(hash common.Hash, number *big.Int) bool {
+// HasBlock implements istanbul.Backend.HasBlock
+func (sb *Backend) HasBlock(hash common.Hash, number *big.Int) bool {
 	return sb.chain.GetHeader(hash, number.Uint64()) != nil
 }
 
@@ -595,13 +595,13 @@ func (sb *Backend) getOrderedValidators(number uint64, hash common.Hash) istanbu
 	return valSet
 }
 
-// LastBlock retrieves the last block
-func (sb *Backend) LastBlock() istanbul.Proposal {
+// GetCurrentHeadBlock retrieves the last block
+func (sb *Backend) GetCurrentHeadBlock() istanbul.Proposal {
 	return sb.currentBlock()
 }
 
-// LastBlockAndAuthor retrieves the last block alongside the coinbase address for it
-func (sb *Backend) LastBlockAndAuthor() (istanbul.Proposal, common.Address) {
+// GetCurrentHeadBlockAndAuthorAndAuthor retrieves the last block alongside the coinbase address for it
+func (sb *Backend) GetCurrentHeadBlockAndAuthorAndAuthor() (istanbul.Proposal, common.Address) {
 	block := sb.currentBlock()
 
 	if block.Number().Cmp(common.Big0) == 0 {
@@ -620,7 +620,7 @@ func (sb *Backend) LastBlockAndAuthor() (istanbul.Proposal, common.Address) {
 }
 
 func (sb *Backend) LastSubject() (istanbul.Subject, error) {
-	lastProposal, _ := sb.LastBlockAndAuthor()
+	lastProposal, _ := sb.GetCurrentHeadBlockAndAuthorAndAuthor()
 	istExtra, err := types.ExtractIstanbulExtra(lastProposal.Header())
 	if err != nil {
 		return istanbul.Subject{}, err

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -600,8 +600,8 @@ func (sb *Backend) GetCurrentHeadBlock() istanbul.Proposal {
 	return sb.currentBlock()
 }
 
-// GetCurrentHeadBlockAndAuthorAndAuthor retrieves the last block alongside the coinbase address for it
-func (sb *Backend) GetCurrentHeadBlockAndAuthorAndAuthor() (istanbul.Proposal, common.Address) {
+// GetCurrentHeadBlockAndAuthor retrieves the last block alongside the coinbase address for it
+func (sb *Backend) GetCurrentHeadBlockAndAuthor() (istanbul.Proposal, common.Address) {
 	block := sb.currentBlock()
 
 	if block.Number().Cmp(common.Big0) == 0 {
@@ -620,7 +620,7 @@ func (sb *Backend) GetCurrentHeadBlockAndAuthorAndAuthor() (istanbul.Proposal, c
 }
 
 func (sb *Backend) LastSubject() (istanbul.Subject, error) {
-	lastProposal, _ := sb.GetCurrentHeadBlockAndAuthorAndAuthor()
+	lastProposal, _ := sb.GetCurrentHeadBlockAndAuthor()
 	istExtra, err := types.ExtractIstanbulExtra(lastProposal.Header())
 	if err != nil {
 		return istanbul.Subject{}, err

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -215,6 +215,11 @@ func (sb *Backend) Validators(proposal istanbul.Proposal) istanbul.ValidatorSet 
 	return sb.getOrderedValidators(proposal.Number().Uint64(), proposal.Hash())
 }
 
+// ParentBlockValidators implements istanbul.Backend.GetParentValidators
+func (sb *Backend) ParentBlockValidators(proposal istanbul.Proposal) istanbul.ValidatorSet {
+	return sb.getOrderedValidators(proposal.Number().Uint64()-1, proposal.ParentHash())
+}
+
 func (sb *Backend) GetValidators(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator {
 	validatorSet := sb.getValidators(blockNumber.Uint64(), headerHash)
 	return validatorSet.FilteredList()
@@ -471,7 +476,7 @@ func (sb *Backend) verifyValSetDiff(proposal istanbul.Proposal, block *types.Blo
 			return errInvalidValidatorSetDiff
 		}
 	} else {
-		parentValidators := sb.ParentValidators(proposal)
+		parentValidators := sb.ParentBlockValidators(proposal)
 		oldValSet := make([]istanbul.ValidatorData, 0, parentValidators.Size())
 
 		for _, val := range parentValidators.List() {
@@ -533,26 +538,18 @@ func (sb *Backend) CheckSignature(data []byte, address common.Address, sig []byt
 	return nil
 }
 
-// HasProposal implements istanbul.Backend.HasProposal
-func (sb *Backend) HasProposal(hash common.Hash, number *big.Int) bool {
+// HasBlockMatching implements istanbul.Backend.HasBlockMatching
+func (sb *Backend) HasBlockMatching(hash common.Hash, number *big.Int) bool {
 	return sb.chain.GetHeader(hash, number.Uint64()) != nil
 }
 
-// GetProposer implements istanbul.Backend.GetProposer
-func (sb *Backend) GetProposer(number uint64) common.Address {
+// AuthorForBlock implements istanbul.Backend.AuthorForBlock
+func (sb *Backend) AuthorForBlock(number uint64) common.Address {
 	if h := sb.chain.GetHeaderByNumber(number); h != nil {
 		a, _ := sb.Author(h)
 		return a
 	}
-	return common.Address{}
-}
-
-// ParentValidators implements istanbul.Backend.GetParentValidators
-func (sb *Backend) ParentValidators(proposal istanbul.Proposal) istanbul.ValidatorSet {
-	if block, ok := proposal.(*types.Block); ok {
-		return sb.getOrderedValidators(block.Number().Uint64()-1, block.ParentHash())
-	}
-	return validator.NewSet(nil, sb.config.ProposerPolicy)
+	return common.ZeroAddress
 }
 
 func (sb *Backend) getValidators(number uint64, hash common.Hash) istanbul.ValidatorSet {
@@ -598,17 +595,24 @@ func (sb *Backend) getOrderedValidators(number uint64, hash common.Hash) istanbu
 	return valSet
 }
 
-func (sb *Backend) LastProposal() (istanbul.Proposal, common.Address) {
+// LastBlock retrieves the last block
+func (sb *Backend) LastBlock() istanbul.Proposal {
+	return sb.currentBlock()
+}
+
+// LastBlockAndAuthor retrieves the last block alongside the coinbase address for it
+func (sb *Backend) LastBlockAndAuthor() (istanbul.Proposal, common.Address) {
 	block := sb.currentBlock()
 
-	var proposer common.Address
-	if block.Number().Cmp(common.Big0) > 0 {
-		var err error
-		proposer, err = sb.Author(block.Header())
-		if err != nil {
-			sb.logger.Error("Failed to get block proposer", "err", err)
-			return nil, common.Address{}
-		}
+	if block.Number().Cmp(common.Big0) == 0 {
+		return block, common.ZeroAddress
+	}
+
+	proposer, err := sb.Author(block.Header())
+
+	if err != nil {
+		sb.logger.Error("Failed to get block proposer", "err", err)
+		return nil, common.ZeroAddress
 	}
 
 	// Return header only block here since we don't need block body
@@ -616,7 +620,7 @@ func (sb *Backend) LastProposal() (istanbul.Proposal, common.Address) {
 }
 
 func (sb *Backend) LastSubject() (istanbul.Subject, error) {
-	lastProposal, _ := sb.LastProposal()
+	lastProposal, _ := sb.LastBlockAndAuthor()
 	istExtra, err := types.ExtractIstanbulExtra(lastProposal.Header())
 	if err != nil {
 		return istanbul.Subject{}, err

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -180,7 +180,7 @@ func TestGetProposer(t *testing.T) {
 	chain, engine := newBlockChain(1, true)
 	block := makeBlock(chain, engine, chain.Genesis())
 	chain.InsertChain(types.Blocks{block})
-	expected := engine.GetProposer(1)
+	expected := engine.AuthorForBlock(1)
 	actual := engine.Address()
 	if actual != expected {
 		t.Errorf("proposer mismatch: have %v, want %v, currentblock: %v", actual.Hex(), expected.Hex(), chain.CurrentBlock().Number())

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -97,10 +97,10 @@ func (c *core) handleCommit(msg *istanbul.Message) error {
 
 func (c *core) handleCheckedCommitForPreviousSequence(msg *istanbul.Message, commit *istanbul.CommittedSubject) error {
 	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "handleCheckedCommitForPreviousSequence", "tag", "handleMsg")
-	lastProposal, _ := c.backend.LastProposal()
+	lastBlock := c.backend.LastBlock()
 	// Retrieve the validator set for the previous proposal (which should
 	// match the one broadcast)
-	parentValset := c.backend.ParentValidators(lastProposal)
+	parentValset := c.backend.ParentBlockValidators(lastBlock)
 	_, validator := parentValset.GetByAddress(msg.Address)
 	if validator == nil {
 		return errInvalidValidatorAddress
@@ -109,8 +109,8 @@ func (c *core) handleCheckedCommitForPreviousSequence(msg *istanbul.Message, com
 		return errInvalidCommittedSeal
 	}
 	// Ensure that the commit's digest (ie the received proposal's hash) matches the saved last proposal's hash
-	if lastProposal.Number().Uint64() > 0 && commit.Subject.Digest != lastProposal.Hash() {
-		logger.Debug("Received a commit message for the previous sequence with an unexpected hash", "expected", lastProposal.Hash().String(), "received", commit.Subject.Digest.String())
+	if lastBlock.Number().Uint64() > 0 && commit.Subject.Digest != lastBlock.Hash() {
+		logger.Debug("Received a commit message for the previous sequence with an unexpected hash", "expected", lastBlock.Hash().String(), "received", commit.Subject.Digest.String())
 		return errInconsistentSubject
 	}
 	return c.acceptParentCommit(msg, commit.Subject.View)

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -97,10 +97,10 @@ func (c *core) handleCommit(msg *istanbul.Message) error {
 
 func (c *core) handleCheckedCommitForPreviousSequence(msg *istanbul.Message, commit *istanbul.CommittedSubject) error {
 	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "handleCheckedCommitForPreviousSequence", "tag", "handleMsg")
-	lastBlock := c.backend.LastBlock()
+	headBlock := c.backend.GetCurrentHeadBlock()
 	// Retrieve the validator set for the previous proposal (which should
 	// match the one broadcast)
-	parentValset := c.backend.ParentBlockValidators(lastBlock)
+	parentValset := c.backend.ParentBlockValidators(headBlock)
 	_, validator := parentValset.GetByAddress(msg.Address)
 	if validator == nil {
 		return errInvalidValidatorAddress
@@ -109,8 +109,8 @@ func (c *core) handleCheckedCommitForPreviousSequence(msg *istanbul.Message, com
 		return errInvalidCommittedSeal
 	}
 	// Ensure that the commit's digest (ie the received proposal's hash) matches the saved last proposal's hash
-	if lastBlock.Number().Uint64() > 0 && commit.Subject.Digest != lastBlock.Hash() {
-		logger.Debug("Received a commit message for the previous sequence with an unexpected hash", "expected", lastBlock.Hash().String(), "received", commit.Subject.Digest.String())
+	if headBlock.Number().Uint64() > 0 && commit.Subject.Digest != headBlock.Hash() {
+		logger.Debug("Received a commit message for the previous sequence with an unexpected hash", "expected", headBlock.Hash().String(), "received", commit.Subject.Digest.String())
 		return errInconsistentSubject
 	}
 	return c.acceptParentCommit(msg, commit.Subject.View)

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -270,7 +270,7 @@ func (c *core) startNewRound(round *big.Int) {
 
 	roundChange := false
 	// Try to get last proposal
-	headBlock, headAuthor := c.backend.GetCurrentHeadBlockAndAuthorAndAuthor()
+	headBlock, headAuthor := c.backend.GetCurrentHeadBlockAndAuthor()
 	if c.current == nil {
 		logger.Trace("Start the initial round")
 	} else if headBlock.Number().Cmp(c.current.Sequence()) >= 0 {
@@ -359,7 +359,7 @@ func (c *core) waitForDesiredRound(r *big.Int) {
 	// Perform all of the updates
 	c.setState(StateWaitingForNewRound)
 	c.current.SetDesiredRound(r)
-	_, headAuthor := c.backend.GetCurrentHeadBlockAndAuthorAndAuthor()
+	_, headAuthor := c.backend.GetCurrentHeadBlockAndAuthor()
 	c.valSet.CalcProposer(headAuthor, desiredView.Round.Uint64())
 	c.newRoundChangeTimerForView(desiredView)
 

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -333,12 +333,12 @@ func (c *core) startNewRound(round *big.Int) {
 	// Calculate new proposer
 	c.valSet.CalcProposer(headAuthor, newView.Round.Uint64())
 	c.setState(StateAcceptRequest)
-	if roundChange && c.current != nil && c.valSet.IsProposer(c.address) && request != nil {
+	if roundChange && c.current != nil && c.isProposer() && request != nil {
 		c.sendPreprepare(request, roundChangeCertificate)
 	}
 	c.newRoundChangeTimer()
 
-	logger.Debug("New round", "new_round", newView.Round, "new_seq", newView.Sequence, "new_proposer", c.valSet.GetProposer(), "valSet", c.valSet.List(), "size", c.valSet.Size(), "isProposer", c.valSet.IsProposer(c.address))
+	logger.Debug("New round", "new_round", newView.Round, "new_seq", newView.Sequence, "new_proposer", c.valSet.GetProposer(), "valSet", c.valSet.List(), "size", c.valSet.Size(), "isProposer", c.isProposer())
 }
 
 // All actions that occur when transitioning to waiting for round change state.
@@ -390,6 +390,13 @@ func (c *core) updateRoundState(view *istanbul.View, validatorSet istanbul.Valid
 		// either `validatorSet` or `backend.Validators(lastProposal)` works here
 		c.current = newRoundState(view, validatorSet, nil, nil, istanbul.EmptyPreparedCertificate(), newMessageSet(validatorSet))
 	}
+}
+
+func (c *core) isProposer() bool {
+	if c.valSet == nil {
+		return false
+	}
+	return c.valSet.IsProposer(c.address)
 }
 
 func (c *core) setState(state State) {

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -104,7 +104,7 @@ func (c *core) handlePreprepare(msg *istanbul.Message) error {
 	}
 
 	// Check if the message comes from current proposer
-	if !c.isProposer() {
+	if !c.valSet.IsProposer(msg.Address) {
 		logger.Warn("Ignore preprepare messages from non-proposer")
 		return errNotFromProposer
 	}

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -92,7 +92,7 @@ func (c *core) handlePreprepare(msg *istanbul.Message) error {
 			// Broadcast COMMIT if it is an existing block
 			// 1. The proposer needs to be a proposer matches the given (Sequence + Round)
 			// 2. The given block must exist
-			if valSet.IsProposer(msg.Address) && c.backend.HasBlockMatching(preprepare.Proposal.Hash(), preprepare.Proposal.Number()) {
+			if valSet.IsProposer(msg.Address) && c.backend.HasBlock(preprepare.Proposal.Hash(), preprepare.Proposal.Number()) {
 				logger.Trace("Sending a commit message for an old block", "view", preprepare.View, "block hash", preprepare.Proposal.Hash())
 				c.sendCommitForOldBlock(preprepare.View, preprepare.Proposal.Hash())
 				return nil

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -28,7 +28,7 @@ func (c *core) sendPreprepare(request *istanbul.Request, roundChangeCertificate 
 	logger := c.newLogger("func", "sendPreprepare")
 
 	// If I'm the proposer and I have the same sequence with the proposal
-	if c.current.Sequence().Cmp(request.Proposal.Number()) == 0 && c.valSet.IsProposer(c.address) {
+	if c.current.Sequence().Cmp(request.Proposal.Number()) == 0 && c.isProposer() {
 		curView := c.current.View()
 		preprepare, err := Encode(&istanbul.Preprepare{
 			View:                   curView,
@@ -104,7 +104,7 @@ func (c *core) handlePreprepare(msg *istanbul.Message) error {
 	}
 
 	// Check if the message comes from current proposer
-	if !c.valSet.IsProposer(msg.Address) {
+	if !c.isProposer() {
 		logger.Warn("Ignore preprepare messages from non-proposer")
 		return errNotFromProposer
 	}

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -28,7 +28,7 @@ func (c *core) sendPreprepare(request *istanbul.Request, roundChangeCertificate 
 	logger := c.newLogger("func", "sendPreprepare")
 
 	// If I'm the proposer and I have the same sequence with the proposal
-	if c.current.Sequence().Cmp(request.Proposal.Number()) == 0 && c.isProposer() {
+	if c.current.Sequence().Cmp(request.Proposal.Number()) == 0 && c.valSet.IsProposer(c.address) {
 		curView := c.current.View()
 		preprepare, err := Encode(&istanbul.Preprepare{
 			View:                   curView,
@@ -86,13 +86,13 @@ func (c *core) handlePreprepare(msg *istanbul.Message) error {
 	if err := c.checkMessage(istanbul.MsgPreprepare, preprepare.View); err != nil {
 		if err == errOldMessage {
 			// Get validator set for the given proposal
-			valSet := c.backend.ParentValidators(preprepare.Proposal).Copy()
-			previousProposer := c.backend.GetProposer(preprepare.Proposal.Number().Uint64() - 1)
+			valSet := c.backend.ParentBlockValidators(preprepare.Proposal).Copy()
+			previousProposer := c.backend.AuthorForBlock(preprepare.Proposal.Number().Uint64() - 1)
 			valSet.CalcProposer(previousProposer, preprepare.View.Round.Uint64())
 			// Broadcast COMMIT if it is an existing block
 			// 1. The proposer needs to be a proposer matches the given (Sequence + Round)
 			// 2. The given block must exist
-			if valSet.IsProposer(msg.Address) && c.backend.HasProposal(preprepare.Proposal.Hash(), preprepare.Proposal.Number()) {
+			if valSet.IsProposer(msg.Address) && c.backend.HasBlockMatching(preprepare.Proposal.Hash(), preprepare.Proposal.Number()) {
 				logger.Trace("Sending a commit message for an old block", "view", preprepare.View, "block hash", preprepare.Proposal.Hash())
 				c.sendCommitForOldBlock(preprepare.View, preprepare.Proposal.Hash())
 				return nil

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -149,7 +149,7 @@ func TestHandlePreprepare(t *testing.T) {
 			func(_ *testSystem) istanbul.RoundChangeCertificate {
 				return istanbul.RoundChangeCertificate{}
 			},
-			// In the method testbackend_test.go:HasProposal(), it will return true if the proposal's block number == 5
+			// In the method testbackend_test.go:HasBlockMatching(), it will return true if the proposal's block number == 5
 			makeBlock(5),
 			nil,
 			true,

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -446,9 +446,9 @@ func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 		}
 		// Wait for all backends to finalize the block.
 		<-time.After(1 * time.Second)
-		expectedCommitted, _ := sys.backends[0].GetCurrentHeadBlockAndAuthorAndAuthor()
+		expectedCommitted, _ := sys.backends[0].GetCurrentHeadBlockAndAuthor()
 		for i, b := range sys.backends {
-			committed, _ := b.GetCurrentHeadBlockAndAuthorAndAuthor()
+			committed, _ := b.GetCurrentHeadBlockAndAuthor()
 			// We don't expect any particular block to be committed here. We do expect them to be consistent.
 			if committed.Number().Cmp(common.Big1) != 0 {
 				t.Errorf("Backend %v got committed block with unexpected number: expected %v, got %v", i, 1, committed.Number())
@@ -517,7 +517,7 @@ func TestPreparedCertificatePersistsThroughRoundChanges(t *testing.T) {
 		// Wait for all backends to finalize the block.
 		<-time.After(2 * time.Second)
 		for i, b := range sys.backends {
-			committed, _ := b.GetCurrentHeadBlockAndAuthorAndAuthor()
+			committed, _ := b.GetCurrentHeadBlockAndAuthor()
 			// We expect to commit the block proposed by the first proposer.
 			expectedCommitted := makeBlockWithDifficulty(1, 0)
 			if committed.Number().Cmp(common.Big1) != 0 {

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -446,9 +446,9 @@ func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 		}
 		// Wait for all backends to finalize the block.
 		<-time.After(1 * time.Second)
-		expectedCommitted, _ := sys.backends[0].LastProposal()
+		expectedCommitted, _ := sys.backends[0].LastBlockAndAuthor()
 		for i, b := range sys.backends {
-			committed, _ := b.LastProposal()
+			committed, _ := b.LastBlockAndAuthor()
 			// We don't expect any particular block to be committed here. We do expect them to be consistent.
 			if committed.Number().Cmp(common.Big1) != 0 {
 				t.Errorf("Backend %v got committed block with unexpected number: expected %v, got %v", i, 1, committed.Number())
@@ -517,7 +517,7 @@ func TestPreparedCertificatePersistsThroughRoundChanges(t *testing.T) {
 		// Wait for all backends to finalize the block.
 		<-time.After(2 * time.Second)
 		for i, b := range sys.backends {
-			committed, _ := b.LastProposal()
+			committed, _ := b.LastBlockAndAuthor()
 			// We expect to commit the block proposed by the first proposer.
 			expectedCommitted := makeBlockWithDifficulty(1, 0)
 			if committed.Number().Cmp(common.Big1) != 0 {

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -446,9 +446,9 @@ func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 		}
 		// Wait for all backends to finalize the block.
 		<-time.After(1 * time.Second)
-		expectedCommitted, _ := sys.backends[0].LastBlockAndAuthor()
+		expectedCommitted, _ := sys.backends[0].GetCurrentHeadBlockAndAuthorAndAuthor()
 		for i, b := range sys.backends {
-			committed, _ := b.LastBlockAndAuthor()
+			committed, _ := b.GetCurrentHeadBlockAndAuthorAndAuthor()
 			// We don't expect any particular block to be committed here. We do expect them to be consistent.
 			if committed.Number().Cmp(common.Big1) != 0 {
 				t.Errorf("Backend %v got committed block with unexpected number: expected %v, got %v", i, 1, committed.Number())
@@ -517,7 +517,7 @@ func TestPreparedCertificatePersistsThroughRoundChanges(t *testing.T) {
 		// Wait for all backends to finalize the block.
 		<-time.After(2 * time.Second)
 		for i, b := range sys.backends {
-			committed, _ := b.LastBlockAndAuthor()
+			committed, _ := b.GetCurrentHeadBlockAndAuthorAndAuthor()
 			// We expect to commit the block proposed by the first proposer.
 			expectedCommitted := makeBlockWithDifficulty(1, 0)
 			if committed.Number().Cmp(common.Big1) != 0 {

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -153,7 +153,7 @@ func (self *testSystemBackend) NewRequest(request istanbul.Proposal) {
 	})
 }
 
-func (self *testSystemBackend) LastBlock() istanbul.Proposal {
+func (self *testSystemBackend) GetCurrentHeadBlock() istanbul.Proposal {
 	l := len(self.committedMsgs)
 	if l > 0 {
 		testLogger.Info("have proposal for block", "num", l)
@@ -163,7 +163,7 @@ func (self *testSystemBackend) LastBlock() istanbul.Proposal {
 	return makeBlock(0)
 }
 
-func (self *testSystemBackend) LastBlockAndAuthor() (istanbul.Proposal, common.Address) {
+func (self *testSystemBackend) GetCurrentHeadBlockAndAuthorAndAuthor() (istanbul.Proposal, common.Address) {
 	l := len(self.committedMsgs)
 	if l > 0 {
 		testLogger.Info("have proposal for block", "num", l)
@@ -174,13 +174,13 @@ func (self *testSystemBackend) LastBlockAndAuthor() (istanbul.Proposal, common.A
 }
 
 func (self *testSystemBackend) LastSubject() (istanbul.Subject, error) {
-	lastProposal := self.LastBlock()
+	lastProposal := self.GetCurrentHeadBlock()
 	lastView := &istanbul.View{Sequence: lastProposal.Number(), Round: big.NewInt(1)}
 	return istanbul.Subject{View: lastView, Digest: lastProposal.Hash()}, nil
 }
 
 // Only block height 5 will return true
-func (self *testSystemBackend) HasBlockMatching(hash common.Hash, number *big.Int) bool {
+func (self *testSystemBackend) HasBlock(hash common.Hash, number *big.Int) bool {
 	return number.Cmp(big.NewInt(5)) == 0
 }
 

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -153,7 +153,17 @@ func (self *testSystemBackend) NewRequest(request istanbul.Proposal) {
 	})
 }
 
-func (self *testSystemBackend) LastProposal() (istanbul.Proposal, common.Address) {
+func (self *testSystemBackend) LastBlock() istanbul.Proposal {
+	l := len(self.committedMsgs)
+	if l > 0 {
+		testLogger.Info("have proposal for block", "num", l)
+		return self.committedMsgs[l-1].commitProposal
+	}
+	testLogger.Info("do not have proposal for block", "num", 0)
+	return makeBlock(0)
+}
+
+func (self *testSystemBackend) LastBlockAndAuthor() (istanbul.Proposal, common.Address) {
 	l := len(self.committedMsgs)
 	if l > 0 {
 		testLogger.Info("have proposal for block", "num", l)
@@ -164,21 +174,21 @@ func (self *testSystemBackend) LastProposal() (istanbul.Proposal, common.Address
 }
 
 func (self *testSystemBackend) LastSubject() (istanbul.Subject, error) {
-	lastProposal, _ := self.LastProposal()
+	lastProposal := self.LastBlock()
 	lastView := &istanbul.View{Sequence: lastProposal.Number(), Round: big.NewInt(1)}
 	return istanbul.Subject{View: lastView, Digest: lastProposal.Hash()}, nil
 }
 
 // Only block height 5 will return true
-func (self *testSystemBackend) HasProposal(hash common.Hash, number *big.Int) bool {
+func (self *testSystemBackend) HasBlockMatching(hash common.Hash, number *big.Int) bool {
 	return number.Cmp(big.NewInt(5)) == 0
 }
 
-func (self *testSystemBackend) GetProposer(number uint64) common.Address {
+func (self *testSystemBackend) AuthorForBlock(number uint64) common.Address {
 	return common.Address{}
 }
 
-func (self *testSystemBackend) ParentValidators(proposal istanbul.Proposal) istanbul.ValidatorSet {
+func (self *testSystemBackend) ParentBlockValidators(proposal istanbul.Proposal) istanbul.ValidatorSet {
 	return self.peers
 }
 

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -163,7 +163,7 @@ func (self *testSystemBackend) GetCurrentHeadBlock() istanbul.Proposal {
 	return makeBlock(0)
 }
 
-func (self *testSystemBackend) GetCurrentHeadBlockAndAuthorAndAuthor() (istanbul.Proposal, common.Address) {
+func (self *testSystemBackend) GetCurrentHeadBlockAndAuthor() (istanbul.Proposal, common.Address) {
 	l := len(self.committedMsgs)
 	if l > 0 {
 		testLogger.Info("have proposal for block", "num", l)

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -33,8 +33,11 @@ type Proposal interface {
 
 	Header() *types.Header
 
-	// Hash retrieves the hash of this proposal.
+	// Hash retrieves the hash of this block
 	Hash() common.Hash
+
+	// ParentHash retrieves the hash of this block's parent
+	ParentHash() common.Hash
 
 	EncodeRLP(w io.Writer) error
 


### PR DESCRIPTION
### Description

- We don't want a new name for Block.
- The author or coinbase is the name already used. We leave proposer for
the current round proposer (which not always will be the final
author/coinbase)
- Rename ParentValidators to ParentBlockValidators

### Tested

unit/ci

