### PR TITLE
Move state inside RoundState.

### DIFF
--- a/consensus/istanbul/core/backlog.go
+++ b/consensus/istanbul/core/backlog.go
@@ -72,13 +72,13 @@ func (c *core) checkMessage(msgCode uint64, view *istanbul.View) error {
 	}
 
 	// Round change messages are already let through.
-	if c.state == StateWaitingForNewRound {
+	if c.current.State() == StateWaitingForNewRound {
 		return errFutureMessage
 	}
 
 	// StateAcceptRequest only accepts istanbul.MsgPreprepare
 	// other messages are future messages
-	if c.state == StateAcceptRequest && msgCode > istanbul.MsgPreprepare {
+	if c.current.State() == StateAcceptRequest && msgCode > istanbul.MsgPreprepare {
 		return errFutureMessage
 	}
 

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -108,7 +108,7 @@ func (c *core) handleCheckedCommitForPreviousSequence(msg *istanbul.Message, com
 	if err := c.verifyCommittedSeal(commit, validator); err != nil {
 		return errInvalidCommittedSeal
 	}
-	// Ensure that the commit's digest (ie the received proposal's hash) matches the saved last proposal's hash
+	// Ensure that the commit's digest (ie the received proposal's hash) matches the head block's hash
 	if headBlock.Number().Uint64() > 0 && commit.Subject.Digest != headBlock.Hash() {
 		logger.Debug("Received a commit message for the previous sequence with an unexpected hash", "expected", headBlock.Hash().String(), "received", commit.Subject.Digest.String())
 		return errInconsistentSubject

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -96,7 +96,7 @@ func (c *core) handleCommit(msg *istanbul.Message) error {
 }
 
 func (c *core) handleCheckedCommitForPreviousSequence(msg *istanbul.Message, commit *istanbul.CommittedSubject) error {
-	logger := c.newLogger("func", "handleCheckedCommitForPreviousSequence", "tag", "handleMsg")
+	logger := c.newLogger("func", "handleCheckedCommitForPreviousSequence", "tag", "handleMsg", "msg_view", commit.Subject.View)
 	headBlock := c.backend.GetCurrentHeadBlock()
 	// Retrieve the validator set for the previous proposal (which should
 	// match the one broadcast)

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -49,7 +49,7 @@ func (c *core) generateCommittedSeal(sub *istanbul.Subject) ([]byte, error) {
 }
 
 func (c *core) broadcastCommit(sub *istanbul.Subject) {
-	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence())
+	logger := c.newLogger("func", "broadcastCommit")
 
 	committedSeal, err := c.generateCommittedSeal(sub)
 	if err != nil {
@@ -96,7 +96,7 @@ func (c *core) handleCommit(msg *istanbul.Message) error {
 }
 
 func (c *core) handleCheckedCommitForPreviousSequence(msg *istanbul.Message, commit *istanbul.CommittedSubject) error {
-	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "handleCheckedCommitForPreviousSequence", "tag", "handleMsg")
+	logger := c.newLogger("func", "handleCheckedCommitForPreviousSequence", "tag", "handleMsg")
 	headBlock := c.backend.GetCurrentHeadBlock()
 	// Retrieve the validator set for the previous proposal (which should
 	// match the one broadcast)
@@ -113,11 +113,17 @@ func (c *core) handleCheckedCommitForPreviousSequence(msg *istanbul.Message, com
 		logger.Debug("Received a commit message for the previous sequence with an unexpected hash", "expected", headBlock.Hash().String(), "received", commit.Subject.Digest.String())
 		return errInconsistentSubject
 	}
-	return c.acceptParentCommit(msg, commit.Subject.View)
+
+	// Add the ParentCommit to current round state
+	if err := c.current.AddParentCommit(msg); err != nil {
+		logger.Error("Failed to record parent seal", "msg", msg, "err", err)
+		return err
+	}
+	return nil
 }
 
 func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, commit *istanbul.CommittedSubject) error {
-	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "handleCheckedCommitForCurrentSequence", "tag", "handleMsg")
+	logger := c.newLogger("func", "handleCheckedCommitForCurrentSequence", "tag", "handleMsg")
 	_, validator := c.valSet.GetByAddress(msg.Address)
 	if validator == nil {
 		return errInvalidValidatorAddress
@@ -132,7 +138,11 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 		return err
 	}
 
-	c.acceptCommit(msg)
+	// Add the COMMIT message to current round state
+	if err := c.current.AddCommit(msg); err != nil {
+		logger.Error("Failed to record commit message", "msg", msg, "err", err)
+		return err
+	}
 	numberOfCommits := c.current.Commits().Size()
 	minQuorumSize := c.valSet.MinQuorumSize()
 	logger.Trace("Accepted commit", "Number of commits", numberOfCommits)
@@ -142,16 +152,19 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 	// If we already have a proposal, we may have chance to speed up the consensus process
 	// by committing the proposal without PREPARE messages.
 	// TODO(joshua): Remove state comparisons (or change the cmp function)
-	if numberOfCommits >= minQuorumSize && c.state.Cmp(StateCommitted) < 0 {
+	if numberOfCommits >= minQuorumSize && c.current.State().Cmp(StateCommitted) < 0 {
 		logger.Trace("Got a quorum of commits", "tag", "stateTransition", "commits", c.current.Commits)
 		c.commit()
-	} else if c.current.GetPrepareOrCommitSize() >= minQuorumSize && c.state.Cmp(StatePrepared) < 0 {
-		if err := c.current.CreateAndSetPreparedCertificate(minQuorumSize); err != nil {
+	} else if c.current.GetPrepareOrCommitSize() >= minQuorumSize && c.current.State().Cmp(StatePrepared) < 0 {
+		err := c.current.TransitionToPrepared(minQuorumSize)
+		if err != nil {
 			logger.Error("Failed to create and set preprared certificate", "err", err)
 			return err
 		}
+		// Process Backlog Messages
+		c.processBacklog()
+
 		logger.Trace("Got quorum prepares or commits", "tag", "stateTransition", "commits", c.current.Commits, "prepares", c.current.Prepares)
-		c.setState(StatePrepared)
 		c.sendCommit()
 	}
 	return nil
@@ -160,7 +173,7 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 
 // verifyCommit verifies if the received COMMIT message is equivalent to our subject
 func (c *core) verifyCommit(commit *istanbul.CommittedSubject) error {
-	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "verifyCommit")
+	logger := c.newLogger("func", "verifyCommit")
 
 	sub := c.current.Subject()
 	if !reflect.DeepEqual(commit.Subject, sub) {
@@ -175,28 +188,4 @@ func (c *core) verifyCommit(commit *istanbul.CommittedSubject) error {
 func (c *core) verifyCommittedSeal(comSub *istanbul.CommittedSubject, src istanbul.Validator) error {
 	seal := PrepareCommittedSeal(comSub.Subject.Digest, comSub.Subject.View.Round)
 	return blscrypto.VerifySignature(src.BLSPublicKey(), seal, []byte{}, comSub.CommittedSeal, false)
-}
-
-func (c *core) acceptCommit(msg *istanbul.Message) error {
-	logger := c.logger.New("from", msg.Address, "state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "acceptCommit")
-
-	// Add the COMMIT message to current round state
-	if err := c.current.Commits().Add(msg); err != nil {
-		logger.Error("Failed to record commit message", "msg", msg, "err", err)
-		return err
-	}
-
-	return nil
-}
-
-func (c *core) acceptParentCommit(msg *istanbul.Message, view *istanbul.View) error {
-	logger := c.logger.New("from", msg.Address, "state", c.state, "parent_round", view.Round, "parent_seq", view.Sequence, "func", "acceptParentCommit")
-
-	// Add the ParentCommit to current round state
-	if err := c.current.ParentCommits().Add(msg); err != nil {
-		logger.Error("Failed to record parent seal", "msg", msg, "err", err)
-		return err
-	}
-
-	return nil
 }

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -64,7 +64,7 @@ func TestHandleCommit(t *testing.T) {
 
 					if i == 0 {
 						// replica 0 is the proposer
-						c.state = StatePrepared
+						c.current.(*roundStateImpl).state = StatePrepared
 					}
 				}
 				return sys
@@ -86,7 +86,7 @@ func TestHandleCommit(t *testing.T) {
 							expectedSubject.View,
 							c.valSet,
 						)
-						c.state = StatePreprepared
+						c.current.(*roundStateImpl).state = StatePreprepared
 					} else {
 						c.current = newTestRoundState(
 							&istanbul.View{
@@ -117,7 +117,7 @@ func TestHandleCommit(t *testing.T) {
 							expectedSubject.View,
 							c.valSet,
 						)
-						c.state = StatePreprepared
+						c.current.(*roundStateImpl).state = StatePreprepared
 					} else {
 						c.current = newTestRoundState(
 							&istanbul.View{
@@ -155,9 +155,9 @@ func TestHandleCommit(t *testing.T) {
 					// only replica0 stays at StatePreprepared
 					// other replicas are at StatePrepared
 					if i != 0 {
-						c.state = StatePrepared
+						c.current.(*roundStateImpl).state = StatePrepared
 					} else {
-						c.state = StatePreprepared
+						c.current.(*roundStateImpl).state = StatePreprepared
 					}
 				}
 				return sys
@@ -182,7 +182,7 @@ func TestHandleCommit(t *testing.T) {
 							expectedSubject.View,
 							c.valSet,
 						)
-						c.state = StatePrepared
+						c.current.(*roundStateImpl).state = StatePrepared
 					} else {
 						c.current = newTestRoundState(
 							&istanbul.View{
@@ -245,10 +245,10 @@ OUTER:
 		}
 
 		// prepared is normal case
-		if r0.state != StateCommitted {
+		if r0.current.State() != StateCommitted {
 			// There are not enough commit messages in core
-			if r0.state != StatePrepared {
-				t.Errorf("state mismatch: have %v, want %v", r0.state, StatePrepared)
+			if r0.current.State() != StatePrepared {
+				t.Errorf("state mismatch: have %v, want %v", r0.current.State(), StatePrepared)
 			}
 			if r0.current.Commits().Size() > r0.valSet.MinQuorumSize() {
 				t.Errorf("the size of commit messages should be less than %v", r0.valSet.MinQuorumSize())

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -39,7 +39,6 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 	c := &core{
 		config:             config,
 		address:            backend.Address(),
-		state:              StateAcceptRequest,
 		handlerWg:          new(sync.WaitGroup),
 		logger:             log.New("address", backend.Address()),
 		backend:            backend,
@@ -61,7 +60,6 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 type core struct {
 	config  *istanbul.Config
 	address common.Address
-	state   State
 	logger  log.Logger
 
 	backend               istanbul.Backend
@@ -97,16 +95,17 @@ type core struct {
 // Appends the current view and state to the given context.
 func (c *core) newLogger(ctx ...interface{}) log.Logger {
 	var seq, round *big.Int
-	state := c.state
+	var state State
 	if c.current != nil {
+		state = c.current.State()
 		seq = c.current.Sequence()
 		round = c.current.Round()
 	} else {
 		seq = common.Big0
 		round = big.NewInt(-1)
 	}
-	tmp := c.logger.New(ctx...)
-	return tmp.New("cur_seq", seq, "cur_round", round, "state", state, "address", c.address)
+	logger := c.logger.New(ctx...)
+	return logger.New("cur_seq", seq, "cur_round", round, "state", state, "address", c.address)
 }
 
 func (c *core) SetAddress(address common.Address) {
@@ -132,7 +131,7 @@ func (c *core) finalizeMessage(msg *istanbul.Message) ([]byte, error) {
 }
 
 func (c *core) broadcast(msg *istanbul.Message) {
-	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence())
+	logger := c.newLogger("func", "broadcast")
 
 	payload, err := c.finalizeMessage(msg)
 	if err != nil {
@@ -148,7 +147,10 @@ func (c *core) broadcast(msg *istanbul.Message) {
 }
 
 func (c *core) commit() {
-	c.setState(StateCommitted)
+	c.current.TransitionToCommited()
+
+	// Process Backlog Messages
+	c.processBacklog()
 
 	proposal := c.current.Proposal()
 	if proposal != nil {
@@ -328,11 +330,13 @@ func (c *core) startNewRound(round *big.Int) {
 
 	// Update logger
 	logger = logger.New("old_proposer", c.valSet.GetProposer())
-	// New snapshot for new round
-	c.updateRoundState(newView, c.valSet, roundChange)
 	// Calculate new proposer
 	c.valSet.CalcProposer(headAuthor, newView.Round.Uint64())
-	c.setState(StateAcceptRequest)
+	// New snapshot for new round
+	c.resetRoundState(newView, c.valSet, roundChange)
+	c.processPendingRequests()
+	c.processBacklog()
+
 	if roundChange && c.current != nil && c.isProposer() && request != nil {
 		c.sendPreprepare(request, roundChangeCertificate)
 	}
@@ -357,38 +361,41 @@ func (c *core) waitForDesiredRound(r *big.Int) {
 		Round:    new(big.Int).Set(r),
 	}
 	// Perform all of the updates
-	c.setState(StateWaitingForNewRound)
-	c.current.SetDesiredRound(r)
+	c.current.TransitionToWaitingForNewRound(r)
+
 	_, headAuthor := c.backend.GetCurrentHeadBlockAndAuthor()
-	c.valSet.CalcProposer(headAuthor, desiredView.Round.Uint64())
+	c.valSet.CalcProposer(headAuthor, r.Uint64())
 	c.newRoundChangeTimerForView(desiredView)
 
+	// Process Backlog Messages
+	c.processBacklog()
+
 	// Send round change
-	c.sendRoundChange(desiredView.Round)
+	c.sendRoundChange(r)
 }
 
-func (c *core) updateRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, roundChange bool) {
+func (c *core) resetRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, roundChange bool) {
 	// TODO(Joshua): Include desired round here.
 	if c.current != nil {
 		if roundChange {
-			c.current = newRoundState(view, validatorSet, nil, c.current.PendingRequest(), c.current.PreparedCertificate(), c.current.ParentCommits())
+			c.current = newRoundState(view, validatorSet, c.current.PendingRequest(), c.current.PreparedCertificate(), c.current.ParentCommits())
 		} else {
 			lastSubject, err := c.backend.LastSubject()
 			if err != nil && c.current.Proposal() != nil && c.current.Proposal().Hash() == lastSubject.Digest && c.current.Round().Cmp(lastSubject.View.Round) == 0 {
 				// When changing sequences, if our current Commit messages match the latest block in the chain
 				// (i.e. they're for the same block hash and round), we use this sequence's commits as the ParentCommits field
 				// in the next round.
-				c.current = newRoundState(view, validatorSet, nil, nil, istanbul.EmptyPreparedCertificate(), c.current.Commits())
+				c.current = newRoundState(view, validatorSet, nil, istanbul.EmptyPreparedCertificate(), c.current.Commits())
 			} else {
 				headBlock := c.backend.GetCurrentHeadBlock()
 				// Otherwise, we will initialize an empty ParentCommits field with the validator set of the last proposal.
-				c.current = newRoundState(view, validatorSet, nil, nil, istanbul.EmptyPreparedCertificate(), newMessageSet(c.backend.ParentBlockValidators(headBlock)))
+				c.current = newRoundState(view, validatorSet, nil, istanbul.EmptyPreparedCertificate(), newMessageSet(c.backend.ParentBlockValidators(headBlock)))
 			}
 		}
 	} else {
 		// When the current round is nil, we must start with the current validator set in the parent commits
 		// either `validatorSet` or `backend.Validators(lastProposal)` works here
-		c.current = newRoundState(view, validatorSet, nil, nil, istanbul.EmptyPreparedCertificate(), newMessageSet(validatorSet))
+		c.current = newRoundState(view, validatorSet, nil, istanbul.EmptyPreparedCertificate(), newMessageSet(validatorSet))
 	}
 }
 
@@ -397,16 +404,6 @@ func (c *core) isProposer() bool {
 		return false
 	}
 	return c.valSet.IsProposer(c.address)
-}
-
-func (c *core) setState(state State) {
-	if c.state != state {
-		c.state = state
-	}
-	if state == StateAcceptRequest {
-		c.processPendingRequests()
-	}
-	c.processBacklog()
 }
 
 func (c *core) stopFuturePreprepareTimer() {

--- a/consensus/istanbul/core/final_committed.go
+++ b/consensus/istanbul/core/final_committed.go
@@ -19,7 +19,7 @@ package core
 import "github.com/ethereum/go-ethereum/common"
 
 func (c *core) handleFinalCommitted() error {
-	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence())
+	logger := c.newLogger("func", "handleFinalCommitted")
 	logger.Trace("Received a final committed proposal")
 	c.startNewRound(common.Big0)
 	return nil

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -151,7 +151,7 @@ func TestHandlePrepare(t *testing.T) {
 
 					if i == 0 {
 						// replica 0 is the proposer
-						c.state = StatePreprepared
+						c.current.(*roundStateImpl).state = StatePreprepared
 					}
 				}
 				return sys
@@ -186,7 +186,7 @@ func TestHandlePrepare(t *testing.T) {
 
 					if i == 0 {
 						// replica 0 is the proposer
-						c.state = StatePreprepared
+						c.current.(*roundStateImpl).state = StatePreprepared
 					}
 				}
 				return sys
@@ -221,7 +221,7 @@ func TestHandlePrepare(t *testing.T) {
 
 					if i == 0 {
 						// replica 0 is the proposer
-						c.state = StatePreprepared
+						c.current.(*roundStateImpl).state = StatePreprepared
 					}
 				}
 				return sys
@@ -242,7 +242,7 @@ func TestHandlePrepare(t *testing.T) {
 							expectedSubject.View,
 							c.valSet,
 						)
-						c.state = StatePreprepared
+						c.current.(*roundStateImpl).state = StatePreprepared
 					} else {
 						c.current = newTestRoundState(
 							&istanbul.View{
@@ -271,7 +271,7 @@ func TestHandlePrepare(t *testing.T) {
 							expectedSubject.View,
 							c.valSet,
 						)
-						c.state = StatePreprepared
+						c.current.(*roundStateImpl).state = StatePreprepared
 					} else {
 						c.current = newTestRoundState(
 							&istanbul.View{
@@ -300,7 +300,7 @@ func TestHandlePrepare(t *testing.T) {
 							expectedSubject.View,
 							c.valSet,
 						)
-						c.state = StatePreprepared
+						c.current.(*roundStateImpl).state = StatePreprepared
 					} else {
 						c.current = newTestRoundState(
 							&istanbul.View{
@@ -332,7 +332,7 @@ func TestHandlePrepare(t *testing.T) {
 
 					if i == 0 {
 						// replica 0 is the proposer
-						c.state = StatePreprepared
+						c.current.(*roundStateImpl).state = StatePreprepared
 					}
 				}
 				return sys
@@ -365,10 +365,10 @@ OUTER:
 		}
 
 		// prepared is normal case
-		if r0.state != StatePrepared {
+		if r0.current.State() != StatePrepared {
 			// There are not enough PREPARE messages in core
-			if r0.state != StatePreprepared {
-				t.Errorf("state mismatch: have %v, want %v", r0.state, StatePreprepared)
+			if r0.current.State() != StatePreprepared {
+				t.Errorf("state mismatch: have %v, want %v", r0.current.State(), StatePreprepared)
 			}
 			if r0.current.Prepares().Size() >= r0.valSet.MinQuorumSize() {
 				t.Errorf("the size of PREPARE messages should be less than %v", 2*r0.valSet.MinQuorumSize()+1)

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -130,17 +130,17 @@ func (c *core) handlePreprepare(msg *istanbul.Message) error {
 		return err
 	}
 
-	if c.state == StateAcceptRequest {
+	if c.current.State() == StateAcceptRequest {
 		logger.Trace("Accepted preprepare", "tag", "stateTransition")
-		c.acceptPreprepare(preprepare)
-		c.setState(StatePreprepared)
+		c.consensusTimestamp = time.Now()
+
+		c.current.TransitionToPreprepared(preprepare)
+
+		// Process Backlog Messages
+		c.processBacklog()
+
 		c.sendPrepare()
 	}
 
 	return nil
-}
-
-func (c *core) acceptPreprepare(preprepare *istanbul.Preprepare) {
-	c.consensusTimestamp = time.Now()
-	c.current.SetPreprepare(preprepare)
 }

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -51,7 +51,7 @@ func TestHandlePreprepare(t *testing.T) {
 					c := backend.engine.(*core)
 					c.valSet = backend.peers
 					if i != 0 {
-						c.state = StateAcceptRequest
+						c.current.(*roundStateImpl).state = StateAcceptRequest
 					}
 				}
 				return sys
@@ -72,7 +72,7 @@ func TestHandlePreprepare(t *testing.T) {
 					c := backend.engine.(*core)
 					c.valSet = backend.peers
 					if i != 0 {
-						c.state = StateAcceptRequest
+						c.current.(*roundStateImpl).state = StateAcceptRequest
 					}
 				}
 				return sys
@@ -97,7 +97,7 @@ func TestHandlePreprepare(t *testing.T) {
 					c.valSet = backend.peers
 					if i != 0 {
 						// replica 0 is the proposer
-						c.state = StatePreprepared
+						c.current.(*roundStateImpl).state = StatePreprepared
 					}
 				}
 				return sys
@@ -118,9 +118,9 @@ func TestHandlePreprepare(t *testing.T) {
 					c := backend.engine.(*core)
 					c.valSet = backend.peers
 					if i != 0 {
-						c.state = StatePreprepared
-						c.current.SetSequence(big.NewInt(10))
-						c.current.SetRound(big.NewInt(10))
+						c.current.(*roundStateImpl).state = StatePreprepared
+						c.current.(*roundStateImpl).sequence = big.NewInt(10)
+						c.current.(*roundStateImpl).round = big.NewInt(10)
 					}
 				}
 				return sys
@@ -140,9 +140,9 @@ func TestHandlePreprepare(t *testing.T) {
 				for _, backend := range sys.backends {
 					c := backend.engine.(*core)
 					c.valSet = backend.peers
-					c.state = StatePreprepared
-					c.current.SetSequence(big.NewInt(10))
-					c.current.SetRound(big.NewInt(10))
+					c.current.(*roundStateImpl).state = StatePreprepared
+					c.current.(*roundStateImpl).sequence = big.NewInt(10)
+					c.current.(*roundStateImpl).round = big.NewInt(10)
 				}
 				return sys
 			}(),
@@ -162,8 +162,8 @@ func TestHandlePreprepare(t *testing.T) {
 				for _, backend := range sys.backends {
 					c := backend.engine.(*core)
 					c.valSet = backend.peers
-					c.state = StatePreprepared
-					c.current.SetRound(big.NewInt(1))
+					c.current.(*roundStateImpl).state = StatePreprepared
+					c.current.(*roundStateImpl).round = big.NewInt(1)
 				}
 				return sys
 			}(),
@@ -182,8 +182,8 @@ func TestHandlePreprepare(t *testing.T) {
 				for _, backend := range sys.backends {
 					c := backend.engine.(*core)
 					c.valSet = backend.peers
-					c.state = StatePreprepared
-					c.current.SetRound(big.NewInt(1))
+					c.current.(*roundStateImpl).state = StatePreprepared
+					c.current.(*roundStateImpl).round = big.NewInt(1)
 				}
 				return sys
 			}(),
@@ -205,9 +205,9 @@ func TestHandlePreprepare(t *testing.T) {
 				for _, backend := range sys.backends {
 					c := backend.engine.(*core)
 					c.valSet = backend.peers
-					c.state = StatePreprepared
-					c.current.SetRound(big.NewInt(1))
-					c.current.SetPreprepare(&istanbul.Preprepare{
+					c.current.(*roundStateImpl).state = StatePreprepared
+					c.current.(*roundStateImpl).round = big.NewInt(1)
+					c.current.TransitionToPreprepared(&istanbul.Preprepare{
 						View: &istanbul.View{
 							Round:    big.NewInt(1),
 							Sequence: big.NewInt(2),
@@ -241,9 +241,9 @@ func TestHandlePreprepare(t *testing.T) {
 				for _, backend := range sys.backends {
 					c := backend.engine.(*core)
 					c.valSet = backend.peers
-					c.state = StatePreprepared
-					c.current.SetRound(big.NewInt(1))
-					c.current.SetPreprepare(&istanbul.Preprepare{
+					c.current.(*roundStateImpl).state = StatePreprepared
+					c.current.(*roundStateImpl).round = big.NewInt(1)
+					c.current.TransitionToPreprepared(&istanbul.Preprepare{
 						View: &istanbul.View{
 							Round:    big.NewInt(1),
 							Sequence: big.NewInt(0),
@@ -272,9 +272,9 @@ func TestHandlePreprepare(t *testing.T) {
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
 					c.valSet = backend.peers
-					c.current.SetRound(big.NewInt(int64(N)))
+					c.current.(*roundStateImpl).round = big.NewInt(int64(N))
 					if i != 0 {
-						c.state = StateAcceptRequest
+						c.current.(*roundStateImpl).state = StateAcceptRequest
 					}
 				}
 				return sys
@@ -297,9 +297,9 @@ func TestHandlePreprepare(t *testing.T) {
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
 					c.valSet = backend.peers
-					c.current.SetRound(big.NewInt(int64(N)))
+					c.current.(*roundStateImpl).round = big.NewInt(int64(N))
 					if i != 0 {
-						c.state = StateAcceptRequest
+						c.current.(*roundStateImpl).state = StateAcceptRequest
 					}
 				}
 				return sys
@@ -356,8 +356,8 @@ OUTER:
 				continue OUTER
 			}
 
-			if c.state != StatePreprepared {
-				t.Errorf("state mismatch: have %v, want %v", c.state, StatePreprepared)
+			if c.current.State() != StatePreprepared {
+				t.Errorf("state mismatch: have %v, want %v", c.current.State(), StatePreprepared)
 			}
 
 			if !test.existingBlock && !reflect.DeepEqual(c.current.Subject().View, curView) {

--- a/consensus/istanbul/core/request.go
+++ b/consensus/istanbul/core/request.go
@@ -38,7 +38,7 @@ func (c *core) handleRequest(request *istanbul.Request) error {
 	c.current.SetPendingRequest(request)
 
 	// Must go through startNewRound to send proposals for round > 0 to ensure a round change certificate is generated.
-	if c.state == StateAcceptRequest && c.current.Round().Cmp(common.Big0) == 0 {
+	if c.current.State() == StateAcceptRequest && c.current.Round().Cmp(common.Big0) == 0 {
 		c.sendPreprepare(request, istanbul.RoundChangeCertificate{})
 	}
 	return nil

--- a/consensus/istanbul/core/request_test.go
+++ b/consensus/istanbul/core/request_test.go
@@ -31,11 +31,10 @@ import (
 
 func TestCheckRequestMsg(t *testing.T) {
 	c := &core{
-		state: StateAcceptRequest,
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4), nil, nil, istanbul.EmptyPreparedCertificate(), nil),
+		}, newTestValidatorSet(4), nil, istanbul.EmptyPreparedCertificate(), nil),
 	}
 
 	// invalid request
@@ -86,11 +85,10 @@ func TestStoreRequestMsg(t *testing.T) {
 	c := &core{
 		logger:  log.New("backend", "test", "id", 0),
 		backend: backend,
-		state:   StateAcceptRequest,
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4), nil, nil, istanbul.EmptyPreparedCertificate(), nil),
+		}, newTestValidatorSet(4), nil, istanbul.EmptyPreparedCertificate(), nil),
 		pendingRequests:   prque.New(nil),
 		pendingRequestsMu: new(sync.Mutex),
 	}
@@ -113,7 +111,7 @@ func TestStoreRequestMsg(t *testing.T) {
 		t.Errorf("the size of pending requests mismatch: have %v, want %v", c.pendingRequests.Size(), len(requests))
 	}
 
-	c.current.SetSequence(big.NewInt(3))
+	c.current.(*roundStateImpl).sequence = big.NewInt(3)
 
 	c.subscribeEvents()
 	defer c.unsubscribeEvents()

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -35,7 +35,7 @@ func (c *core) sendNextRoundChange() {
 
 // sendRoundChange sends the ROUND CHANGE message with the given round
 func (c *core) sendRoundChange(round *big.Int) {
-	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "sendRoundChange", "target round", round)
+	logger := c.newLogger("func", "sendRoundChange", "target round", round)
 
 	cv := c.current.View()
 	if cv.Round.Cmp(round) >= 0 {
@@ -152,7 +152,7 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 }
 
 func (c *core) handleRoundChange(msg *istanbul.Message) error {
-	logger := c.logger.New("state", c.state, "from", msg.Address, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "handleRoundChange", "tag", "handleMsg")
+	logger := c.newLogger("func", "handleRoundChange", "tag", "handleMsg", "from", msg.Address)
 
 	// Decode ROUND CHANGE message
 	var rc *istanbul.RoundChange

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -259,7 +259,7 @@ func TestHandleRoundChange(t *testing.T) {
 			// valid message for future round
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
-				sys.backends[0].engine.(*core).current.SetRound(big.NewInt(10))
+				sys.backends[0].engine.(*core).current.(*roundStateImpl).round = big.NewInt(10)
 				return sys
 			}(),
 			func(_ *testSystem) istanbul.PreparedCertificate {
@@ -271,7 +271,8 @@ func TestHandleRoundChange(t *testing.T) {
 			// invalid message for future sequence
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
-				sys.backends[0].engine.(*core).current.SetSequence(big.NewInt(10))
+				sys.backends[0].engine.(*core).current.(*roundStateImpl).sequence = big.NewInt(10)
+
 				return sys
 			}(),
 			func(_ *testSystem) istanbul.PreparedCertificate {
@@ -283,7 +284,7 @@ func TestHandleRoundChange(t *testing.T) {
 			// invalid message for previous round
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
-				sys.backends[0].engine.(*core).current.SetRound(big.NewInt(0))
+				sys.backends[0].engine.(*core).current.(*roundStateImpl).round = big.NewInt(0)
 				return sys
 			}(),
 			func(_ *testSystem) istanbul.PreparedCertificate {

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -200,6 +200,7 @@ func (s *roundStateImpl) TransitionToWaitingForNewRound(r *big.Int) {
 	s.state = StateWaitingForNewRound
 }
 
+// TransitionToPrepared will create a PreparedCertificate and change state to Prepared
 func (s *roundStateImpl) TransitionToPrepared(quorumSize int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -339,7 +339,7 @@ func NewTestSystemWithBackend(n, f uint64) *testSystem {
 		return newRoundState(&istanbul.View{
 			Round:    big.NewInt(0),
 			Sequence: big.NewInt(1),
-		}, vset, nil, nil, istanbul.EmptyPreparedCertificate(), nil)
+		}, vset, nil, istanbul.EmptyPreparedCertificate(), nil)
 	})
 }
 
@@ -360,7 +360,7 @@ func NewTestSystemWithBackendAndCurrentRoundState(n, f uint64, getRoundState fun
 		backend.blsKey = blsKeys[i]
 
 		core := New(backend, config).(*core)
-		core.state = StateAcceptRequest
+		// core.state = StateAcceptRequest
 		core.current = getRoundState(vset)
 		core.roundChangeSet = newRoundChangeSet(vset)
 		core.valSet = vset

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -360,7 +360,6 @@ func NewTestSystemWithBackendAndCurrentRoundState(n, f uint64, getRoundState fun
 		backend.blsKey = blsKeys[i]
 
 		core := New(backend, config).(*core)
-		// core.state = StateAcceptRequest
 		core.current = getRoundState(vset)
 		core.roundChangeSet = newRoundChangeSet(vset)
 		core.valSet = vset

--- a/consensus/istanbul/core/testutils_test.go
+++ b/consensus/istanbul/core/testutils_test.go
@@ -21,12 +21,13 @@ import (
 )
 
 func newTestRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet) RoundState {
-	return newRoundState(
+	current := newRoundState(
 		view,
 		validatorSet,
-		newTestPreprepare(view),
 		nil,
 		istanbul.PreparedCertificate{},
 		newMessageSet(validatorSet),
 	)
+	current.(*roundStateImpl).preprepare = newTestPreprepare(view)
+	return current
 }


### PR DESCRIPTION
### Description

- c.state now lives inside RoundState
- RoundState has method for every state transition
- Use RoundState methods to Add Prepare/Commit/ParentCommit msgs
- Cleanup everywhere
- Remove unncessary construction arguments for RoundState
- Change where backlog processing is dispatched (at the beginning of a
round)
### Tested

ci/unit

