### PR TITLE
Fix for backlogging of commit messages

### DIFF
--- a/consensus/istanbul/core/backlog.go
+++ b/consensus/istanbul/core/backlog.go
@@ -112,12 +112,16 @@ func (c *core) storeBacklog(msg *istanbul.Message, src istanbul.Validator) {
 			backlog.Push(msg, toPriority(msg.Code, p.View))
 		}
 	case istanbul.MsgPrepare:
-		fallthrough
-	case istanbul.MsgCommit:
 		var p *istanbul.Subject
 		err := msg.Decode(&p)
 		if err == nil {
 			backlog.Push(msg, toPriority(msg.Code, p.View))
+		}
+	case istanbul.MsgCommit:
+		var cs *istanbul.CommittedSubject
+		err := msg.Decode(&cs)
+		if err == nil {
+			backlog.Push(msg, toPriority(msg.Code, cs.Subject.View))
 		}
 	case istanbul.MsgRoundChange:
 		var p *istanbul.RoundChange
@@ -156,12 +160,16 @@ func (c *core) processBacklog() {
 					view = m.View
 				}
 			case istanbul.MsgPrepare:
-				fallthrough
-			case istanbul.MsgCommit:
 				var sub *istanbul.Subject
 				err := msg.Decode(&sub)
 				if err == nil {
 					view = sub.View
+				}
+			case istanbul.MsgCommit:
+				var cs *istanbul.CommittedSubject
+				err := msg.Decode(&cs)
+				if err == nil {
+					view = cs.Subject.View
 				}
 			case istanbul.MsgRoundChange:
 				var rc *istanbul.RoundChange

--- a/consensus/istanbul/core/backlog_test.go
+++ b/consensus/istanbul/core/backlog_test.go
@@ -264,9 +264,16 @@ func TestStoreBacklog(t *testing.T) {
 	}
 
 	// push commit msg
+	committedSubject := &istanbul.CommittedSubject{
+		Subject:       subject,
+		CommittedSeal: []byte{0x63, 0x65, 0x6C, 0x6F}, // celo in hex!
+	}
+
+	committedSubjectPayload, _ := Encode(committedSubject)
+
 	m = &istanbul.Message{
 		Code:    istanbul.MsgCommit,
-		Msg:     subjectPayload,
+		Msg:     committedSubjectPayload,
 		Address: p.Address(),
 	}
 	c.storeBacklog(m, p)
@@ -319,14 +326,18 @@ func TestProcessFutureBacklog(t *testing.T) {
 	}
 	p := validator.New(common.BytesToAddress([]byte("12345667890")), []byte{})
 	// push a future msg
-	subject := &istanbul.Subject{
-		View:   v,
-		Digest: common.BytesToHash([]byte("1234567890")),
+	committedSubject := &istanbul.CommittedSubject{
+		Subject: &istanbul.Subject{
+			View:   v,
+			Digest: common.BytesToHash([]byte("1234567890")),
+		},
+		CommittedSeal: []byte{0x63, 0x65, 0x6C, 0x6F},
 	}
-	subjectPayload, _ := Encode(subject)
+
+	committedSubjectPayload, _ := Encode(committedSubject)
 	m := &istanbul.Message{
 		Code: istanbul.MsgCommit,
-		Msg:  subjectPayload,
+		Msg:  committedSubjectPayload,
 	}
 	c.storeBacklog(m, p)
 	c.processBacklog()
@@ -361,6 +372,12 @@ func TestProcessBacklog(t *testing.T) {
 	}
 	subjectPayload, _ := Encode(subject)
 
+	committedSubject := &istanbul.CommittedSubject{
+		Subject:       subject,
+		CommittedSeal: []byte{0x63, 0x65, 0x6C, 0x6F},
+	}
+	committedSubjectPayload, _ := Encode(committedSubject)
+
 	rc := &istanbul.RoundChange{
 		View:                v,
 		PreparedCertificate: istanbul.EmptyPreparedCertificate(),
@@ -382,7 +399,7 @@ func TestProcessBacklog(t *testing.T) {
 		},
 		{
 			Code:    istanbul.MsgCommit,
-			Msg:     subjectPayload,
+			Msg:     committedSubjectPayload,
 			Address: address,
 		},
 		{


### PR DESCRIPTION
### Description

The format of the commit message's payload changed recently.  The backlog was still parsing the commit msg payload using the old format.

### Tested

Unit tests.

### Other changes


### Related issues


### Backwards compatibility

Yes