### PR TITLE
Add StartNewRound/Sequence to RoundState

### DIFF
--- a/consensus/istanbul/core/backlog_test.go
+++ b/consensus/istanbul/core/backlog_test.go
@@ -42,7 +42,7 @@ func TestCheckMessage(t *testing.T) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(2),
 			Round:    big.NewInt(2),
-		}, newTestValidatorSet(4), nil, istanbul.EmptyPreparedCertificate(), nil),
+		}, newTestValidatorSet(4)),
 	}
 
 	// invalid view format
@@ -313,7 +313,7 @@ func TestProcessFutureBacklog(t *testing.T) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4), nil, istanbul.EmptyPreparedCertificate(), nil),
+		}, newTestValidatorSet(4)),
 	}
 	c.subscribeEvents()
 	defer c.unsubscribeEvents()
@@ -426,7 +426,7 @@ func testProcessBacklog(t *testing.T, msg *istanbul.Message) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4), nil, istanbul.EmptyPreparedCertificate(), nil),
+		}, newTestValidatorSet(4)),
 	}
 	c.current.(*roundStateImpl).state = State(msg.Code)
 	c.subscribeEvents()

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -376,26 +376,28 @@ func (c *core) waitForDesiredRound(r *big.Int) {
 
 func (c *core) resetRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, roundChange bool) {
 	// TODO(Joshua): Include desired round here.
-	if c.current != nil {
-		if roundChange {
-			c.current = newRoundState(view, validatorSet, c.current.PendingRequest(), c.current.PreparedCertificate(), c.current.ParentCommits())
-		} else {
-			lastSubject, err := c.backend.LastSubject()
-			if err != nil && c.current.Proposal() != nil && c.current.Proposal().Hash() == lastSubject.Digest && c.current.Round().Cmp(lastSubject.View.Round) == 0 {
-				// When changing sequences, if our current Commit messages match the latest block in the chain
-				// (i.e. they're for the same block hash and round), we use this sequence's commits as the ParentCommits field
-				// in the next round.
-				c.current = newRoundState(view, validatorSet, nil, istanbul.EmptyPreparedCertificate(), c.current.Commits())
-			} else {
-				headBlock := c.backend.GetCurrentHeadBlock()
-				// Otherwise, we will initialize an empty ParentCommits field with the validator set of the last proposal.
-				c.current = newRoundState(view, validatorSet, nil, istanbul.EmptyPreparedCertificate(), newMessageSet(c.backend.ParentBlockValidators(headBlock)))
-			}
-		}
-	} else {
+	if c.current == nil {
 		// When the current round is nil, we must start with the current validator set in the parent commits
 		// either `validatorSet` or `backend.Validators(lastProposal)` works here
-		c.current = newRoundState(view, validatorSet, nil, istanbul.EmptyPreparedCertificate(), newMessageSet(validatorSet))
+		c.current = newRoundState(view, validatorSet)
+	} else if roundChange {
+		c.current.StartNewRound(view.Round, validatorSet)
+	} else {
+		// sequence change
+
+		var newParentCommits MessageSet
+		lastSubject, err := c.backend.LastSubject()
+		if err != nil && c.current.Proposal() != nil && c.current.Proposal().Hash() == lastSubject.Digest && c.current.Round().Cmp(lastSubject.View.Round) == 0 {
+			// When changing sequences, if our current Commit messages match the latest block in the chain
+			// (i.e. they're for the same block hash and round), we use this sequence's commits as the ParentCommits field
+			// in the next round.
+			newParentCommits = c.current.Commits()
+		} else {
+			// Otherwise, we will initialize an empty ParentCommits field with the validator set of the last proposal.
+			headBlock := c.backend.GetCurrentHeadBlock()
+			newParentCommits = newMessageSet(c.backend.ParentBlockValidators(headBlock))
+		}
+		c.current.StartNewSequence(view, validatorSet, newParentCommits)
 	}
 }
 

--- a/consensus/istanbul/core/request_test.go
+++ b/consensus/istanbul/core/request_test.go
@@ -34,7 +34,7 @@ func TestCheckRequestMsg(t *testing.T) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4), nil, istanbul.EmptyPreparedCertificate(), nil),
+		}, newTestValidatorSet(4)),
 	}
 
 	// invalid request
@@ -88,7 +88,7 @@ func TestStoreRequestMsg(t *testing.T) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4), nil, istanbul.EmptyPreparedCertificate(), nil),
+		}, newTestValidatorSet(4)),
 		pendingRequests:   prque.New(nil),
 		pendingRequestsMu: new(sync.Mutex),
 	}

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -339,7 +339,7 @@ func NewTestSystemWithBackend(n, f uint64) *testSystem {
 		return newRoundState(&istanbul.View{
 			Round:    big.NewInt(0),
 			Sequence: big.NewInt(1),
-		}, vset, nil, istanbul.EmptyPreparedCertificate(), nil)
+		}, vset)
 	})
 }
 

--- a/consensus/istanbul/core/testutils_test.go
+++ b/consensus/istanbul/core/testutils_test.go
@@ -21,13 +21,7 @@ import (
 )
 
 func newTestRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet) RoundState {
-	current := newRoundState(
-		view,
-		validatorSet,
-		nil,
-		istanbul.PreparedCertificate{},
-		newMessageSet(validatorSet),
-	)
+	current := newRoundState(view, validatorSet)
 	current.(*roundStateImpl).preprepare = newTestPreprepare(view)
 	return current
 }


### PR DESCRIPTION

### Description

Instead of replacing c.current, we now call
c.current.StartNewRound/Sequence() to transation round or sequence.

### Tested

ci/unit

