### PR TITLE
Copy randomness on valset copy

### DIFF
--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -248,7 +248,9 @@ func (valSet *defaultSet) Copy() istanbul.ValidatorSet {
 		})
 	}
 
-	return NewSet(validators, valSet.policy)
+	valSetCopy := NewSet(validators, valSet.policy)
+	valSetCopy.SetRandomness(valSet.randomness)
+	return valSetCopy
 }
 
 func (valSet *defaultSet) F() int { return int(math.Ceil(float64(valSet.Size())/3)) - 1 }


### PR DESCRIPTION
### Description

Randomness should be copied when copying a valset