### PR TITLE
Move Proposer outside ValidatorSet

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -556,7 +556,7 @@ func (sb *Backend) getValidators(number uint64, hash common.Hash) istanbul.Valid
 	snap, err := sb.snapshot(sb.chain, number, hash, nil)
 	if err != nil {
 		sb.logger.Warn("Error getting snapshot", "number", number, "hash", hash, "err", err)
-		return validator.NewSet(nil, sb.config.ProposerPolicy)
+		return validator.NewSet(nil)
 	}
 	return snap.ValSet
 }
@@ -584,7 +584,7 @@ func (sb *Backend) getOrderedValidators(number uint64, hash common.Hash) istanbu
 		return valSet
 	}
 
-	if valSet.Policy() == istanbul.ShuffledRoundRobin {
+	if sb.config.ProposerPolicy == istanbul.ShuffledRoundRobin {
 		seed, err := sb.validatorRandomnessAtBlockNumber(number, hash)
 		if err != nil {
 			sb.logger.Error("Failed to set randomness for proposer selection", "block_number", number, "hash", hash, "error", err)

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -225,7 +225,7 @@ func newTestValidatorSet(n int) (istanbul.ValidatorSet, []*ecdsa.PrivateKey) {
 			blsPublicKey,
 		}
 	}
-	vset := validator.NewSet(validators, istanbul.RoundRobin)
+	vset := validator.NewSet(validators)
 	return vset, keys
 }
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -774,7 +774,7 @@ func (sb *Backend) snapshot(chain consensus.ChainReader, number uint64, hash com
 			log.Error("Cannot construct validators data from istanbul extra")
 			return nil, errInvalidValidatorSetDiff
 		}
-		snap = newSnapshot(sb.config.Epoch, 0, genesis.Hash(), validator.NewSet(validators, sb.config.ProposerPolicy))
+		snap = newSnapshot(sb.config.Epoch, 0, genesis.Hash(), validator.NewSet(validators))
 
 		if err := snap.store(sb.db); err != nil {
 			log.Error("Unable to store snapshot", "err", err)

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -141,7 +141,8 @@ func newBlockChain(n int, isFullChain bool) (*core.BlockChain, *Backend) {
 	if snap == nil {
 		panic("failed to get snapshot")
 	}
-	proposerAddr := snap.ValSet.GetProposer().Address()
+	proposerAddr := b.AuthorForBlock(snap.Number)
+	// proposerAddr := snap.ValSet.GetProposer().Address()
 
 	// find proposer key
 	for _, key := range nodeKeys {

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -170,7 +170,6 @@ type snapshotJSON struct {
 
 	// for validator set
 	Validators []istanbul.ValidatorData `json:"validators"`
-	Policy     istanbul.ProposerPolicy  `json:"policy"`
 }
 
 func (s *Snapshot) toJSONStruct() *snapshotJSON {
@@ -180,11 +179,10 @@ func (s *Snapshot) toJSONStruct() *snapshotJSON {
 		Number:     s.Number,
 		Hash:       s.Hash,
 		Validators: validators,
-		Policy:     s.ValSet.Policy(),
 	}
 }
 
-// Unmarshal from a json byte array
+// UnmarshalJSON from a json byte array
 func (s *Snapshot) UnmarshalJSON(b []byte) error {
 	var j snapshotJSON
 	if err := json.Unmarshal(b, &j); err != nil {
@@ -194,11 +192,11 @@ func (s *Snapshot) UnmarshalJSON(b []byte) error {
 	s.Epoch = j.Epoch
 	s.Number = j.Number
 	s.Hash = j.Hash
-	s.ValSet = validator.NewSet(j.Validators, j.Policy)
+	s.ValSet = validator.NewSet(j.Validators)
 	return nil
 }
 
-// Marshal to a json byte array
+// MarshalJSON to a json byte array
 func (s *Snapshot) MarshalJSON() ([]byte, error) {
 	j := s.toJSONStruct()
 	return json.Marshal(j)

--- a/consensus/istanbul/backend/snapshot_test.go
+++ b/consensus/istanbul/backend/snapshot_test.go
@@ -424,7 +424,7 @@ func TestSaveAndLoad(t *testing.T) {
 				common.BytesToAddress([]byte("1234567895")),
 				nil,
 			},
-		}, istanbul.RoundRobin),
+		}),
 	}
 	db := ethdb.NewMemDatabase()
 	err := snap.store(db)

--- a/consensus/istanbul/core/backlog_test.go
+++ b/consensus/istanbul/core/backlog_test.go
@@ -36,13 +36,14 @@ func TestCheckMessage(t *testing.T) {
 	backend := &testSystemBackend{
 		events: new(event.TypeMux),
 	}
+	valSet := newTestValidatorSet(4)
 	c := &core{
 		logger:  testLogger,
 		backend: backend,
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(2),
 			Round:    big.NewInt(2),
-		}, newTestValidatorSet(4)),
+		}, valSet, valSet.GetByIndex(0)),
 	}
 
 	// invalid view format
@@ -305,6 +306,7 @@ func TestProcessFutureBacklog(t *testing.T) {
 		events: new(event.TypeMux),
 	}
 	testLogger.SetHandler(elog.StdoutHandler)
+	valSet := newTestValidatorSet(4)
 	c := &core{
 		logger:     testLogger,
 		backlogs:   make(map[istanbul.Validator]*prque.Prque),
@@ -313,7 +315,7 @@ func TestProcessFutureBacklog(t *testing.T) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4)),
+		}, valSet, valSet.GetByIndex(0)),
 	}
 	c.subscribeEvents()
 	defer c.unsubscribeEvents()
@@ -418,6 +420,7 @@ func testProcessBacklog(t *testing.T, msg *istanbul.Message) {
 		peers:  vset,
 	}
 	testLogger.SetHandler(elog.StdoutHandler)
+	valSet := newTestValidatorSet(4)
 	c := &core{
 		logger:     testLogger,
 		backlogs:   make(map[istanbul.Validator]*prque.Prque),
@@ -426,7 +429,7 @@ func testProcessBacklog(t *testing.T, msg *istanbul.Message) {
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4)),
+		}, valSet, valSet.GetByIndex(0)),
 	}
 	c.current.(*roundStateImpl).state = State(msg.Code)
 	c.subscribeEvents()

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -124,7 +124,7 @@ func (c *core) handleCheckedCommitForPreviousSequence(msg *istanbul.Message, com
 
 func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, commit *istanbul.CommittedSubject) error {
 	logger := c.newLogger("func", "handleCheckedCommitForCurrentSequence", "tag", "handleMsg")
-	_, validator := c.valSet.GetByAddress(msg.Address)
+	validator := c.current.GetValidatorByAddress(msg.Address)
 	if validator == nil {
 		return errInvalidValidatorAddress
 	}
@@ -144,7 +144,7 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 		return err
 	}
 	numberOfCommits := c.current.Commits().Size()
-	minQuorumSize := c.valSet.MinQuorumSize()
+	minQuorumSize := c.current.ValidatorSet().MinQuorumSize()
 	logger.Trace("Accepted commit", "Number of commits", numberOfCommits)
 
 	// Commit the proposal once we have enough COMMIT messages and we are not in the Committed state.

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -55,11 +55,10 @@ func TestHandleCommit(t *testing.T) {
 
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					// same view as the expected one to everyone
 					c.current = newTestRoundState(
 						expectedSubject.View,
-						c.valSet,
+						backend.peers,
 					)
 
 					if i == 0 {
@@ -79,12 +78,11 @@ func TestHandleCommit(t *testing.T) {
 
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					if i == 0 {
 						// replica 0 is the proposer
 						c.current = newTestRoundState(
 							expectedSubject.View,
-							c.valSet,
+							backend.peers,
 						)
 						c.current.(*roundStateImpl).state = StatePreprepared
 					} else {
@@ -94,7 +92,7 @@ func TestHandleCommit(t *testing.T) {
 								// proposal from 1 round in the future
 								Sequence: big.NewInt(0).Add(proposal.Number(), common.Big1),
 							},
-							c.valSet,
+							backend.peers,
 						)
 					}
 				}
@@ -110,12 +108,12 @@ func TestHandleCommit(t *testing.T) {
 
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
+
 					if i == 0 {
 						// replica 0 is the proposer
 						c.current = newTestRoundState(
 							expectedSubject.View,
-							c.valSet,
+							backend.peers,
 						)
 						c.current.(*roundStateImpl).state = StatePreprepared
 					} else {
@@ -127,7 +125,7 @@ func TestHandleCommit(t *testing.T) {
 								// with an old error message
 								Sequence: big.NewInt(0).Sub(proposal.Number(), common.Big2),
 							},
-							c.valSet,
+							backend.peers,
 						)
 					}
 				}
@@ -143,13 +141,12 @@ func TestHandleCommit(t *testing.T) {
 
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					c.current = newTestRoundState(
 						&istanbul.View{
 							Round:    big.NewInt(0),
 							Sequence: proposal.Number(),
 						},
-						c.valSet,
+						backend.peers,
 					)
 
 					// only replica0 stays at StatePreprepared
@@ -175,12 +172,11 @@ func TestHandleCommit(t *testing.T) {
 				for i, backend := range sys.backends {
 					backend.Commit(newTestProposalWithNum(3), types.IstanbulAggregatedSeal{})
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					if i == 0 {
 						// replica 0 is the proposer
 						c.current = newTestRoundState(
 							expectedSubject.View,
-							c.valSet,
+							backend.peers,
 						)
 						c.current.(*roundStateImpl).state = StatePrepared
 					} else {
@@ -189,7 +185,7 @@ func TestHandleCommit(t *testing.T) {
 								Round:    big.NewInt(1),
 								Sequence: big.NewInt(0).Sub(proposal.Number(), common.Big1),
 							},
-							c.valSet,
+							backend.peers,
 						)
 					}
 				}
@@ -209,7 +205,7 @@ OUTER:
 		r0 := v0.engine.(*core)
 
 		for i, v := range test.system.backends {
-			validator := r0.valSet.GetByIndex(uint64(i))
+			validator := r0.current.ValidatorSet().GetByIndex(uint64(i))
 			privateKey, _ := bls.DeserializePrivateKey(test.system.validatorsKeys[i])
 			defer privateKey.Destroy()
 
@@ -239,8 +235,8 @@ OUTER:
 		// how can we add our signature to the ParentCommit? Broadcast to ourselve
 		// does not make much sense
 		if test.checkParentCommits {
-			if r0.current.ParentCommits().Size() != r0.valSet.Size()-1 { // TODO: Maybe remove the -1?
-				t.Errorf("parent seals mismatch: have %v, want %v", r0.current.ParentCommits().Size(), r0.valSet.Size()-1)
+			if r0.current.ParentCommits().Size() != r0.current.ValidatorSet().Size()-1 { // TODO: Maybe remove the -1?
+				t.Errorf("parent seals mismatch: have %v, want %v", r0.current.ParentCommits().Size(), r0.current.ValidatorSet().Size()-1)
 			}
 		}
 
@@ -250,26 +246,26 @@ OUTER:
 			if r0.current.State() != StatePrepared {
 				t.Errorf("state mismatch: have %v, want %v", r0.current.State(), StatePrepared)
 			}
-			if r0.current.Commits().Size() > r0.valSet.MinQuorumSize() {
-				t.Errorf("the size of commit messages should be less than %v", r0.valSet.MinQuorumSize())
+			if r0.current.Commits().Size() > r0.current.ValidatorSet().MinQuorumSize() {
+				t.Errorf("the size of commit messages should be less than %v", r0.current.ValidatorSet().MinQuorumSize())
 			}
 			continue
 		}
 
 		// core should have min quorum size prepare messages
-		if r0.current.Commits().Size() < r0.valSet.MinQuorumSize() {
+		if r0.current.Commits().Size() < r0.current.ValidatorSet().MinQuorumSize() {
 			t.Errorf("the size of commit messages should be greater than or equal to minQuorumSize: size %v", r0.current.Commits().Size())
 		}
 
 		// check signatures large than MinQuorumSize
 		signedCount := 0
-		for i := 0; i < r0.valSet.Size(); i++ {
+		for i := 0; i < r0.current.ValidatorSet().Size(); i++ {
 			if v0.committedMsgs[0].aggregatedSeal.Bitmap.Bit(i) == 1 {
 				signedCount++
 			}
 		}
-		if signedCount < r0.valSet.MinQuorumSize() {
-			t.Errorf("the expected signed count should be greater than or equal to %v, but got %v", r0.valSet.MinQuorumSize(), signedCount)
+		if signedCount < r0.current.ValidatorSet().MinQuorumSize() {
+			t.Errorf("the expected signed count should be greater than or equal to %v, but got %v", r0.current.ValidatorSet().MinQuorumSize(), signedCount)
 		}
 	}
 }
@@ -286,7 +282,8 @@ func TestVerifyCommit(t *testing.T) {
 			peer.Address(),
 			blsPublicKey,
 		},
-	}, istanbul.RoundRobin)
+	})
+	// }, istanbul.RoundRobin)
 
 	sys := NewTestSystemWithBackend(uint64(1), uint64(0))
 

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
+	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
@@ -39,8 +40,9 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 	c := &core{
 		config:             config,
 		address:            backend.Address(),
-		handlerWg:          new(sync.WaitGroup),
 		logger:             log.New("address", backend.Address()),
+		selectProposer:     validator.GetProposerSelector(config.ProposerPolicy),
+		handlerWg:          new(sync.WaitGroup),
 		backend:            backend,
 		backlogs:           make(map[istanbul.Validator]*prque.Prque),
 		backlogsMu:         new(sync.Mutex),
@@ -58,9 +60,10 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 // ----------------------------------------------------------------------------
 
 type core struct {
-	config  *istanbul.Config
-	address common.Address
-	logger  log.Logger
+	config         *istanbul.Config
+	address        common.Address
+	logger         log.Logger
+	selectProposer istanbul.ProposerSelector
 
 	backend               istanbul.Backend
 	events                *event.TypeMuxSubscription
@@ -68,7 +71,6 @@ type core struct {
 	timeoutSub            *event.TypeMuxSubscription
 	futurePreprepareTimer *time.Timer
 
-	valSet     istanbul.ValidatorSet
 	validateFn func([]byte, []byte) (common.Address, error)
 
 	backlogs   map[istanbul.Validator]*prque.Prque
@@ -140,7 +142,8 @@ func (c *core) broadcast(msg *istanbul.Message) {
 	}
 
 	// Broadcast payload
-	if err := c.backend.BroadcastConsensusMsg(istanbul.GetAddressesFromValidatorList(c.valSet.FilteredList()), payload); err != nil {
+	validators := istanbul.GetAddressesFromValidatorList(c.current.ValidatorSet().FilteredList())
+	if err := c.backend.BroadcastConsensusMsg(validators, payload); err != nil {
 		logger.Error("Failed to broadcast message", "msg", msg, "err", err)
 		return
 	}
@@ -240,7 +243,7 @@ func UnionOfSeals(aggregatedSignature types.IstanbulAggregatedSeal, seals Messag
 
 // Generates the next preprepare request and associated round change certificate
 func (c *core) getPreprepareWithRoundChangeCertificate(round *big.Int) (*istanbul.Request, istanbul.RoundChangeCertificate, error) {
-	roundChangeCertificate, err := c.roundChangeSet.getCertificate(round, c.valSet.MinQuorumSize())
+	roundChangeCertificate, err := c.roundChangeSet.getCertificate(round, c.current.ValidatorSet().MinQuorumSize())
 	if err != nil {
 		return &istanbul.Request{}, istanbul.RoundChangeCertificate{}, err
 	}
@@ -273,6 +276,7 @@ func (c *core) startNewRound(round *big.Int) {
 	roundChange := false
 	// Try to get last proposal
 	headBlock, headAuthor := c.backend.GetCurrentHeadBlockAndAuthor()
+
 	if c.current == nil {
 		logger.Trace("Start the initial round")
 	} else if headBlock.Number().Cmp(c.current.Sequence()) >= 0 {
@@ -304,6 +308,12 @@ func (c *core) startNewRound(round *big.Int) {
 	var newView *istanbul.View
 	var roundChangeCertificate istanbul.RoundChangeCertificate
 	var request *istanbul.Request
+
+	var valSet istanbul.ValidatorSet
+	if c.current != nil {
+		valSet = c.current.ValidatorSet()
+	}
+
 	if roundChange {
 		newView = &istanbul.View{
 			Sequence: new(big.Int).Set(c.current.Sequence()),
@@ -324,16 +334,20 @@ func (c *core) startNewRound(round *big.Int) {
 			Sequence: new(big.Int).Add(headBlock.Number(), common.Big1),
 			Round:    new(big.Int),
 		}
-		c.valSet = c.backend.Validators(headBlock)
-		c.roundChangeSet = newRoundChangeSet(c.valSet)
+		valSet = c.backend.Validators(headBlock)
+		c.roundChangeSet = newRoundChangeSet(valSet)
 	}
 
-	// Update logger
-	logger = logger.New("old_proposer", c.valSet.GetProposer())
+	if c.current != nil {
+		// Update logger
+		logger = logger.New("old_proposer", c.current.Proposer())
+	}
+
 	// Calculate new proposer
-	c.valSet.CalcProposer(headAuthor, newView.Round.Uint64())
-	// New snapshot for new round
-	c.resetRoundState(newView, c.valSet, roundChange)
+	nextProposer := c.selectProposer(valSet, headAuthor, newView.Round.Uint64())
+	c.resetRoundState(newView, valSet, nextProposer, roundChange)
+
+	// Process backlog
 	c.processPendingRequests()
 	c.processBacklog()
 
@@ -342,7 +356,7 @@ func (c *core) startNewRound(round *big.Int) {
 	}
 	c.newRoundChangeTimer()
 
-	logger.Debug("New round", "new_round", newView.Round, "new_seq", newView.Sequence, "new_proposer", c.valSet.GetProposer(), "valSet", c.valSet.List(), "size", c.valSet.Size(), "isProposer", c.isProposer())
+	logger.Debug("New round", "new_round", newView.Round, "new_seq", newView.Sequence, "new_proposer", c.current.Proposer(), "valSet", c.current.ValidatorSet().List(), "size", c.current.ValidatorSet().Size(), "isProposer", c.isProposer())
 }
 
 // All actions that occur when transitioning to waiting for round change state.
@@ -360,11 +374,12 @@ func (c *core) waitForDesiredRound(r *big.Int) {
 		Sequence: new(big.Int).Set(c.current.Sequence()),
 		Round:    new(big.Int).Set(r),
 	}
-	// Perform all of the updates
-	c.current.TransitionToWaitingForNewRound(r)
 
+	// Perform all of the updates
 	_, headAuthor := c.backend.GetCurrentHeadBlockAndAuthor()
-	c.valSet.CalcProposer(headAuthor, r.Uint64())
+	nextProposer := c.selectProposer(c.current.ValidatorSet(), headAuthor, r.Uint64())
+	c.current.TransitionToWaitingForNewRound(r, nextProposer)
+
 	c.newRoundChangeTimerForView(desiredView)
 
 	// Process Backlog Messages
@@ -374,14 +389,14 @@ func (c *core) waitForDesiredRound(r *big.Int) {
 	c.sendRoundChange(r)
 }
 
-func (c *core) resetRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, roundChange bool) {
+func (c *core) resetRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, roundChange bool) {
 	// TODO(Joshua): Include desired round here.
 	if c.current == nil {
 		// When the current round is nil, we must start with the current validator set in the parent commits
 		// either `validatorSet` or `backend.Validators(lastProposal)` works here
-		c.current = newRoundState(view, validatorSet)
+		c.current = newRoundState(view, validatorSet, nextProposer)
 	} else if roundChange {
-		c.current.StartNewRound(view.Round, validatorSet)
+		c.current.StartNewRound(view.Round, validatorSet, nextProposer)
 	} else {
 		// sequence change
 
@@ -397,15 +412,15 @@ func (c *core) resetRoundState(view *istanbul.View, validatorSet istanbul.Valida
 			headBlock := c.backend.GetCurrentHeadBlock()
 			newParentCommits = newMessageSet(c.backend.ParentBlockValidators(headBlock))
 		}
-		c.current.StartNewSequence(view, validatorSet, newParentCommits)
+		c.current.StartNewSequence(view, validatorSet, nextProposer, newParentCommits)
 	}
 }
 
 func (c *core) isProposer() bool {
-	if c.valSet == nil {
+	if c.current == nil {
 		return false
 	}
-	return c.valSet.IsProposer(c.address)
+	return c.current.IsProposer(c.address)
 }
 
 func (c *core) stopFuturePreprepareTimer() {
@@ -444,7 +459,7 @@ func (c *core) newRoundChangeTimerForView(view *istanbul.View) {
 }
 
 func (c *core) checkValidatorSignature(data []byte, sig []byte) (common.Address, error) {
-	return istanbul.CheckValidatorSignature(c.valSet, data, sig)
+	return istanbul.CheckValidatorSignature(c.current.ValidatorSet(), data, sig)
 }
 
 // PrepareCommittedSeal returns a committed seal for the given hash and round number.

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -400,6 +400,11 @@ func (c *core) resetRoundState(view *istanbul.View, validatorSet istanbul.Valida
 	} else {
 		// sequence change
 
+		// TODO remove this when we refactor startNewRound()
+		if view.Round.Cmp(common.Big0) != 0 {
+			c.logger.Crit("BUG: DevError: trying to start a new sequence with round != 0", "wanted_round", view.Round)
+		}
+
 		var newParentCommits MessageSet
 		lastSubject, err := c.backend.LastSubject()
 		if err != nil && c.current.Proposal() != nil && c.current.Proposal().Hash() == lastSubject.Digest && c.current.Round().Cmp(lastSubject.View.Round) == 0 {
@@ -412,7 +417,7 @@ func (c *core) resetRoundState(view *istanbul.View, validatorSet istanbul.Valida
 			headBlock := c.backend.GetCurrentHeadBlock()
 			newParentCommits = newMessageSet(c.backend.ParentBlockValidators(headBlock))
 		}
-		c.current.StartNewSequence(view, validatorSet, nextProposer, newParentCommits)
+		c.current.StartNewSequence(view.Sequence, validatorSet, nextProposer, newParentCommits)
 	}
 }
 

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -154,7 +154,7 @@ func (c *core) handleMsg(payload []byte) error {
 	}
 
 	// Only accept message if the address is valid
-	_, src := c.valSet.GetByAddress(msg.Address)
+	_, src := c.current.ValidatorSet().GetByAddress(msg.Address)
 	if src == nil {
 		logger.Error("Invalid address in message", "msg", msg)
 		return istanbul.ErrUnauthorizedAddress

--- a/consensus/istanbul/core/message_set_test.go
+++ b/consensus/istanbul/core/message_set_test.go
@@ -48,7 +48,7 @@ func TestMessageSetWithSubject(t *testing.T) {
 	msg := &istanbul.Message{
 		Code:    istanbul.MsgPrepare,
 		Msg:     rawSub,
-		Address: valSet.GetProposer().Address(),
+		Address: valSet.GetByIndex(0).Address(),
 	}
 
 	err = ms.Add(msg)

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -47,7 +47,7 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 		return errInvalidPreparedCertificateProposal
 	}
 
-	if len(preparedCertificate.PrepareOrCommitMessages) > c.valSet.Size() || len(preparedCertificate.PrepareOrCommitMessages) < c.valSet.MinQuorumSize() {
+	if len(preparedCertificate.PrepareOrCommitMessages) > c.current.ValidatorSet().Size() || len(preparedCertificate.PrepareOrCommitMessages) < c.current.ValidatorSet().MinQuorumSize() {
 		return errInvalidPreparedCertificateNumMsgs
 	}
 
@@ -92,7 +92,7 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 			}
 
 			// Verify the committedSeal
-			_, src := c.valSet.GetByAddress(signer)
+			src := c.current.GetValidatorByAddress(signer)
 			err = c.verifyCommittedSeal(committedSubject, src)
 			if err != nil {
 				logger.Error("Commit seal did not contain signature from message signer.", "err", err)
@@ -153,7 +153,7 @@ func (c *core) handlePrepare(msg *istanbul.Message) error {
 	}
 
 	preparesAndCommits := c.current.GetPrepareOrCommitSize()
-	minQuorumSize := c.valSet.MinQuorumSize()
+	minQuorumSize := c.current.ValidatorSet().MinQuorumSize()
 	logger.Trace("Accepted prepare", "Number of prepares or commits", preparesAndCommits)
 
 	// Change to Prepared state if we've received enough PREPARE messages and we are in earlier state

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -86,13 +86,14 @@ func (c *core) handlePreprepare(msg *istanbul.Message) error {
 	if err := c.checkMessage(istanbul.MsgPreprepare, preprepare.View); err != nil {
 		if err == errOldMessage {
 			// Get validator set for the given proposal
-			valSet := c.backend.ParentBlockValidators(preprepare.Proposal).Copy()
-			previousProposer := c.backend.AuthorForBlock(preprepare.Proposal.Number().Uint64() - 1)
-			valSet.CalcProposer(previousProposer, preprepare.View.Round.Uint64())
+			valSet := c.backend.ParentBlockValidators(preprepare.Proposal)
+			prevBlockAuthor := c.backend.AuthorForBlock(preprepare.Proposal.Number().Uint64() - 1)
+			proposer := c.selectProposer(valSet, prevBlockAuthor, preprepare.View.Round.Uint64())
+
 			// Broadcast COMMIT if it is an existing block
 			// 1. The proposer needs to be a proposer matches the given (Sequence + Round)
 			// 2. The given block must exist
-			if valSet.IsProposer(msg.Address) && c.backend.HasBlock(preprepare.Proposal.Hash(), preprepare.Proposal.Number()) {
+			if proposer.Address() == msg.Address && c.backend.HasBlock(preprepare.Proposal.Hash(), preprepare.Proposal.Number()) {
 				logger.Trace("Sending a commit message for an old block", "view", preprepare.View, "block hash", preprepare.Proposal.Hash())
 				c.sendCommitForOldBlock(preprepare.View, preprepare.Proposal.Hash())
 				return nil
@@ -104,7 +105,7 @@ func (c *core) handlePreprepare(msg *istanbul.Message) error {
 	}
 
 	// Check if the message comes from current proposer
-	if !c.valSet.IsProposer(msg.Address) {
+	if !c.current.IsProposer(msg.Address) {
 		logger.Warn("Ignore preprepare messages from non-proposer")
 		return errNotFromProposer
 	}

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -49,7 +49,6 @@ func TestHandlePreprepare(t *testing.T) {
 
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					if i != 0 {
 						c.current.(*roundStateImpl).state = StateAcceptRequest
 					}
@@ -70,7 +69,6 @@ func TestHandlePreprepare(t *testing.T) {
 
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					if i != 0 {
 						c.current.(*roundStateImpl).state = StateAcceptRequest
 					}
@@ -94,7 +92,6 @@ func TestHandlePreprepare(t *testing.T) {
 
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					if i != 0 {
 						// replica 0 is the proposer
 						c.current.(*roundStateImpl).state = StatePreprepared
@@ -116,7 +113,6 @@ func TestHandlePreprepare(t *testing.T) {
 
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					if i != 0 {
 						c.current.(*roundStateImpl).state = StatePreprepared
 						c.current.(*roundStateImpl).sequence = big.NewInt(10)
@@ -139,7 +135,6 @@ func TestHandlePreprepare(t *testing.T) {
 
 				for _, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					c.current.(*roundStateImpl).state = StatePreprepared
 					c.current.(*roundStateImpl).sequence = big.NewInt(10)
 					c.current.(*roundStateImpl).round = big.NewInt(10)
@@ -161,7 +156,6 @@ func TestHandlePreprepare(t *testing.T) {
 
 				for _, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					c.current.(*roundStateImpl).state = StatePreprepared
 					c.current.(*roundStateImpl).round = big.NewInt(1)
 				}
@@ -181,7 +175,6 @@ func TestHandlePreprepare(t *testing.T) {
 
 				for _, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					c.current.(*roundStateImpl).state = StatePreprepared
 					c.current.(*roundStateImpl).round = big.NewInt(1)
 				}
@@ -204,7 +197,6 @@ func TestHandlePreprepare(t *testing.T) {
 
 				for _, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					c.current.(*roundStateImpl).state = StatePreprepared
 					c.current.(*roundStateImpl).round = big.NewInt(1)
 					c.current.TransitionToPreprepared(&istanbul.Preprepare{
@@ -240,7 +232,6 @@ func TestHandlePreprepare(t *testing.T) {
 
 				for _, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					c.current.(*roundStateImpl).state = StatePreprepared
 					c.current.(*roundStateImpl).round = big.NewInt(1)
 					c.current.TransitionToPreprepared(&istanbul.Preprepare{
@@ -271,7 +262,6 @@ func TestHandlePreprepare(t *testing.T) {
 
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					c.current.(*roundStateImpl).round = big.NewInt(int64(N))
 					if i != 0 {
 						c.current.(*roundStateImpl).state = StateAcceptRequest
@@ -296,7 +286,6 @@ func TestHandlePreprepare(t *testing.T) {
 
 				for i, backend := range sys.backends {
 					c := backend.engine.(*core)
-					c.valSet = backend.peers
 					c.current.(*roundStateImpl).round = big.NewInt(int64(N))
 					if i != 0 {
 						c.current.(*roundStateImpl).state = StateAcceptRequest
@@ -404,7 +393,7 @@ OUTER:
 			}
 
 			if expectedCode == istanbul.MsgCommit {
-				_, srcValidator := c.valSet.GetByAddress(v.address)
+				srcValidator := c.current.GetValidatorByAddress(v.address)
 
 				if err := c.verifyCommittedSeal(committedSubject, srcValidator); err != nil {
 					t.Errorf("invalid seal.  verify commmited seal error: %v, subject: %v, committedSeal: %v", err, expectedSubject, committedSubject.CommittedSeal)

--- a/consensus/istanbul/core/request_test.go
+++ b/consensus/istanbul/core/request_test.go
@@ -30,11 +30,12 @@ import (
 )
 
 func TestCheckRequestMsg(t *testing.T) {
+	valSet := newTestValidatorSet(4)
 	c := &core{
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(1),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4)),
+		}, valSet, valSet.GetByIndex(0)),
 	}
 
 	// invalid request
@@ -82,13 +83,14 @@ func TestStoreRequestMsg(t *testing.T) {
 	backend := &testSystemBackend{
 		events: new(event.TypeMux),
 	}
+	valSet := newTestValidatorSet(4)
 	c := &core{
 		logger:  log.New("backend", "test", "id", 0),
 		backend: backend,
 		current: newRoundState(&istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
-		}, newTestValidatorSet(4)),
+		}, valSet, valSet.GetByIndex(0)),
 		pendingRequests:   prque.New(nil),
 		pendingRequestsMu: new(sync.Mutex),
 	}

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -69,7 +69,7 @@ func (c *core) sendRoundChange(round *big.Int) {
 func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChangeCertificate istanbul.RoundChangeCertificate) error {
 	logger := c.newLogger("func", "handleRoundChangeCertificate")
 
-	if len(roundChangeCertificate.RoundChangeMessages) > c.valSet.Size() || len(roundChangeCertificate.RoundChangeMessages) < c.valSet.MinQuorumSize() {
+	if len(roundChangeCertificate.RoundChangeMessages) > c.current.ValidatorSet().Size() || len(roundChangeCertificate.RoundChangeMessages) < c.current.ValidatorSet().MinQuorumSize() {
 		return errInvalidRoundChangeCertificateNumMsgs
 	}
 
@@ -188,8 +188,8 @@ func (c *core) handleRoundChange(msg *istanbul.Message) error {
 
 	// Skip to the highest round we know F+1 (one honest validator) is at, but
 	// don't start a round until we have a quorum who want to start a given round.
-	ffRound := c.roundChangeSet.MaxRound(c.valSet.F() + 1)
-	quorumRound := c.roundChangeSet.MaxOnOneRound(c.valSet.MinQuorumSize())
+	ffRound := c.roundChangeSet.MaxRound(c.current.ValidatorSet().F() + 1)
+	quorumRound := c.roundChangeSet.MaxOnOneRound(c.current.ValidatorSet().MinQuorumSize())
 
 	logger.Trace("Got round change message", "msg_round", roundView.Round, "rcs", c.roundChangeSet.String(), "ffRound", ffRound, "quorumRound", quorumRound)
 	// On f+1 round changes we send a round change and wait for the next round if we haven't done so already

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestRoundChangeSet(t *testing.T) {
 	vals, _, _ := generateValidators(4)
-	vset := validator.NewSet(vals, istanbul.RoundRobin)
+	vset := validator.NewSet(vals)
 	rc := newRoundChangeSet(vset)
 
 	view := &istanbul.View{

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -58,7 +58,7 @@ func newRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, prop
 type RoundState interface {
 	State() State
 	StartNewRound(nextRound *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator)
-	StartNewSequence(view *istanbul.View, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet)
+	StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet)
 	TransitionToPreprepared(preprepare *istanbul.Preprepare)
 	TransitionToWaitingForNewRound(r *big.Int, nextProposer istanbul.Validator)
 	TransitionToCommited()
@@ -241,15 +241,15 @@ func (s *roundStateImpl) StartNewRound(nextRound *big.Int, validatorSet istanbul
 	s.changeRound(nextRound, validatorSet, nextProposer)
 }
 
-func (s *roundStateImpl) StartNewSequence(view *istanbul.View, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet) {
+func (s *roundStateImpl) StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.validatorSet = validatorSet
 
-	s.changeRound(view.Round, validatorSet, nextProposer)
+	s.changeRound(big.NewInt(0), validatorSet, nextProposer)
 
-	s.sequence = view.Sequence
+	s.sequence = nextSequence
 	s.preparedCertificate = istanbul.EmptyPreparedCertificate()
 	s.pendingRequest = nil
 	s.parentCommits = parentCommits

--- a/consensus/istanbul/core/testutils_test.go
+++ b/consensus/istanbul/core/testutils_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func newTestRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet) RoundState {
-	current := newRoundState(view, validatorSet)
+	current := newRoundState(view, validatorSet, validatorSet.GetByIndex(0))
 	current.(*roundStateImpl).preprepare = newTestPreprepare(view)
 	return current
 }

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -85,16 +85,10 @@ type Validators []Validator
 // ----------------------------------------------------------------------------
 
 type ValidatorSet interface {
-	// Calculate the proposer
-	CalcProposer(lastProposer common.Address, round uint64)
-	// Get current proposer
-	GetProposer() Validator
-	// Check whether the validator with given address is the current proposer
-	IsProposer(address common.Address) bool
-	// Policy by which this selector chooses proposers
-	Policy() ProposerPolicy
 	// Sets the randomness for use in the proposer policy
 	SetRandomness(seed common.Hash)
+	// Sets the randomness for use in the proposer policy
+	GetRandomness() common.Hash
 
 	// Return the validator size
 	PaddedSize() int
@@ -127,5 +121,5 @@ type ValidatorSet interface {
 
 // ----------------------------------------------------------------------------
 
-// Returns the block proposer for a round given the last proposer, round number, and randomness.
-type ProposerSelector func(ValidatorSet, common.Address, uint64, common.Hash) Validator
+// ProposerSelector returns the block proposer for a round given the last proposer, round number, and randomness.
+type ProposerSelector func(validatorSet ValidatorSet, lastBlockProposer common.Address, currentRound uint64) Validator

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -85,7 +85,8 @@ type Validators []Validator
 // ----------------------------------------------------------------------------
 
 type ValidatorSet interface {
-	// Sets the randomness for use in the proposer policy
+	// Sets the randomness for use in the proposer policy.
+	// This is injected into the ValidatorSet when we call `getOrderedValidators`
 	SetRandomness(seed common.Hash)
 	// Sets the randomness for use in the proposer policy
 	GetRandomness() common.Hash

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -47,7 +47,9 @@ func (val *defaultValidator) String() string {
 type defaultSet struct {
 	validators  istanbul.Validators
 	validatorMu sync.RWMutex
-	randomness  common.Hash
+	// This is set when we call `getOrderedValidators`
+	// TODO Rename to `EpochState` that has validators & randomness
+	randomness common.Hash
 }
 
 func newDefaultSet(validators []istanbul.ValidatorData) *defaultSet {

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -17,10 +17,8 @@
 package validator
 
 import (
-	"fmt"
 	"math"
 	"math/big"
-	"reflect"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -47,39 +45,18 @@ func (val *defaultValidator) String() string {
 // ----------------------------------------------------------------------------
 
 type defaultSet struct {
-	validators istanbul.Validators
-	policy     istanbul.ProposerPolicy
-
-	proposer    istanbul.Validator
+	validators  istanbul.Validators
 	validatorMu sync.RWMutex
-	selector    istanbul.ProposerSelector
 	randomness  common.Hash
 }
 
-func newDefaultSet(validators []istanbul.ValidatorData, policy istanbul.ProposerPolicy) *defaultSet {
+func newDefaultSet(validators []istanbul.ValidatorData) *defaultSet {
 	valSet := &defaultSet{}
 
-	valSet.policy = policy
 	// init validators
 	valSet.validators = make([]istanbul.Validator, len(validators))
 	for i, validator := range validators {
 		valSet.validators[i] = New(validator.Address, validator.BLSPublicKey)
-	}
-	// init proposer
-	if valSet.Size() > 0 {
-		valSet.proposer = valSet.GetByIndex(0)
-	}
-
-	switch policy {
-	case istanbul.Sticky:
-		valSet.selector = StickyProposer
-	case istanbul.RoundRobin:
-		valSet.selector = RoundRobinProposer
-	case istanbul.ShuffledRoundRobin:
-		valSet.selector = ShuffledRoundRobinProposer
-	default:
-		// Programming error.
-		panic(fmt.Sprintf("unknown proposer selection policy: %v", policy))
 	}
 
 	return valSet
@@ -161,21 +138,6 @@ func (valSet *defaultSet) GetFilteredIndex(addr common.Address) int {
 	return -1
 }
 
-func (valSet *defaultSet) GetProposer() istanbul.Validator {
-	return valSet.proposer
-}
-
-func (valSet *defaultSet) IsProposer(address common.Address) bool {
-	_, val := valSet.GetByAddress(address)
-	return reflect.DeepEqual(valSet.GetProposer(), val)
-}
-
-func (valSet *defaultSet) CalcProposer(lastProposer common.Address, round uint64) {
-	valSet.validatorMu.RLock()
-	defer valSet.validatorMu.RUnlock()
-	valSet.proposer = valSet.selector(valSet, lastProposer, round, valSet.randomness)
-}
-
 func (valSet *defaultSet) AddValidators(validators []istanbul.ValidatorData) bool {
 	newValidators := make([]istanbul.Validator, 0, len(validators))
 	newAddressesMap := make(map[common.Address]bool)
@@ -229,11 +191,7 @@ func (valSet *defaultSet) RemoveValidators(removedValidators *big.Int) bool {
 		}
 	}
 
-	if !hadRemoval {
-		return false
-	} else {
-		return true
-	}
+	return hadRemoval
 }
 
 func (valSet *defaultSet) Copy() istanbul.ValidatorSet {
@@ -248,7 +206,9 @@ func (valSet *defaultSet) Copy() istanbul.ValidatorSet {
 		})
 	}
 
-	return NewSet(validators, valSet.policy)
+	newValSet := NewSet(validators)
+	newValSet.SetRandomness(valSet.GetRandomness())
+	return newValSet
 }
 
 func (valSet *defaultSet) F() int { return int(math.Ceil(float64(valSet.Size())/3)) - 1 }
@@ -257,6 +217,5 @@ func (valSet *defaultSet) MinQuorumSize() int {
 	return int(math.Ceil(float64(2*valSet.Size()) / 3))
 }
 
-func (valSet *defaultSet) Policy() istanbul.ProposerPolicy { return valSet.policy }
-
 func (valSet *defaultSet) SetRandomness(seed common.Hash) { valSet.randomness = seed }
+func (valSet *defaultSet) GetRandomness() common.Hash     { return valSet.randomness }

--- a/consensus/istanbul/validator/default_test.go
+++ b/consensus/istanbul/validator/default_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/bls"
+	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 )
 
 var (
@@ -58,7 +58,7 @@ func testNewValidatorSet(t *testing.T) {
 	}
 
 	// Create ValidatorSet
-	valSet := NewSet(ExtractValidators(b), istanbul.RoundRobin)
+	valSet := NewSet(ExtractValidators(b))
 	if valSet == nil {
 		t.Errorf("the validator byte array cannot be parsed")
 		t.FailNow()
@@ -74,7 +74,7 @@ func testNormalValSet(t *testing.T) {
 	val2 := New(addr2, []byte{})
 
 	validators, _ := istanbul.CombineIstanbulExtraToValidatorData([]common.Address{addr1, addr2}, [][]byte{{}, {}})
-	valSet := newDefaultSet(validators, istanbul.RoundRobin)
+	valSet := newDefaultSet(validators)
 	if valSet == nil {
 		t.Errorf("the format of validator set is invalid")
 		t.FailNow()
@@ -104,14 +104,14 @@ func testNormalValSet(t *testing.T) {
 }
 
 func testEmptyValSet(t *testing.T) {
-	valSet := NewSet(ExtractValidators([]byte{}), istanbul.RoundRobin)
+	valSet := NewSet(ExtractValidators([]byte{}))
 	if valSet == nil {
 		t.Errorf("validator set should not be nil")
 	}
 }
 
 func testAddAndRemoveValidator(t *testing.T) {
-	valSet := NewSet(ExtractValidators([]byte{}), istanbul.RoundRobin)
+	valSet := NewSet(ExtractValidators([]byte{}))
 	if !valSet.AddValidators(
 		[]istanbul.ValidatorData{
 			{
@@ -207,7 +207,7 @@ func testQuorumSizes(t *testing.T) {
 
 	for _, testCase := range testCases {
 		vals, _ := generateValidators(testCase.validatorSetSize)
-		valSet := newDefaultSet(vals, istanbul.RoundRobin)
+		valSet := newDefaultSet(vals)
 
 		if valSet.MinQuorumSize() != testCase.expectedMinQuorumSize {
 			t.Errorf("error mismatch quorum size for valset of size %d: have %d, want %d", valSet.Size(), valSet.MinQuorumSize(), testCase.expectedMinQuorumSize)

--- a/consensus/istanbul/validator/selectors_test.go
+++ b/consensus/istanbul/validator/selectors_test.go
@@ -46,7 +46,8 @@ func TestStickyProposer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CombineIstanbulExtraToValidatorData(...): %v", err)
 	}
-	valSet := newDefaultSet(v, istanbul.Sticky)
+	valSet := newDefaultSet(v)
+	selector := GetProposerSelector(istanbul.Sticky)
 
 	cases := []struct {
 		lastProposer common.Address
@@ -78,17 +79,11 @@ func TestStickyProposer(t *testing.T) {
 		want:         validators[3],
 	}}
 
-	t.Run("initial", func(t *testing.T) {
-		if val := valSet.GetProposer(); !reflect.DeepEqual(val, validators[0]) {
-			t.Errorf("proposer mismatch: got %v, want %v", val, validators[0])
-		}
-	})
-
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case:%d", i), func(t *testing.T) {
-			t.Logf("CalcProposer(%s, %d)", c.lastProposer.String(), c.round)
-			valSet.CalcProposer(c.lastProposer, c.round)
-			if val := valSet.GetProposer(); !reflect.DeepEqual(val, c.want) {
+			t.Logf("selectProposer(%s, %d)", c.lastProposer.String(), c.round)
+			proposer := selector(valSet, c.lastProposer, c.round)
+			if val := proposer; !reflect.DeepEqual(val, c.want) {
 				t.Errorf("proposer mismatch: have %v, want %v", val, c.want)
 			}
 		})
@@ -108,7 +103,8 @@ func TestRoundRobinProposer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CombineIstanbulExtraToValidatorData(...): %v", err)
 	}
-	valSet := newDefaultSet(v, istanbul.RoundRobin)
+	valSet := newDefaultSet(v)
+	selector := GetProposerSelector(istanbul.RoundRobin)
 
 	cases := []struct {
 		lastProposer common.Address
@@ -140,17 +136,11 @@ func TestRoundRobinProposer(t *testing.T) {
 		want:         validators[3],
 	}}
 
-	t.Run("initial", func(t *testing.T) {
-		if val := valSet.GetProposer(); !reflect.DeepEqual(val, validators[0]) {
-			t.Errorf("proposer mismatch: got %v, want %v", val, validators[0])
-		}
-	})
-
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case:%d", i), func(t *testing.T) {
-			t.Logf("CalcProposer(%s, %d)", c.lastProposer.String(), c.round)
-			valSet.CalcProposer(c.lastProposer, c.round)
-			if val := valSet.GetProposer(); !reflect.DeepEqual(val, c.want) {
+			t.Logf("selectProposer(%s, %d)", c.lastProposer.String(), c.round)
+			proposer := selector(valSet, c.lastProposer, c.round)
+			if val := proposer; !reflect.DeepEqual(val, c.want) {
 				t.Errorf("proposer mismatch: have %v, want %v", val, c.want)
 			}
 		})
@@ -170,7 +160,8 @@ func TestShuffledRoundRobinProposer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CombineIstanbulExtraToValidatorData(...): %v", err)
 	}
-	valSet := newDefaultSet(v, istanbul.ShuffledRoundRobin)
+	valSet := newDefaultSet(v)
+	selector := GetProposerSelector(istanbul.ShuffledRoundRobin)
 
 	testSeed := common.HexToHash("f36aa9716b892ec8")
 	cases := []struct {
@@ -219,19 +210,13 @@ func TestShuffledRoundRobinProposer(t *testing.T) {
 		want:         validators[0],
 	}}
 
-	t.Run("initial", func(t *testing.T) {
-		if val := valSet.GetProposer(); !reflect.DeepEqual(val, validators[0]) {
-			t.Errorf("proposer mismatch: got %v, want %v", val, validators[0])
-		}
-	})
-
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case:%d", i), func(t *testing.T) {
 			t.Logf("SetRandomness(%s)", c.seed.String())
 			valSet.SetRandomness(c.seed)
-			t.Logf("CalcProposer(%s, %d)", c.lastProposer.String(), c.round)
-			valSet.CalcProposer(c.lastProposer, c.round)
-			if val := valSet.GetProposer(); !reflect.DeepEqual(val, c.want) {
+			t.Logf("selectProposer(%s, %d)", c.lastProposer.String(), c.round)
+			proposer := selector(valSet, c.lastProposer, c.round)
+			if val := proposer; !reflect.DeepEqual(val, c.want) {
 				t.Errorf("proposer mismatch: have %v, want %v", val, c.want)
 			}
 		})

--- a/consensus/istanbul/validator/validator.go
+++ b/consensus/istanbul/validator/validator.go
@@ -19,7 +19,7 @@ package validator
 import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
-	"github.com/ethereum/go-ethereum/crypto/bls"
+	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 )
 
 func New(addr common.Address, blsPublicKey []byte) istanbul.Validator {
@@ -29,8 +29,8 @@ func New(addr common.Address, blsPublicKey []byte) istanbul.Validator {
 	}
 }
 
-func NewSet(validators []istanbul.ValidatorData, policy istanbul.ProposerPolicy) istanbul.ValidatorSet {
-	return newDefaultSet(validators, policy)
+func NewSet(validators []istanbul.ValidatorData) istanbul.ValidatorSet {
+	return newDefaultSet(validators)
 }
 
 func ExtractValidators(extraData []byte) []istanbul.ValidatorData {


### PR DESCRIPTION
### Description

Now ValidatorSet is inmutable, meaning that remains the same for the
whole epoch. While, before ValidatorSet changed every roundChange since
it had the proposer.

Also, by doing this, we eliminate a way of changing data inside the
RoundState without calling any RoundState function.

RounState has a MessageSet which has a ValidatorSet

And on some scenarios the ValidatorSet proposer was being changed
without notifying the RoundState

### Tested

unit
