### PR TITLE
Persist RoundState on every transition

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1215,6 +1215,7 @@ func setIstanbul(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 		cfg.Istanbul.ProposerPolicy = istanbul.ProposerPolicy(ctx.GlobalUint64(IstanbulProposerPolicyFlag.Name))
 	}
 	cfg.Istanbul.ValidatorEnodeDBPath = stack.ResolvePath(cfg.Istanbul.ValidatorEnodeDBPath)
+	cfg.Istanbul.RoundStateDBPath = stack.ResolvePath(cfg.Istanbul.RoundStateDBPath)
 }
 
 func setProxyP2PConfig(ctx *cli.Context, proxyCfg *p2p.Config) {

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -641,6 +641,7 @@ func (sb *Backend) Start(hasBadBlock func(common.Hash) bool,
 	sb.processBlock = processBlock
 	sb.validateState = validateState
 
+	sb.logger.Info("Starting istanbul.Engine")
 	if err := sb.core.Start(); err != nil {
 		return err
 	}
@@ -669,6 +670,7 @@ func (sb *Backend) Stop() error {
 	if !sb.coreStarted {
 		return istanbul.ErrStoppedEngine
 	}
+	sb.logger.Info("Stopping istanbul.Engine")
 	if err := sb.core.Stop(); err != nil {
 		return err
 	}

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -51,6 +51,7 @@ func newBlockChain(n int, isFullChain bool) (*core.BlockChain, *Backend) {
 	memDB := ethdb.NewMemDatabase()
 	config := istanbul.DefaultConfig
 	config.ValidatorEnodeDBPath = ""
+	config.RoundStateDBPath = ""
 	// Use the first key as private key
 	address := crypto.PubkeyToAddress(nodeKeys[0].PublicKey)
 	signerFn := func(_ accounts.Account, data []byte) ([]byte, error) {

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Epoch                uint64         `toml:",omitempty"` // The number of blocks after which to checkpoint and reset the pending votes
 	LookbackWindow       uint64         `toml:",omitempty"` // The window of blocks in which a validator is forgived from voting
 	ValidatorEnodeDBPath string         `toml:",omitempty"` // The location for the validator enodes DB
+	RoundStateDBPath     string         `toml:",omitempty"` // The location for the round states DB
 
 	// Proxy Configs
 	Proxy                   bool           `toml:",omitempty"` // Specifies if this node is a proxy
@@ -54,6 +55,7 @@ var DefaultConfig = &Config{
 	Epoch:                30000,
 	LookbackWindow:       12,
 	ValidatorEnodeDBPath: "validatorenodes",
+	RoundStateDBPath:     "roundstates",
 	Proxy:                false,
 	Proxied:              false,
 }

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -154,7 +154,12 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 	// TODO(joshua): Remove state comparisons (or change the cmp function)
 	if numberOfCommits >= minQuorumSize && c.current.State().Cmp(StateCommitted) < 0 {
 		logger.Trace("Got a quorum of commits", "tag", "stateTransition", "commits", c.current.Commits)
-		c.commit()
+		err := c.commit()
+		if err != nil {
+			logger.Error("Failed to commit()", "err", err)
+			return err
+		}
+
 	} else if c.current.GetPrepareOrCommitSize() >= minQuorumSize && c.current.State().Cmp(StatePrepared) < 0 {
 		err := c.current.TransitionToPrepared(minQuorumSize)
 		if err != nil {

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -149,8 +149,11 @@ func (c *core) broadcast(msg *istanbul.Message) {
 	}
 }
 
-func (c *core) commit() {
-	c.current.TransitionToCommited()
+func (c *core) commit() error {
+	err := c.current.TransitionToCommited()
+	if err != nil {
+		return err
+	}
 
 	// Process Backlog Messages
 	c.processBacklog()
@@ -160,13 +163,14 @@ func (c *core) commit() {
 		aggregatedSeal, err := GetAggregatedSeal(c.current.Commits(), c.current.Round())
 		if err != nil {
 			c.sendNextRoundChange()
-			return
+			return nil
 		}
 		if err := c.backend.Commit(proposal, aggregatedSeal); err != nil {
 			c.sendNextRoundChange()
-			return
+			return nil
 		}
 	}
+	return nil
 }
 
 // GetAggregatedSeal aggregates all the given seals for a given message set to a bls aggregated
@@ -270,16 +274,14 @@ func (c *core) getPreprepareWithRoundChangeCertificate(round *big.Int) (*istanbu
 }
 
 // startNewRound starts a new round. if round equals to 0, it means to starts a new sequence
-func (c *core) startNewRound(round *big.Int) {
+func (c *core) startNewRound(round *big.Int) error {
 	logger := c.newLogger("func", "startNewRound", "tag", "stateTransition")
 
 	roundChange := false
 	// Try to get last proposal
 	headBlock, headAuthor := c.backend.GetCurrentHeadBlockAndAuthor()
 
-	if c.current == nil {
-		logger.Trace("Start the initial round")
-	} else if headBlock.Number().Cmp(c.current.Sequence()) >= 0 {
+	if headBlock.Number().Cmp(c.current.Sequence()) >= 0 {
 		// Want to be working on the block 1 beyond the last committed block.
 		diff := new(big.Int).Sub(headBlock.Number(), c.current.Sequence())
 		c.sequenceMeter.Mark(new(big.Int).Add(diff, common.Big1).Int64())
@@ -293,15 +295,15 @@ func (c *core) startNewRound(round *big.Int) {
 		// Working on the block immediately after the last committed block.
 		if round.Cmp(c.current.Round()) == 0 {
 			logger.Trace("Already in the desired round.")
-			return
+			return nil
 		} else if round.Cmp(c.current.Round()) < 0 {
 			logger.Warn("New round should not be smaller than current round", "lastBlockNumber", headBlock.Number().Int64(), "new_round", round)
-			return
+			return nil
 		}
 		roundChange = true
 	} else {
 		logger.Warn("New sequence should be larger than current sequence", "new_seq", headBlock.Number().Int64())
-		return
+		return nil
 	}
 
 	// Generate next view and pre-prepare
@@ -309,11 +311,7 @@ func (c *core) startNewRound(round *big.Int) {
 	var roundChangeCertificate istanbul.RoundChangeCertificate
 	var request *istanbul.Request
 
-	var valSet istanbul.ValidatorSet
-	if c.current != nil {
-		valSet = c.current.ValidatorSet()
-	}
-
+	valSet := c.current.ValidatorSet()
 	if roundChange {
 		newView = &istanbul.View{
 			Sequence: new(big.Int).Set(c.current.Sequence()),
@@ -324,12 +322,10 @@ func (c *core) startNewRound(round *big.Int) {
 		request, roundChangeCertificate, err = c.getPreprepareWithRoundChangeCertificate(round)
 		if err != nil {
 			logger.Error("Unable to produce round change certificate", "err", err, "new_round", round)
-			return
+			return nil
 		}
 	} else {
-		if c.current != nil {
-			request = c.current.PendingRequest()
-		}
+		request = c.current.PendingRequest()
 		newView = &istanbul.View{
 			Sequence: new(big.Int).Add(headBlock.Number(), common.Big1),
 			Round:    new(big.Int),
@@ -338,35 +334,37 @@ func (c *core) startNewRound(round *big.Int) {
 		c.roundChangeSet = newRoundChangeSet(valSet)
 	}
 
-	if c.current != nil {
-		// Update logger
-		logger = logger.New("old_proposer", c.current.Proposer())
-	}
+	logger = logger.New("old_proposer", c.current.Proposer())
 
 	// Calculate new proposer
 	nextProposer := c.selectProposer(valSet, headAuthor, newView.Round.Uint64())
-	c.resetRoundState(newView, valSet, nextProposer, roundChange)
+	err := c.resetRoundState(newView, valSet, nextProposer, roundChange)
+
+	if err != nil {
+		return err
+	}
 
 	// Process backlog
 	c.processPendingRequests()
 	c.processBacklog()
 
-	if roundChange && c.current != nil && c.isProposer() && request != nil {
+	if roundChange && c.isProposer() && request != nil {
 		c.sendPreprepare(request, roundChangeCertificate)
 	}
 	c.newRoundChangeTimer()
 
 	logger.Debug("New round", "new_round", newView.Round, "new_seq", newView.Sequence, "new_proposer", c.current.Proposer(), "valSet", c.current.ValidatorSet().List(), "size", c.current.ValidatorSet().Size(), "isProposer", c.isProposer())
+	return nil
 }
 
 // All actions that occur when transitioning to waiting for round change state.
-func (c *core) waitForDesiredRound(r *big.Int) {
+func (c *core) waitForDesiredRound(r *big.Int) error {
 	logger := c.newLogger("func", "waitForDesiredRound", "old_desired_round", c.current.DesiredRound(), "new_desired_round", r)
 
 	// Don't wait for an older round
 	if c.current.DesiredRound().Cmp(r) >= 0 {
 		logger.Debug("New desired round not greater than current desired round")
-		return
+		return nil
 	}
 
 	logger.Debug("Waiting for desired round")
@@ -378,7 +376,10 @@ func (c *core) waitForDesiredRound(r *big.Int) {
 	// Perform all of the updates
 	_, headAuthor := c.backend.GetCurrentHeadBlockAndAuthor()
 	nextProposer := c.selectProposer(c.current.ValidatorSet(), headAuthor, r.Uint64())
-	c.current.TransitionToWaitingForNewRound(r, nextProposer)
+	err := c.current.TransitionToWaitingForNewRound(r, nextProposer)
+	if err != nil {
+		return err
+	}
 
 	c.newRoundChangeTimerForView(desiredView)
 
@@ -387,38 +388,35 @@ func (c *core) waitForDesiredRound(r *big.Int) {
 
 	// Send round change
 	c.sendRoundChange(r)
+	return nil
 }
 
-func (c *core) resetRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, roundChange bool) {
+func (c *core) resetRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, roundChange bool) error {
 	// TODO(Joshua): Include desired round here.
-	if c.current == nil {
-		// When the current round is nil, we must start with the current validator set in the parent commits
-		// either `validatorSet` or `backend.Validators(lastProposal)` works here
-		c.current = newRoundState(view, validatorSet, nextProposer)
-	} else if roundChange {
-		c.current.StartNewRound(view.Round, validatorSet, nextProposer)
-	} else {
-		// sequence change
-
-		// TODO remove this when we refactor startNewRound()
-		if view.Round.Cmp(common.Big0) != 0 {
-			c.logger.Crit("BUG: DevError: trying to start a new sequence with round != 0", "wanted_round", view.Round)
-		}
-
-		var newParentCommits MessageSet
-		lastSubject, err := c.backend.LastSubject()
-		if err == nil && c.current.Proposal() != nil && c.current.Proposal().Hash() == lastSubject.Digest && c.current.Round().Cmp(lastSubject.View.Round) == 0 {
-			// When changing sequences, if our current Commit messages match the latest block in the chain
-			// (i.e. they're for the same block hash and round), we use this sequence's commits as the ParentCommits field
-			// in the next round.
-			newParentCommits = c.current.Commits()
-		} else {
-			// Otherwise, we will initialize an empty ParentCommits field with the validator set of the last proposal.
-			headBlock := c.backend.GetCurrentHeadBlock()
-			newParentCommits = newMessageSet(c.backend.ParentBlockValidators(headBlock))
-		}
-		c.current.StartNewSequence(view.Sequence, validatorSet, nextProposer, newParentCommits)
+	if roundChange {
+		return c.current.StartNewRound(view.Round, validatorSet, nextProposer)
 	}
+
+	// sequence change
+	// TODO remove this when we refactor startNewRound()
+	if view.Round.Cmp(common.Big0) != 0 {
+		c.logger.Crit("BUG: DevError: trying to start a new sequence with round != 0", "wanted_round", view.Round)
+	}
+
+	var newParentCommits MessageSet
+	lastSubject, err := c.backend.LastSubject()
+	if err == nil && c.current.Proposal() != nil && c.current.Proposal().Hash() == lastSubject.Digest && c.current.Round().Cmp(lastSubject.View.Round) == 0 {
+		// When changing sequences, if our current Commit messages match the latest block in the chain
+		// (i.e. they're for the same block hash and round), we use this sequence's commits as the ParentCommits field
+		// in the next round.
+		newParentCommits = c.current.Commits()
+	} else {
+		// Otherwise, we will initialize an empty ParentCommits field with the validator set of the last proposal.
+		headBlock := c.backend.GetCurrentHeadBlock()
+		newParentCommits = newMessageSet(c.backend.ParentBlockValidators(headBlock))
+	}
+	return c.current.StartNewSequence(view.Sequence, validatorSet, nextProposer, newParentCommits)
+
 }
 
 func (c *core) isProposer() bool {

--- a/consensus/istanbul/core/final_committed.go
+++ b/consensus/istanbul/core/final_committed.go
@@ -21,6 +21,5 @@ import "github.com/ethereum/go-ethereum/common"
 func (c *core) handleFinalCommitted() error {
 	logger := c.newLogger("func", "handleFinalCommitted")
 	logger.Trace("Received a final committed proposal")
-	c.startNewRound(common.Big0)
-	return nil
+	return c.startNewRound(common.Big0)
 }

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -38,17 +38,22 @@ func TestVerifyPreparedCertificate(t *testing.T) {
 	}
 	proposal := makeBlock(0)
 
+	for _, b := range sys.backends {
+		b.engine.Start() // start Istanbul core
+	}
+
 	testCases := []struct {
+		name        string
 		certificate istanbul.PreparedCertificate
 		expectedErr error
 	}{
 		{
-			// Valid PREPARED certificate
+			"Valid PREPARED certificate",
 			sys.getPreparedCertificate(t, []istanbul.View{view}, proposal),
 			nil,
 		},
 		{
-			// Invalid PREPARED certificate, duplicate message
+			"Invalid PREPARED certificate, duplicate message",
 			func() istanbul.PreparedCertificate {
 				preparedCertificate := sys.getPreparedCertificate(t, []istanbul.View{view}, proposal)
 				preparedCertificate.PrepareOrCommitMessages[1] = preparedCertificate.PrepareOrCommitMessages[0]
@@ -57,7 +62,7 @@ func TestVerifyPreparedCertificate(t *testing.T) {
 			errInvalidPreparedCertificateDuplicate,
 		},
 		{
-			// Invalid PREPARED certificate, future message
+			"Invalid PREPARED certificate, future message",
 			func() istanbul.PreparedCertificate {
 				futureView := istanbul.View{
 					Round:    big.NewInt(0),
@@ -69,7 +74,7 @@ func TestVerifyPreparedCertificate(t *testing.T) {
 			errInvalidPreparedCertificateMsgView,
 		},
 		{
-			// Invalid PREPARED certificate, includes preprepare message
+			"Invalid PREPARED certificate, includes preprepare message",
 			func() istanbul.PreparedCertificate {
 				preparedCertificate := sys.getPreparedCertificate(t, []istanbul.View{view}, proposal)
 				testInvalidMsg, _ := sys.backends[0].getRoundChangeMessage(view, sys.getPreparedCertificate(t, []istanbul.View{view}, proposal))
@@ -79,7 +84,7 @@ func TestVerifyPreparedCertificate(t *testing.T) {
 			errInvalidPreparedCertificateMsgCode,
 		},
 		{
-			// Invalid PREPARED certificate, hash mismatch
+			"Invalid PREPARED certificate, hash mismatch",
 			func() istanbul.PreparedCertificate {
 				preparedCertificate := sys.getPreparedCertificate(t, []istanbul.View{view}, proposal)
 				preparedCertificate.PrepareOrCommitMessages[1] = preparedCertificate.PrepareOrCommitMessages[0]
@@ -89,7 +94,7 @@ func TestVerifyPreparedCertificate(t *testing.T) {
 			errInvalidPreparedCertificateDigestMismatch,
 		},
 		{
-			// Invalid PREPARED certificate, view inconsistencies
+			"Invalid PREPARED certificate, view inconsistencies",
 			func() istanbul.PreparedCertificate {
 				var view2 istanbul.View
 				view2.Sequence = big.NewInt(view.Sequence.Int64())
@@ -100,19 +105,21 @@ func TestVerifyPreparedCertificate(t *testing.T) {
 			errInvalidPreparedCertificateInconsistentViews,
 		},
 		{
-			// Empty certificate
+			"Empty certificate",
 			istanbul.EmptyPreparedCertificate(),
 			errInvalidPreparedCertificateNumMsgs,
 		},
 	}
 	for _, test := range testCases {
-		for _, backend := range sys.backends {
-			c := backend.engine.(*core)
-			err := c.verifyPreparedCertificate(test.certificate)
-			if err != test.expectedErr {
-				t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
+		t.Run(test.name, func(t *testing.T) {
+			for _, backend := range sys.backends {
+				c := backend.engine.(*core)
+				err := c.verifyPreparedCertificate(test.certificate)
+				if err != test.expectedErr {
+					t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -130,11 +137,12 @@ func TestHandlePrepare(t *testing.T) {
 	}
 
 	testCases := []struct {
+		name        string
 		system      *testSystem
 		expectedErr error
 	}{
 		{
-			// normal case
+			"normal case",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
@@ -159,7 +167,7 @@ func TestHandlePrepare(t *testing.T) {
 			nil,
 		},
 		{
-			// normal case with prepared certificate
+			"normal case with prepared certificate",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 				preparedCert := sys.getPreparedCertificate(
@@ -193,7 +201,7 @@ func TestHandlePrepare(t *testing.T) {
 			nil,
 		},
 		{
-			// Inconsistent subject due to prepared certificate
+			"Inconsistent subject due to prepared certificate",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 				preparedCert := sys.getPreparedCertificate(
@@ -227,7 +235,7 @@ func TestHandlePrepare(t *testing.T) {
 			errInconsistentSubject,
 		},
 		{
-			// future message
+			"future message",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
@@ -255,7 +263,7 @@ func TestHandlePrepare(t *testing.T) {
 			errFutureMessage,
 		},
 		{
-			// subject not match
+			"subject not match",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
@@ -283,7 +291,7 @@ func TestHandlePrepare(t *testing.T) {
 			errOldMessage,
 		},
 		{
-			// subject not match
+			"subject not match",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
@@ -310,7 +318,7 @@ func TestHandlePrepare(t *testing.T) {
 			errInconsistentSubject,
 		},
 		{
-			// less than 2F+1
+			"less than 2F+1",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
@@ -336,69 +344,72 @@ func TestHandlePrepare(t *testing.T) {
 		// TODO: double send message
 	}
 
-OUTER:
 	for _, test := range testCases {
-		test.system.Run(false)
+		t.Run(test.name, func(t *testing.T) {
 
-		v0 := test.system.backends[0]
-		r0 := v0.engine.(*core)
+			test.system.Run(false)
 
-		for i, v := range test.system.backends {
-			validator := r0.current.ValidatorSet().GetByIndex(uint64(i))
-			m, _ := Encode(v.engine.(*core).current.Subject())
-			if err := r0.handlePrepare(&istanbul.Message{
-				Code:    istanbul.MsgPrepare,
-				Msg:     m,
-				Address: validator.Address(),
-			}); err != nil {
-				if err != test.expectedErr {
-					t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
+			v0 := test.system.backends[0]
+			r0 := v0.engine.(*core)
+
+			for i, v := range test.system.backends {
+				validator := r0.current.ValidatorSet().GetByIndex(uint64(i))
+				m, _ := Encode(v.engine.(*core).current.Subject())
+				err := r0.handlePrepare(&istanbul.Message{
+					Code:    istanbul.MsgPrepare,
+					Msg:     m,
+					Address: validator.Address(),
+				})
+				if err != nil {
+					if err != test.expectedErr {
+						t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
+					}
+					return
 				}
-				continue OUTER
-			}
-		}
-
-		// prepared is normal case
-		if r0.current.State() != StatePrepared {
-			// There are not enough PREPARE messages in core
-			if r0.current.State() != StatePreprepared {
-				t.Errorf("state mismatch: have %v, want %v", r0.current.State(), StatePreprepared)
-			}
-			if r0.current.Prepares().Size() >= r0.current.ValidatorSet().MinQuorumSize() {
-				t.Errorf("the size of PREPARE messages should be less than %v", 2*r0.current.ValidatorSet().MinQuorumSize()+1)
 			}
 
-			continue
-		}
+			// prepared is normal case
+			if r0.current.State() != StatePrepared {
+				// There are not enough PREPARE messages in core
+				if r0.current.State() != StatePreprepared {
+					t.Errorf("state mismatch: have %v, want %v", r0.current.State(), StatePreprepared)
+				}
+				if r0.current.Prepares().Size() >= r0.current.ValidatorSet().MinQuorumSize() {
+					t.Errorf("the size of PREPARE messages should be less than %v", 2*r0.current.ValidatorSet().MinQuorumSize()+1)
+				}
 
-		// core should have MinQuorumSize PREPARE messages
-		if r0.current.Prepares().Size() < r0.current.ValidatorSet().MinQuorumSize() {
-			t.Errorf("the size of PREPARE messages should be greater than or equal to MinQuorumSize: size %v", r0.current.Prepares().Size())
-		}
+				return
+			}
 
-		// a message will be delivered to backend if 2F+1
-		if int64(len(v0.sentMsgs)) != 1 {
-			t.Errorf("the Send() should be called once: times %v", len(test.system.backends[0].sentMsgs))
-		}
+			// core should have MinQuorumSize PREPARE messages
+			if r0.current.Prepares().Size() < r0.current.ValidatorSet().MinQuorumSize() {
+				t.Errorf("the size of PREPARE messages should be greater than or equal to MinQuorumSize: size %v", r0.current.Prepares().Size())
+			}
 
-		// verify COMMIT messages
-		decodedMsg := new(istanbul.Message)
-		err := decodedMsg.FromPayload(v0.sentMsgs[0], nil)
-		if err != nil {
-			t.Errorf("error mismatch: have %v, want nil", err)
-		}
+			// a message will be delivered to backend if 2F+1
+			if int64(len(v0.sentMsgs)) != 1 {
+				t.Errorf("the Send() should be called once: times %v", len(test.system.backends[0].sentMsgs))
+			}
 
-		if decodedMsg.Code != istanbul.MsgCommit {
-			t.Errorf("message code mismatch: have %v, want %v", decodedMsg.Code, istanbul.MsgCommit)
-		}
-		var m *istanbul.CommittedSubject
-		err = decodedMsg.Decode(&m)
-		if err != nil {
-			t.Errorf("error mismatch: have %v, want nil", err)
-		}
-		if !reflect.DeepEqual(m.Subject, expectedSubject) {
-			t.Errorf("subject mismatch: have %v, want %v", m, expectedSubject)
-		}
+			// verify COMMIT messages
+			decodedMsg := new(istanbul.Message)
+			err := decodedMsg.FromPayload(v0.sentMsgs[0], nil)
+			if err != nil {
+				t.Errorf("error mismatch: have %v, want nil", err)
+			}
+
+			if decodedMsg.Code != istanbul.MsgCommit {
+				t.Errorf("message code mismatch: have %v, want %v", decodedMsg.Code, istanbul.MsgCommit)
+			}
+			var m *istanbul.CommittedSubject
+			err = decodedMsg.Decode(&m)
+			if err != nil {
+				t.Errorf("error mismatch: have %v, want nil", err)
+			}
+			if !reflect.DeepEqual(m.Subject, expectedSubject) {
+				t.Errorf("subject mismatch: have %v, want %v", m, expectedSubject)
+			}
+		})
 	}
 }
 

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -135,11 +135,13 @@ func (c *core) handlePreprepare(msg *istanbul.Message) error {
 		logger.Trace("Accepted preprepare", "tag", "stateTransition")
 		c.consensusTimestamp = time.Now()
 
-		c.current.TransitionToPreprepared(preprepare)
+		err := c.current.TransitionToPreprepared(preprepare)
+		if err != nil {
+			return err
+		}
 
 		// Process Backlog Messages
 		c.processBacklog()
-
 		c.sendPrepare()
 	}
 

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -35,26 +35,28 @@ func TestHandlePreprepare(t *testing.T) {
 	N := uint64(4) // replica 0 is the proposer, it will send messages to others
 	F := uint64(1) // F does not affect tests
 
+	getRoundState := func(c *core) *roundStateImpl {
+		return c.current.(*roundStatePersistence).delegate.(*roundStateImpl)
+	}
+
 	testCases := []struct {
-		system          *testSystem
+		name            string
+		system          func() *testSystem
 		getCert         func(*testSystem) istanbul.RoundChangeCertificate
 		expectedRequest istanbul.Proposal
 		expectedErr     error
 		existingBlock   bool
 	}{
 		{
-			// normal case
+			"normal case",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
-				for i, backend := range sys.backends {
-					c := backend.engine.(*core)
-					if i != 0 {
-						c.current.(*roundStateImpl).state = StateAcceptRequest
-					}
+				for _, backend := range sys.backends {
+					backend.engine.(*core).Start()
 				}
 				return sys
-			}(),
+			},
 			func(_ *testSystem) istanbul.RoundChangeCertificate {
 				return istanbul.RoundChangeCertificate{}
 			},
@@ -63,18 +65,15 @@ func TestHandlePreprepare(t *testing.T) {
 			false,
 		},
 		{
-			// proposal sequence doesn't match message sequence
+			"proposal sequence doesn't match message sequence",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
-				for i, backend := range sys.backends {
-					c := backend.engine.(*core)
-					if i != 0 {
-						c.current.(*roundStateImpl).state = StateAcceptRequest
-					}
+				for _, backend := range sys.backends {
+					backend.engine.(*core).Start()
 				}
 				return sys
-			}(),
+			},
 			func(_ *testSystem) istanbul.RoundChangeCertificate {
 				return istanbul.RoundChangeCertificate{}
 			},
@@ -83,7 +82,7 @@ func TestHandlePreprepare(t *testing.T) {
 			false,
 		},
 		{
-			// non-proposer
+			"non-proposer",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
@@ -91,14 +90,15 @@ func TestHandlePreprepare(t *testing.T) {
 				sys.backends = sys.backends[1:]
 
 				for i, backend := range sys.backends {
+					backend.engine.(*core).Start()
 					c := backend.engine.(*core)
 					if i != 0 {
 						// replica 0 is the proposer
-						c.current.(*roundStateImpl).state = StatePreprepared
+						getRoundState(c).state = StatePreprepared
 					}
 				}
 				return sys
-			}(),
+			},
 			func(_ *testSystem) istanbul.RoundChangeCertificate {
 				return istanbul.RoundChangeCertificate{}
 			},
@@ -107,20 +107,21 @@ func TestHandlePreprepare(t *testing.T) {
 			false,
 		},
 		{
-			// errOldMessage
+			"errOldMessage",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
 				for i, backend := range sys.backends {
+					backend.engine.(*core).Start()
 					c := backend.engine.(*core)
 					if i != 0 {
-						c.current.(*roundStateImpl).state = StatePreprepared
-						c.current.(*roundStateImpl).sequence = big.NewInt(10)
-						c.current.(*roundStateImpl).round = big.NewInt(10)
+						getRoundState(c).state = StatePreprepared
+						getRoundState(c).sequence = big.NewInt(10)
+						getRoundState(c).round = big.NewInt(10)
 					}
 				}
 				return sys
-			}(),
+			},
 			func(_ *testSystem) istanbul.RoundChangeCertificate {
 				return istanbul.RoundChangeCertificate{}
 			},
@@ -129,18 +130,19 @@ func TestHandlePreprepare(t *testing.T) {
 			false,
 		},
 		{
-			// test existing block
+			"test existing block",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
 				for _, backend := range sys.backends {
+					backend.engine.(*core).Start()
 					c := backend.engine.(*core)
-					c.current.(*roundStateImpl).state = StatePreprepared
-					c.current.(*roundStateImpl).sequence = big.NewInt(10)
-					c.current.(*roundStateImpl).round = big.NewInt(10)
+					getRoundState(c).state = StatePreprepared
+					getRoundState(c).sequence = big.NewInt(10)
+					getRoundState(c).round = big.NewInt(10)
 				}
 				return sys
-			}(),
+			},
 			func(_ *testSystem) istanbul.RoundChangeCertificate {
 				return istanbul.RoundChangeCertificate{}
 			},
@@ -150,17 +152,18 @@ func TestHandlePreprepare(t *testing.T) {
 			true,
 		},
 		{
-			// ROUND CHANGE certificate missing
+			"ROUND CHANGE certificate missing",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
 				for _, backend := range sys.backends {
+					backend.engine.(*core).Start()
 					c := backend.engine.(*core)
-					c.current.(*roundStateImpl).state = StatePreprepared
-					c.current.(*roundStateImpl).round = big.NewInt(1)
+					getRoundState(c).state = StatePreprepared
+					getRoundState(c).round = big.NewInt(1)
 				}
 				return sys
-			}(),
+			},
 			func(_ *testSystem) istanbul.RoundChangeCertificate {
 				return istanbul.RoundChangeCertificate{}
 			},
@@ -169,17 +172,18 @@ func TestHandlePreprepare(t *testing.T) {
 			false,
 		},
 		{
-			// ROUND CHANGE certificate invalid, duplicate messages.
+			"ROUND CHANGE certificate invalid, duplicate messages.",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
 				for _, backend := range sys.backends {
+					backend.engine.(*core).Start()
 					c := backend.engine.(*core)
-					c.current.(*roundStateImpl).state = StatePreprepared
-					c.current.(*roundStateImpl).round = big.NewInt(1)
+					getRoundState(c).state = StatePreprepared
+					getRoundState(c).round = big.NewInt(1)
 				}
 				return sys
-			}(),
+			},
 			func(sys *testSystem) istanbul.RoundChangeCertificate {
 				// Duplicate messages
 				roundChangeCertificate := sys.getRoundChangeCertificate(t, *(sys.backends[0].engine.(*core).current.View()), istanbul.EmptyPreparedCertificate())
@@ -191,14 +195,15 @@ func TestHandlePreprepare(t *testing.T) {
 			false,
 		},
 		{
-			// ROUND CHANGE certificate contains PREPARED certificate with inconsistent views among the cert's messages
+			"ROUND CHANGE certificate contains PREPARED certificate with inconsistent views among the cert's messages",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
 				for _, backend := range sys.backends {
+					backend.engine.(*core).Start()
 					c := backend.engine.(*core)
-					c.current.(*roundStateImpl).state = StatePreprepared
-					c.current.(*roundStateImpl).round = big.NewInt(1)
+					getRoundState(c).state = StatePreprepared
+					getRoundState(c).round = big.NewInt(1)
 					c.current.TransitionToPreprepared(&istanbul.Preprepare{
 						View: &istanbul.View{
 							Round:    big.NewInt(1),
@@ -209,7 +214,7 @@ func TestHandlePreprepare(t *testing.T) {
 					})
 				}
 				return sys
-			}(),
+			},
 			func(sys *testSystem) istanbul.RoundChangeCertificate {
 				view1 := *(sys.backends[0].engine.(*core).current.View())
 
@@ -226,14 +231,15 @@ func TestHandlePreprepare(t *testing.T) {
 			false,
 		},
 		{
-			// ROUND CHANGE certificate contains PREPARED certificate for a different block.
+			"ROUND CHANGE certificate contains PREPARED certificate for a different block.",
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
 				for _, backend := range sys.backends {
+					backend.engine.(*core).Start()
 					c := backend.engine.(*core)
-					c.current.(*roundStateImpl).state = StatePreprepared
-					c.current.(*roundStateImpl).round = big.NewInt(1)
+					getRoundState(c).state = StatePreprepared
+					getRoundState(c).round = big.NewInt(1)
 					c.current.TransitionToPreprepared(&istanbul.Preprepare{
 						View: &istanbul.View{
 							Round:    big.NewInt(1),
@@ -244,7 +250,7 @@ func TestHandlePreprepare(t *testing.T) {
 					})
 				}
 				return sys
-			}(),
+			},
 			func(sys *testSystem) istanbul.RoundChangeCertificate {
 				preparedCertificate := sys.getPreparedCertificate(t, []istanbul.View{*(sys.backends[0].engine.(*core).current.View())}, makeBlock(2))
 				roundChangeCertificate := sys.getRoundChangeCertificate(t, *(sys.backends[0].engine.(*core).current.View()), preparedCertificate)
@@ -255,20 +261,21 @@ func TestHandlePreprepare(t *testing.T) {
 			false,
 		},
 		{
-			// ROUND CHANGE certificate for N+1 round with valid PREPARED certificates
+			"ROUND CHANGE certificate for N+1 round with valid PREPARED certificates",
 			// Round is N+1 to match the correct proposer.
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
 				for i, backend := range sys.backends {
+					backend.engine.(*core).Start()
 					c := backend.engine.(*core)
-					c.current.(*roundStateImpl).round = big.NewInt(int64(N))
+					getRoundState(c).round = big.NewInt(int64(N))
 					if i != 0 {
-						c.current.(*roundStateImpl).state = StateAcceptRequest
+						getRoundState(c).state = StateAcceptRequest
 					}
 				}
 				return sys
-			}(),
+			},
 			func(sys *testSystem) istanbul.RoundChangeCertificate {
 				preparedCertificate := sys.getPreparedCertificate(t, []istanbul.View{*(sys.backends[0].engine.(*core).current.View())}, makeBlock(1))
 				roundChangeCertificate := sys.getRoundChangeCertificate(t, *(sys.backends[0].engine.(*core).current.View()), preparedCertificate)
@@ -279,20 +286,21 @@ func TestHandlePreprepare(t *testing.T) {
 			false,
 		},
 		{
-			// ROUND CHANGE certificate for N+1 round with empty PREPARED certificates
+			"ROUND CHANGE certificate for N+1 round with empty PREPARED certificates",
 			// Round is N+1 to match the correct proposer.
 			func() *testSystem {
 				sys := NewTestSystemWithBackend(N, F)
 
 				for i, backend := range sys.backends {
+					backend.engine.(*core).Start()
 					c := backend.engine.(*core)
-					c.current.(*roundStateImpl).round = big.NewInt(int64(N))
+					getRoundState(c).round = big.NewInt(int64(N))
 					if i != 0 {
-						c.current.(*roundStateImpl).state = StateAcceptRequest
+						getRoundState(c).state = StateAcceptRequest
 					}
 				}
 				return sys
-			}(),
+			},
 			func(sys *testSystem) istanbul.RoundChangeCertificate {
 				roundChangeCertificate := sys.getRoundChangeCertificate(t, *(sys.backends[0].engine.(*core).current.View()), istanbul.EmptyPreparedCertificate())
 				return roundChangeCertificate
@@ -303,102 +311,104 @@ func TestHandlePreprepare(t *testing.T) {
 		},
 	}
 
-OUTER:
-	for i, test := range testCases {
-		testLogger.Info("Running handle preprepare test case", "number", i)
-		test.system.Run(false)
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
 
-		v0 := test.system.backends[0]
-		r0 := v0.engine.(*core)
+			sys := test.system()
+			sys.Run(false)
 
-		curView := r0.current.View()
+			v0 := sys.backends[0]
+			r0 := v0.engine.(*core)
 
-		preprepareView := curView
-		if test.existingBlock {
-			preprepareView = &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(5)}
-		}
+			curView := r0.current.View()
 
-		preprepare := &istanbul.Preprepare{
-			View:                   preprepareView,
-			Proposal:               test.expectedRequest,
-			RoundChangeCertificate: test.getCert(test.system),
-		}
-
-		for i, v := range test.system.backends {
-			// i == 0 is primary backend, it is responsible for send PRE-PREPARE messages to others.
-			if i == 0 {
-				continue
-			}
-
-			c := v.engine.(*core)
-
-			m, _ := Encode(preprepare)
-			// run each backends and verify handlePreprepare function.
-			if err := c.handlePreprepare(&istanbul.Message{
-				Code:    istanbul.MsgPreprepare,
-				Msg:     m,
-				Address: v0.Address(),
-			}); err != nil {
-				if err != test.expectedErr {
-					t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
-				}
-				continue OUTER
-			}
-
-			if c.current.State() != StatePreprepared {
-				t.Errorf("state mismatch: have %v, want %v", c.current.State(), StatePreprepared)
-			}
-
-			if !test.existingBlock && !reflect.DeepEqual(c.current.Subject().View, curView) {
-				t.Errorf("view mismatch: have %v, want %v", c.current.Subject().View, curView)
-			}
-
-			// verify prepare messages
-			decodedMsg := new(istanbul.Message)
-			err := decodedMsg.FromPayload(v.sentMsgs[0], nil)
-			if err != nil {
-				t.Errorf("error mismatch: have %v, want nil", err)
-			}
-
-			expectedCode := istanbul.MsgPrepare
+			preprepareView := curView
 			if test.existingBlock {
-				expectedCode = istanbul.MsgCommit
-			}
-			if decodedMsg.Code != expectedCode {
-				t.Errorf("message code mismatch: have %v, want %v", decodedMsg.Code, expectedCode)
+				preprepareView = &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(5)}
 			}
 
-			var subject *istanbul.Subject
-			var committedSubject *istanbul.CommittedSubject
-
-			if decodedMsg.Code == istanbul.MsgPrepare {
-				err = decodedMsg.Decode(&subject)
-			} else if decodedMsg.Code == istanbul.MsgCommit {
-				err = decodedMsg.Decode(&committedSubject)
-				subject = committedSubject.Subject
+			preprepare := &istanbul.Preprepare{
+				View:                   preprepareView,
+				Proposal:               test.expectedRequest,
+				RoundChangeCertificate: test.getCert(sys),
 			}
 
-			if err != nil {
-				t.Errorf("error mismatch: have %v, want nil", err)
-			}
+			for i, v := range sys.backends {
+				// i == 0 is primary backend, it is responsible for send PRE-PREPARE messages to others.
+				if i == 0 {
+					continue
+				}
 
-			expectedSubject := c.current.Subject()
-			if test.existingBlock {
-				expectedSubject = &istanbul.Subject{View: &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(5)},
-					Digest: test.expectedRequest.Hash()}
-			}
+				c := v.engine.(*core)
 
-			if !reflect.DeepEqual(subject, expectedSubject) {
-				t.Errorf("subject mismatch: have %v, want %v", subject, expectedSubject)
-			}
+				m, _ := Encode(preprepare)
+				// run each backends and verify handlePreprepare function.
+				if err := c.handlePreprepare(&istanbul.Message{
+					Code:    istanbul.MsgPreprepare,
+					Msg:     m,
+					Address: v0.Address(),
+				}); err != nil {
+					if err != test.expectedErr {
+						t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
+					}
+					return
+				}
 
-			if expectedCode == istanbul.MsgCommit {
-				srcValidator := c.current.GetValidatorByAddress(v.address)
+				if c.current.State() != StatePreprepared {
+					t.Errorf("state mismatch: have %v, want %v", c.current.State(), StatePreprepared)
+				}
 
-				if err := c.verifyCommittedSeal(committedSubject, srcValidator); err != nil {
-					t.Errorf("invalid seal.  verify commmited seal error: %v, subject: %v, committedSeal: %v", err, expectedSubject, committedSubject.CommittedSeal)
+				if !test.existingBlock && !reflect.DeepEqual(c.current.Subject().View, curView) {
+					t.Errorf("view mismatch: have %v, want %v", c.current.Subject().View, curView)
+				}
+
+				// verify prepare messages
+				decodedMsg := new(istanbul.Message)
+				err := decodedMsg.FromPayload(v.sentMsgs[0], nil)
+				if err != nil {
+					t.Errorf("error mismatch: have %v, want nil", err)
+				}
+
+				expectedCode := istanbul.MsgPrepare
+				if test.existingBlock {
+					expectedCode = istanbul.MsgCommit
+				}
+				if decodedMsg.Code != expectedCode {
+					t.Errorf("message code mismatch: have %v, want %v", decodedMsg.Code, expectedCode)
+				}
+
+				var subject *istanbul.Subject
+				var committedSubject *istanbul.CommittedSubject
+
+				if decodedMsg.Code == istanbul.MsgPrepare {
+					err = decodedMsg.Decode(&subject)
+				} else if decodedMsg.Code == istanbul.MsgCommit {
+					err = decodedMsg.Decode(&committedSubject)
+					subject = committedSubject.Subject
+				}
+
+				if err != nil {
+					t.Errorf("error mismatch: have %v, want nil", err)
+				}
+
+				expectedSubject := c.current.Subject()
+				if test.existingBlock {
+					expectedSubject = &istanbul.Subject{View: &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(5)},
+						Digest: test.expectedRequest.Hash()}
+				}
+
+				if !reflect.DeepEqual(subject, expectedSubject) {
+					t.Errorf("subject mismatch: have %v, want %v", subject, expectedSubject)
+				}
+
+				if expectedCode == istanbul.MsgCommit {
+					srcValidator := c.current.GetValidatorByAddress(v.address)
+
+					if err := c.verifyCommittedSeal(committedSubject, srcValidator); err != nil {
+						t.Errorf("invalid seal.  verify commmited seal error: %v, subject: %v, committedSeal: %v", err, expectedSubject, committedSubject.CommittedSeal)
+					}
 				}
 			}
-		}
+		})
 	}
 }

--- a/consensus/istanbul/core/request.go
+++ b/consensus/istanbul/core/request.go
@@ -35,7 +35,9 @@ func (c *core) handleRequest(request *istanbul.Request) error {
 
 	logger.Trace("handleRequest", "number", request.Proposal.Number(), "hash", request.Proposal.Hash())
 
-	c.current.SetPendingRequest(request)
+	if err = c.current.SetPendingRequest(request); err != nil {
+		return err
+	}
 
 	// Must go through startNewRound to send proposals for round > 0 to ensure a round change certificate is generated.
 	if c.current.State() == StateAcceptRequest && c.current.Round().Cmp(common.Big0) == 0 {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -146,9 +146,8 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 
 	// May have already moved to this round based on quorum round change messages.
 	logger.Trace("Trying to move to round change certificate's round", "target round", proposal.View.Round)
-	c.startNewRound(proposal.View.Round)
 
-	return nil
+	return c.startNewRound(proposal.View.Round)
 }
 
 func (c *core) handleRoundChange(msg *istanbul.Message) error {
@@ -196,7 +195,7 @@ func (c *core) handleRoundChange(msg *istanbul.Message) error {
 	// On quorum round change messages we go to the next round immediately.
 	if quorumRound != nil && quorumRound.Cmp(c.current.DesiredRound()) >= 0 {
 		logger.Trace("Got quorum round change messages, starting new round.")
-		c.startNewRound(quorumRound)
+		return c.startNewRound(quorumRound)
 	} else if ffRound != nil {
 		logger.Trace("Got f+1 round change messages, sending own round change message and waiting for next round.")
 		c.waitForDesiredRound(ffRound)

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -165,26 +165,27 @@ func TestHandleRoundChangeCertificate(t *testing.T) {
 	}
 
 	testCases := []struct {
-		getCertificate func(*testSystem) istanbul.RoundChangeCertificate
+		name           string
+		getCertificate func(*testing.T, *testSystem) istanbul.RoundChangeCertificate
 		expectedErr    error
 	}{
 		{
-			// Valid round change certificate without PREPARED certificate
-			func(sys *testSystem) istanbul.RoundChangeCertificate {
+			"Valid round change certificate without PREPARED certificate",
+			func(t *testing.T, sys *testSystem) istanbul.RoundChangeCertificate {
 				return sys.getRoundChangeCertificate(t, view, istanbul.EmptyPreparedCertificate())
 			},
 			nil,
 		},
 		{
-			// Valid round change certificate with PREPARED certificate
-			func(sys *testSystem) istanbul.RoundChangeCertificate {
+			"Valid round change certificate with PREPARED certificate",
+			func(t *testing.T, sys *testSystem) istanbul.RoundChangeCertificate {
 				return sys.getRoundChangeCertificate(t, view, sys.getPreparedCertificate(t, []istanbul.View{view}, makeBlock(0)))
 			},
 			nil,
 		},
 		{
-			// Invalid round change certificate, duplicate message
-			func(sys *testSystem) istanbul.RoundChangeCertificate {
+			"Invalid round change certificate, duplicate message",
+			func(t *testing.T, sys *testSystem) istanbul.RoundChangeCertificate {
 				roundChangeCertificate := sys.getRoundChangeCertificate(t, view, istanbul.EmptyPreparedCertificate())
 				roundChangeCertificate.RoundChangeMessages[1] = roundChangeCertificate.RoundChangeMessages[0]
 				return roundChangeCertificate
@@ -192,31 +193,35 @@ func TestHandleRoundChangeCertificate(t *testing.T) {
 			errInvalidRoundChangeCertificateDuplicate,
 		},
 		{
-			// Empty certificate
-			func(sys *testSystem) istanbul.RoundChangeCertificate {
+			"Empty certificate",
+			func(t *testing.T, sys *testSystem) istanbul.RoundChangeCertificate {
 				return istanbul.RoundChangeCertificate{}
 			},
 			errInvalidRoundChangeCertificateNumMsgs,
 		},
 	}
 	for _, test := range testCases {
-		sys := NewTestSystemWithBackend(N, F)
-		for i, backend := range sys.backends {
-			c := backend.engine.(*core)
-			certificate := test.getCertificate(sys)
-			subject := istanbul.Subject{
-				View:   &view,
-				Digest: makeBlock(0).Hash(),
-			}
-			err := c.handleRoundChangeCertificate(subject, certificate)
+		t.Run(test.name, func(t *testing.T) {
+			sys := NewTestSystemWithBackend(N, F)
+			for i, backend := range sys.backends {
+				c := backend.engine.(*core)
+				c.Start()
+				certificate := test.getCertificate(t, sys)
+				subject := istanbul.Subject{
+					View:   &view,
+					Digest: makeBlock(0).Hash(),
+				}
+				err := c.handleRoundChangeCertificate(subject, certificate)
 
-			if err != test.expectedErr {
-				t.Errorf("error mismatch for test case %v: have %v, want %v", i, err, test.expectedErr)
+				if err != test.expectedErr {
+					t.Errorf("error mismatch for test case %v: have %v, want %v", i, err, test.expectedErr)
+				}
+				if err == nil && c.current.View().Cmp(&view) != 0 {
+					t.Errorf("view mismatch for test case %v: have %v, want %v", i, c.current.View(), view)
+				}
 			}
-			if err == nil && c.current.View().Cmp(&view) != 0 {
-				t.Errorf("view mismatch for test case %v: have %v, want %v", i, c.current.View(), view)
-			}
-		}
+
+		})
 	}
 }
 
@@ -224,31 +229,36 @@ func TestHandleRoundChange(t *testing.T) {
 	N := uint64(4) // replica 0 is the proposer, it will send messages to others
 	F := uint64(1) // F does not affect tests
 
+	buildEmptyCertificate := func(_ *testing.T, _ *testSystem) istanbul.PreparedCertificate {
+		return istanbul.EmptyPreparedCertificate()
+	}
+
+	noopPrepare := func(_ *testSystem) {}
+
 	testCases := []struct {
-		system      *testSystem
-		getCert     func(*testSystem) istanbul.PreparedCertificate
-		expectedErr error
+		name          string
+		prepareSystem func(*testSystem)
+		getCert       func(*testing.T, *testSystem) istanbul.PreparedCertificate
+		expectedErr   error
 	}{
 		{
-			// normal case
-			NewTestSystemWithBackend(N, F),
-			func(_ *testSystem) istanbul.PreparedCertificate {
-				return istanbul.EmptyPreparedCertificate()
-			},
+			"normal case",
+			noopPrepare,
+			buildEmptyCertificate,
 			nil,
 		},
 		{
-			// normal case with valid prepared certificate
-			NewTestSystemWithBackend(N, F),
-			func(sys *testSystem) istanbul.PreparedCertificate {
+			"normal case with valid prepared certificate",
+			noopPrepare,
+			func(t *testing.T, sys *testSystem) istanbul.PreparedCertificate {
 				return sys.getPreparedCertificate(t, []istanbul.View{*sys.backends[0].engine.(*core).current.View()}, makeBlock(1))
 			},
 			nil,
 		},
 		{
-			// normal case with invalid prepared certificate
-			NewTestSystemWithBackend(N, F),
-			func(sys *testSystem) istanbul.PreparedCertificate {
+			"normal case with invalid prepared certificate",
+			noopPrepare,
+			func(t *testing.T, sys *testSystem) istanbul.PreparedCertificate {
 				preparedCert := sys.getPreparedCertificate(t, []istanbul.View{*sys.backends[0].engine.(*core).current.View()}, makeBlock(1))
 				preparedCert.PrepareOrCommitMessages[0] = preparedCert.PrepareOrCommitMessages[1]
 				return preparedCert
@@ -256,83 +266,79 @@ func TestHandleRoundChange(t *testing.T) {
 			errInvalidPreparedCertificateDuplicate,
 		},
 		{
-			// valid message for future round
-			func() *testSystem {
-				sys := NewTestSystemWithBackend(N, F)
-				sys.backends[0].engine.(*core).current.(*roundStateImpl).round = big.NewInt(10)
-				return sys
-			}(),
-			func(_ *testSystem) istanbul.PreparedCertificate {
+			"valid message for future round",
+			func(sys *testSystem) {
+				sys.backends[0].engine.(*core).current.(*roundStatePersistence).delegate.(*roundStateImpl).round = big.NewInt(10)
+			},
+			func(t *testing.T, _ *testSystem) istanbul.PreparedCertificate {
 				return istanbul.EmptyPreparedCertificate()
 			},
 			nil,
 		},
 		{
-			// invalid message for future sequence
-			func() *testSystem {
-				sys := NewTestSystemWithBackend(N, F)
-				sys.backends[0].engine.(*core).current.(*roundStateImpl).sequence = big.NewInt(10)
-
-				return sys
-			}(),
-			func(_ *testSystem) istanbul.PreparedCertificate {
-				return istanbul.EmptyPreparedCertificate()
+			"invalid message for future sequence",
+			func(sys *testSystem) {
+				sys.backends[0].engine.(*core).current.(*roundStatePersistence).delegate.(*roundStateImpl).sequence = big.NewInt(10)
 			},
+			buildEmptyCertificate,
 			errFutureMessage,
 		},
 		{
-			// invalid message for previous round
-			func() *testSystem {
-				sys := NewTestSystemWithBackend(N, F)
-				sys.backends[0].engine.(*core).current.(*roundStateImpl).round = big.NewInt(0)
-				return sys
-			}(),
-			func(_ *testSystem) istanbul.PreparedCertificate {
-				return istanbul.EmptyPreparedCertificate()
+			"invalid message for previous round",
+			func(sys *testSystem) {
+				sys.backends[0].engine.(*core).current.(*roundStatePersistence).delegate.(*roundStateImpl).round = big.NewInt(0)
 			},
+			buildEmptyCertificate,
 			nil,
 		},
 	}
 
-OUTER:
 	for _, test := range testCases {
-		test.system.Run(false)
+		t.Run(test.name, func(t *testing.T) {
+			sys := NewTestSystemWithBackend(N, F)
 
-		v0 := test.system.backends[0]
-		r0 := v0.engine.(*core)
+			sys.Run(false)
+			for _, v := range sys.backends {
+				v.engine.(*core).Start()
+			}
+			test.prepareSystem(sys)
 
-		curView := r0.current.View()
-		nextView := &istanbul.View{
-			Round:    new(big.Int).Add(curView.Round, common.Big1),
-			Sequence: curView.Sequence,
-		}
+			v0 := sys.backends[0]
+			r0 := v0.engine.(*core)
 
-		roundChange := &istanbul.RoundChange{
-			View:                nextView,
-			PreparedCertificate: test.getCert(test.system),
-		}
-
-		for i, v := range test.system.backends {
-			// i == 0 is primary backend, it is responsible for send ROUND CHANGE messages to others.
-			if i == 0 {
-				continue
+			curView := r0.current.View()
+			nextView := &istanbul.View{
+				Round:    new(big.Int).Add(curView.Round, common.Big1),
+				Sequence: curView.Sequence,
 			}
 
-			c := v.engine.(*core)
-
-			m, _ := Encode(roundChange)
-
-			// run each backends and verify handlePreprepare function.
-			err := c.handleRoundChange(&istanbul.Message{
-				Code:    istanbul.MsgRoundChange,
-				Msg:     m,
-				Address: v0.Address(),
-			})
-			if err != test.expectedErr {
-				t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
+			roundChange := &istanbul.RoundChange{
+				View:                nextView,
+				PreparedCertificate: test.getCert(t, sys),
 			}
-			continue OUTER
-		}
+
+			for i, v := range sys.backends {
+				// i == 0 is primary backend, it is responsible for send ROUND CHANGE messages to others.
+				if i == 0 {
+					continue
+				}
+
+				c := v.engine.(*core)
+
+				m, _ := Encode(roundChange)
+
+				// run each backends and verify handlePreprepare function.
+				err := c.handleRoundChange(&istanbul.Message{
+					Code:    istanbul.MsgRoundChange,
+					Msg:     m,
+					Address: v0.Address(),
+				})
+				if err != test.expectedErr {
+					t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
+				}
+				return
+			}
+		})
 	}
 }
 
@@ -402,8 +408,7 @@ var noGossip = map[int]bool{
 // In the new implementation, the PRE-PREPARE will include a ROUND CHANGE certificate,
 // and all nodes will accept the newly proposed block.
 func TestCommitsBlocksAfterRoundChange(t *testing.T) {
-	// Initialize the system with a nil round state so that we properly start round 0.
-	sys := NewTestSystemWithBackendAndCurrentRoundState(4, 1, func(vset istanbul.ValidatorSet) RoundState { return nil })
+	sys := NewTestSystemWithBackend(4, 1)
 
 	for i, b := range sys.backends {
 		b.engine.Start() // start Istanbul core
@@ -470,8 +475,7 @@ func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 // This tests that when F+1 nodes receive 2F+1 PREPARE messages for a particular proposal, the
 // system enforces that as the only valid proposal for this sequence.
 func TestPreparedCertificatePersistsThroughRoundChanges(t *testing.T) {
-	// Initialize the system with a nil round state so that we properly start round 0.
-	sys := NewTestSystemWithBackendAndCurrentRoundState(4, 1, func(vset istanbul.ValidatorSet) RoundState { return nil })
+	sys := NewTestSystemWithBackend(4, 1)
 
 	for i, b := range sys.backends {
 		b.engine.Start() // start Istanbul core

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -42,7 +42,7 @@ type RoundState interface {
 	StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet) error
 	TransitionToPreprepared(preprepare *istanbul.Preprepare) error
 	TransitionToWaitingForNewRound(r *big.Int, nextProposer istanbul.Validator) error
-	TransitionToCommited() error
+	TransitionToCommitted() error
 	TransitionToPrepared(quorumSize int) error
 	AddCommit(msg *istanbul.Message) error
 	AddPrepare(msg *istanbul.Message) error
@@ -267,7 +267,7 @@ func (s *roundStateImpl) StartNewSequence(nextSequence *big.Int, validatorSet is
 	return nil
 }
 
-func (s *roundStateImpl) TransitionToCommited() error {
+func (s *roundStateImpl) TransitionToCommitted() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -17,10 +17,13 @@
 package core
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"math/big"
 	"sync"
+
+	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
@@ -40,10 +43,10 @@ func newRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, prop
 		sequence:     view.Sequence,
 
 		// data for current round
-		preprepare: nil,
-		prepares:   newMessageSet(validatorSet),
-		commits:    newMessageSet(validatorSet),
-		proposer:   proposer,
+		// preprepare: nil,
+		prepares: newMessageSet(validatorSet),
+		commits:  newMessageSet(validatorSet),
+		proposer: proposer,
 
 		// data saves across rounds, same sequence
 		validatorSet:        validatorSet,
@@ -56,13 +59,21 @@ func newRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, prop
 }
 
 type RoundState interface {
-	State() State
-	StartNewRound(nextRound *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator)
-	StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet)
-	TransitionToPreprepared(preprepare *istanbul.Preprepare)
-	TransitionToWaitingForNewRound(r *big.Int, nextProposer istanbul.Validator)
-	TransitionToCommited()
+	// mutation functions
+	StartNewRound(nextRound *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator) error
+	StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet) error
+	TransitionToPreprepared(preprepare *istanbul.Preprepare) error
+	TransitionToWaitingForNewRound(r *big.Int, nextProposer istanbul.Validator) error
+	TransitionToCommited() error
 	TransitionToPrepared(quorumSize int) error
+	AddCommit(msg *istanbul.Message) error
+	AddPrepare(msg *istanbul.Message) error
+	AddParentCommit(msg *istanbul.Message) error
+	SetPendingRequest(pendingRequest *istanbul.Request) error
+
+	// view functions
+	DesiredRound() *big.Int
+	State() State
 	GetPrepareOrCommitSize() int
 	GetValidatorByAddress(address common.Address) istanbul.Validator
 	ValidatorSet() istanbul.ValidatorSet
@@ -72,14 +83,9 @@ type RoundState interface {
 	Preprepare() *istanbul.Preprepare
 	Proposal() istanbul.Proposal
 	Round() *big.Int
-	DesiredRound() *big.Int
-	AddCommit(msg *istanbul.Message) error
-	AddPrepare(msg *istanbul.Message) error
-	AddParentCommit(msg *istanbul.Message) error
 	Commits() MessageSet
 	Prepares() MessageSet
 	ParentCommits() MessageSet
-	SetPendingRequest(pendingRequest *istanbul.Request)
 	PendingRequest() *istanbul.Request
 	Sequence() *big.Int
 	View() *istanbul.View
@@ -234,14 +240,15 @@ func (s *roundStateImpl) changeRound(nextRound *big.Int, validatorSet istanbul.V
 	s.preprepare = nil
 }
 
-func (s *roundStateImpl) StartNewRound(nextRound *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator) {
+func (s *roundStateImpl) StartNewRound(nextRound *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.changeRound(nextRound, validatorSet, nextProposer)
+	return nil
 }
 
-func (s *roundStateImpl) StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet) {
+func (s *roundStateImpl) StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -253,30 +260,34 @@ func (s *roundStateImpl) StartNewSequence(nextSequence *big.Int, validatorSet is
 	s.preparedCertificate = istanbul.EmptyPreparedCertificate()
 	s.pendingRequest = nil
 	s.parentCommits = parentCommits
+	return nil
 }
 
-func (s *roundStateImpl) TransitionToCommited() {
+func (s *roundStateImpl) TransitionToCommited() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.state = StateCommitted
+	return nil
 }
 
-func (s *roundStateImpl) TransitionToPreprepared(preprepare *istanbul.Preprepare) {
+func (s *roundStateImpl) TransitionToPreprepared(preprepare *istanbul.Preprepare) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.preprepare = preprepare
 	s.state = StatePreprepared
+	return nil
 }
 
-func (s *roundStateImpl) TransitionToWaitingForNewRound(r *big.Int, nextProposer istanbul.Validator) {
+func (s *roundStateImpl) TransitionToWaitingForNewRound(r *big.Int, nextProposer istanbul.Validator) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.desiredRound = new(big.Int).Set(r)
 	s.proposer = nextProposer
 	s.state = StateWaitingForNewRound
+	return nil
 }
 
 // TransitionToPrepared will create a PreparedCertificate and change state to Prepared
@@ -339,11 +350,12 @@ func (s *roundStateImpl) DesiredRound() *big.Int {
 	return s.desiredRound
 }
 
-func (s *roundStateImpl) SetPendingRequest(pendingRequest *istanbul.Request) {
+func (s *roundStateImpl) SetPendingRequest(pendingRequest *istanbul.Request) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.pendingRequest = pendingRequest
+	return nil
 }
 
 func (s *roundStateImpl) PendingRequest() *istanbul.Request {
@@ -365,31 +377,21 @@ func (s *roundStateImpl) PreparedCertificate() istanbul.PreparedCertificate {
 	return s.preparedCertificate
 }
 
-// The DecodeRLP method should read one value from the given
-// Stream. It is not forbidden to read less or more, but it might
-// be confusing.
-func (s *roundStateImpl) DecodeRLP(stream *rlp.Stream) error {
-	var ss struct {
-		Round          *big.Int
-		Sequence       *big.Int
-		Preprepare     *istanbul.Preprepare
-		Prepares       MessageSet
-		Commits        MessageSet
-		pendingRequest *istanbul.Request
-	}
+type roundStateRLP struct {
+	State               State
+	Round               *big.Int
+	DesiredRound        *big.Int
+	Sequence            *big.Int
+	PreparedCertificate *istanbul.PreparedCertificate
 
-	if err := stream.Decode(&ss); err != nil {
-		return err
-	}
-	s.round = ss.Round
-	s.sequence = ss.Sequence
-	s.preprepare = ss.Preprepare
-	s.prepares = ss.Prepares
-	s.commits = ss.Commits
-	s.pendingRequest = ss.pendingRequest
-	s.mu = new(sync.RWMutex)
-
-	return nil
+	// custom serialized fields
+	SerializedValSet         []byte
+	SerializedProposer       []byte
+	SerializedParentCommits  []byte
+	SerializedPrepares       []byte
+	SerializedCommits        []byte
+	SerializedPreprepare     []byte
+	SerializedPendingRequest []byte
 }
 
 // EncodeRLP should write the RLP encoding of its receiver to w.
@@ -404,12 +406,123 @@ func (s *roundStateImpl) EncodeRLP(w io.Writer) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return rlp.Encode(w, []interface{}{
-		s.round,
-		s.sequence,
-		s.preprepare,
-		s.prepares,
-		s.commits,
-		s.pendingRequest,
-	})
+	serializedValSet, err := s.validatorSet.Serialize()
+	if err != nil {
+		return err
+	}
+	serializedProposer, err := s.proposer.Serialize()
+	if err != nil {
+		return err
+	}
+
+	serializedParentCommits, err := s.parentCommits.Serialize()
+	if err != nil {
+		return err
+	}
+	serializedPrepares, err := s.prepares.Serialize()
+	if err != nil {
+		return err
+	}
+	serializedCommits, err := s.commits.Serialize()
+	if err != nil {
+		return err
+	}
+
+	// handle nullable field. Serialized them to rlp.EmptyList or the rlp version of them
+	var serializedPendingRequest []byte
+	if s.pendingRequest == nil {
+		serializedPendingRequest = rlp.EmptyList
+	} else {
+		serializedPendingRequest, err = rlp.EncodeToBytes(s.pendingRequest)
+		if err != nil {
+			return err
+		}
+	}
+
+	var serializedPreprepare []byte
+	if s.preprepare == nil {
+		serializedPreprepare = rlp.EmptyList
+	} else {
+		serializedPreprepare, err = rlp.EncodeToBytes(s.preprepare)
+		if err != nil {
+			return err
+		}
+	}
+
+	entry := roundStateRLP{
+		State:               s.state,
+		Round:               s.round,
+		DesiredRound:        s.desiredRound,
+		Sequence:            s.sequence,
+		PreparedCertificate: &s.preparedCertificate,
+
+		SerializedValSet:         serializedValSet,
+		SerializedProposer:       serializedProposer,
+		SerializedParentCommits:  serializedParentCommits,
+		SerializedPrepares:       serializedPrepares,
+		SerializedCommits:        serializedCommits,
+		SerializedPendingRequest: serializedPendingRequest,
+		SerializedPreprepare:     serializedPreprepare,
+	}
+	return rlp.Encode(w, entry)
+}
+
+// The DecodeRLP method should read one value from the given
+// Stream. It is not forbidden to read less or more, but it might
+// be confusing.
+func (s *roundStateImpl) DecodeRLP(stream *rlp.Stream) error {
+	var data roundStateRLP
+	err := stream.Decode(&data)
+	if err != nil {
+		return err
+	}
+
+	s.mu = new(sync.RWMutex)
+	s.state = data.State
+	s.round = data.Round
+	s.desiredRound = data.DesiredRound
+	s.sequence = data.Sequence
+	s.preparedCertificate = *data.PreparedCertificate
+
+	s.prepares, err = deserializeMessageSet(data.SerializedPrepares)
+	if err != nil {
+		return err
+	}
+	s.parentCommits, err = deserializeMessageSet(data.SerializedParentCommits)
+	if err != nil {
+		return err
+	}
+	s.commits, err = deserializeMessageSet(data.SerializedCommits)
+	if err != nil {
+		return err
+	}
+	s.validatorSet, err = validator.DeserializeValidatorSet(data.SerializedValSet)
+	if err != nil {
+		return err
+	}
+	s.proposer, err = validator.DeserializeValidator(data.SerializedProposer)
+	if err != nil {
+		return err
+	}
+
+	if !bytes.Equal(data.SerializedPendingRequest, rlp.EmptyList) {
+		var value istanbul.Request
+		err := rlp.DecodeBytes(data.SerializedPendingRequest, &value)
+		if err != nil {
+			return err
+		}
+		s.pendingRequest = &value
+
+	}
+
+	if !bytes.Equal(data.SerializedPreprepare, rlp.EmptyList) {
+		var value istanbul.Preprepare
+		err := rlp.DecodeBytes(data.SerializedPreprepare, &value)
+		if err != nil {
+			return err
+		}
+		s.preprepare = &value
+	}
+
+	return nil
 }

--- a/consensus/istanbul/core/roundstate_persist.go
+++ b/consensus/istanbul/core/roundstate_persist.go
@@ -1,0 +1,334 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/big"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/syndtr/goleveldb/leveldb"
+	lvlerrors "github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+)
+
+const (
+	dbVersion    = 1
+	dbVersionKey = "version"  // Version of the database to flush if changes
+	lastViewKey  = "lastView" // Last View that we know of
+)
+
+func newRoundStateWithPersistence(sequence *big.Int, validatorSet istanbul.ValidatorSet, proposer istanbul.Validator, path string) (RoundState, error) {
+	// create DB
+	var db *leveldb.DB
+	var err error
+	if path == "" {
+		db, err = newMemoryDB()
+	} else {
+		db, err = newPersistentDB(path)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	view := &istanbul.View{
+		Sequence: sequence,
+		Round:    common.Big0,
+	}
+
+	lastStoredView, err := getLastStoredView(db)
+
+	if err != nil && err != leveldb.ErrNotFound {
+		db.Close()
+		return nil, err
+	}
+
+	if err == leveldb.ErrNotFound || lastStoredView.Cmp(view) < 0 {
+		return &roundStatePersistence{
+			db:       db,
+			delegate: newRoundState(view, validatorSet, proposer),
+		}, nil
+	}
+
+	lastStoredRoundState, err := getStoredRoundState(db, lastStoredView)
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	return &roundStatePersistence{
+		db:       db,
+		delegate: lastStoredRoundState,
+	}, nil
+}
+
+// newMemoryDB creates a new in-memory node database without a persistent backend.
+func newMemoryDB() (*leveldb.DB, error) {
+	db, err := leveldb.Open(storage.NewMemStorage(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// newPersistentNodeDB creates/opens a leveldb backed persistent node database,
+// also flushing its contents in case of a version mismatch.
+func newPersistentDB(path string) (*leveldb.DB, error) {
+	opts := &opt.Options{OpenFilesCacheCapacity: 5}
+	db, err := leveldb.OpenFile(path, opts)
+	if _, iscorrupted := err.(*lvlerrors.ErrCorrupted); iscorrupted {
+		db, err = leveldb.RecoverFile(path, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+	// The nodes contained in the cache correspond to a certain protocol version.
+	// Flush all nodes if the version doesn't match.
+	currentVer := make([]byte, binary.MaxVarintLen64)
+	currentVer = currentVer[:binary.PutVarint(currentVer, int64(dbVersion))]
+
+	blob, err := db.Get([]byte(dbVersionKey), nil)
+	switch err {
+	case leveldb.ErrNotFound:
+		// Version not found (i.e. empty cache), insert it
+		if err := db.Put([]byte(dbVersionKey), currentVer, nil); err != nil {
+			db.Close()
+			return nil, err
+		}
+
+	case nil:
+		// Version present, flush if different
+		if !bytes.Equal(blob, currentVer) {
+			db.Close()
+			if err = os.RemoveAll(path); err != nil {
+				return nil, err
+			}
+			return newPersistentDB(path)
+		}
+	}
+	return db, nil
+}
+
+type roundStatePersistence struct {
+	delegate RoundState
+	db       *leveldb.DB //the actual DB
+}
+
+// mutation functions
+func (rsp *roundStatePersistence) StartNewRound(nextRound *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator) error {
+	err := rsp.delegate.StartNewRound(nextRound, validatorSet, nextProposer)
+	if err != nil {
+		return err
+	}
+
+	return rsp.storeRoundState()
+}
+func (rsp *roundStatePersistence) StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet) error {
+	err := rsp.delegate.StartNewSequence(nextSequence, validatorSet, nextProposer, parentCommits)
+	if err != nil {
+		return err
+	}
+
+	return rsp.storeRoundState()
+}
+func (rsp *roundStatePersistence) TransitionToPreprepared(preprepare *istanbul.Preprepare) error {
+	err := rsp.delegate.TransitionToPreprepared(preprepare)
+	if err != nil {
+		return err
+	}
+
+	return rsp.storeRoundState()
+}
+func (rsp *roundStatePersistence) TransitionToWaitingForNewRound(r *big.Int, nextProposer istanbul.Validator) error {
+	err := rsp.delegate.TransitionToWaitingForNewRound(r, nextProposer)
+	if err != nil {
+		return err
+	}
+
+	return rsp.storeRoundState()
+}
+func (rsp *roundStatePersistence) TransitionToCommited() error {
+	err := rsp.delegate.TransitionToCommited()
+	if err != nil {
+		return err
+	}
+
+	return rsp.storeRoundState()
+}
+func (rsp *roundStatePersistence) TransitionToPrepared(quorumSize int) error {
+	err := rsp.delegate.TransitionToPrepared(quorumSize)
+	if err != nil {
+		return err
+	}
+
+	return rsp.storeRoundState()
+}
+func (rsp *roundStatePersistence) AddCommit(msg *istanbul.Message) error {
+	err := rsp.delegate.AddCommit(msg)
+	if err != nil {
+		return err
+	}
+
+	return rsp.storeRoundState()
+}
+func (rsp *roundStatePersistence) AddPrepare(msg *istanbul.Message) error {
+	err := rsp.delegate.AddPrepare(msg)
+	if err != nil {
+		return err
+	}
+
+	return rsp.storeRoundState()
+}
+func (rsp *roundStatePersistence) AddParentCommit(msg *istanbul.Message) error {
+	err := rsp.delegate.AddParentCommit(msg)
+	if err != nil {
+		return err
+	}
+
+	return rsp.storeRoundState()
+}
+func (rsp *roundStatePersistence) SetPendingRequest(pendingRequest *istanbul.Request) error {
+	err := rsp.delegate.SetPendingRequest(pendingRequest)
+	if err != nil {
+		return err
+	}
+
+	return rsp.storeRoundState()
+}
+
+// DesiredRound implements RoundState.DesiredRound
+func (rsp *roundStatePersistence) DesiredRound() *big.Int { return rsp.delegate.DesiredRound() }
+
+// State implements RoundState.State
+func (rsp *roundStatePersistence) State() State { return rsp.delegate.State() }
+
+// Proposer implements RoundState.Proposer
+func (rsp *roundStatePersistence) Proposer() istanbul.Validator { return rsp.delegate.Proposer() }
+
+// Subject implements RoundState.Subject
+func (rsp *roundStatePersistence) Subject() *istanbul.Subject { return rsp.delegate.Subject() }
+
+// Proposal implements RoundState.Proposal
+func (rsp *roundStatePersistence) Proposal() istanbul.Proposal { return rsp.delegate.Proposal() }
+
+// Round implements RoundState.Round
+func (rsp *roundStatePersistence) Round() *big.Int { return rsp.delegate.Round() }
+
+// Commits implements RoundState.Commits
+func (rsp *roundStatePersistence) Commits() MessageSet { return rsp.delegate.Commits() }
+
+// Prepares implements RoundState.Prepares
+func (rsp *roundStatePersistence) Prepares() MessageSet { return rsp.delegate.Prepares() }
+
+// ParentCommits implements RoundState.ParentCommits
+func (rsp *roundStatePersistence) ParentCommits() MessageSet { return rsp.delegate.ParentCommits() }
+
+// Sequence implements RoundState.Sequence
+func (rsp *roundStatePersistence) Sequence() *big.Int { return rsp.delegate.Sequence() }
+
+// View implements RoundState.View
+func (rsp *roundStatePersistence) View() *istanbul.View { return rsp.delegate.View() }
+
+// GetPrepareOrCommitSize implements RoundState.GetPrepareOrCommitSize
+func (rsp *roundStatePersistence) GetPrepareOrCommitSize() int {
+	return rsp.delegate.GetPrepareOrCommitSize()
+}
+
+// GetValidatorByAddress implements RoundState.GetValidatorByAddress
+func (rsp *roundStatePersistence) GetValidatorByAddress(address common.Address) istanbul.Validator {
+	return rsp.delegate.GetValidatorByAddress(address)
+}
+
+// ValidatorSet implements RoundState.ValidatorSet
+func (rsp *roundStatePersistence) ValidatorSet() istanbul.ValidatorSet {
+	return rsp.delegate.ValidatorSet()
+}
+
+// IsProposer implements RoundState.IsProposer
+func (rsp *roundStatePersistence) IsProposer(address common.Address) bool {
+	return rsp.delegate.IsProposer(address)
+}
+
+// Preprepare implements RoundState.Preprepare
+func (rsp *roundStatePersistence) Preprepare() *istanbul.Preprepare {
+	return rsp.delegate.Preprepare()
+}
+
+// PendingRequest implements RoundState.PendingRequest
+func (rsp *roundStatePersistence) PendingRequest() *istanbul.Request {
+	return rsp.delegate.PendingRequest()
+}
+
+// PreparedCertificate implements RoundState.PreparedCertificate
+func (rsp *roundStatePersistence) PreparedCertificate() istanbul.PreparedCertificate {
+	return rsp.delegate.PreparedCertificate()
+}
+
+func (rsp *roundStatePersistence) storeRoundState() error {
+	viewKey, err := rlp.EncodeToBytes(rsp.delegate.View())
+	if err != nil {
+		return err
+	}
+
+	entryBytes, err := rlp.EncodeToBytes(rsp)
+	if err != nil {
+		return err
+	}
+
+	batch := new(leveldb.Batch)
+	batch.Put([]byte(lastViewKey), viewKey)
+	batch.Put(viewKey, entryBytes)
+
+	return rsp.db.Write(batch, nil)
+}
+
+func getLastStoredView(db *leveldb.DB) (*istanbul.View, error) {
+	rawEntry, err := db.Get([]byte(lastViewKey), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var entry istanbul.View
+	if err = rlp.DecodeBytes(rawEntry, &entry); err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}
+
+func getStoredRoundState(db *leveldb.DB, view *istanbul.View) (RoundState, error) {
+	viewKey, err := rlp.EncodeToBytes(view)
+	if err != nil {
+		return nil, err
+	}
+
+	rawEntry, err := db.Get(viewKey, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var entry roundStateImpl
+	if err = rlp.DecodeBytes(rawEntry, &entry); err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}

--- a/consensus/istanbul/core/roundstate_persist.go
+++ b/consensus/istanbul/core/roundstate_persist.go
@@ -302,21 +302,22 @@ func (rsp *roundStatePersistence) PreparedCertificate() istanbul.PreparedCertifi
 }
 
 func (rsp *roundStatePersistence) storeRoundState() error {
-	viewKey, err := rlp.EncodeToBytes(rsp.delegate.View())
-	if err != nil {
-		return err
-	}
+	return nil
+	// viewKey, err := rlp.EncodeToBytes(rsp.delegate.View())
+	// if err != nil {
+	// 	return err
+	// }
 
-	entryBytes, err := rlp.EncodeToBytes(rsp)
-	if err != nil {
-		return err
-	}
+	// entryBytes, err := rlp.EncodeToBytes(rsp)
+	// if err != nil {
+	// 	return err
+	// }
 
-	batch := new(leveldb.Batch)
-	batch.Put([]byte(lastViewKey), viewKey)
-	batch.Put(viewKey, entryBytes)
+	// batch := new(leveldb.Batch)
+	// batch.Put([]byte(lastViewKey), viewKey)
+	// batch.Put(viewKey, entryBytes)
 
-	return rsp.db.Write(batch, nil)
+	// return rsp.db.Write(batch, nil)
 }
 
 func getLastStoredView(db *leveldb.DB) (*istanbul.View, error) {

--- a/consensus/istanbul/core/roundstate_persist.go
+++ b/consensus/istanbul/core/roundstate_persist.go
@@ -302,22 +302,21 @@ func (rsp *roundStatePersistence) PreparedCertificate() istanbul.PreparedCertifi
 }
 
 func (rsp *roundStatePersistence) storeRoundState() error {
-	return nil
-	// viewKey, err := rlp.EncodeToBytes(rsp.delegate.View())
-	// if err != nil {
-	// 	return err
-	// }
+	viewKey, err := rlp.EncodeToBytes(rsp.delegate.View())
+	if err != nil {
+		return err
+	}
 
-	// entryBytes, err := rlp.EncodeToBytes(rsp)
-	// if err != nil {
-	// 	return err
-	// }
+	entryBytes, err := rlp.EncodeToBytes(rsp)
+	if err != nil {
+		return err
+	}
 
-	// batch := new(leveldb.Batch)
-	// batch.Put([]byte(lastViewKey), viewKey)
-	// batch.Put(viewKey, entryBytes)
+	batch := new(leveldb.Batch)
+	batch.Put([]byte(lastViewKey), viewKey)
+	batch.Put(viewKey, entryBytes)
 
-	// return rsp.db.Write(batch, nil)
+	return rsp.db.Write(batch, nil)
 }
 
 func getLastStoredView(db *leveldb.DB) (*istanbul.View, error) {

--- a/consensus/istanbul/core/roundstate_test.go
+++ b/consensus/istanbul/core/roundstate_test.go
@@ -1,0 +1,149 @@
+package core
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
+	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+func TestRoundStateRLPEncoding(t *testing.T) {
+	dummyRoundState := func() RoundState {
+		valSet := validator.NewSet([]istanbul.ValidatorData{
+			{Address: common.BytesToAddress([]byte(string(2))), BLSPublicKey: []byte{1, 2, 3}},
+			{Address: common.BytesToAddress([]byte(string(4))), BLSPublicKey: []byte{3, 1, 4}},
+		})
+		view := &istanbul.View{Round: big.NewInt(1), Sequence: big.NewInt(2)}
+		return newRoundState(view, valSet, valSet.GetByIndex(0))
+	}
+
+	t.Run("With nil fields", func(t *testing.T) {
+		rs := dummyRoundState()
+
+		rawVal, err := rlp.EncodeToBytes(rs)
+		if err != nil {
+			t.Errorf("Error %v", err)
+		}
+
+		var result *roundStateImpl
+		if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+			t.Errorf("Error %v", err)
+		}
+
+		assertEqualRoundState(t, rs, result)
+	})
+
+	t.Run("With a Pending Request", func(t *testing.T) {
+		rs := dummyRoundState()
+		rs.SetPendingRequest(&istanbul.Request{
+			Proposal: makeBlock(1),
+		})
+
+		rawVal, err := rlp.EncodeToBytes(rs)
+		if err != nil {
+			t.Errorf("Error %v", err)
+		}
+
+		var result *roundStateImpl
+		if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+			t.Errorf("Error %v", err)
+		}
+
+		assertEqualRoundState(t, rs, result)
+	})
+
+	t.Run("With a Preprepare", func(t *testing.T) {
+		rs := dummyRoundState()
+
+		rs.TransitionToPreprepared(&istanbul.Preprepare{
+			Proposal:               makeBlock(1),
+			View:                   rs.View(),
+			RoundChangeCertificate: istanbul.RoundChangeCertificate{},
+		})
+
+		rawVal, err := rlp.EncodeToBytes(rs)
+		if err != nil {
+			t.Errorf("Error %v", err)
+		}
+
+		var result *roundStateImpl
+		if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+			t.Errorf("Error %v", err)
+		}
+
+		assertEqualRoundState(t, rs, result)
+	})
+
+}
+
+func assertEqualRoundState(t *testing.T, have, want RoundState) {
+	testEqual := func(name string, have, want interface{}) {
+		if !reflect.DeepEqual(have, want) {
+			t.Errorf("RoundState.%s mismatch: have %v, want %v", name, have, want)
+		}
+	}
+
+	testEqual("State", have.State(), want.State())
+	testEqual("Round", have.Round(), want.Round())
+	testEqual("DesiredRound", have.DesiredRound(), want.DesiredRound())
+	testEqual("Sequence", have.Sequence(), want.Sequence())
+	testEqual("ValidatorSet", have.ValidatorSet(), want.ValidatorSet())
+	testEqual("Proposer", have.Proposer(), want.Proposer())
+	testEqual("ParentCommits", have.ParentCommits(), want.ParentCommits())
+	testEqual("Commits", have.Commits(), want.Commits())
+	testEqual("Prepares", have.Prepares(), want.Prepares())
+
+	if have.PendingRequest() == nil || want.PendingRequest() == nil {
+		testEqual("PendingRequest", have.PendingRequest(), want.PendingRequest())
+	} else {
+		haveBlock := have.PendingRequest().Proposal
+		wantBlock := want.PendingRequest().Proposal
+		testEqual("PendingRequest.Proposal.Hash", haveBlock.Hash(), wantBlock.Hash())
+	}
+
+	if have.Preprepare() == nil || want.Preprepare() == nil {
+		testEqual("Preprepare", have.Preprepare(), want.Preprepare())
+	} else {
+		testEqual("Preprepare.Proposal.Hash", have.Preprepare().Proposal.Hash(), want.Preprepare().Proposal.Hash())
+		testEqual("Preprepare.View", have.Preprepare().View, want.Preprepare().View)
+		testEqual("Preprepare.RoundChangeCertificate.IsEmpty", have.Preprepare().RoundChangeCertificate.IsEmpty(), want.Preprepare().RoundChangeCertificate.IsEmpty())
+
+		if !have.Preprepare().RoundChangeCertificate.IsEmpty() && !want.Preprepare().RoundChangeCertificate.IsEmpty() {
+			testEqual("Preprepare.RoundChangeCertificate.RoundChangeMessages", have.Preprepare().RoundChangeCertificate.RoundChangeMessages, want.Preprepare().RoundChangeCertificate.RoundChangeMessages)
+		}
+
+	}
+
+	havePPBlock := have.PreparedCertificate().Proposal
+	wantPPBlock := want.PreparedCertificate().Proposal
+	testEqual("PreparedCertificate().Proposal.Hash", havePPBlock.Hash(), wantPPBlock.Hash())
+	testEqual("PreparedCertificate().PrepareOrCommitMessages", have.PreparedCertificate().PrepareOrCommitMessages, want.PreparedCertificate().PrepareOrCommitMessages)
+}
+
+// func TestBlockRLPEncoding(t *testing.T) {
+// 	block := makeBlock(1)
+
+// 	raw, err := rlp.EncodeToBytes(block)
+// 	if err != nil {
+// 		t.Errorf("Error %v", err)
+// 	}
+
+// 	var result *types.Block
+// 	if err = rlp.DecodeBytes(raw, &result); err != nil {
+// 		t.Errorf("Error %v", err)
+// 	}
+
+// 	if !reflect.DeepEqual(block.Hash(), result.Hash()) {
+// 		t.Errorf("Block.Hash() mismatch: have %v, want %v", block.Hash(), result.Hash())
+// 	} else {
+// 		t.Log("Block.Hash() matches")
+// 	}
+
+// 	if !reflect.DeepEqual(block, result) {
+// 		t.Errorf("Block mismatch: have %v, want %v", block, result)
+// 	}
+// }

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -351,6 +351,7 @@ func NewTestSystemWithBackendAndCurrentRoundState(n, f uint64, getRoundState fun
 	sys := newTestSystem(n, f, blsKeys)
 	config := *istanbul.DefaultConfig
 	config.ProposerPolicy = istanbul.RoundRobin
+	config.RoundStateDBPath = ""
 
 	for i := uint64(0); i < n; i++ {
 		vset := validator.NewSet(validators)

--- a/consensus/istanbul/core/types.go
+++ b/consensus/istanbul/core/types.go
@@ -31,8 +31,10 @@ type Engine interface {
 	ParentCommits() MessageSet
 }
 
+// State represents the IBFT state
 type State uint64
 
+// Different IBFT Core States
 const (
 	StateAcceptRequest State = iota
 	StatePreprepared

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -67,6 +67,25 @@ type Request struct {
 	Proposal Proposal
 }
 
+// EncodeRLP serializes b into the Ethereum RLP format.
+func (b *Request) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, []interface{}{b.Proposal})
+}
+
+// DecodeRLP implements rlp.Decoder, and load the consensus fields from a RLP stream.
+func (b *Request) DecodeRLP(s *rlp.Stream) error {
+	var request struct {
+		Proposal *types.Block
+	}
+
+	if err := s.Decode(&request); err != nil {
+		return err
+	}
+
+	b.Proposal = request.Proposal
+	return nil
+}
+
 // View includes a round number and a sequence number.
 // Sequence is the block number we'd like to commit.
 // Each round has a number and is composed by 3 steps: preprepare, prepare and commit.

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -67,6 +67,10 @@ type Validator interface {
 
 	// String representation of Validator
 	String() string
+
+	// Serialize returns binary reprenstation of the Validator
+	// can be use used to instantiate a validator with DeserializeValidator()
+	Serialize() ([]byte, error)
 }
 
 func GetAddressesFromValidatorList(validators []Validator) []common.Address {
@@ -124,6 +128,10 @@ type ValidatorSet interface {
 	RemoveValidators(removedValidators *big.Int) bool
 	// Copy validator set
 	Copy() ValidatorSet
+
+	// Serialize returns binary reprentation of the ValidatorSet
+	// can be use used to instantiate a validator with DeserializeValidatorSet()
+	Serialize() ([]byte, error)
 }
 
 // ----------------------------------------------------------------------------

--- a/consensus/istanbul/validator/validator.go
+++ b/consensus/istanbul/validator/validator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 func New(addr common.Address, blsPublicKey []byte) istanbul.Validator {
@@ -29,8 +30,28 @@ func New(addr common.Address, blsPublicKey []byte) istanbul.Validator {
 	}
 }
 
+func DeserializeValidator(binaryData []byte) (istanbul.Validator, error) {
+	var value defaultValidator
+
+	err := rlp.DecodeBytes(binaryData, &value)
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
 func NewSet(validators []istanbul.ValidatorData) istanbul.ValidatorSet {
 	return newDefaultSet(validators)
+}
+
+func DeserializeValidatorSet(binaryData []byte) (istanbul.ValidatorSet, error) {
+	var value defaultSet
+
+	err := rlp.DecodeBytes(binaryData, &value)
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
 }
 
 func ExtractValidators(extraData []byte) []istanbul.ValidatorData {


### PR DESCRIPTION
### Description

Creates a RoundStatePersistence object that will save state to levelDB on each change.

- Now all transition method returns errors on are handled by clients
- RLP encoding for some missing parts

**TODO** RLP encoding for MessageSet. Not sure how to do it for a `map`. @kevjue can you help?

### Tested

ci/test