### PR TITLE
Validators: Removes holed variant of validator set

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -222,7 +222,7 @@ func (sb *Backend) ParentBlockValidators(proposal istanbul.Proposal) istanbul.Va
 
 func (sb *Backend) GetValidators(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator {
 	validatorSet := sb.getValidators(blockNumber.Uint64(), headerHash)
-	return validatorSet.FilteredList()
+	return validatorSet.List()
 }
 
 // This function will return the peers with the addresses in the "destAddresses" parameter.

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -327,7 +327,7 @@ func (sb *Backend) verifyAggregatedSeal(headerHash common.Hash, validators istan
 	proposalSeal := istanbulCore.PrepareCommittedSeal(headerHash, aggregatedSeal.Round)
 	// Find which public keys signed from the provided validator set
 	publicKeys := [][]byte{}
-	for i := 0; i < validators.PaddedSize(); i++ {
+	for i := 0; i < validators.Size(); i++ {
 		if aggregatedSeal.Bitmap.Bit(i) == 1 {
 			pubKey := validators.GetByIndex(uint64(i)).BLSPublicKey()
 			publicKeys = append(publicKeys, pubKey)

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -153,7 +153,7 @@ func (s *Snapshot) apply(headers []*types.Header, db ethdb.Database) (*Snapshot,
 }
 
 func (s *Snapshot) validators() []istanbul.ValidatorData {
-	validators := make([]istanbul.ValidatorData, 0, s.ValSet.PaddedSize())
+	validators := make([]istanbul.ValidatorData, 0, s.ValSet.Size())
 	for _, validator := range s.ValSet.List() {
 		validators = append(validators, istanbul.ValidatorData{
 			validator.Address(),

--- a/consensus/istanbul/backend/snapshot_test.go
+++ b/consensus/istanbul/backend/snapshot_test.go
@@ -19,9 +19,9 @@ package backend
 import (
 	"bytes"
 	"crypto/ecdsa"
-  "sort"
 	"math/big"
 	"reflect"
+	"sort"
 	"testing"
 
 	bls "github.com/celo-org/bls-zexe/go"
@@ -403,8 +403,8 @@ func TestValSetChange(t *testing.T) {
 			continue
 		}
 
-    sort.Sort(istanbul.ValidatorsDataByAddress(result))
-    sort.Sort(istanbul.ValidatorsDataByAddress(validators))
+		sort.Sort(istanbul.ValidatorsDataByAddress(result))
+		sort.Sort(istanbul.ValidatorsDataByAddress(validators))
 		for j := 0; j < len(result); j++ {
 			if !bytes.Equal(result[j].Address[:], validators[j].Address[:]) {
 				t.Errorf("test %d, validator %d: validator mismatch: have %x, want %x", i, j, result[j], validators[j])

--- a/consensus/istanbul/backend/snapshot_test.go
+++ b/consensus/istanbul/backend/snapshot_test.go
@@ -19,6 +19,7 @@ package backend
 import (
 	"bytes"
 	"crypto/ecdsa"
+  "sort"
 	"math/big"
 	"reflect"
 	"testing"
@@ -187,7 +188,7 @@ func TestValSetChange(t *testing.T) {
 			epoch:       1,
 			validators:  []string{"A", "B"},
 			valsetdiffs: []testerValSetDiff{{proposer: "B", addedValidators: []string{}, removedValidators: []string{"A", "B"}}},
-			results:     []string{"", ""},
+			results:     []string{},
 			err:         nil,
 		}, {
 			// Three validator, add two validators and remove two validators
@@ -210,7 +211,7 @@ func TestValSetChange(t *testing.T) {
 			validators: []string{"A", "B", "C"},
 			valsetdiffs: []testerValSetDiff{{proposer: "A", addedValidators: []string{"D", "E"}, removedValidators: []string{"B", "C"}},
 				{proposer: "E", addedValidators: []string{"F"}, removedValidators: []string{"A", "D"}}},
-			results: []string{"F", "", "E"},
+			results: []string{"F", "E"},
 			err:     nil,
 		}, {
 			// Three validator, add two validators and remove two validators.  Second header will add 1 validators and remove 2 validators.  The first header will
@@ -219,7 +220,7 @@ func TestValSetChange(t *testing.T) {
 			validators: []string{"A", "B", "C"},
 			valsetdiffs: []testerValSetDiff{{proposer: "A", addedValidators: []string{"D", "E"}, removedValidators: []string{"B", "C"}},
 				{proposer: "A", addedValidators: []string{"F"}, removedValidators: []string{"A", "B"}}},
-			results: []string{"F", "", "C"},
+			results: []string{"F", "C"},
 			err:     nil,
 		},
 	}
@@ -402,6 +403,8 @@ func TestValSetChange(t *testing.T) {
 			continue
 		}
 
+    sort.Sort(istanbul.ValidatorsDataByAddress(result))
+    sort.Sort(istanbul.ValidatorsDataByAddress(validators))
 		for j := 0; j < len(result); j++ {
 			if !bytes.Equal(result[j].Address[:], validators[j].Address[:]) {
 				t.Errorf("test %d, validator %d: validator mismatch: have %x, want %x", i, j, result[j], validators[j])

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -141,7 +141,7 @@ func (c *core) broadcast(msg *istanbul.Message) {
 	}
 
 	// Broadcast payload
-	if err := c.backend.BroadcastConsensusMsg(istanbul.GetAddressesFromValidatorList(c.valSet.FilteredList()), payload); err != nil {
+	if err := c.backend.BroadcastConsensusMsg(istanbul.GetAddressesFromValidatorList(c.valSet.List()), payload); err != nil {
 		logger.Error("Failed to broadcast message", "msg", msg, "err", err)
 		return
 	}

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -17,9 +17,9 @@
 package istanbul
 
 import (
+	"bytes"
 	"errors"
 	"math/big"
-  "bytes"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -84,11 +84,13 @@ func GetAddressesFromValidatorList(validators []Validator) []common.Address {
 type Validators []Validator
 
 type ValidatorsDataByAddress []ValidatorData
-func (a ValidatorsDataByAddress) Len() int           { return len(a) }
-func (a ValidatorsDataByAddress) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+func (a ValidatorsDataByAddress) Len() int      { return len(a) }
+func (a ValidatorsDataByAddress) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a ValidatorsDataByAddress) Less(i, j int) bool {
-  return bytes.Compare(a[i].Address[:], a[j].Address[:]) < 0
+	return bytes.Compare(a[i].Address[:], a[j].Address[:]) < 0
 }
+
 // ----------------------------------------------------------------------------
 
 type ValidatorSet interface {

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -19,6 +19,7 @@ package istanbul
 import (
 	"errors"
 	"math/big"
+  "bytes"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -82,6 +83,12 @@ func GetAddressesFromValidatorList(validators []Validator) []common.Address {
 
 type Validators []Validator
 
+type ValidatorsDataByAddress []ValidatorData
+func (a ValidatorsDataByAddress) Len() int           { return len(a) }
+func (a ValidatorsDataByAddress) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ValidatorsDataByAddress) Less(i, j int) bool {
+  return bytes.Compare(a[i].Address[:], a[j].Address[:]) < 0
+}
 // ----------------------------------------------------------------------------
 
 type ValidatorSet interface {
@@ -97,7 +104,6 @@ type ValidatorSet interface {
 	SetRandomness(seed common.Hash)
 
 	// Return the validator size
-	PaddedSize() int
 	Size() int
 	// Get the maximum number of faulty nodes
 	F() int
@@ -106,10 +112,8 @@ type ValidatorSet interface {
 
 	// Return the validator array
 	List() []Validator
-	// Return the validator array without holes
-	FilteredList() []Validator
-	// Return the validator index in the filtered list
-	GetFilteredIndex(addr common.Address) int
+	// Return the validator index
+	GetIndex(addr common.Address) int
 	// Get validator by index
 	GetByIndex(i uint64) Validator
 	// Get validator by given address

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -17,216 +17,215 @@
 package validator
 
 import (
-  "fmt"
-  "math"
-  "math/big"
-  "reflect"
-  "sync"
+	"fmt"
+	"math"
+	"math/big"
+	"reflect"
+	"sync"
 
-  "github.com/ethereum/go-ethereum/common"
-  "github.com/ethereum/go-ethereum/consensus/istanbul"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
 type defaultValidator struct {
-  address      common.Address
-  blsPublicKey []byte
+	address      common.Address
+	blsPublicKey []byte
 }
 
 func (val *defaultValidator) Address() common.Address {
-  return val.address
+	return val.address
 }
 
 func (val *defaultValidator) BLSPublicKey() []byte {
-  return val.blsPublicKey
+	return val.blsPublicKey
 }
 
 func (val *defaultValidator) String() string {
-  return val.Address().String()
+	return val.Address().String()
 }
 
 // ----------------------------------------------------------------------------
 
 type defaultSet struct {
-  validators istanbul.Validators
-  policy     istanbul.ProposerPolicy
+	validators istanbul.Validators
+	policy     istanbul.ProposerPolicy
 
-  proposer    istanbul.Validator
-  validatorMu sync.RWMutex
-  selector    istanbul.ProposerSelector
-  randomness  common.Hash
+	proposer    istanbul.Validator
+	validatorMu sync.RWMutex
+	selector    istanbul.ProposerSelector
+	randomness  common.Hash
 }
 
 func newDefaultSet(validators []istanbul.ValidatorData, policy istanbul.ProposerPolicy) *defaultSet {
-  valSet := &defaultSet{}
+	valSet := &defaultSet{}
 
-  valSet.policy = policy
-  // init validators
-  valSet.validators = make([]istanbul.Validator, len(validators))
-  for i, validator := range validators {
-    valSet.validators[i] = New(validator.Address, validator.BLSPublicKey)
-  }
-  // init proposer
-  if valSet.Size() > 0 {
-    valSet.proposer = valSet.GetByIndex(0)
-  }
+	valSet.policy = policy
+	// init validators
+	valSet.validators = make([]istanbul.Validator, len(validators))
+	for i, validator := range validators {
+		valSet.validators[i] = New(validator.Address, validator.BLSPublicKey)
+	}
+	// init proposer
+	if valSet.Size() > 0 {
+		valSet.proposer = valSet.GetByIndex(0)
+	}
 
-  switch policy {
-  case istanbul.Sticky:
-    valSet.selector = StickyProposer
-  case istanbul.RoundRobin:
-    valSet.selector = RoundRobinProposer
-  case istanbul.ShuffledRoundRobin:
-    valSet.selector = ShuffledRoundRobinProposer
-  default:
-    // Programming error.
-    panic(fmt.Sprintf("unknown proposer selection policy: %v", policy))
-  }
+	switch policy {
+	case istanbul.Sticky:
+		valSet.selector = StickyProposer
+	case istanbul.RoundRobin:
+		valSet.selector = RoundRobinProposer
+	case istanbul.ShuffledRoundRobin:
+		valSet.selector = ShuffledRoundRobinProposer
+	default:
+		// Programming error.
+		panic(fmt.Sprintf("unknown proposer selection policy: %v", policy))
+	}
 
-  return valSet
+	return valSet
 }
 
 func (valSet *defaultSet) Size() int {
-  valSet.validatorMu.RLock()
-  defer valSet.validatorMu.RUnlock()
+	valSet.validatorMu.RLock()
+	defer valSet.validatorMu.RUnlock()
 
-  return len(valSet.validators)
+	return len(valSet.validators)
 }
 
 func (valSet *defaultSet) List() []istanbul.Validator {
-  valSet.validatorMu.RLock()
-  defer valSet.validatorMu.RUnlock()
-  return valSet.validators
+	valSet.validatorMu.RLock()
+	defer valSet.validatorMu.RUnlock()
+	return valSet.validators
 }
 
 func (valSet *defaultSet) GetByIndex(i uint64) istanbul.Validator {
-  valSet.validatorMu.RLock()
-  defer valSet.validatorMu.RUnlock()
-  if i < uint64(valSet.Size()) {
-    return valSet.validators[i]
-  }
-  return nil
+	valSet.validatorMu.RLock()
+	defer valSet.validatorMu.RUnlock()
+	if i < uint64(valSet.Size()) {
+		return valSet.validators[i]
+	}
+	return nil
 }
 
 func (valSet *defaultSet) GetByAddress(addr common.Address) (int, istanbul.Validator) {
-  for i, val := range valSet.List() {
-    if addr == val.Address() {
-      return i, val
-    }
-  }
-  return -1, nil
+	for i, val := range valSet.List() {
+		if addr == val.Address() {
+			return i, val
+		}
+	}
+	return -1, nil
 }
 
 func (valSet *defaultSet) ContainsByAddress(addr common.Address) bool {
-  for _, val := range valSet.List() {
-    if addr == val.Address() {
-      return true
-    }
-  }
-  return false
+	for _, val := range valSet.List() {
+		if addr == val.Address() {
+			return true
+		}
+	}
+	return false
 }
 
 func (valSet *defaultSet) GetIndex(addr common.Address) int {
-  for i, val := range valSet.List() {
-    if addr == val.Address() {
-      return i
-    }
-  }
-  return -1
+	for i, val := range valSet.List() {
+		if addr == val.Address() {
+			return i
+		}
+	}
+	return -1
 }
 
 func (valSet *defaultSet) GetProposer() istanbul.Validator {
-  return valSet.proposer
+	return valSet.proposer
 }
 
 func (valSet *defaultSet) IsProposer(address common.Address) bool {
-  _, val := valSet.GetByAddress(address)
-  return reflect.DeepEqual(valSet.GetProposer(), val)
+	_, val := valSet.GetByAddress(address)
+	return reflect.DeepEqual(valSet.GetProposer(), val)
 }
 
 func (valSet *defaultSet) CalcProposer(lastProposer common.Address, round uint64) {
-  valSet.validatorMu.RLock()
-  defer valSet.validatorMu.RUnlock()
-  valSet.proposer = valSet.selector(valSet, lastProposer, round, valSet.randomness)
+	valSet.validatorMu.RLock()
+	defer valSet.validatorMu.RUnlock()
+	valSet.proposer = valSet.selector(valSet, lastProposer, round, valSet.randomness)
 }
 
 func (valSet *defaultSet) AddValidators(validators []istanbul.ValidatorData) bool {
-  newValidators := make([]istanbul.Validator, 0, len(validators))
-  newAddressesMap := make(map[common.Address]bool)
-  for i := range validators {
-    address := validators[i].Address
-    blsPublicKey := validators[i].BLSPublicKey
+	newValidators := make([]istanbul.Validator, 0, len(validators))
+	newAddressesMap := make(map[common.Address]bool)
+	for i := range validators {
+		address := validators[i].Address
+		blsPublicKey := validators[i].BLSPublicKey
 
-    newAddressesMap[address] = true
-    newValidators = append(newValidators, New(address, blsPublicKey))
-  }
+		newAddressesMap[address] = true
+		newValidators = append(newValidators, New(address, blsPublicKey))
+	}
 
-  valSet.validatorMu.Lock()
-  defer valSet.validatorMu.Unlock()
+	valSet.validatorMu.Lock()
+	defer valSet.validatorMu.Unlock()
 
-  // Verify that the validators to add is not already in the valset
-  for _, v := range valSet.validators {
-    if _, ok := newAddressesMap[v.Address()]; ok {
-      return false
-    }
-  }
+	// Verify that the validators to add is not already in the valset
+	for _, v := range valSet.validators {
+		if _, ok := newAddressesMap[v.Address()]; ok {
+			return false
+		}
+	}
 
-  valSet.validators = append(valSet.validators, newValidators...)
+	valSet.validators = append(valSet.validators, newValidators...)
 
-  return true
+	return true
 }
 
 func (valSet *defaultSet) RemoveValidators(removedValidators *big.Int) bool {
-  if removedValidators.BitLen() == 0 {
-    return true
-  }
+	if removedValidators.BitLen() == 0 {
+		return true
+	}
 
-  if (removedValidators.BitLen() > len(valSet.validators)) {
-    return false
-  }
+	if removedValidators.BitLen() > len(valSet.validators) {
+		return false
+	}
 
-  valSet.validatorMu.Lock()
-  defer valSet.validatorMu.Unlock()
+	valSet.validatorMu.Lock()
+	defer valSet.validatorMu.Unlock()
 
-  // Using this method to filter the validators list: https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating, so that no
-  // new memory will be allocated
-  tempList := valSet.validators[:0]
-  defer func() {
-    valSet.validators = tempList
-  }()
+	// Using this method to filter the validators list: https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating, so that no
+	// new memory will be allocated
+	tempList := valSet.validators[:0]
+	defer func() {
+		valSet.validators = tempList
+	}()
 
-  for i, v := range valSet.validators {
-    if removedValidators.Bit(i) == 0 {
-      tempList = append(tempList, v)
-    }
-  }
+	for i, v := range valSet.validators {
+		if removedValidators.Bit(i) == 0 {
+			tempList = append(tempList, v)
+		}
+	}
 
-  return true
+	return true
 }
 
 func (valSet *defaultSet) Copy() istanbul.ValidatorSet {
-  valSet.validatorMu.RLock()
-  defer valSet.validatorMu.RUnlock()
+	valSet.validatorMu.RLock()
+	defer valSet.validatorMu.RUnlock()
 
-  validators := make([]istanbul.ValidatorData, 0, len(valSet.validators))
-  for _, v := range valSet.validators {
-    validators = append(validators, istanbul.ValidatorData{
-      v.Address(),
-      v.BLSPublicKey(),
-    })
-  }
+	validators := make([]istanbul.ValidatorData, 0, len(valSet.validators))
+	for _, v := range valSet.validators {
+		validators = append(validators, istanbul.ValidatorData{
+			v.Address(),
+			v.BLSPublicKey(),
+		})
+	}
 
-  valSetCopy := NewSet(validators, valSet.policy)
-  valSetCopy.SetRandomness(valSet.randomness)
-  return valSetCopy
+	valSetCopy := NewSet(validators, valSet.policy)
+	valSetCopy.SetRandomness(valSet.randomness)
+	return valSetCopy
 }
 
 func (valSet *defaultSet) F() int { return int(math.Ceil(float64(valSet.Size())/3)) - 1 }
 
 func (valSet *defaultSet) MinQuorumSize() int {
-  return int(math.Ceil(float64(2*valSet.Size()) / 3))
+	return int(math.Ceil(float64(2*valSet.Size()) / 3))
 }
 
 func (valSet *defaultSet) Policy() istanbul.ProposerPolicy { return valSet.policy }
 
 func (valSet *defaultSet) SetRandomness(seed common.Hash) { valSet.randomness = seed }
-

--- a/consensus/istanbul/validator/default_test.go
+++ b/consensus/istanbul/validator/default_test.go
@@ -163,11 +163,11 @@ func testAddAndRemoveValidator(t *testing.T) {
 	if len(valSet.List()) != 2 || len(valSet.List()) != valSet.Size() { // validators set should have the same size
 		t.Error("the size of validator set should be 2")
 	}
-	valSet.RemoveValidators(big.NewInt(2))                                    // remove second validator
+	valSet.RemoveValidators(big.NewInt(2))                              // remove second validator
 	if len(valSet.List()) != 1 || len(valSet.List()) != valSet.Size() { // validators set should have the same size
 		t.Error("the size of validator set should be 1")
 	}
-	valSet.RemoveValidators(big.NewInt(1))                                    // remove third validator
+	valSet.RemoveValidators(big.NewInt(1))                              // remove third validator
 	if len(valSet.List()) != 0 || len(valSet.List()) != valSet.Size() { // validators set should have the same size
 		t.Error("the size of validator set should be 0")
 	}

--- a/consensus/istanbul/validator/default_test.go
+++ b/consensus/istanbul/validator/default_test.go
@@ -159,18 +159,16 @@ func testAddAndRemoveValidator(t *testing.T) {
 	if !valSet.RemoveValidators(big.NewInt(1)) { // remove first falidator
 		t.Error("the validator should be removed")
 	}
-	if valSet.RemoveValidators(big.NewInt(1)) {
-		t.Error("the non-existing validator should not be removed")
-	}
-	if len(valSet.List()) != 3 || len(valSet.List()) != valSet.PaddedSize() || valSet.Size() != 2 { // validators set should have the same padded size but reduced size
+
+	if len(valSet.List()) != 2 || len(valSet.List()) != valSet.Size() { // validators set should have the same size
 		t.Error("the size of validator set should be 2")
 	}
-	valSet.RemoveValidators(big.NewInt(2))                                                          // remove second validator
-	if len(valSet.List()) != 3 || len(valSet.List()) != valSet.PaddedSize() || valSet.Size() != 1 { // validators set should have the same padded size but reduced size
+	valSet.RemoveValidators(big.NewInt(2))                                    // remove second validator
+	if len(valSet.List()) != 1 || len(valSet.List()) != valSet.Size() { // validators set should have the same size
 		t.Error("the size of validator set should be 1")
 	}
-	valSet.RemoveValidators(big.NewInt(4))                                                          // remove third validator
-	if len(valSet.List()) != 3 || len(valSet.List()) != valSet.PaddedSize() || valSet.Size() != 0 { // validators set should have the same padded size but reduced size
+	valSet.RemoveValidators(big.NewInt(1))                                    // remove third validator
+	if len(valSet.List()) != 0 || len(valSet.List()) != valSet.Size() { // validators set should have the same size
 		t.Error("the size of validator set should be 0")
 	}
 }

--- a/consensus/istanbul/validator/selectors.go
+++ b/consensus/istanbul/validator/selectors.go
@@ -25,7 +25,7 @@ import (
 )
 
 func proposerIndex(valSet istanbul.ValidatorSet, proposer common.Address) uint64 {
-	if idx := valSet.GetFilteredIndex(proposer); idx >= 0 {
+	if idx := valSet.GetIndex(proposer); idx >= 0 {
 		return uint64(idx)
 	}
 	return 0
@@ -55,7 +55,7 @@ func ShuffledRoundRobinProposer(valSet istanbul.ValidatorSet, proposer common.Ad
 	if proposer != (common.Address{}) {
 		idx += uint64(reverse[proposerIndex(valSet, proposer)]) + 1
 	}
-	return valSet.FilteredList()[shuffle[idx%uint64(valSet.Size())]]
+	return valSet.List()[shuffle[idx%uint64(valSet.Size())]]
 }
 
 // RoundRobinProposer selects the next proposer with a round robin strategy according to storage order.
@@ -67,7 +67,7 @@ func RoundRobinProposer(valSet istanbul.ValidatorSet, proposer common.Address, r
 	if proposer != (common.Address{}) {
 		idx += proposerIndex(valSet, proposer) + 1
 	}
-	return valSet.FilteredList()[idx%uint64(valSet.Size())]
+	return valSet.List()[idx%uint64(valSet.Size())]
 }
 
 // StickyProposer selects the next proposer with a sticky strategy, advancing on round change.
@@ -79,5 +79,5 @@ func StickyProposer(valSet istanbul.ValidatorSet, proposer common.Address, round
 	if proposer != (common.Address{}) {
 		idx += proposerIndex(valSet, proposer)
 	}
-	return valSet.FilteredList()[idx%uint64(valSet.Size())]
+	return valSet.List()[idx%uint64(valSet.Size())]
 }


### PR DESCRIPTION
### Description

The holed validator set is unneeded any more because:

1. We don't limit the validator diff size, so the SNARK encoding always signs the whole validator set
2. I would do it differently now, making the holed variant local