### PR TITLE
Use stable sorting algorithm when distributing epoch rewards

### DIFF
--- a/contract_comm/election/election.go
+++ b/contract_comm/election/election.go
@@ -181,7 +181,7 @@ func DistributeEpochRewards(header *types.Header, state vm.StateDB, groups []com
 			}
 		}
 
-		sort.Slice(voteTotals, func(j, k int) bool {
+		sort.SliceStable(voteTotals, func(j, k int) bool {
 			return voteTotals[j].Value.Cmp(voteTotals[k].Value) < 0
 		})
 


### PR DESCRIPTION
### Description

This PR fixes a bug that would lead to inconsistent merkle roots when proposing and validating blocks, which prevented block production. Because the ordering of the sort determines the new ordering of the validator groups in the election, any inconsistencies in the sorting order are reflected in the state.


### Tested

- Copied the datadir from a stalled validator, ran the node, saw the merkle root inconsistency. Reran with the new binary, no inconsistency.

### Other changes

None

