### PR TITLE
Always run the election after block finalization

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -344,7 +344,8 @@ func (b *Block) ReceiptHash() common.Hash { return b.header.ReceiptHash }
 func (b *Block) UncleHash() common.Hash   { return b.header.UncleHash }
 func (b *Block) Extra() []byte            { return common.CopyBytes(b.header.Extra) }
 
-func (b *Block) Header() *Header { return CopyHeader(b.header) }
+func (b *Block) Header() *Header        { return CopyHeader(b.header) }
+func (b *Block) MutableHeader() *Header { return b.header }
 
 // Body returns the non-header content of the block.
 func (b *Block) Body() *Body { return &Body{b.transactions, b.uncles, b.randomness} }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1063,15 +1063,15 @@ func (w *worker) commit(uncles []*types.Header, interval func(), update bool, st
 	}
 	s := w.current.state.Copy()
 
+	block, err := w.engine.Finalize(w.chain, w.current.header, s, w.current.txs, uncles, w.current.receipts, w.current.randomness)
+
 	// Set the validator set diff in the new header if we're using Istanbul and it's the last block of the epoch
 	if istanbul, ok := w.engine.(consensus.Istanbul); ok {
-		if err := istanbul.UpdateValSetDiff(w.chain, w.current.header, s); err != nil {
+		if err := istanbul.UpdateValSetDiff(w.chain, block.MutableHeader(), s); err != nil {
 			log.Error("Unable to update Validator Set Diff", "err", err)
 			return err
 		}
 	}
-
-	block, err := w.engine.Finalize(w.chain, w.current.header, s, w.current.txs, uncles, w.current.receipts, w.current.randomness)
 
 	if len(s.GetLogs(common.Hash{})) > 0 {
 		receipt := types.NewReceipt(nil, false, 0)


### PR DESCRIPTION
### Description

This PR fixes a discrepancy between block proposal creation and block proposal verification. In the former, the block was finalized after the election was run, while in the latter, the block was finalized before the election was run. When block finalization affects the results of the election (as it sometimes will via rewards to voters), this would lead to proposals that would fail to be verified.
  
### Tested

By running the end-to-end tests with 10 validators multiple times.

### Other changes

- None

### Backwards compatibility

Not backwards compatible