### PR TITLE
Separate public key and signature in proof-of-possession command

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -105,7 +105,7 @@ type Wallet interface {
 	SignHash(account Account, hash []byte) ([]byte, error)
 	SignHashBLS(account Account, hash []byte) ([]byte, error)
 	SignMessageBLS(account Account, msg []byte, extraData []byte) ([]byte, error)
-	GenerateProofOfPossession(account Account) ([]byte, error)
+	GenerateProofOfPossession(account Account) ([]byte, []byte, error)
 	GetPublicKey(account Account) (*ecdsa.PublicKey, error)
 
 	// SignTx requests the wallet to sign the given transaction.

--- a/accounts/keystore/wallet.go
+++ b/accounts/keystore/wallet.go
@@ -138,11 +138,11 @@ func (w *keystoreWallet) SignMessageBLS(account accounts.Account, msg []byte, ex
 	return w.keystore.SignMessageBLS(account, msg, extraData)
 }
 
-func (w *keystoreWallet) GenerateProofOfPossession(account accounts.Account) ([]byte, error) {
+func (w *keystoreWallet) GenerateProofOfPossession(account accounts.Account) ([]byte, []byte, error) {
 	// Make sure the requested account is contained within
 	if !w.Contains(account) {
 		log.Debug(accounts.ErrUnknownAccount.Error(), "account", account)
-		return nil, accounts.ErrUnknownAccount
+		return nil, nil, accounts.ErrUnknownAccount
 	}
 	// Account seems valid, request the keystore to sign
 	return w.keystore.GenerateProofOfPossession(account)

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -518,8 +518,8 @@ func (w *wallet) SignMessageBLS(account accounts.Account, msg []byte, extraData 
 	return nil, accounts.ErrNotSupported
 }
 
-func (w *wallet) GenerateProofOfPossession(account accounts.Account) ([]byte, error) {
-	return nil, accounts.ErrNotSupported
+func (w *wallet) GenerateProofOfPossession(account accounts.Account) ([]byte, []byte, error) {
+	return nil, nil, accounts.ErrNotSupported
 }
 
 // SignTx implements accounts.Wallet. It sends the transaction over to the Ledger

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -250,11 +250,11 @@ func accountProofOfPossession(ctx *cli.Context) error {
 
 	for _, addr := range ctx.Args() {
 		account, _ := unlockAccount(ctx, ks, addr, 0, nil)
-		pop, err := ks.GenerateProofOfPossession(account)
+		key, pop, err := ks.GenerateProofOfPossession(account)
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Account {%x}: %s\n", account.Address, hex.EncodeToString(pop))
+		fmt.Printf("Account {%x}:\n  Signature: %s\n  Public Key: %s\n", account.Address, hex.EncodeToString(pop), hex.EncodeToString(key))
 	}
 
 	return nil


### PR DESCRIPTION
### Description

Needed now that these are supplied separately when registering a validator.

### Tested

- Ran `account new` and `account proof-of-possession`.

