### PR TITLE
Deterministically iterate over groups when distributing epoch rewards

### DIFF
--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -147,20 +147,16 @@ func (sb *Backend) distributeEpochRewards(header *types.Header, state *state.Sta
 		totalEpochRewards.Add(totalEpochRewards, infrastructureEpochReward)
 	}
 
-	groupElectedValidator := make(map[common.Address]bool)
+	var groups []common.Address
 	for _, val := range valSet {
 		group, err := validators.GetMembershipInLastEpoch(header, state, val.Address())
 		if err != nil {
 			return totalEpochRewards, err
 		} else {
-			groupElectedValidator[group] = true
+			groups = append(groups, group)
 		}
 	}
 
-	groups := make([]common.Address, 0, len(groupElectedValidator))
-	for group := range groupElectedValidator {
-		groups = append(groups, group)
-	}
 	electionRewards, err := election.DistributeEpochRewards(header, state, groups, maxTotalRewards)
 	lockedGoldAddress, err := contract_comm.GetRegisteredAddress(params.LockedGoldRegistryId, header, state)
 	if err != nil {

--- a/contract_comm/election/election.go
+++ b/contract_comm/election/election.go
@@ -181,7 +181,7 @@ func DistributeEpochRewards(header *types.Header, state vm.StateDB, groups []com
 			}
 		}
 
-		sort.Slice(voteTotals, func(j, k int) bool {
+		sort.SliceStable(voteTotals, func(j, k int) bool {
 			return voteTotals[j].Value.Cmp(voteTotals[k].Value) < 0
 		})
 


### PR DESCRIPTION
### Description

This PR fixes a bug that would lead to inconsistent merkle roots when proposing and validating blocks, which prevented block production. Because the ordering in which voters for groups receive  epoch rewards may determines the new ordering of the validator set in the election, any inconsistencies in the sorting order are reflected in the state.

### Tested

- Copied the datadir from a stalled validator, ran the node, saw the merkle root inconsistency. Reran with the new binary, no inconsistency.

