### PR TITLE
Rename web3 instambul proxy (old sentry) methods

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -783,18 +783,18 @@ web3._extend({
 			params: 1
 		}),
 		new web3._extend.Method({
-			name: 'addSentry',
-			call: 'istanbul_addSentry',
+			name: 'addProxy',
+			call: 'istanbul_addProxy',
 			params: 2
 		}),
 		new web3._extend.Method({
-			name: 'removeSentry',
-			call: 'istanbul_removeSentry',
+			name: 'removeProxy',
+			call: 'istanbul_removeProxy',
 			params: 1
 		}),
 		new web3._extend.Property({
-			name: 'sentryInfo',
-			getter: 'istanbul_sentryInfo'
+			name: 'proxyInfo',
+			getter: 'istanbul_proxyInfo'
 		}),		
 	],
 	properties:


### PR DESCRIPTION
### Description

Got some errors trying to access `istambul.addProxy`, `istambul.proxyInfo` methods. I think this is because some minnor changes from sentry -> proxy.

### Tested

Trying to test on a testnet. Not working so far.

