### PR TITLE
Move init/close valenodedb to Engine start/stop

### DIFF
--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -85,9 +85,6 @@ type Backend interface {
 	// ParentBlockValidators returns the validator set of the given proposal's parent block
 	ParentBlockValidators(proposal Proposal) ValidatorSet
 
-	// RefreshValPeers will connect with all the validators in the valset and disconnect validator peers that are not in the set
-	RefreshValPeers(valset ValidatorSet)
-
 	// Authorize injects a private key into the consensus engine.
 	Authorize(address common.Address, signFn SignerFn, signHashBLSFn SignerFn, signMessageBLSFn MessageSignerFn)
 }

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -258,9 +258,12 @@ func (sb *Backend) handleIstAnnounce(payload []byte) error {
 
 	logger = logger.New("msgAddress", msg.Address, "msg_round", announceData.View.Round, "msg_seq", announceData.View.Sequence)
 
-	if view, err := sb.valEnodeTable.GetViewFromAddress(msg.Address); err == nil && announceData.View.Cmp(view) <= 0 {
-		logger.Trace("Received an old announce message", "senderAddr", msg.Address, "messageView", announceData.View, "currentEntryView", view)
-		return errOldAnnounceMessage
+	if sb.coreStarted {
+		view, err := sb.valEnodeTable.GetViewFromAddress(msg.Address)
+		if err == nil && announceData.View.Cmp(view) <= 0 {
+			logger.Trace("Received an old announce message", "senderAddr", msg.Address, "messageView", announceData.View, "currentEntryView", view)
+			return errOldAnnounceMessage
+		}
 	}
 
 	// If the message is not within the registered validator set, then ignore it

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -681,21 +681,6 @@ func (sb *Backend) removeProxy(node *enode.Node) {
 	}
 }
 
-// RefreshValPeers will create 'validator' type peers to all the valset validators, and disconnect from the
-// peers that are not part of the valset.
-// It will also disconnect all validator connections if this node is not a validator.
-// Note that adding and removing validators are idempotent operations.  If the validator
-// being added or removed is already added or removed, then a no-op will be done.
-func (sb *Backend) RefreshValPeers(valset istanbul.ValidatorSet) {
-	sb.logger.Trace("Called RefreshValPeers", "valset length", valset.Size())
-
-	if sb.broadcaster == nil {
-		return
-	}
-
-	sb.valEnodeTable.RefreshValPeers(valset, sb.ValidatorAddress())
-}
-
 func (sb *Backend) ValidatorAddress() common.Address {
 	var localAddress common.Address
 	if sb.config.Proxy {

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -117,13 +117,6 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 	}
 	backend.core = istanbulCore.New(backend, backend.config)
 
-	vph := &validatorPeerHandler{sb: backend}
-	table, err := enodes.OpenValidatorEnodeDB(config.ValidatorEnodeDBPath, vph)
-	if err != nil {
-		logger.Crit("Can't open ValidatorEnodeDB", "err", err, "dbpath", config.ValidatorEnodeDBPath)
-	}
-	backend.valEnodeTable = table
-
 	return backend
 }
 
@@ -241,7 +234,7 @@ func (sb *Backend) Address() common.Address {
 // Close the backend
 func (sb *Backend) Close() error {
 	sb.delegateSignScope.Close()
-	return sb.valEnodeTable.Close()
+	return nil
 }
 
 // Validators implements istanbul.Backend.Validators

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -282,8 +282,6 @@ func (self *testSystemBackend) Enode() *enode.Node {
 	return nil
 }
 
-func (self *testSystemBackend) RefreshValPeers(valSet istanbul.ValidatorSet) {}
-
 // ==============================================
 //
 // define the struct that need to be provided for integration tests.


### PR DESCRIPTION


### Description

To avoid light clients and others create an unnecessary level db table.

### Tested

e2e tests

