### PR TITLE
Fix for dropped validator peers on new epoch

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -700,7 +700,7 @@ func (sb *Backend) RefreshValPeers(valset istanbul.ValidatorSet) {
 		return
 	}
 
-	sb.valEnodeTable.RefreshValPeers(valset, sb.Address())
+	sb.valEnodeTable.RefreshValPeers(valset, sb.ValidatorAddress())
 }
 
 func (sb *Backend) ValidatorAddress() common.Address {


### PR DESCRIPTION
### Description

This is a bug fix for dropped validator peers on new epoch.

### Tested

unit test

### Other changes

None

### Related issues


### Backwards compatibility

Is backwards compatible.