### PR TITLE
Specify the address to be signed for BLS POP

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -105,7 +105,7 @@ type Wallet interface {
 	SignHash(account Account, hash []byte) ([]byte, error)
 	SignHashBLS(account Account, hash []byte) ([]byte, error)
 	SignMessageBLS(account Account, msg []byte, extraData []byte) ([]byte, error)
-	GenerateProofOfPossession(account Account) ([]byte, []byte, error)
+	GenerateProofOfPossession(account Account, address common.Address) ([]byte, []byte, error)
 	GetPublicKey(account Account) (*ecdsa.PublicKey, error)
 
 	// SignTx requests the wallet to sign the given transaction.

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -353,7 +353,7 @@ func (ks *KeyStore) SignMessageBLS(a accounts.Account, msg []byte, extraData []b
 	return signatureBytes, nil
 }
 
-func (ks *KeyStore) GenerateProofOfPossession(a accounts.Account) ([]byte, []byte, error) {
+func (ks *KeyStore) GenerateProofOfPossession(a accounts.Account, address common.Address) ([]byte, []byte, error) {
 	// Look up the key to sign with and abort if it cannot be found
 	ks.mu.RLock()
 	defer ks.mu.RUnlock()
@@ -374,7 +374,7 @@ func (ks *KeyStore) GenerateProofOfPossession(a accounts.Account) ([]byte, []byt
 	}
 	defer privateKey.Destroy()
 
-	signature, err := privateKey.SignPoP(a.Address.Bytes())
+	signature, err := privateKey.SignPoP(address.Bytes())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/accounts/keystore/wallet.go
+++ b/accounts/keystore/wallet.go
@@ -23,6 +23,7 @@ import (
 
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -138,14 +139,14 @@ func (w *keystoreWallet) SignMessageBLS(account accounts.Account, msg []byte, ex
 	return w.keystore.SignMessageBLS(account, msg, extraData)
 }
 
-func (w *keystoreWallet) GenerateProofOfPossession(account accounts.Account) ([]byte, []byte, error) {
+func (w *keystoreWallet) GenerateProofOfPossession(account accounts.Account, address common.Address) ([]byte, []byte, error) {
 	// Make sure the requested account is contained within
 	if !w.Contains(account) {
 		log.Debug(accounts.ErrUnknownAccount.Error(), "account", account)
 		return nil, nil, accounts.ErrUnknownAccount
 	}
 	// Account seems valid, request the keystore to sign
-	return w.keystore.GenerateProofOfPossession(account)
+	return w.keystore.GenerateProofOfPossession(account, address)
 }
 
 // SignTx implements accounts.Wallet, attempting to sign the given transaction

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -518,7 +518,7 @@ func (w *wallet) SignMessageBLS(account accounts.Account, msg []byte, extraData 
 	return nil, accounts.ErrNotSupported
 }
 
-func (w *wallet) GenerateProofOfPossession(account accounts.Account) ([]byte, []byte, error) {
+func (w *wallet) GenerateProofOfPossession(account accounts.Account, address common.Address) ([]byte, []byte, error) {
 	return nil, nil, accounts.ErrNotSupported
 }
 

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/console"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -242,20 +243,20 @@ func accountList(ctx *cli.Context) error {
 }
 
 func accountProofOfPossession(ctx *cli.Context) error {
-	if len(ctx.Args()) == 0 {
-		utils.Fatalf("No accounts specified to update")
+	if len(ctx.Args()) != 2 {
+		utils.Fatalf("Please specify the address from which to generate the BLS key, and the address to sign as proof-of-possession.")
 	}
 	stack, _ := makeConfigNode(ctx)
 	ks := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
 
-	for _, addr := range ctx.Args() {
-		account, _ := unlockAccount(ctx, ks, addr, 0, nil)
-		key, pop, err := ks.GenerateProofOfPossession(account)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("Account {%x}:\n  Signature: %s\n  Public Key: %s\n", account.Address, hex.EncodeToString(pop), hex.EncodeToString(key))
+	blsAddr := ctx.Args()[0]
+	popAddr := common.HexToAddress(ctx.Args()[1])
+	account, _ := unlockAccount(ctx, ks, blsAddr, 0, nil)
+	key, pop, err := ks.GenerateProofOfPossession(account, popAddr)
+	if err != nil {
+		return err
 	}
+	fmt.Printf("Account {%x}:\n  Signature: %s\n  Public Key: %s\n", account.Address, hex.EncodeToString(pop), hex.EncodeToString(key))
 
 	return nil
 }


### PR DESCRIPTION
### Description

This PR allows the user to specify the address to sign for generating the BLS POP, which is necessary to allow the decoupling of the BLS and ECDSA signing keys.

### Tested

- Generated a PoP this way and used it to register a validator on baklava staging.

### Other changes

None

