### PR TITLE
Ensure ScoreTally gets calculated correctly

### DIFF
--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -92,15 +92,15 @@ func (sb *Backend) updateValidatorScores(header *types.Header, state *state.Stat
 	bc := sb.chain.(*core.BlockChain)
 	db := bc.GetDatabase()
 	uptimes := rawdb.ReadAccumulatedEpochUptime(db, epoch)
-	if uptimes == nil {
+	if len(uptimes.Entries) == 0 {
 		logger.Error("no accumulated uptimes found, will not update validator scores")
 		return errors.New("no accumulated uptimes found, will not update validator scores")
 	}
 
 	for i, val := range valSet {
-		scoreTally := uptimes[i].ScoreTally
+		scoreTally := uptimes.Entries[i].ScoreTally
 		logger = logger.New("scoreTally", scoreTally, "denominator", denominator, "index", i, "address", val.Address())
-		numerator := big.NewInt(0).Mul(big.NewInt(int64(uptimes[i].ScoreTally)), params.Fixidity1)
+		numerator := big.NewInt(0).Mul(big.NewInt(int64(uptimes.Entries[i].ScoreTally)), params.Fixidity1)
 		uptime := big.NewInt(0).Div(numerator, big.NewInt(int64(denominator)))
 
 		if scoreTally > denominator {

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -26,13 +26,23 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-type Uptime struct {
+// UptimeEntry contains the uptime score of a validator during an epoch as well as the
+// last block they signed on
+type UptimeEntry struct {
 	ScoreTally      uint64
 	LastSignedBlock uint64
 }
 
-func (u *Uptime) String() string {
-	return fmt.Sprintf("Uptime { scoreTally: %v, lastBlock: %v}", u.ScoreTally, u.LastSignedBlock)
+func (u *UptimeEntry) String() string {
+	return fmt.Sprintf("UptimeEntry { scoreTally: %v, lastBlock: %v}", u.ScoreTally, u.LastSignedBlock)
+}
+
+// Uptime contains the latest block for which uptime metrics were accounted for. It also contains
+// an array of Entries where the `i`th entry represents the uptime statistics of the `i`th validator
+// in the validator set for that epoch
+type Uptime struct {
+	LatestBlock uint64
+	Entries     []UptimeEntry
 }
 
 // Proposal supports retrieving height and serialized block to be used during Istanbul consensus.

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -978,8 +978,6 @@ func updateUptime(uptime *istanbul.Uptime, blockNumber uint64, bitmap *big.Int, 
 		uptime.Entries = make([]istanbul.UptimeEntry, validatorsSizeUpperBound)
 	}
 
-	uptime.LatestBlock = blockNumber
-
 	valScoreTallyFirstBlockNum := istanbul.GetValScoreTallyFirstBlockNumber(epochNum, epochSize, window)
 	valScoreTallyLastBlockNum := istanbul.GetValScoreTallyLastBlockNumber(epochNum, epochSize)
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -114,10 +114,9 @@ type BlockChain struct {
 	chainmu sync.RWMutex // blockchain insertion lock
 	procmu  sync.RWMutex // block processor lock
 
-	checkpoint         int          // checkpoint counts towards the new checkpoint
-	currentBlock       atomic.Value // Current head of the block chain
-	currentFastBlock   atomic.Value // Current head of the fast-sync chain (may be above the block chain!)
-	lastMonitoredBlock uint64       // Latest block for which we calculated the uptime for (only usable with Istanbul)
+	checkpoint       int          // checkpoint counts towards the new checkpoint
+	currentBlock     atomic.Value // Current head of the block chain
+	currentFastBlock atomic.Value // Current head of the fast-sync chain (may be above the block chain!)
 
 	stateCache    state.Database // State database to reuse between imports (contains state cache)
 	bodyCache     *lru.Cache     // Cache for the most recent block bodies
@@ -968,14 +967,18 @@ func popcount(x uint64) int {
 	return int((x * h01) >> 56)    //returns left 8 bits of x + (x<<8) + (x<<16) + (x<<24) + ...
 }
 
-func updateUptime(uptime []istanbul.Uptime, blockNumber uint64, bitmap *big.Int, window uint64, epochNum uint64, epochSize uint64) []istanbul.Uptime {
-	var validatorsSizeUpperBound uint64
-	if len(uptime) == 0 {
+// updateUptime receives the currently accumulated uptime for all validators in an epoch and proceeds to update it
+// based on which validators signed on the provided block by inspecting the block's parent bitmap
+func updateUptime(uptime *istanbul.Uptime, blockNumber uint64, bitmap *big.Int, window uint64, epochNum uint64, epochSize uint64) *istanbul.Uptime {
+	if uptime == nil {
+		uptime = new(istanbul.Uptime)
 		// The number of validators is upper bounded by 3/2 of the number of 1s in the bitmap
 		// We multiply by 2 just to be extra cautious of off-by-one errors.
-		validatorsSizeUpperBound = uint64(math.Ceil(float64(bitCount(bitmap)) * 2))
-		uptime = make([]istanbul.Uptime, validatorsSizeUpperBound)
+		validatorsSizeUpperBound := uint64(math.Ceil(float64(bitCount(bitmap)) * 2))
+		uptime.Entries = make([]istanbul.UptimeEntry, validatorsSizeUpperBound)
 	}
+
+	uptime.LatestBlock = blockNumber
 
 	valScoreTallyFirstBlockNum := istanbul.GetValScoreTallyFirstBlockNumber(epochNum, epochSize, window)
 	valScoreTallyLastBlockNum := istanbul.GetValScoreTallyLastBlockNumber(epochNum, epochSize)
@@ -984,22 +987,23 @@ func updateUptime(uptime []istanbul.Uptime, blockNumber uint64, bitmap *big.Int,
 	signedBlockWindowLastBlockNum := blockNumber - 1
 	signedBlockWindowFirstBlockNum := signedBlockWindowLastBlockNum - (window - 1)
 
-	for i := 0; i < len(uptime); i++ {
+	uptime.LatestBlock = blockNumber
+	for i := 0; i < len(uptime.Entries); i++ {
 		if bitmap.Bit(i) == 1 {
 			// update their latest signed block
-			uptime[i].LastSignedBlock = blockNumber - 1
+			uptime.Entries[i].LastSignedBlock = blockNumber - 1
 		}
 
-		// If we are within the validator uptime tally window, then update the validator's score if its last signed block is within
-		// the lookback window
+		// If we are within the validator uptime tally window, then update the validator's score
+		// if its last signed block is within the lookback window
 		if valScoreTallyFirstBlockNum <= blockNumber && blockNumber <= valScoreTallyLastBlockNum {
-			lastSignedBlock := uptime[i].LastSignedBlock
+			lastSignedBlock := uptime.Entries[i].LastSignedBlock
 
 			// Note that the second condition in the if condition is not necessary.  But it does
 			// make the logic easier to understand.  (e.g. it's checking is lastSignedBlock is within
 			// the range [signedBlockWindowFirstBlockNum, signedBlockWindowLastBlockNum])
 			if signedBlockWindowFirstBlockNum <= lastSignedBlock && lastSignedBlock <= signedBlockWindowLastBlockNum {
-				uptime[i].ScoreTally++
+				uptime.Entries[i].ScoreTally++
 			}
 		}
 	}
@@ -1017,18 +1021,10 @@ func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.
 
 	// We are going to update the uptime tally.
 	if bc.engine.Protocol().Name == "istanbul" {
-		// We only update the uptime for blocks which are greater than the last block we saw.
-		// This ensures that we do not count the same block twice for any reason.
-		latestMonitoredBlock := bc.lastMonitoredBlock
-		// Update the last block we have monitored for the Tally
-		bc.lastMonitoredBlock = block.NumberU64()
 		// The epoch's first block's aggregated parent signatures is for the previous epoch's valset.
 		// We can ignore updating the tally for that block.
-		if latestMonitoredBlock < block.NumberU64() && !istanbul.IsFirstBlockOfEpoch(block.NumberU64(), bc.chainConfig.Istanbul.Epoch) {
+		if !istanbul.IsFirstBlockOfEpoch(block.NumberU64(), bc.chainConfig.Istanbul.Epoch) {
 			epochNum := istanbul.GetEpochNumber(block.NumberU64(), bc.chainConfig.Istanbul.Epoch)
-
-			// Get the uptime scores
-			uptime := rawdb.ReadAccumulatedEpochUptime(bc.db, epochNum)
 
 			// Get the bitmap from the previous block
 			extra, err := types.ExtractIstanbulExtra(block.Header())
@@ -1038,11 +1034,20 @@ func (bc *BlockChain) WriteBlockWithState(block *types.Block, receipts []*types.
 			}
 			signedValidatorsBitmap := extra.ParentAggregatedSeal.Bitmap
 
-			// Update the uptime scores
-			uptime = updateUptime(uptime, block.NumberU64(), signedValidatorsBitmap, bc.chainConfig.Istanbul.LookbackWindow, epochNum, bc.chainConfig.Istanbul.Epoch)
+			// Get the uptime scores
+			uptime := rawdb.ReadAccumulatedEpochUptime(bc.db, epochNum)
 
-			// Write the new uptime scores
-			rawdb.WriteAccumulatedEpochUptime(bc.db, epochNum, uptime)
+			// We only update the uptime for blocks which are greater than the last block we saw.
+			// This ensures that we do not count the same block twice for any reason.
+			if uptime == nil || uptime.LatestBlock < block.NumberU64() {
+				// Update the uptime scores
+				uptime = updateUptime(uptime, block.NumberU64(), signedValidatorsBitmap, bc.chainConfig.Istanbul.LookbackWindow, epochNum, bc.chainConfig.Istanbul.Epoch)
+
+				// Write the new uptime scores
+				rawdb.WriteAccumulatedEpochUptime(bc.db, epochNum, uptime)
+			} else {
+				log.Trace("WritingBlockWithState with block number less than a block we previously wrote", "latestUptimeBlock", uptime.LatestBlock, "blockNumber", block.NumberU64())
+			}
 		}
 	}
 
@@ -1224,7 +1229,7 @@ func (bc *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 // is imported, but then new canon-head is added before the actual sidechain
 // completes, then the historic state could be pruned again
 func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, []interface{}, []*types.Log, error) {
-	// If the chain is terminating, don't even bother starting u
+	// If the chain is terminating, don't even bother starting up
 	if atomic.LoadInt32(&bc.procInterrupt) == 1 {
 		return 0, nil, nil, nil
 	}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -45,35 +45,38 @@ var (
 )
 
 func TestUptimeSingle(t *testing.T) {
-	var uptimes []istanbul.Uptime
+	var uptimes *istanbul.Uptime
 	uptimes = updateUptime(uptimes, 212, big.NewInt(7), 3, 2, 211)
 	// the first 2 uptime updates do not get scored since they're within the
 	// first window after the epoch block
-	expected := []istanbul.Uptime{
-		{
-			ScoreTally:      0,
-			LastSignedBlock: 211,
-		},
-		{
-			ScoreTally:      0,
-			LastSignedBlock: 211,
-		},
-		{
-			ScoreTally:      0,
-			LastSignedBlock: 211,
-		},
-		// plus 2 dummies due to the *2
-		{
-			ScoreTally:      0,
-			LastSignedBlock: 0,
-		},
-		{
-			ScoreTally:      0,
-			LastSignedBlock: 0,
-		},
-		{
-			ScoreTally:      0,
-			LastSignedBlock: 0,
+	expected := &istanbul.Uptime{
+		LatestBlock: 212,
+		Entries: []istanbul.UptimeEntry{
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 211,
+			},
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 211,
+			},
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 211,
+			},
+			// plus 2 dummies due to the *2
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 0,
+			},
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 0,
+			},
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 0,
+			},
 		},
 	}
 	if !reflect.DeepEqual(uptimes, expected) {
@@ -82,7 +85,7 @@ func TestUptimeSingle(t *testing.T) {
 }
 
 func TestUptime(t *testing.T) {
-	var uptimes []istanbul.Uptime
+	var uptimes *istanbul.Uptime
 	// (there can't be less than 2/3rds of validators sigs in a valid bitmap)
 	bitmaps := []*big.Int{
 		big.NewInt(3), // 011     // Parent aggregated seal for block #1
@@ -102,22 +105,25 @@ func TestUptime(t *testing.T) {
 		block++
 	}
 
-	expected := []istanbul.Uptime{
-		{
-			ScoreTally:      5,
-			LastSignedBlock: 6,
-		},
-		{
-			ScoreTally:      5,
-			LastSignedBlock: 5,
-		},
-		{
-			ScoreTally:      5,
-			LastSignedBlock: 6,
-		},
-		{
-			ScoreTally:      0,
-			LastSignedBlock: 0,
+	expected := &istanbul.Uptime{
+		LatestBlock: 7,
+		Entries: []istanbul.UptimeEntry{
+			{
+				ScoreTally:      5,
+				LastSignedBlock: 6,
+			},
+			{
+				ScoreTally:      5,
+				LastSignedBlock: 5,
+			},
+			{
+				ScoreTally:      5,
+				LastSignedBlock: 6,
+			},
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 0,
+			},
 		},
 	}
 	if !reflect.DeepEqual(uptimes, expected) {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -255,22 +255,22 @@ func ReadTd(db DatabaseReader, hash common.Hash, number uint64) *big.Int {
 }
 
 // ReadAccumulatedEpochUptime retrieves the so-far accumulated uptime array for the validators of the specified epoch
-func ReadAccumulatedEpochUptime(db DatabaseReader, epoch uint64) []istanbul.Uptime {
+func ReadAccumulatedEpochUptime(db DatabaseReader, epoch uint64) *istanbul.Uptime {
 	data, _ := db.Get(uptimeKey(epoch))
 	if len(data) == 0 {
 		log.Trace("ReadAccumulatedEpochUptime EMPTY", "epoch", epoch)
 		return nil
 	}
-	uptime := new([]istanbul.Uptime)
+	uptime := new(istanbul.Uptime)
 	if err := rlp.Decode(bytes.NewReader(data), uptime); err != nil {
 		log.Error("Invalid uptime RLP", "err", err)
 		return nil
 	}
-	return *uptime
+	return uptime
 }
 
 // WriteAccumulatedEpochUptime updates the accumulated uptime array for the validators of the specified epoch
-func WriteAccumulatedEpochUptime(db DatabaseWriter, epoch uint64, uptime []istanbul.Uptime) {
+func WriteAccumulatedEpochUptime(db DatabaseWriter, epoch uint64, uptime *istanbul.Uptime) {
 	data, err := rlp.EncodeToBytes(uptime)
 	if err != nil {
 		log.Crit("Failed to RLP encode updated uptime", "err", err)
@@ -282,7 +282,6 @@ func WriteAccumulatedEpochUptime(db DatabaseWriter, epoch uint64, uptime []istan
 
 // DeleteAccumulatedEpochUptime removes all accumulated uptime data for that epoch
 func DeleteAccumulatedEpochUptime(db DatabaseDeleter, epoch uint64) {
-	log.Debug("uptime-trace: DeleteAccumulatedEpochUptime", "epoch", epoch)
 	if err := db.Delete(uptimeKey(epoch)); err != nil {
 		log.Crit("Failed to delete stored uptime of validators", "err", err)
 	}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -195,18 +195,22 @@ func TestUptimeStorage(t *testing.T) {
 		t.Fatalf("Non existent uptime returned: %v", entry)
 	}
 	// Write and verify the uptime in the database
-	uptime := make([]istanbul.Uptime, 3)
-	uptime[0] = istanbul.Uptime{
+	uptimeEntries := make([]istanbul.UptimeEntry, 3)
+	uptimeEntries[0] = istanbul.UptimeEntry{
 		ScoreTally:      0,
 		LastSignedBlock: 1,
 	}
-	uptime[1] = istanbul.Uptime{
+	uptimeEntries[1] = istanbul.UptimeEntry{
 		ScoreTally:      2,
 		LastSignedBlock: 2,
 	}
-	uptime[2] = istanbul.Uptime{
+	uptimeEntries[2] = istanbul.UptimeEntry{
 		ScoreTally:      8,
 		LastSignedBlock: 8,
+	}
+	uptime := &istanbul.Uptime{
+		Entries:     uptimeEntries,
+		LatestBlock: 5,
 	}
 	WriteAccumulatedEpochUptime(db, epoch, uptime)
 	if entry := ReadAccumulatedEpochUptime(db, epoch); entry == nil {


### PR DESCRIPTION
# Description

There was an edge case where both the [miner](https://github.com/celo-org/celo-blockchain/blob/09a217ff58a95214cbc5189c933359707f4fdaf2/miner/worker.go#L625) and the fetcher were calling `WriteBlockWithState` for the same block height (the miner calls it directly, the fetcher inserts blocks via `InsertChain` which calls it internally). This resulted in a race where the uptime would be updated more than once in a block, which ultimately led to wrong `ScoreTally` calculations.

Our [investigation](https://console.cloud.google.com/logs/viewer?interval=NO_LIMIT&project=celo-testnet&organizationId=54829595577&minLogLevel=0&expandAll=false&timestamp=2019-11-27T05:35:03.059000140Z&customFacets=&limitCustomFacetWidth=true&scrollTimestamp=2019-11-27T05:34:58.075082770Z&advancedFilter=resource.type%3D%22container%22%0Aresource.labels.cluster_name%3D%22celo-networks-dev%22%0Aresource.labels.namespace_id%3D%22victorwithfix%22%0Aresource.labels.project_id%3D%22celo-testnet%22%0Aresource.labels.zone:%22us-west1-a%22%0Aresource.labels.container_name%3D(%22init-genesis%22%20OR%20%22get-account%22%20OR%20%22import-geth-account%22%20OR%20%22geth%22%20OR%20%22geth-exporter%22%20OR%20%22prom-to-sd%22)%0Aresource.labels.pod_id:%22victorwithfix-validators-%22%0Alabels.%22container.googleapis.com%2Fpod_name%22%3D%22victorwithfix-validators-2%22%0AjsonPayload.msg!%3D%22Cannot%20read%20block%20gas%20limit%22%0AjsonPayload.msg!%3D%22Reinjecting%20stale%20transactions%22%0AjsonPayload.msg!%3D%22Registry%20contract%20not%20yet%20deployed%22%0AjsonPayload.msg!%3D%22Error%20in%20unpacking%20EVM%20call%20return%20bytes%22%0AjsonPayload.msg!%3D%22Dereferenced%20trie%20from%20memory%20database%22%0AjsonPayload.msg!%3D%22Registry%20address%20lookup%20failed%22&pinnedLogId=qx48sdfp8dfav&pinnedLogTimestamp=2019-11-27T05:34:58.078524423Z) confirms that this is the case, note how there is a call to the `WriteBlockWithState` function which logs the error right after a miner log, which is preceded by a "In Fetcher inserter" log

![image](https://user-images.githubusercontent.com/17802178/69698910-43dce680-10ef-11ea-90c8-cf931686d980.png)

# The Fix

As suggested by @kevjue, we add a monotonic counter which represents the last block for which we tallied uptimes for. That number is also stored in the database to ensure it persists between restarts of the node. 


### Tested
- Unclear how we can test this change other than existing E2E tests and deploying testnets
- @nategraf [deployed a testnet](https://celo-org.slack.com/archives/CE8KJ192M/p1574829996155700) and verified that this works. 


This bug was also reproduced by [others](https://celo-org.slack.com/archives/CE8KJ192M/p1574810646141800)
### Other changes
- Remove unused uptime cache
### Related issues

- Fixes https://github.com/celo-org/celo-blockchain/issues/650