### PR TITLE
Fix bug that prevented commits from being carried over to the next sequence

### DIFF
--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -374,7 +374,7 @@ func (c *core) updateRoundState(view *istanbul.View, validatorSet istanbul.Valid
 			c.current = newRoundState(view, validatorSet, nil, c.current.PendingRequest(), c.current.PreparedCertificate(), c.current.ParentCommits())
 		} else {
 			lastSubject, err := c.backend.LastSubject()
-			if err != nil && c.current.Proposal() != nil && c.current.Proposal().Hash() == lastSubject.Digest && c.current.Round().Cmp(lastSubject.View.Round) == 0 {
+			if err == nil && c.current.Proposal() != nil && c.current.Proposal().Hash() == lastSubject.Digest && c.current.Round().Cmp(lastSubject.View.Round) == 0 {
 				// When changing sequences, if our current Commit messages match the latest block in the chain
 				// (i.e. they're for the same block hash and round), we use this sequence's commits as the ParentCommits field
 				// in the next round.


### PR DESCRIPTION
### Description

This bug meant that we never carried over `Commits` into `ParentCommits`, reducing the number of signatures that the proposer would include in the `ParentAggregatedSeal`

## Tested

- Ran a validator with these changes.

