### PR TITLE
Update account proof-of-possession command to work with BLS and ECDSA

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -105,7 +105,8 @@ type Wallet interface {
 	SignHash(account Account, hash []byte) ([]byte, error)
 	SignHashBLS(account Account, hash []byte) ([]byte, error)
 	SignMessageBLS(account Account, msg []byte, extraData []byte) ([]byte, error)
-	GenerateProofOfPossession(account Account, address common.Address) ([]byte, []byte, error)
+	GenerateProofOfPossession(account Account, address common.Address) ([]byte, error)
+	GenerateProofOfPossessionBLS(account Account, address common.Address) ([]byte, []byte, error)
 	GetPublicKey(account Account) (*ecdsa.PublicKey, error)
 
 	// SignTx requests the wallet to sign the given transaction.

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -353,7 +353,15 @@ func (ks *KeyStore) SignMessageBLS(a accounts.Account, msg []byte, extraData []b
 	return signatureBytes, nil
 }
 
-func (ks *KeyStore) GenerateProofOfPossession(a accounts.Account, address common.Address) ([]byte, []byte, error) {
+func (ks *KeyStore) GenerateProofOfPossession(a accounts.Account, address common.Address) ([]byte, error) {
+	hash := crypto.Keccak256(address.Bytes())
+	msg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(hash), hash)
+	hash = crypto.Keccak256([]byte(msg))
+
+	return ks.SignHash(a, hash)
+}
+
+func (ks *KeyStore) GenerateProofOfPossessionBLS(a accounts.Account, address common.Address) ([]byte, []byte, error) {
 	// Look up the key to sign with and abort if it cannot be found
 	ks.mu.RLock()
 	defer ks.mu.RUnlock()

--- a/accounts/keystore/wallet.go
+++ b/accounts/keystore/wallet.go
@@ -139,14 +139,24 @@ func (w *keystoreWallet) SignMessageBLS(account accounts.Account, msg []byte, ex
 	return w.keystore.SignMessageBLS(account, msg, extraData)
 }
 
-func (w *keystoreWallet) GenerateProofOfPossession(account accounts.Account, address common.Address) ([]byte, []byte, error) {
+func (w *keystoreWallet) GenerateProofOfPossession(account accounts.Account, address common.Address) ([]byte, error) {
+	// Make sure the requested account is contained within
+	if !w.Contains(account) {
+		log.Debug(accounts.ErrUnknownAccount.Error(), "account", account)
+		return nil, accounts.ErrUnknownAccount
+	}
+	// Account seems valid, request the keystore to sign
+	return w.keystore.GenerateProofOfPossession(account, address)
+}
+
+func (w *keystoreWallet) GenerateProofOfPossessionBLS(account accounts.Account, address common.Address) ([]byte, []byte, error) {
 	// Make sure the requested account is contained within
 	if !w.Contains(account) {
 		log.Debug(accounts.ErrUnknownAccount.Error(), "account", account)
 		return nil, nil, accounts.ErrUnknownAccount
 	}
 	// Account seems valid, request the keystore to sign
-	return w.keystore.GenerateProofOfPossession(account, address)
+	return w.keystore.GenerateProofOfPossessionBLS(account, address)
 }
 
 // SignTx implements accounts.Wallet, attempting to sign the given transaction

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -518,7 +518,11 @@ func (w *wallet) SignMessageBLS(account accounts.Account, msg []byte, extraData 
 	return nil, accounts.ErrNotSupported
 }
 
-func (w *wallet) GenerateProofOfPossession(account accounts.Account, address common.Address) ([]byte, []byte, error) {
+func (w *wallet) GenerateProofOfPossession(account accounts.Account, address common.Address) ([]byte, error) {
+	return nil, accounts.ErrNotSupported
+}
+
+func (w *wallet) GenerateProofOfPossessionBLS(account accounts.Account, address common.Address) ([]byte, []byte, error) {
 	return nil, nil, accounts.ErrNotSupported
 }
 

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -250,7 +250,7 @@ func accountList(ctx *cli.Context) error {
 
 func accountProofOfPossession(ctx *cli.Context) error {
 	if len(ctx.Args()) != 2 {
-		utils.Fatalf("Please specify the address to proove possession of and the address to sign as proof-of-possession.")
+		utils.Fatalf("Please specify the address to prove possession of and the address to sign as proof-of-possession.")
 	}
 
 	stack, _ := makeConfigNode(ctx)

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -28,10 +28,14 @@ import (
 	"github.com/ethereum/go-ethereum/console"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"gopkg.in/urfave/cli.v1"
+	cli "gopkg.in/urfave/cli.v1"
 )
 
 var (
+	blsFlag = cli.BoolFlag{
+		Name:  "bls",
+		Usage: "Set to specify generation of proof-of-possession of a BLS key.",
+	}
 	walletCommand = cli.Command{
 		Name:      "wallet",
 		Usage:     "Manage Ethereum presale wallets",
@@ -104,14 +108,16 @@ Make sure you backup your keys regularly.`,
 Print a short summary of all accounts`,
 			},
 			{
-				Name:   "proof-of-possession",
-				Usage:  "Generate a proof-of-possession for the given account",
-				Action: utils.MigrateFlags(accountProofOfPossession),
+				Name:      "proof-of-possession",
+				Usage:     "Generate a proof-of-possession for the given account",
+				Action:    utils.MigrateFlags(accountProofOfPossession),
+				ArgsUsage: "<address> <address>",
 				Flags: []cli.Flag{
 					utils.DataDirFlag,
 					utils.KeyStoreDirFlag,
 					utils.PasswordFileFlag,
 					utils.LightKDFFlag,
+					blsFlag,
 				},
 				Description: `
 Print a proof-of-possession signature for the given account.
@@ -244,19 +250,28 @@ func accountList(ctx *cli.Context) error {
 
 func accountProofOfPossession(ctx *cli.Context) error {
 	if len(ctx.Args()) != 2 {
-		utils.Fatalf("Please specify the address from which to generate the BLS key, and the address to sign as proof-of-possession.")
+		utils.Fatalf("Please specify the address to proove possession of and the address to sign as proof-of-possession.")
 	}
+
 	stack, _ := makeConfigNode(ctx)
 	ks := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
 
-	blsAddr := ctx.Args()[0]
-	popAddr := common.HexToAddress(ctx.Args()[1])
-	account, _ := unlockAccount(ctx, ks, blsAddr, 0, nil)
-	key, pop, err := ks.GenerateProofOfPossession(account, popAddr)
-	if err != nil {
-		return err
+	signer := common.HexToAddress(ctx.Args()[0])
+	message := common.HexToAddress(ctx.Args()[1])
+	account, _ := unlockAccount(ctx, ks, signer.String(), 0, nil)
+	if ctx.IsSet(blsFlag.Name) {
+		key, pop, err := ks.GenerateProofOfPossessionBLS(account, message)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Account {%x}:\n  Signature: %s\n  Public Key: %s\n", account.Address, hex.EncodeToString(pop), hex.EncodeToString(key))
+	} else {
+		pop, err := ks.GenerateProofOfPossession(account, message)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Account {%x}:\n  Signature: %s\n", account.Address, hex.EncodeToString(pop))
 	}
-	fmt.Printf("Account {%x}:\n  Signature: %s\n  Public Key: %s\n", account.Address, hex.EncodeToString(pop), hex.EncodeToString(key))
 
 	return nil
 }


### PR DESCRIPTION
### Description

This will allow validators to generate a proof-of-possession to authorize a signer without having to install the celocli.
 
### Tested

- Ran the commands and compared against the CLI. Format appears to be slightly different (RSV vs VRS) but our signature parsing library should handle that for us.

### Other changes

None

