### PR TITLE
create validator connections on upsert

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -700,7 +700,7 @@ func (sb *Backend) RefreshValPeers(valset istanbul.ValidatorSet) {
 		return
 	}
 
-	sb.valEnodeTable.RefreshValPeers(valset, sb.Address())
+	sb.valEnodeTable.RefreshValPeers(valset, sb.ValidatorAddress())
 }
 
 func (sb *Backend) ValidatorAddress() common.Address {

--- a/consensus/istanbul/backend/internal/enodes/val_enode_db.go
+++ b/consensus/istanbul/backend/internal/enodes/val_enode_db.go
@@ -304,9 +304,9 @@ func (vet *ValidatorEnodeDB) Upsert(valEnodeEntries map[common.Address]*AddressE
 			peersToRemove = append(peersToRemove, currentEntry.Node)
 		} else if isNew {
 			batch.Put(nodeIDKey(addressEntry.Node.ID()), remoteAddress.Bytes())
-			peersToAdd[remoteAddress] = addressEntry.Node
 		}
 		batch.Put(addressKey(remoteAddress), rawEntry)
+		peersToAdd[remoteAddress] = addressEntry.Node
 
 		vet.logger.Trace("Going to upsert an entry in the valEnodeTable", "address", remoteAddress, "enodeURL", addressEntry.Node.String())
 	}

--- a/consensus/istanbul/backend/internal/enodes/val_enode_db.go
+++ b/consensus/istanbul/backend/internal/enodes/val_enode_db.go
@@ -266,6 +266,9 @@ func (vet *ValidatorEnodeDB) GetAllValEnodes() (map[common.Address]*AddressEntry
 
 // Upsert will update or insert a validator enode entry; given that the existing entry
 // is older (determined by view parameter) that the new one
+// TODO - In addition to modifying the val_enode_db, this function also will disconnect
+//        and/or connect the corresponding validator connenctions.  The validator connections
+//        should be managed be a separate thread (see https://github.com/celo-org/celo-blockchain/issues/607)
 func (vet *ValidatorEnodeDB) Upsert(valEnodeEntries map[common.Address]*AddressEntry) error {
 	vet.lock.Lock()
 	defer vet.lock.Unlock()


### PR DESCRIPTION
### Description

This is a temporary fix to handle the case when a proxy or validator starts up and it's val_enode_table is persisted.  It originally wouldn't establish validator connections because the announce/val_enode_share entries are already on disk.  

This change will establish those val connections even if the entries are already on disk.

The more permanent fix is to have a separate validator conn manager goroutine that will monitor the val connections with respect to the val_enode_table (https://github.com/celo-org/celo-blockchain/issues/607).

### Tested

Unit tests

### Other changes

None

### Related issues

- Fixes #662

### Backwards compatibility

Is backwards compatible.