### PR TITLE
Fix non-fatal panic on forwarding transactions without gateway fee

### DIFF
--- a/les/peer.go
+++ b/les/peer.go
@@ -607,17 +607,20 @@ func (ps *peerSet) randomPeerEtherbase() common.Address {
 	return r
 }
 
-func (ps *peerSet) getPeerWithEtherbase(etherbase common.Address) (*peer, error) {
+func (ps *peerSet) getPeerWithEtherbase(etherbase *common.Address) (*peer, error) {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
+	if etherbase == nil {
+		etherbase = new(common.Address)
+	}
 	var pid string
 	for id, petherbase := range ps.etherbases {
-		if etherbase == petherbase {
+		if *etherbase == petherbase {
 			pid = id
 		}
 	}
 	if pid == "" {
-		log.Info(errNoPeerWithEtherbaseFound.Error(), "etherbase", etherbase)
+		log.Info(errNoPeerWithEtherbaseFound.Error(), "etherbase", *etherbase)
 		return nil, errNoPeerWithEtherbaseFound
 	}
 	peer := ps.peers[pid]

--- a/les/txrelay.go
+++ b/les/txrelay.go
@@ -64,7 +64,7 @@ func (self *LesTxRelay) unregisterPeer(p *peer) {
 	self.peerList = self.ps.AllPeers()
 }
 
-func (self *LesTxRelay) HasPeerWithEtherbase(etherbase common.Address) error {
+func (self *LesTxRelay) HasPeerWithEtherbase(etherbase *common.Address) error {
 	_, err := self.ps.getPeerWithEtherbase(etherbase)
 	return err
 }
@@ -78,7 +78,7 @@ func (self *LesTxRelay) send(txs types.Transactions) {
 		hash := tx.Hash()
 		ltr, ok := self.txSent[hash]
 		if !ok {
-			p, err := self.ps.getPeerWithEtherbase(*tx.GatewayFeeRecipient())
+			p, err := self.ps.getPeerWithEtherbase(tx.GatewayFeeRecipient())
 			// TODO(asa): When this happens, the nonce is still incremented, preventing future txs from being added.
 			// We rely on transactions to be rejected in light/txpool validateTx to prevent transactions
 			// with GatewayFeeRecipient != one of our peers from making it to the relayer.

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -87,7 +87,7 @@ type TxRelayBackend interface {
 	Send(txs types.Transactions)
 	NewHead(head common.Hash, mined []common.Hash, rollback []common.Hash)
 	Discard(hashes []common.Hash)
-	HasPeerWithEtherbase(etherbase common.Address) error
+	HasPeerWithEtherbase(etherbase *common.Address) error
 }
 
 // NewTxPool creates a new light transaction pool
@@ -392,12 +392,7 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 	}
 
 	// Should have a peer that will accept and broadcast our transaction
-	if tx.GatewayFeeRecipient() == nil {
-		err = pool.relay.HasPeerWithEtherbase(common.Address{})
-	} else {
-		err = pool.relay.HasPeerWithEtherbase(*tx.GatewayFeeRecipient())
-	}
-	if err != nil {
+	if err := pool.relay.HasPeerWithEtherbase(tx.GatewayFeeRecipient()); err != nil {
 		return err
 	}
 

--- a/light/txpool_test.go
+++ b/light/txpool_test.go
@@ -51,7 +51,7 @@ func (self *testTxRelay) Discard(hashes []common.Hash) {
 	self.discard <- len(hashes)
 }
 
-func (self *testTxRelay) HasPeerWithEtherbase(common.Address) error {
+func (self *testTxRelay) HasPeerWithEtherbase(*common.Address) error {
 	return nil
 }
 


### PR DESCRIPTION
### Description

If a light client is connected to a full-node who does not specify an etherbase, a panic will prevent the light client from forwarding them transactions. This panic is nonfatal, as it is recovered from in a resonable place.

### Tested

Tested with a local testnet where no etherbase is specified on a full-node and transactions are forwarded.

### Backwards compatibility

Fully backwards compatible and only the light client needs to be changed.
