### PR TITLE
Print public key in ECDSA account proof-of-possession

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -105,7 +105,7 @@ type Wallet interface {
 	SignHash(account Account, hash []byte) ([]byte, error)
 	SignHashBLS(account Account, hash []byte) ([]byte, error)
 	SignMessageBLS(account Account, msg []byte, extraData []byte) ([]byte, error)
-	GenerateProofOfPossession(account Account, address common.Address) ([]byte, error)
+	GenerateProofOfPossession(account Account, address common.Address) ([]byte, []byte, error)
 	GenerateProofOfPossessionBLS(account Account, address common.Address) ([]byte, []byte, error)
 	GetPublicKey(account Account) (*ecdsa.PublicKey, error)
 

--- a/accounts/keystore/keystore.go
+++ b/accounts/keystore/keystore.go
@@ -353,12 +353,22 @@ func (ks *KeyStore) SignMessageBLS(a accounts.Account, msg []byte, extraData []b
 	return signatureBytes, nil
 }
 
-func (ks *KeyStore) GenerateProofOfPossession(a accounts.Account, address common.Address) ([]byte, error) {
+func (ks *KeyStore) GenerateProofOfPossession(a accounts.Account, address common.Address) ([]byte, []byte, error) {
+	publicKey, err := ks.GetPublicKey(a)
+	if err != nil {
+		return nil, nil, err
+	}
+	publicKeyBytes := crypto.FromECDSAPub(publicKey)
+
 	hash := crypto.Keccak256(address.Bytes())
 	msg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(hash), hash)
 	hash = crypto.Keccak256([]byte(msg))
 
-	return ks.SignHash(a, hash)
+	signature, err := ks.SignHash(a, hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	return publicKeyBytes, signature, nil
 }
 
 func (ks *KeyStore) GenerateProofOfPossessionBLS(a accounts.Account, address common.Address) ([]byte, []byte, error) {

--- a/accounts/keystore/wallet.go
+++ b/accounts/keystore/wallet.go
@@ -139,11 +139,11 @@ func (w *keystoreWallet) SignMessageBLS(account accounts.Account, msg []byte, ex
 	return w.keystore.SignMessageBLS(account, msg, extraData)
 }
 
-func (w *keystoreWallet) GenerateProofOfPossession(account accounts.Account, address common.Address) ([]byte, error) {
+func (w *keystoreWallet) GenerateProofOfPossession(account accounts.Account, address common.Address) ([]byte, []byte, error) {
 	// Make sure the requested account is contained within
 	if !w.Contains(account) {
 		log.Debug(accounts.ErrUnknownAccount.Error(), "account", account)
-		return nil, accounts.ErrUnknownAccount
+		return nil, nil, accounts.ErrUnknownAccount
 	}
 	// Account seems valid, request the keystore to sign
 	return w.keystore.GenerateProofOfPossession(account, address)

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -518,8 +518,8 @@ func (w *wallet) SignMessageBLS(account accounts.Account, msg []byte, extraData 
 	return nil, accounts.ErrNotSupported
 }
 
-func (w *wallet) GenerateProofOfPossession(account accounts.Account, address common.Address) ([]byte, error) {
-	return nil, accounts.ErrNotSupported
+func (w *wallet) GenerateProofOfPossession(account accounts.Account, address common.Address) ([]byte, []byte, error) {
+	return nil, nil, accounts.ErrNotSupported
 }
 
 func (w *wallet) GenerateProofOfPossessionBLS(account accounts.Account, address common.Address) ([]byte, []byte, error) {

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -240,7 +240,9 @@ func accountProofOfPossession(ctx *cli.Context) error {
 	var key []byte
 	var pop []byte
 	var err error
+	keyType := "ECDSA"
 	if ctx.IsSet(blsFlag.Name) {
+		keyType = "BLS"
 		key, pop, err = ks.GenerateProofOfPossessionBLS(account, message)
 	} else {
 		key, pop, err = ks.GenerateProofOfPossession(account, message)
@@ -248,7 +250,8 @@ func accountProofOfPossession(ctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Account {%x}:\n  Signature: %s\n  Public Key: %s\n", account.Address, hex.EncodeToString(pop), hex.EncodeToString(key))
+
+	fmt.Printf("Account {%x}:\n  Signature: %s\n  %s Public Key: %s\n", account.Address, keyType, hex.EncodeToString(pop), hex.EncodeToString(key))
 
 	return nil
 }

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -237,19 +237,18 @@ func accountProofOfPossession(ctx *cli.Context) error {
 	signer := common.HexToAddress(ctx.Args()[0])
 	message := common.HexToAddress(ctx.Args()[1])
 	account, _ := unlockAccount(ctx, ks, signer.String(), 0, nil)
+	var key []byte
+	var pop []byte
+	var err error
 	if ctx.IsSet(blsFlag.Name) {
-		key, pop, err := ks.GenerateProofOfPossessionBLS(account, message)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("Account {%x}:\n  Signature: %s\n  Public Key: %s\n", account.Address, hex.EncodeToString(pop), hex.EncodeToString(key))
+		key, pop, err = ks.GenerateProofOfPossessionBLS(account, message)
 	} else {
-		pop, err := ks.GenerateProofOfPossession(account, message)
-		if err != nil {
-			return err
-		}
-		fmt.Printf("Account {%x}:\n  Signature: %s\n", account.Address, hex.EncodeToString(pop))
+		key, pop, err = ks.GenerateProofOfPossession(account, message)
 	}
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Account {%x}:\n  Signature: %s\n  Public Key: %s\n", account.Address, hex.EncodeToString(pop), hex.EncodeToString(key))
 
 	return nil
 }

--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -45,7 +45,7 @@ func (sb *Backend) distributeEpochPaymentsAndRewards(header *types.Header, state
 	if err != nil {
 		return err
 	}
-	log.Info("Calculated target epoch payment and rewards", "validatorEpochPayment", validatorEpochPayment, "totalVoterRewards", totalVoterRewards)
+	log.Debug("Calculated target epoch payment and rewards", "validatorEpochPayment", validatorEpochPayment, "totalVoterRewards", totalVoterRewards)
 
 	// The validator set that signs off on the last block of the epoch is the one that we need to
 	// iterate over.
@@ -121,7 +121,7 @@ func (sb *Backend) updateValidatorScores(header *types.Header, state *state.Stat
 func (sb *Backend) distributeEpochPayments(header *types.Header, state *state.StateDB, valSet []istanbul.Validator, maxPayment *big.Int) (*big.Int, error) {
 	totalEpochPayments := big.NewInt(0)
 	for _, val := range valSet {
-		sb.logger.Info("Distributing epoch payment for address", "address", val.Address())
+		sb.logger.Debug("Distributing epoch payment for address", "address", val.Address())
 		epochPayment, err := validators.DistributeEpochPayment(header, state, val.Address(), maxPayment)
 		if err != nil {
 			return totalEpochPayments, nil


### PR DESCRIPTION
### Description

This is needed so that validators can register with validator signers. Accompanying monorepo PR:
https://github.com/celo-org/celo-monorepo/pull/1952

### Tested

- Used to register a validator on baklavastaging.


_Brief explanation of why these changes are/are not backwards compatible. Feel free to remove for trivial, backwards compatible changes._
