### PR TITLE
Wait T before committing new work so that the round is updated

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -447,6 +447,10 @@ func (w *worker) mainLoop() {
 		case req := <-w.newWorkCh:
 			if h, ok := w.engine.(consensus.Handler); ok {
 				h.NewWork()
+				// Wait a minimal amount of time so that the FinalizeCommittedEvent gets picked up by
+				// the engine and a new sequence gets started, so that we get the correct
+				// `ParentCommits` in `backend.Prepare`
+				time.Sleep(100 * time.Millisecond)
 			}
 			w.commitNewWork(req.interrupt, req.noempty, req.timestamp)
 

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -261,7 +261,7 @@ func testPendingStateAndBlock(t *testing.T, chainConfig *params.ChainConfig, eng
 	defer w.close()
 
 	// Ensure snapshot has been updated.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 	block, state := w.pending()
 	if block.NumberU64() != 1 {
 		t.Errorf("block number mismatch: have %d, want %d", block.NumberU64(), 1)
@@ -272,7 +272,7 @@ func testPendingStateAndBlock(t *testing.T, chainConfig *params.ChainConfig, eng
 	b.txPool.AddLocals(newTxs)
 
 	// Ensure the new tx events has been processed
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 	block, state = w.pending()
 	if balance := state.GetBalance(testUserAddress); balance.Cmp(big.NewInt(2000)) != 0 {
 		t.Errorf("account balance mismatch: have %d, want %d", balance, 2000)


### PR DESCRIPTION
### Description

We need to guarantee the backend will always receive the `FinalCommittedEvent` event to change the sequence, before the worker calls `backend.Prepare`. The event gets emitted via the handler's [NewWork](https://github.com/celo-org/celo-blockchain/blob/87e07a2cd532222baeae876c3d284adc506669b4/consensus/istanbul/backend/handler.go#L208) function. 

I suspect that `commitNewWork` gets called "too quickly", which results in `ParentCommits` being called before the event has been captured by the engine

Approaches:
- Add a tiny sleep in Line 450 in worker.go
- A sustainable fix would be to wait for the FinalCommittedEvent on the worker and call commitNewWork after it has been emitted.

### Tested

I manually ran all E2E tests with approach (1) and there is no occurrence of the error from Line https://github.com/celo-org/celo-blockchain/blob/10faac32afbf49b92f26e83f2a3949bf75e4813b/consensus/istanbul/backend/engine.go#L421

It might be the case that 100ms delay is too much and we can fix the issue with less. 

Ideally we want to deploy another cluster with this fix and see if it fixes the issue 

### Related issues

- Fixes #649 

### Backwards compatibility

OK
