### PR TITLE
Don't reuse variable i in pos.go

### DIFF
--- a/contract_comm/election/election.go
+++ b/contract_comm/election/election.go
@@ -188,13 +188,13 @@ func DistributeEpochRewards(header *types.Header, state vm.StateDB, groups []com
 
 		lesser := common.ZeroAddress
 		greater := common.ZeroAddress
-		for i, voteTotal := range voteTotals {
+		for j, voteTotal := range voteTotals {
 			if voteTotal.Group == group {
-				if i > 0 {
-					lesser = voteTotals[i-1].Group
+				if j > 0 {
+					lesser = voteTotals[j-1].Group
 				}
-				if i+1 < len(voteTotals) {
-					greater = voteTotals[i+1].Group
+				if j+1 < len(voteTotals) {
+					greater = voteTotals[j+1].Group
 				}
 				break
 			}


### PR DESCRIPTION
### Description

Unclear if this fixes the bug that @mrsmkl saw which caused rewards not to be distributed.


### Tested

Not tested.

