### PR TITLE
Use validator account addresses rather than signers in celostats

### DIFF
--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -205,7 +205,7 @@ func (sb *Backend) sendIstAnnounce() error {
 func (sb *Backend) retrieveActiveAndRegisteredValidators() (map[common.Address]bool, error) {
 	validatorsSet := make(map[common.Address]bool)
 
-	registeredValidators, err := validators.RetrieveRegisteredValidators(nil, nil)
+	registeredValidators, err := validators.RetrieveRegisteredValidatorSigners(nil, nil)
 
 	// The validator contract may not be deployed yet.
 	// Even if it is deployed, it may not have any registered validators yet.
@@ -270,7 +270,7 @@ func (sb *Backend) handleIstAnnounce(payload []byte) error {
 	}
 
 	if !regAndActiveVals[msg.Address] {
-		logger.Warn("Received an IstanbulAnnounce message from a non registered validator. Ignoring it.", "AnnounceMsg", msg.String(), "validators", regAndActiveVals, "err", err)
+		logger.Warn("Received an IstanbulAnnounce message from a non registered validator. Ignoring it.", "AnnounceMsg", msg.String(), "err", err)
 		return errUnauthorizedAnnounceMessage
 	}
 

--- a/contract_comm/validators/validators.go
+++ b/contract_comm/validators/validators.go
@@ -35,6 +35,20 @@ const validatorsABIString string = `[
 		{
 			"constant": true,
 			"inputs": [],
+			"name": "getRegisteredValidators",
+			"outputs": [
+			{
+				"name": "",
+				"type": "address[]"
+			}
+			],
+			"payable": false,
+			"stateMutability": "view",
+			"type": "function"
+		},
+		{
+			"constant": true,
+			"inputs": [],
 			"name": "getRegisteredValidatorSigners",
 			"outputs": [
 			{
@@ -168,6 +182,17 @@ type ValidatorContractData struct {
 var validatorsABI, _ = abi.JSON(strings.NewReader(validatorsABIString))
 
 func RetrieveRegisteredValidators(header *types.Header, state vm.StateDB) ([]common.Address, error) {
+	var regVals []common.Address
+
+	// Get the new epoch's validator set
+	if _, err := contract_comm.MakeStaticCall(params.ValidatorsRegistryId, validatorsABI, "getRegisteredValidators", []interface{}{}, &regVals, params.MaxGasForGetRegisteredValidators, header, state); err != nil {
+		return nil, err
+	}
+
+	return regVals, nil
+}
+
+func RetrieveRegisteredValidatorSigners(header *types.Header, state vm.StateDB) ([]common.Address, error) {
 	var regVals []common.Address
 
 	// Get the new epoch's validator set


### PR DESCRIPTION
### Description

Fixes a bug in which we'd fail to fetch validator info due to the wrong address being used.

### Tested

Not tested

