### PR TITLE
Sort validator group votes in descending order

### DIFF
--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -251,7 +251,7 @@ func accountProofOfPossession(ctx *cli.Context) error {
 		return err
 	}
 
-	fmt.Printf("Account {%x}:\n  Signature: %s\n  %s Public Key: %s\n", account.Address, keyType, hex.EncodeToString(pop), hex.EncodeToString(key))
+	fmt.Printf("Account {%x}:\n  Signature: %s\n  %s Public Key: %s\n", account.Address, hex.EncodeToString(pop), keyType, hex.EncodeToString(key))
 
 	return nil
 }

--- a/contract_comm/election/election.go
+++ b/contract_comm/election/election.go
@@ -182,8 +182,9 @@ func DistributeEpochRewards(header *types.Header, state vm.StateDB, groups []com
 			}
 		}
 
+		// Sorting in descending order is necessary to match the order on-chain.
 		sort.SliceStable(voteTotals, func(j, k int) bool {
-			return voteTotals[j].Value.Cmp(voteTotals[k].Value) < 0
+			return voteTotals[j].Value.Cmp(voteTotals[k].Value) > 0
 		})
 
 		lesser := common.ZeroAddress
@@ -191,10 +192,10 @@ func DistributeEpochRewards(header *types.Header, state vm.StateDB, groups []com
 		for i, voteTotal := range voteTotals {
 			if voteTotal.Group == group {
 				if i > 0 {
-					lesser = voteTotals[i-1].Group
+					greater = voteTotals[i-1].Group
 				}
 				if i+1 < len(voteTotals) {
-					greater = voteTotals[i+1].Group
+					lesser = voteTotals[i+1].Group
 				}
 				break
 			}


### PR DESCRIPTION
### Description

This PR fixes a bug in epoch rewards distribution. By sorting in ascending order, which does not match the order of the on-chain list, we risk not perfectly reversing the array. By sorting in descending order, we are guaranteed that the order continues to match the on-chain order.  

h/t @mrsmkl for discovering this

### Tested

Not tested

