### PR TITLE
retrieve validators and signers

### DIFF
--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -205,7 +205,7 @@ func (sb *Backend) sendIstAnnounce() error {
 func (sb *Backend) retrieveActiveAndRegisteredValidators() (map[common.Address]bool, error) {
 	validatorsSet := make(map[common.Address]bool)
 
-	registeredValidators, err := validators.RetrieveRegisteredValidators(nil, nil)
+	registeredValidators, err := validators.RetrieveRegisteredValidatorSigners(nil, nil)
 
 	// The validator contract may not be deployed yet.
 	// Even if it is deployed, it may not have any registered validators yet.

--- a/contract_comm/validators/validators.go
+++ b/contract_comm/validators/validators.go
@@ -32,20 +32,34 @@ import (
 
 // This is taken from celo-monorepo/packages/protocol/build/<env>/contracts/Validators.json
 const validatorsABIString string = `[
-		{
-			"constant": true,
-			"inputs": [],
-			"name": "getRegisteredValidatorSigners",
-			"outputs": [
-			{
-				"name": "",
-				"type": "address[]"
-			}
-			],
-			"payable": false,
-			"stateMutability": "view",
-			"type": "function"
-		},
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "getRegisteredValidatorSigners",
+        "outputs": [
+        {
+            "name": "",
+            "type": "address[]"
+        }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getRegisteredValidators",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address[]"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
     {
       "constant": true,
       "inputs": [
@@ -119,7 +133,7 @@ const validatorsABIString string = `[
       "stateMutability": "nonpayable",
       "type": "function"
     },
-		    {
+    {
       "constant": false,
       "inputs": [
         {
@@ -137,7 +151,7 @@ const validatorsABIString string = `[
       "stateMutability": "nonpayable",
       "type": "function"
     },
-		    {
+    {
       "constant": true,
       "inputs": [
         {
@@ -167,11 +181,22 @@ type ValidatorContractData struct {
 
 var validatorsABI, _ = abi.JSON(strings.NewReader(validatorsABIString))
 
+func RetrieveRegisteredValidatorSigners(header *types.Header, state vm.StateDB) ([]common.Address, error) {
+	var regVals []common.Address
+
+	// Get the new epoch's validator signer set
+	if _, err := contract_comm.MakeStaticCall(params.ValidatorsRegistryId, validatorsABI, "getRegisteredValidatorSigners", []interface{}{}, &regVals, params.MaxGasForGetRegisteredValidators, header, state); err != nil {
+		return nil, err
+	}
+
+	return regVals, nil
+}
+
 func RetrieveRegisteredValidators(header *types.Header, state vm.StateDB) ([]common.Address, error) {
 	var regVals []common.Address
 
 	// Get the new epoch's validator set
-	if _, err := contract_comm.MakeStaticCall(params.ValidatorsRegistryId, validatorsABI, "getRegisteredValidatorSigners", []interface{}{}, &regVals, params.MaxGasForGetRegisteredValidators, header, state); err != nil {
+	if _, err := contract_comm.MakeStaticCall(params.ValidatorsRegistryId, validatorsABI, "getRegisteredValidators", []interface{}{}, &regVals, params.MaxGasForGetRegisteredValidators, header, state); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Description
Fixes a bug in which we'd fail to fetch validator info due to the wrong address being used.

Tested
Tested locally and with a tx node against baklavastaging