### PR TITLE
expose validator.signer address and warn on latency error

### DIFF
--- a/contract_comm/validators/validators.go
+++ b/contract_comm/validators/validators.go
@@ -104,6 +104,10 @@ const validatorsABIString string = `[
         {
           "name": "score",
           "type": "uint256"
+        },
+        {
+          "name": "signer",
+          "type": "address"
         }
       ],
       "payable": false,
@@ -177,6 +181,7 @@ type ValidatorContractData struct {
 	BlsPublicKey   []byte
 	Affiliation    common.Address
 	Score          *big.Int
+	Signer         common.Address
 }
 
 var validatorsABI, _ = abi.JSON(strings.NewReader(validatorsABIString))

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -569,7 +569,8 @@ func (s *Service) readLoop(conn *websocket.Conn) {
 // server. Use the individual methods for reporting subscribed events.
 func (s *Service) report(conn *websocket.Conn, sendCh chan *StatsPayload) error {
 	if err := s.reportLatency(conn, sendCh); err != nil {
-		return err
+		log.Warn("Latency failed to report", "err", err)
+		return nil
 	}
 	if err := s.reportBlock(conn, nil); err != nil {
 		return err
@@ -841,6 +842,7 @@ type validatorInfo struct {
 	BLSPublicKey   []byte         `json:"blsPublicKey"`
 	EcdsaPublicKey []byte         `json:"ecdsaPublicKey"`
 	Affiliation    common.Address `json:"affiliation"`
+	Signer         common.Address `json:"signer"`
 }
 
 func (s *Service) assembleValidatorSet(block *types.Block, state vm.StateDB) validatorSet {
@@ -868,6 +870,7 @@ func (s *Service) assembleValidatorSet(block *types.Block, state vm.StateDB) val
 			BLSPublicKey:   valData.BlsPublicKey,
 			EcdsaPublicKey: valData.EcdsaPublicKey,
 			Affiliation:    valData.Affiliation,
+			Signer:         valData.Signer,
 		})
 	}
 


### PR DESCRIPTION
- expose the validator.signer field for account coupling in the operator, see https://github.com/celo-org/celo-monorepo/pull/1997/ for the contract side

- `reportLatency` often errors because of handshaking with `ethstats-server` (hello-ack, ping-pong). This might throw and close the connection on initialReport as both login and initialReport are waiting for responses. This is a patch that might give a glitch in latency, but avoids new connections being made upon every login try

### Tested
Not tested, best tested in staging with >50 nodes

### Logs
Connections are being made and not closed due to a ping-pong hello-ack conflict:
![image](https://user-images.githubusercontent.com/6178597/70004517-d3a6e880-1566-11ea-86de-071ac954b0c5.png)
