### PR TITLE
Use inmemory valnodedb for mobile geth

### DIFF
--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -191,6 +191,8 @@ func NewNode(datadir string, config *NodeConfig) (stack *Node, _ error) {
 		ethConf.SyncMode = getSyncMode(config.SyncMode)
 		ethConf.NetworkId = uint64(config.EthereumNetworkID)
 		ethConf.DatabaseCache = config.EthereumDatabaseCache
+		// Use an in memory DB for validatorEnode table
+		ethConf.Istanbul.ValidatorEnodeDBPath = ""
 		if err := rawStack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 			return les.New(ctx, &ethConf)
 		}); err != nil {


### PR DESCRIPTION
### Description

When running geth on mobile we set validatorEnodeDbPath to `""` so we use the inmemory version of it.

### Tested

Manual

