### PR TITLE
Reduce intrinsic gas cost for txs paying fees in alternative currencies

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -147,7 +147,7 @@ func makeRegistryId(contractName string) [32]byte {
 const (
 	// Default intrinsic gas cost of transactions paying for gas in alternative currencies.
 	// Calculated to estimate 1 balance read, 1 debit, and 4 credit transactions.
-	IntrinsicGasForAlternativeFeeCurrency uint64 = 166000
+	IntrinsicGasForAlternativeFeeCurrency uint64 = 50000
 
 	// Contract communication gas limits
 	MaxGasForCalculateTargetEpochPaymentAndRewards uint64 = 2000000


### PR DESCRIPTION
### Description

Reduces the previous, extremely conservative value of 166,000 to 50,000.


### Tested

Unit tests
### Other changes

None

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/1443

### Backwards compatibility

Not backwards compatible