### PR TITLE
Proxy SNBAT disconnect proxied validator from a max peers limit

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -279,8 +279,8 @@ func (pm *ProtocolManager) newPeer(pv int, p *p2p.Peer, rw p2p.MsgReadWriter) *p
 // handle is the callback invoked to manage the life cycle of an eth peer. When
 // this function terminates, the peer is disconnected.
 func (pm *ProtocolManager) handle(p *peer) error {
-	// Ignore maxPeers if this is a trusted or statically dialed peer
-	if pm.peers.Len() >= pm.maxPeers && !(p.Peer.Info().Network.Trusted || p.Peer.Info().Network.Static) {
+	// Ignore maxPeers if this is a trusted or statically dialed peer or if the peer is from from the proxy server (e.g. peers connected to this node's internal network interface)
+	if pm.peers.Len() >= pm.maxPeers && !(p.Peer.Info().Network.Trusted || p.Peer.Info().Network.Static) && p.Peer.Server != pm.proxyServer {
 		return p2p.DiscTooManyPeers
 	}
 	p.Log().Debug("Ethereum peer connected", "name", p.Name())


### PR DESCRIPTION
### Description

This is a bug fix to prevent any peers connected via a proxy's "internal" network interface get disconnected from a max peers limit.

### Tested

Reproduced the issue on my local computer without the fix.  Added the fix and verified that the proxied validator doesn't get disconnected from the proxy.

### Other changes

None

### Related issues

- Fixes https://github.com/celo-org/celo-blockchain/issues/691

### Backwards compatibility

Is backwards compatible.
