### PR TITLE
Exp backoff for RC messages 

### DIFF
--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
-
 	"github.com/ethereum/go-ethereum/core/types"
 	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 	"github.com/ethereum/go-ethereum/event"
@@ -435,8 +434,8 @@ func (c *core) newRoundChangeTimerForView(view *istanbul.View) {
 		// timeout for first round takes into account expected block period
 		timeout += time.Duration(c.config.BlockPeriod) * time.Second
 	} else {
-		// timeout for subsequent rounds adds an exponential backup, capped at 2**5 = 32s
-		timeout += time.Duration(math.Pow(2, math.Min(float64(round), 5.))) * time.Second
+		// timeout for subsequent rounds adds an exponential backup.
+		timeout += time.Duration(math.Pow(2, float64(round))) * time.Second
 	}
 
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -435,7 +435,7 @@ func (c *core) newRoundChangeTimerForView(view *istanbul.View) {
 		timeout += time.Duration(c.config.BlockPeriod) * time.Second
 	} else {
 		// timeout for subsequent rounds adds an exponential backup.
-		timeout += time.Duration(math.Pow(2, float64(round))) * time.Second
+		timeout += time.Duration(math.Pow(1.05, float64(round))) * time.Second
 	}
 
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -77,7 +77,10 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 	preferredDigest := common.Hash{}
 	seen := make(map[common.Address]bool)
 	decodedMessages := make([]istanbul.RoundChange, len(roundChangeCertificate.RoundChangeMessages))
-	for i, message := range roundChangeCertificate.RoundChangeMessages {
+	for i := range roundChangeCertificate.RoundChangeMessages {
+		// use a different variable each time since we'll store a pointer to the variable
+		message := roundChangeCertificate.RoundChangeMessages[i]
+
 		// Verify message signed by a validator
 		data, err := message.PayloadNoSig()
 		if err != nil {


### PR DESCRIPTION
### Description

* Remove the cap on exponential backoff for IBFT round change messages.
* Merge fix: Storage for message loop variable is reused

### Tested

Integration tests. plus reverting to behavior in PBFT paper.

### Other changes

_Describe any minor or "drive-by" changes here._

### Related issues

- Fixes #706 

### Backwards compatibility

Yes