### PR TITLE
On receipt of earlier RC msg, send one back to initiator

### DIFF
--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -516,7 +516,7 @@ func (c *core) newRoundChangeTimerForView(view *istanbul.View) {
 		timeout += time.Duration(c.config.BlockPeriod) * time.Second
 	} else {
 		// timeout for subsequent rounds adds an exponential backoff.
-		timeout += time.Duration(math.Pow(1.05, float64(round))) * time.Second
+		timeout += time.Duration(math.Pow(2, float64(round))) * time.Second
 	}
 
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -28,13 +28,12 @@ import (
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
-	"github.com/syndtr/goleveldb/leveldb"
-
 	"github.com/ethereum/go-ethereum/core/types"
 	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 // New creates an Istanbul consensus core
@@ -145,8 +144,18 @@ func (c *core) finalizeMessage(msg *istanbul.Message) ([]byte, error) {
 	return payload, nil
 }
 
+// Send message to all current validators
 func (c *core) broadcast(msg *istanbul.Message) {
-	logger := c.newLogger("func", "broadcast")
+	c.sendMsgTo(msg, istanbul.GetAddressesFromValidatorList(c.current.ValidatorSet().List()))
+}
+
+// Send message to a specific address
+func (c *core) unicast(msg *istanbul.Message, addr common.Address) {
+	c.sendMsgTo(msg, []common.Address{addr})
+}
+
+func (c *core) sendMsgTo(msg *istanbul.Message, addresses []common.Address) {
+	logger := c.newLogger("func", "sendMsgTo")
 
 	payload, err := c.finalizeMessage(msg)
 	if err != nil {
@@ -154,10 +163,9 @@ func (c *core) broadcast(msg *istanbul.Message) {
 		return
 	}
 
-	// Broadcast payload
-	validators := istanbul.GetAddressesFromValidatorList(c.current.ValidatorSet().List())
-	if err := c.backend.BroadcastConsensusMsg(validators, payload); err != nil {
-		logger.Error("Failed to broadcast message", "msg", msg, "err", err)
+	// Send payload to the specified addresses
+	if err := c.backend.BroadcastConsensusMsg(addresses, payload); err != nil {
+		logger.Error("Failed to send message", "msg", msg, "err", err)
 		return
 	}
 }
@@ -175,11 +183,11 @@ func (c *core) commit() error {
 	if proposal != nil {
 		aggregatedSeal, err := GetAggregatedSeal(c.current.Commits(), c.current.Round())
 		if err != nil {
-			c.sendNextRoundChange()
+			c.waitForDesiredRound(new(big.Int).Add(c.current.Round(), common.Big1))
 			return nil
 		}
 		if err := c.backend.Commit(proposal, aggregatedSeal); err != nil {
-			c.sendNextRoundChange()
+			c.waitForDesiredRound(new(big.Int).Add(c.current.Round(), common.Big1))
 			return nil
 		}
 	}
@@ -380,7 +388,7 @@ func (c *core) waitForDesiredRound(r *big.Int) error {
 		return nil
 	}
 
-	logger.Debug("Waiting for desired round")
+	logger.Debug("Round Change: Waiting for desired round")
 	desiredView := &istanbul.View{
 		Sequence: new(big.Int).Set(c.current.Sequence()),
 		Round:    new(big.Int).Set(r),
@@ -507,8 +515,8 @@ func (c *core) newRoundChangeTimerForView(view *istanbul.View) {
 		// timeout for first round takes into account expected block period
 		timeout += time.Duration(c.config.BlockPeriod) * time.Second
 	} else {
-		// timeout for subsequent rounds adds an exponential backup, capped at 2**5 = 32s
-		timeout += time.Duration(math.Pow(2, math.Min(float64(round), 5.))) * time.Second
+		// timeout for subsequent rounds adds an exponential backoff.
+		timeout += time.Duration(math.Pow(1.05, float64(round))) * time.Second
 	}
 
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -346,8 +346,22 @@ func (rcs *roundChangeSet) String() string {
 	rcs.mu.Lock()
 	defer rcs.mu.Unlock()
 
-	msgsForRoundStr := make([]string, 0, len(rcs.msgsForRound))
-	for r, rms := range rcs.msgsForRound {
+	// Sort rounds descending
+	var sortedRounds []uint64
+	for r := range rcs.msgsForRound {
+		sortedRounds = append(sortedRounds, r)
+	}
+	sort.Slice(sortedRounds, func(i, j int) bool { return sortedRounds[i] > sortedRounds[j] })
+
+	modeRound := uint64(0)
+	modeRoundSize := 0
+	msgsForRoundStr := make([]string, 0, len(sortedRounds))
+	for _, r := range sortedRounds {
+		rms := rcs.msgsForRound[r]
+		if rms.Size() > modeRoundSize {
+			modeRound = r
+			modeRoundSize = rms.Size()
+		}
 		msgsForRoundStr = append(msgsForRoundStr, fmt.Sprintf("%v: %v", r, rms.String()))
 	}
 
@@ -356,8 +370,10 @@ func (rcs *roundChangeSet) String() string {
 		latestRoundForValStr = append(latestRoundForValStr, fmt.Sprintf("%v: %v", addr.String(), r))
 	}
 
-	return fmt.Sprintf("RCS len=%v  By round: {<%v> %v}  By val: {<%v> %v}",
+	return fmt.Sprintf("RCS len=%v mode_round=%v mode_round_len=%v By round: {<%v> %v}  By val: {<%v> %v}",
 		len(rcs.latestRoundForVal),
+		modeRound,
+		modeRoundSize,
 		len(rcs.msgsForRound),
 		strings.Join(msgsForRoundStr, ", "),
 		len(rcs.latestRoundForVal),

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -182,9 +182,9 @@ func (c *core) handleRoundChange(msg *istanbul.Message) error {
 	err := c.checkMessage(istanbul.MsgRoundChange, rc.View)
 
 	// If the RC message is for the current sequence but a prior round, help the sender fast forward
-	// by sending back to it (not broadcasting) a round change message for our current/desired TODO round.
+	// by sending back to it (not broadcasting) a round change message for our desired round.
 	if err == errOldMessage && rc.View.Sequence.Cmp(c.current.Sequence()) == 0 {
-		logger.Trace("Sending round change for current round to node in previous round", "msg_round", rc.View.Round)
+		logger.Trace("Sending round change for des1ired round to node with a previous desired round", "msg_round", rc.View.Round)
 		c.sendRoundChangeAgain(msg.Address)
 		return nil
 	} else if err != nil {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -32,7 +32,7 @@ func (c *core) sendRoundChange(round *big.Int) {
 	logger := c.newLogger("func", "sendRoundChange", "target_round", round)
 
 	if c.current.View().Round.Cmp(round) >= 0 {
-		logger.Warn("Cannot send out the round change")
+		logger.Warn("Cannot send round change for previous round")
 		return
 	}
 
@@ -184,7 +184,7 @@ func (c *core) handleRoundChange(msg *istanbul.Message) error {
 	// If the RC message is for the current sequence but a prior round, help the sender fast forward
 	// by sending back to it (not broadcasting) a round change message for our desired round.
 	if err == errOldMessage && rc.View.Sequence.Cmp(c.current.Sequence()) == 0 {
-		logger.Trace("Sending round change for des1ired round to node with a previous desired round", "msg_round", rc.View.Round)
+		logger.Trace("Sending round change for desired round to node with a previous desired round", "msg_round", rc.View.Round)
 		c.sendRoundChangeAgain(msg.Address)
 		return nil
 	} else if err != nil {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -362,7 +362,7 @@ func (rcs *roundChangeSet) String() string {
 			modeRound = r
 			modeRoundSize = rms.Size()
 		}
-		msgsForRoundStr = append(msgsForRoundStr, fmt.Sprintf("\n%v: %v", r, rms.String()))
+		msgsForRoundStr = append(msgsForRoundStr, fmt.Sprintf("%v: %v", r, rms.String()))
 	}
 
 	latestRoundForValStr := make([]string, 0, len(rcs.latestRoundForVal))
@@ -370,7 +370,7 @@ func (rcs *roundChangeSet) String() string {
 		latestRoundForValStr = append(latestRoundForValStr, fmt.Sprintf("%v: %v", addr.String(), r))
 	}
 
-	return fmt.Sprintf("RCS len=%v mode_round=%v mode_round_len=%v By round: {<%v> %v}",
+	return fmt.Sprintf("RCS len=%v mode_round=%v mode_round_len=%v unique_rounds=<%v> %v",
 		len(rcs.latestRoundForVal),
 		modeRound,
 		modeRoundSize,

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -362,7 +362,7 @@ func (rcs *roundChangeSet) String() string {
 			modeRound = r
 			modeRoundSize = rms.Size()
 		}
-		msgsForRoundStr = append(msgsForRoundStr, fmt.Sprintf("%v: %v", r, rms.String()))
+		msgsForRoundStr = append(msgsForRoundStr, fmt.Sprintf("\n%v: %v", r, rms.String()))
 	}
 
 	latestRoundForValStr := make([]string, 0, len(rcs.latestRoundForVal))
@@ -370,14 +370,12 @@ func (rcs *roundChangeSet) String() string {
 		latestRoundForValStr = append(latestRoundForValStr, fmt.Sprintf("%v: %v", addr.String(), r))
 	}
 
-	return fmt.Sprintf("RCS len=%v mode_round=%v mode_round_len=%v By round: {<%v> %v}  By val: {<%v> %v}",
+	return fmt.Sprintf("RCS len=%v mode_round=%v mode_round_len=%v By round: {<%v> %v}",
 		len(rcs.latestRoundForVal),
 		modeRound,
 		modeRoundSize,
 		len(rcs.msgsForRound),
-		strings.Join(msgsForRoundStr, ", "),
-		len(rcs.latestRoundForVal),
-		strings.Join(latestRoundForValStr, ", "))
+		strings.Join(msgsForRoundStr, ", "))
 }
 
 // Gets a round change certificate for a specific round.

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -27,26 +27,42 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
-// sendNextRoundChange sends the ROUND CHANGE message with current round + 1
-func (c *core) sendNextRoundChange() {
-	cv := c.current.View()
-	c.sendRoundChange(new(big.Int).Add(cv.Round, common.Big1))
-}
-
 // sendRoundChange sends the ROUND CHANGE message with the given round
 func (c *core) sendRoundChange(round *big.Int) {
-	logger := c.newLogger("func", "sendRoundChange", "target round", round)
+	logger := c.newLogger("func", "sendRoundChange", "target_round", round)
 
-	cv := c.current.View()
-	if cv.Round.Cmp(round) >= 0 {
-		logger.Error("Cannot send out the round change")
+	if c.current.View().Round.Cmp(round) >= 0 {
+		logger.Warn("Cannot send out the round change")
 		return
 	}
 
+	msg, err := c.buildRoundChangeMsg(round)
+	if err != nil {
+		logger.Error("Could not build round change message", "err", msg)
+		return
+	}
+
+	c.broadcast(msg)
+}
+
+// sendRoundChange sends a ROUND CHANGE message for the current round back to a single address
+func (c *core) sendRoundChangeAgain(addr common.Address) {
+	logger := c.newLogger("func", "sendRoundChange", "desired_round", c.current.DesiredRound(), "to", addr)
+
+	msg, err := c.buildRoundChangeMsg(c.current.DesiredRound())
+	if err != nil {
+		logger.Error("Could not build round change message", "err", err)
+		return
+	}
+
+	c.unicast(msg, addr)
+}
+
+// buildRoundChangeMsg creates a round change msg for the given round
+func (c *core) buildRoundChangeMsg(round *big.Int) (*istanbul.Message, error) {
 	nextView := &istanbul.View{
-		// The round number we'd like to transfer to.
 		Round:    new(big.Int).Set(round),
-		Sequence: new(big.Int).Set(cv.Sequence),
+		Sequence: new(big.Int).Set(c.current.View().Sequence),
 	}
 
 	rc := &istanbul.RoundChange{
@@ -56,14 +72,13 @@ func (c *core) sendRoundChange(round *big.Int) {
 
 	payload, err := Encode(rc)
 	if err != nil {
-		logger.Error("Failed to encode ROUND CHANGE", "rc", rc, "err", err)
-		return
+		return nil, err
 	}
-	logger.Trace("Sending round change message", "rcs", c.roundChangeSet)
-	c.broadcast(&istanbul.Message{
+
+	return &istanbul.Message{
 		Code: istanbul.MsgRoundChange,
 		Msg:  payload,
-	})
+	}, nil
 }
 
 func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChangeCertificate istanbul.RoundChangeCertificate) error {
@@ -109,7 +124,7 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 
 		var roundChange *istanbul.RoundChange
 		if err := message.Decode(&roundChange); err != nil {
-			logger.Error("Failed to decode ROUND CHANGE in certificate", "err", err)
+			logger.Warn("Failed to decode ROUND CHANGE in certificate", "err", err)
 			return err
 		}
 
@@ -159,12 +174,20 @@ func (c *core) handleRoundChange(msg *istanbul.Message) error {
 	// Decode ROUND CHANGE message
 	var rc *istanbul.RoundChange
 	if err := msg.Decode(&rc); err != nil {
-		logger.Error("Failed to decode ROUND CHANGE", "err", err)
+		logger.Info("Failed to decode ROUND CHANGE", "err", err)
 		return errInvalidMessage
 	}
 
 	// Must be same sequence and future round.
-	if err := c.checkMessage(istanbul.MsgRoundChange, rc.View); err != nil {
+	err := c.checkMessage(istanbul.MsgRoundChange, rc.View)
+
+	// If the RC message is for the current sequence but a prior round, help the sender fast forward
+	// by sending back to it (not broadcasting) a round change message for our current/desired TODO round.
+	if err == errOldMessage && rc.View.Sequence.Cmp(c.current.Sequence()) == 0 {
+		logger.Trace("Sending round change for current round to node in previous round", "msg_round", rc.View.Round)
+		c.sendRoundChangeAgain(msg.Address)
+		return nil
+	} else if err != nil {
 		logger.Info("Check round change message failed", "err", err)
 		return err
 	}


### PR DESCRIPTION
### Description

* Remove the cap on exponential backoff for IBFT round change messages. 
* If we receive a valid RC message for current seq but round earlier than our desired round, send a RC message back to the sender to speed recipent collecting F+1 and fast-forwarding to our desired round. 
* In the exception case that sealing fails, call `waitForDesiredRound` to correctly update state rather than just send the round change message.

### Tested

Unit and integration tests.

### Backwards compatibility

NO -- Nodes with mixed RC timeout policies cannot be mixed.
