### PR TITLE
Reject round changes messages for previous sequences, more logging

### DIFF
--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -99,17 +99,17 @@ func (sb *Backend) updateValidatorScores(header *types.Header, state *state.Stat
 
 	for i, val := range valSet {
 		scoreTally := uptimes.Entries[i].ScoreTally
-		logger = logger.New("scoreTally", scoreTally, "denominator", denominator, "index", i, "address", val.Address())
+		val_logger := logger.New("scoreTally", scoreTally, "denominator", denominator, "index", i, "address", val.Address())
 		numerator := big.NewInt(0).Mul(big.NewInt(int64(uptimes.Entries[i].ScoreTally)), params.Fixidity1)
 		uptime := big.NewInt(0).Div(numerator, big.NewInt(int64(denominator)))
 
 		if scoreTally > denominator {
-			logger.Error("ScoreTally exceeds max possible")
+			val_logger.Error("ScoreTally exceeds max possible")
 			// 1.0 in fixidity
 			uptime = params.Fixidity1
 		}
 
-		logger.Trace("Updating validator score", "uptime", uptime)
+		val_logger.Trace("Updating validator score", "uptime", uptime)
 		err := validators.UpdateValidatorScore(header, state, val.Address(), uptime)
 		if err != nil {
 			return err

--- a/consensus/istanbul/core/backlog.go
+++ b/consensus/istanbul/core/backlog.go
@@ -44,7 +44,7 @@ func (c *core) checkMessage(msgCode uint64, view *istanbul.View) error {
 	if msgCode == istanbul.MsgRoundChange {
 		if view.Sequence.Cmp(c.current.Sequence()) > 0 {
 			return errFutureMessage
-		} else if view.Round.Cmp(c.current.DesiredRound()) < 0 || view.Sequence.Cmp(c.current.Sequence() < 0 {
+		} else if view.Round.Cmp(c.current.DesiredRound()) < 0 || view.Sequence.Cmp(c.current.Sequence()) < 0 {
 			return errOldMessage
 		}
 		return nil

--- a/consensus/istanbul/core/backlog.go
+++ b/consensus/istanbul/core/backlog.go
@@ -44,7 +44,7 @@ func (c *core) checkMessage(msgCode uint64, view *istanbul.View) error {
 	if msgCode == istanbul.MsgRoundChange {
 		if view.Sequence.Cmp(c.current.Sequence()) > 0 {
 			return errFutureMessage
-		} else if view.Round.Cmp(c.current.DesiredRound()) < 0 {
+		} else if view.Round.Cmp(c.current.DesiredRound()) < 0 || view.Sequence.Cmp(c.current.Sequence() < 0 {
 			return errOldMessage
 		}
 		return nil

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -96,17 +96,19 @@ type core struct {
 
 // Appends the current view and state to the given context.
 func (c *core) newLogger(ctx ...interface{}) log.Logger {
-	var seq, round *big.Int
+	var seq, round, desired *big.Int
 	state := c.state
 	if c.current != nil {
 		seq = c.current.Sequence()
 		round = c.current.Round()
+		desired = c.current.DesiredRound()
 	} else {
 		seq = common.Big0
 		round = big.NewInt(-1)
+		desired = big.NewInt(-1)
 	}
-	tmp := c.logger.New(ctx...)
-	return tmp.New("cur_seq", seq, "cur_round", round, "state", state, "address", c.address)
+	logger := c.logger.New(ctx...)
+	return logger.New("cur_seq", seq, "cur_round", round, "desired_round", desired, "state", state, "address", c.address)
 }
 
 func (c *core) SetAddress(address common.Address) {

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -40,7 +40,7 @@ func (c *core) sendPrepare() {
 }
 
 func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCertificate) error {
-	logger := c.newLogger("func", "verifyPreparedCertificate")
+	logger := c.newLogger("func", "verifyPreparedCertificate", "proposal_number", preparedCertificate.Proposal.Number(), "proposal_hash", preparedCertificate.Proposal.Hash().String())
 
 	// Validate the attached proposal
 	if _, err := c.backend.Verify(preparedCertificate.Proposal); err != nil {
@@ -107,6 +107,9 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 			}
 		}
 
+		msg_logger := logger.New("msg_round", subject.View.Round, "msg_seq", subject.View.Sequence, "msg_digest", subject.Digest.String())
+		msg_logger.Trace("Decoded message in prepared certificate", "code", message.Code)
+
 		// Verify message for the proper sequence.
 		if subject.View.Sequence.Cmp(c.current.Sequence()) != 0 {
 			return errInvalidPreparedCertificateMsgView
@@ -130,13 +133,13 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 }
 
 func (c *core) handlePrepare(msg *istanbul.Message) error {
-	logger := c.newLogger("func", "handlePrepare", "tag", "handleMsg")
 	// Decode PREPARE message
 	var prepare *istanbul.Subject
 	err := msg.Decode(&prepare)
 	if err != nil {
 		return errFailedDecodePrepare
 	}
+	logger := c.newLogger("func", "handlePrepare", "tag", "handleMsg", "msg_round", prepare.View.Round, "msg_seq", prepare.View.Sequence, "msg_digest", prepare.Digest.String())
 
 	if err := c.checkMessage(istanbul.MsgPrepare, prepare.View); err != nil {
 		return err
@@ -169,7 +172,7 @@ func (c *core) handlePrepare(msg *istanbul.Message) error {
 
 // verifyPrepare verifies if the received PREPARE message is equivalent to our subject
 func (c *core) verifyPrepare(prepare *istanbul.Subject) error {
-	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "verifyPrepare")
+	logger := c.newLogger("func", "verifyPrepare", "prepare_round", prepare.View.Round, "prepare_seq", prepare.View.Sequence, "prepare_digest", prepare.Digest.String())
 
 	sub := c.current.Subject()
 	if !reflect.DeepEqual(prepare, sub) {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -67,7 +67,7 @@ func (c *core) sendRoundChange(round *big.Int) {
 }
 
 func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChangeCertificate istanbul.RoundChangeCertificate) error {
-	logger := c.newLogger("func", "handleRoundChangeCertificate")
+	logger := c.newLogger("func", "handleRoundChangeCertificate", "proposal_round", proposal.View.Round, "proposal_seq", proposal.View.Sequence, "proposal_digest", proposal.Digest.String())
 
 	if len(roundChangeCertificate.RoundChangeMessages) > c.valSet.Size() || len(roundChangeCertificate.RoundChangeMessages) < c.valSet.MinQuorumSize() {
 		return errInvalidRoundChangeCertificateNumMsgs
@@ -109,13 +109,16 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 			logger.Error("Failed to decode ROUND CHANGE in certificate", "err", err)
 			return err
 		}
+		msg_logger := logger.New("msg_round", roundChange.View.Round, "msg_seq", roundChange.View.Sequence)
 
 		// Verify ROUND CHANGE message is for a proper view
 		if roundChange.View.Cmp(proposal.View) != 0 || roundChange.View.Round.Cmp(c.current.DesiredRound()) < 0 {
+			msg_logger.Error("Round change in certificate for wrong view", "err", err)
 			return errInvalidRoundChangeCertificateMsgView
 		}
 
 		if roundChange.HasPreparedCertificate() {
+			msg_logger.Trace("Round change message has prepared certificate")
 			if err := c.verifyPreparedCertificate(roundChange.PreparedCertificate); err != nil {
 				return err
 			}
@@ -126,9 +129,11 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 			// blocks that were not committed.
 			// Also reject round change messages where the prepared view is greater than the round change view.
 			preparedView := roundChange.PreparedCertificate.View()
+			msg_logger = msg_logger.New("prepared_round", preparedView.Round, "prepared_seq", preparedView.Sequence)
 			if preparedView == nil || preparedView.Round.Cmp(proposal.View.Round) > 0 {
 				return errInvalidRoundChangeViewMismatch
 			} else if preparedView.Round.Cmp(maxRound) > 0 {
+				msg_logger.Trace("Prepared certificate is latest in round change certificate")
 				maxRound = preparedView.Round
 				preferredDigest = roundChange.PreparedCertificate.Proposal.Hash()
 			}
@@ -160,10 +165,11 @@ func (c *core) handleRoundChange(msg *istanbul.Message) error {
 		logger.Error("Failed to decode ROUND CHANGE", "err", err)
 		return errInvalidMessage
 	}
+	logger = logger.New("msg_round", rc.View.Round, "msg_seq", rc.View.Sequence)
 
 	// Must be same sequence and future round.
 	if err := c.checkMessage(istanbul.MsgRoundChange, rc.View); err != nil {
-		logger.Info("Check round change message failed", "err", err)
+		logger.Debug("Check round change message failed", "err", err)
 		return err
 	}
 
@@ -191,7 +197,8 @@ func (c *core) handleRoundChange(msg *istanbul.Message) error {
 	ffRound := c.roundChangeSet.MaxRound(c.valSet.F() + 1)
 	quorumRound := c.roundChangeSet.MaxOnOneRound(c.valSet.MinQuorumSize())
 
-	logger.Trace("Got round change message", "msg_round", roundView.Round, "rcs", c.roundChangeSet.String(), "ffRound", ffRound, "quorumRound", quorumRound)
+	logger = logger.New("ffRound", ffRound, "quorumRound", quorumRound)
+	logger.Trace("Got round change message", "rcs", c.roundChangeSet.String())
 	// On f+1 round changes we send a round change and wait for the next round if we haven't done so already
 	// On quorum round change messages we go to the next round immediately.
 	if quorumRound != nil && quorumRound.Cmp(c.current.DesiredRound()) >= 0 {


### PR DESCRIPTION
### Description

This PR is a patch to baklava phase 1 in which round change messages from previous sequences were not properly rejected. This would ultimately lead to PREPREPAREs with invalid round change certificates, as some of the messages would be for previous sequences.

### Tested

Ran on my own validator

### Other changes

- More logging

### Backwards compatibility
Compatible