### PR TITLE
RC batkatcha, RCS logging improvements

### DIFF
--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
-
 	"github.com/ethereum/go-ethereum/core/types"
 	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 	"github.com/ethereum/go-ethereum/event"
@@ -435,8 +434,8 @@ func (c *core) newRoundChangeTimerForView(view *istanbul.View) {
 		// timeout for first round takes into account expected block period
 		timeout += time.Duration(c.config.BlockPeriod) * time.Second
 	} else {
-		// timeout for subsequent rounds adds an exponential backup, capped at 2**5 = 32s
-		timeout += time.Duration(math.Pow(2, math.Min(float64(round), 5.))) * time.Second
+		// timeout for subsequent rounds adds an exponential backup.
+		timeout += time.Duration(math.Pow(2, float64(round))) * time.Second
 	}
 
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -130,7 +130,17 @@ func (c *core) finalizeMessage(msg *istanbul.Message) ([]byte, error) {
 	return payload, nil
 }
 
+// Send message to all current validators
 func (c *core) broadcast(msg *istanbul.Message) {
+	c.sendMsgTo(msg, istanbul.GetAddressesFromValidatorList(c.valSet.List()))
+}
+
+// Send message to a specific address
+func (c *core) unicast(msg *istanbul.Message, addr common.Address) {
+	c.sendMsgTo(msg, []common.Address{addr})
+}
+
+func (c *core) sendMsgTo(msg *istanbul.Message, addresses []common.Address) {
 	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence())
 
 	payload, err := c.finalizeMessage(msg)
@@ -139,9 +149,9 @@ func (c *core) broadcast(msg *istanbul.Message) {
 		return
 	}
 
-	// Broadcast payload
-	if err := c.backend.BroadcastConsensusMsg(istanbul.GetAddressesFromValidatorList(c.valSet.List()), payload); err != nil {
-		logger.Error("Failed to broadcast message", "msg", msg, "err", err)
+	// Send payload to the specified addresses
+	if err := c.backend.BroadcastConsensusMsg(addresses, payload); err != nil {
+		logger.Error("Failed to send message", "msg", msg, "err", err)
 		return
 	}
 }
@@ -153,11 +163,11 @@ func (c *core) commit() {
 	if proposal != nil {
 		aggregatedSeal, err := GetAggregatedSeal(c.current.Commits(), c.current.Round())
 		if err != nil {
-			c.sendNextRoundChange()
+			c.waitForDesiredRound(new(big.Int).Add(c.current.Round(), common.Big1))
 			return
 		}
 		if err := c.backend.Commit(proposal, aggregatedSeal); err != nil {
-			c.sendNextRoundChange()
+			c.waitForDesiredRound(new(big.Int).Add(c.current.Round(), common.Big1))
 			return
 		}
 	}
@@ -350,7 +360,7 @@ func (c *core) waitForDesiredRound(r *big.Int) {
 		return
 	}
 
-	logger.Debug("Waiting for desired round")
+	logger.Debug("Round Change: Waiting for desired round")
 	desiredView := &istanbul.View{
 		Sequence: new(big.Int).Set(c.current.Sequence()),
 		Round:    new(big.Int).Set(r),
@@ -435,7 +445,7 @@ func (c *core) newRoundChangeTimerForView(view *istanbul.View) {
 		timeout += time.Duration(c.config.BlockPeriod) * time.Second
 	} else {
 		// timeout for subsequent rounds adds an exponential backup.
-		timeout += time.Duration(math.Pow(2, float64(round))) * time.Second
+		timeout += time.Duration(math.Pow(1.05, float64(round))) * time.Second
 	}
 
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -444,8 +444,8 @@ func (c *core) newRoundChangeTimerForView(view *istanbul.View) {
 		// timeout for first round takes into account expected block period
 		timeout += time.Duration(c.config.BlockPeriod) * time.Second
 	} else {
-		// timeout for subsequent rounds adds an exponential backup.
-		timeout += time.Duration(math.Pow(1.05, float64(round))) * time.Second
+		// timeout for subsequent rounds adds an exponential backoff, capped at 2**5 = 32s
+		timeout += time.Duration(math.Pow(2, math.Min(float64(round), 5.))) * time.Second
 	}
 
 	c.roundChangeTimer = time.AfterFunc(timeout, func() {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -27,26 +27,42 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
-// sendNextRoundChange sends the ROUND CHANGE message with current round + 1
-func (c *core) sendNextRoundChange() {
-	cv := c.current.View()
-	c.sendRoundChange(new(big.Int).Add(cv.Round, common.Big1))
-}
-
 // sendRoundChange sends the ROUND CHANGE message with the given round
 func (c *core) sendRoundChange(round *big.Int) {
 	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "sendRoundChange", "target round", round)
 
-	cv := c.current.View()
-	if cv.Round.Cmp(round) >= 0 {
-		logger.Error("Cannot send out the round change")
+	if c.current.View().Round.Cmp(round) >= 0 {
+		logger.Warn("Cannot send out the round change")
 		return
 	}
 
+	msg, err := c.buildRoundChangeMsg(round)
+	if err != nil {
+		logger.Error("Could not build round change message", "err", msg)
+		return
+	}
+
+	c.broadcast(msg)
+}
+
+// sendRoundChange sends a ROUND CHANGE message for the current round back to a single address
+func (c *core) sendRoundChangeAgain(addr common.Address) {
+	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "desired_round", c.current.DesiredRound(), "func", "sendRoundChangeAgain", "dest_addr", addr)
+
+	msg, err := c.buildRoundChangeMsg(c.current.DesiredRound())
+	if err != nil {
+		logger.Error("Could not build round change message", "err", err)
+		return
+	}
+
+	c.unicast(msg, addr)
+}
+
+// buildRoundChangeMsg creates a round change msg for the given round
+func (c *core) buildRoundChangeMsg(round *big.Int) (*istanbul.Message, error) {
 	nextView := &istanbul.View{
-		// The round number we'd like to transfer to.
 		Round:    new(big.Int).Set(round),
-		Sequence: new(big.Int).Set(cv.Sequence),
+		Sequence: new(big.Int).Set(c.current.View().Sequence),
 	}
 
 	rc := &istanbul.RoundChange{
@@ -56,14 +72,13 @@ func (c *core) sendRoundChange(round *big.Int) {
 
 	payload, err := Encode(rc)
 	if err != nil {
-		logger.Error("Failed to encode ROUND CHANGE", "rc", rc, "err", err)
-		return
+		return nil, err
 	}
-	logger.Trace("Sending round change message", "rcs", c.roundChangeSet)
-	c.broadcast(&istanbul.Message{
+
+	return &istanbul.Message{
 		Code: istanbul.MsgRoundChange,
 		Msg:  payload,
-	})
+	}, nil
 }
 
 func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChangeCertificate istanbul.RoundChangeCertificate) error {
@@ -106,7 +121,7 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 
 		var roundChange *istanbul.RoundChange
 		if err := message.Decode(&roundChange); err != nil {
-			logger.Error("Failed to decode ROUND CHANGE in certificate", "err", err)
+			logger.Warn("Failed to decode ROUND CHANGE in certificate", "err", err)
 			return err
 		}
 
@@ -157,12 +172,20 @@ func (c *core) handleRoundChange(msg *istanbul.Message) error {
 	// Decode ROUND CHANGE message
 	var rc *istanbul.RoundChange
 	if err := msg.Decode(&rc); err != nil {
-		logger.Error("Failed to decode ROUND CHANGE", "err", err)
+		logger.Info("Failed to decode ROUND CHANGE", "err", err)
 		return errInvalidMessage
 	}
 
 	// Must be same sequence and future round.
-	if err := c.checkMessage(istanbul.MsgRoundChange, rc.View); err != nil {
+	err := c.checkMessage(istanbul.MsgRoundChange, rc.View)
+
+	// If the RC message is for the current sequence but a prior round, help the sender fast forward
+	// by sending back to it (not broadcasting) a round change message for our current/desired TODO round.
+	if err == errOldMessage && rc.View.Sequence.Cmp(c.current.Sequence()) == 0 {
+		logger.Trace("Sending round change for current round to node in previous round", "msg_round", rc.View.Round)
+		c.sendRoundChangeAgain(msg.Address)
+		return nil
+	} else if err != nil {
 		logger.Info("Check round change message failed", "err", err)
 		return err
 	}

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -363,7 +363,7 @@ func (rcs *roundChangeSet) String() string {
 			modeRound = r
 			modeRoundSize = rms.Size()
 		}
-		msgsForRoundStr = append(msgsForRoundStr, fmt.Sprintf("\n%v: %v", r, rms.String()))
+		msgsForRoundStr = append(msgsForRoundStr, fmt.Sprintf("%v: %v", r, rms.String()))
 	}
 
 	latestRoundForValStr := make([]string, 0, len(rcs.latestRoundForVal))
@@ -371,7 +371,7 @@ func (rcs *roundChangeSet) String() string {
 		latestRoundForValStr = append(latestRoundForValStr, fmt.Sprintf("%v: %v", addr.String(), r))
 	}
 
-	return fmt.Sprintf("RCS len=%v mode_round=%v mode_round_len=%v By round: {<%v> %v}",
+	return fmt.Sprintf("RCS len=%v mode_round=%v mode_round_len=%v unique_rounds=<%v> %v",
 		len(rcs.latestRoundForVal),
 		modeRound,
 		modeRoundSize,

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -363,7 +363,7 @@ func (rcs *roundChangeSet) String() string {
 			modeRound = r
 			modeRoundSize = rms.Size()
 		}
-		msgsForRoundStr = append(msgsForRoundStr, fmt.Sprintf("%v: %v", r, rms.String()))
+		msgsForRoundStr = append(msgsForRoundStr, fmt.Sprintf("\n%v: %v", r, rms.String()))
 	}
 
 	latestRoundForValStr := make([]string, 0, len(rcs.latestRoundForVal))
@@ -371,14 +371,12 @@ func (rcs *roundChangeSet) String() string {
 		latestRoundForValStr = append(latestRoundForValStr, fmt.Sprintf("%v: %v", addr.String(), r))
 	}
 
-	return fmt.Sprintf("RCS len=%v mode_round=%v mode_round_len=%v By round: {<%v> %v}  By val: {<%v> %v}",
+	return fmt.Sprintf("RCS len=%v mode_round=%v mode_round_len=%v By round: {<%v> %v}",
 		len(rcs.latestRoundForVal),
 		modeRound,
 		modeRoundSize,
 		len(rcs.msgsForRound),
-		strings.Join(msgsForRoundStr, ", "),
-		len(rcs.latestRoundForVal),
-		strings.Join(latestRoundForValStr, ", "))
+		strings.Join(msgsForRoundStr, ", "))
 }
 
 // Gets a round change certificate for a specific round.

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -29,7 +29,7 @@ import (
 
 // sendRoundChange sends the ROUND CHANGE message with the given round
 func (c *core) sendRoundChange(round *big.Int) {
-	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "sendRoundChange", "target round", round)
+	logger := c.newLogger("func", "sendRoundChange", "target round", round)
 
 	if c.current.View().Round.Cmp(round) >= 0 {
 		logger.Warn("Cannot send out the round change")
@@ -47,7 +47,7 @@ func (c *core) sendRoundChange(round *big.Int) {
 
 // sendRoundChange sends a ROUND CHANGE message for the current round back to a single address
 func (c *core) sendRoundChangeAgain(addr common.Address) {
-	logger := c.logger.New("state", c.state, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "desired_round", c.current.DesiredRound(), "func", "sendRoundChangeAgain", "dest_addr", addr)
+	logger := c.newLogger("func", "sendRoundChangeAgain", "dest_addr", addr)
 
 	msg, err := c.buildRoundChangeMsg(c.current.DesiredRound())
 	if err != nil {
@@ -175,7 +175,7 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 }
 
 func (c *core) handleRoundChange(msg *istanbul.Message) error {
-	logger := c.logger.New("state", c.state, "from", msg.Address, "cur_round", c.current.Round(), "cur_seq", c.current.Sequence(), "func", "handleRoundChange", "tag", "handleMsg")
+	logger := c.newLogger("from", msg.Address, "func", "handleRoundChange", "tag", "handleMsg")
 
 	// Decode ROUND CHANGE message
 	var rc *istanbul.RoundChange

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -92,7 +92,10 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 	preferredDigest := common.Hash{}
 	seen := make(map[common.Address]bool)
 	decodedMessages := make([]istanbul.RoundChange, len(roundChangeCertificate.RoundChangeMessages))
-	for i, message := range roundChangeCertificate.RoundChangeMessages {
+	for i := range roundChangeCertificate.RoundChangeMessages {
+		// use a different variable each time since we'll store a pointer to the variable
+		message := roundChangeCertificate.RoundChangeMessages[i]
+
 		// Verify message signed by a validator
 		data, err := message.PayloadNoSig()
 		if err != nil {


### PR DESCRIPTION
### Description

* If we receive a valid RC message for current seq but round earlier than our desired round, send a RC message back to the sender to speed recipent collecting F+1 and fast-forwarding to our desired round.
* Logging improvements for RCS.

### Tested

Unit tests, e2e tests.

### Backwards compatibility

Yes.
