### PR TITLE
Diminator/fix ethstats start up error and log msg

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -196,7 +196,7 @@ func (sb *Backend) IsProxy() bool {
 }
 
 func (sb *Backend) IsProxiedValidator() bool {
-	return sb.proxyNode != nil
+	return sb.proxyNode != nil && sb.proxyNode.peer != nil
 }
 
 // SendDelegateSignMsgToProxy sends an istanbulDelegateSign message to a proxy

--- a/contract_comm/validators/validators.go
+++ b/contract_comm/validators/validators.go
@@ -104,6 +104,10 @@ const validatorsABIString string = `[
         {
           "name": "score",
           "type": "uint256"
+        },
+        {
+          "name": "signer",
+          "type": "address"
         }
       ],
       "payable": false,
@@ -177,6 +181,7 @@ type ValidatorContractData struct {
 	BlsPublicKey   []byte
 	Affiliation    common.Address
 	Score          *big.Int
+	Signer         common.Address
 }
 
 var validatorsABI, _ = abi.JSON(strings.NewReader(validatorsABIString))

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -445,7 +445,7 @@ func (s *Service) login(conn *websocket.Conn, sendCh chan *StatsPayload) error {
 	// Retrieve the remote ack or connection termination
 	var ack map[string][]string
 	if err := websocket.JSON.Receive(conn, &ack); err != nil {
-		return err
+		return errors.New("unauthorized, try registering your validator to get whitelisted")
 	}
 	emit, ok := ack["emit"]
 	if !ok {

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -569,7 +569,8 @@ func (s *Service) readLoop(conn *websocket.Conn) {
 // server. Use the individual methods for reporting subscribed events.
 func (s *Service) report(conn *websocket.Conn, sendCh chan *StatsPayload) error {
 	if err := s.reportLatency(conn, sendCh); err != nil {
-		return err
+		log.Warn("Latency failed to report", "err", err)
+		return nil
 	}
 	if err := s.reportBlock(conn, nil); err != nil {
 		return err
@@ -841,6 +842,7 @@ type validatorInfo struct {
 	BLSPublicKey   []byte         `json:"blsPublicKey"`
 	EcdsaPublicKey []byte         `json:"ecdsaPublicKey"`
 	Affiliation    common.Address `json:"affiliation"`
+	Signer         common.Address `json:"signer"`
 }
 
 func (s *Service) assembleValidatorSet(block *types.Block, state vm.StateDB) validatorSet {
@@ -868,6 +870,7 @@ func (s *Service) assembleValidatorSet(block *types.Block, state vm.StateDB) val
 			BLSPublicKey:   valData.BlsPublicKey,
 			EcdsaPublicKey: valData.EcdsaPublicKey,
 			Affiliation:    valData.Affiliation,
+			Signer:         valData.Signer,
 		})
 	}
 


### PR DESCRIPTION
### Description

Don't reference `proxyNode.peer` that could trigger `invalid memory address or nil pointer dereference`

### Tested
Not tested / unable to reproduce error

### Other changes

improve log message on ethstats login ``

### Related issues

- Fixes #712 
