### PR TITLE
Fix ethstats startup error

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -196,7 +196,7 @@ func (sb *Backend) IsProxy() bool {
 }
 
 func (sb *Backend) IsProxiedValidator() bool {
-	return sb.proxyNode != nil
+	return sb.proxyNode != nil && sb.proxyNode.peer != nil
 }
 
 // SendDelegateSignMsgToProxy sends an istanbulDelegateSign message to a proxy

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -445,7 +445,7 @@ func (s *Service) login(conn *websocket.Conn, sendCh chan *StatsPayload) error {
 	// Retrieve the remote ack or connection termination
 	var ack map[string][]string
 	if err := websocket.JSON.Receive(conn, &ack); err != nil {
-		return err
+		return errors.New("unauthorized, try registering your validator to get whitelisted")
 	}
 	emit, ok := ack["emit"]
 	if !ok {


### PR DESCRIPTION
### Description

Don't reference `proxyNode.peer` that could trigger `invalid memory address or nil pointer dereference`

### Tested
Not tested / unable to reproduce error

### Other changes

improve log message on ethstats login ``

### Related issues

- Fixes #712 
