### PR TITLE
refresh val peers on start

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -612,6 +612,14 @@ func (sb *Backend) APIs(chain consensus.ChainReader) []rpc.API {
 func (sb *Backend) SetChain(chain consensus.ChainReader, currentBlock func() *types.Block) {
 	sb.chain = chain
 	sb.currentBlock = currentBlock
+
+	// If this is a proxy, then refresh the val peers.  Note that this will be done within Backend.Start
+	// for non proxied validators
+	if sb.config.Proxy {
+		headBlock := sb.GetCurrentHeadBlock()
+		valset := sb.getValidators(headBlock.Number().Uint64(), headBlock.Hash())
+		sb.RefreshValPeers(valset)
+	}
 }
 
 // Start implements consensus.Istanbul.Start
@@ -657,6 +665,10 @@ func (sb *Backend) Start(hasBadBlock func(common.Hash) bool,
 		}
 
 		go sb.sendValEnodesShareMsgs()
+	} else {
+		headBlock := sb.GetCurrentHeadBlock()
+		valset := sb.getValidators(headBlock.Number().Uint64(), headBlock.Hash())
+		sb.RefreshValPeers(valset)
 	}
 
 	return nil


### PR DESCRIPTION
### Description

This PR makes changes to that the val peers are refreshed on Istanbul create (specifically in backend.SetChain) for proxies and on istanbul start for standalone validators.

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Other changes


### Related issues


### Backwards compatibility

Is backwards compatible.