### PR TITLE
val connections on start

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1270,6 +1270,9 @@ func SetProxyConfig(ctx *cli.Context, nodeCfg *node.Config, ethCfg *eth.Config) 
 			Fatalf("Option --%s must be used if option --%s is used", ProxyEnodeURLPairFlag.Name, ProxiedFlag.Name)
 		} else {
 			proxyEnodeURLPair := strings.Split(ctx.String(ProxyEnodeURLPairFlag.Name), ";")
+			if len(proxyEnodeURLPair) != 2 {
+				Fatalf("Invalid usage for option --%s", ProxyEnodeURLPairFlag.Name)
+			}
 
 			var err error
 			if ethCfg.Istanbul.ProxyInternalFacingNode, err = enode.ParseV4(proxyEnodeURLPair[0]); err != nil {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -151,6 +151,9 @@ type Handler interface {
 
 	// UnregisterPeer will notify the consensus engine that a new peer has been removed
 	UnregisterPeer(peer Peer, fromProxiedNode bool)
+
+	// ConnectToVals
+	ConnectToVals()
 }
 
 // PoW is a consensus engine based on proof-of-work.

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -712,3 +712,13 @@ func (sb *Backend) ValidatorAddress() common.Address {
 	}
 	return localAddress
 }
+
+func (sb *Backend) ConnectToVals() {
+	// If this is a proxy, then refresh the val peers.  Note that this will be done within Backend.Start
+	// for non proxied validators
+	if sb.config.Proxy {
+		headBlock := sb.GetCurrentHeadBlock()
+		valset := sb.getValidators(headBlock.Number().Uint64(), headBlock.Hash())
+		sb.RefreshValPeers(valset)
+	}
+}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -612,6 +612,14 @@ func (sb *Backend) APIs(chain consensus.ChainReader) []rpc.API {
 func (sb *Backend) SetChain(chain consensus.ChainReader, currentBlock func() *types.Block) {
 	sb.chain = chain
 	sb.currentBlock = currentBlock
+
+	// If this is a proxy, then refresh the val peers.  Note that this will be done within Backend.Start
+	// for non proxied validators
+	if sb.config.Proxy {
+		headBlock := sb.GetCurrentHeadBlock()
+		valset := sb.getValidators(headBlock.Number().Uint64(), headBlock.Hash())
+		sb.RefreshValPeers(valset)
+	}
 }
 
 // Start implements consensus.Istanbul.Start

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -612,14 +612,6 @@ func (sb *Backend) APIs(chain consensus.ChainReader) []rpc.API {
 func (sb *Backend) SetChain(chain consensus.ChainReader, currentBlock func() *types.Block) {
 	sb.chain = chain
 	sb.currentBlock = currentBlock
-
-	// If this is a proxy, then refresh the val peers.  Note that this will be done within Backend.Start
-	// for non proxied validators
-	if sb.config.Proxy {
-		headBlock := sb.GetCurrentHeadBlock()
-		valset := sb.getValidators(headBlock.Number().Uint64(), headBlock.Hash())
-		sb.RefreshValPeers(valset)
-	}
 }
 
 // Start implements consensus.Istanbul.Start

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -612,6 +612,14 @@ func (sb *Backend) APIs(chain consensus.ChainReader) []rpc.API {
 func (sb *Backend) SetChain(chain consensus.ChainReader, currentBlock func() *types.Block) {
 	sb.chain = chain
 	sb.currentBlock = currentBlock
+
+	// If this is a proxy, then refresh the val peers.  Note that this will be done within Backend.Start
+	// for non proxied validators
+	if sb.config.Proxy {
+		headBlock := sb.GetCurrentHeadBlock()
+		valset := sb.getValidators(headBlock.Number().Uint64(), headBlock.Hash())
+		sb.RefreshValPeers(valset)
+	}
 }
 
 // Start implements consensus.Istanbul.Start
@@ -657,6 +665,10 @@ func (sb *Backend) Start(hasBadBlock func(common.Hash) bool,
 		}
 
 		go sb.sendValEnodesShareMsgs()
+	} else {
+		headBlock := sb.GetCurrentHeadBlock()
+		valset := sb.getValidators(headBlock.Number().Uint64(), headBlock.Hash())
+		sb.RefreshValPeers(valset)
 	}
 
 	return nil

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -190,6 +190,14 @@ func (sb *Backend) SubscribeNewDelegateSignEvent(ch chan<- istanbul.MessageEvent
 // SetBroadcaster implements consensus.Handler.SetBroadcaster
 func (sb *Backend) SetBroadcaster(broadcaster consensus.Broadcaster) {
 	sb.broadcaster = broadcaster
+
+	// If this is a proxy, then refresh the val peers.  Note that this will be done within Backend.Start
+	// for non proxied validators
+	if sb.config.Proxy {
+		headBlock := sb.GetCurrentHeadBlock()
+		valset := sb.getValidators(headBlock.Number().Uint64(), headBlock.Hash())
+		sb.RefreshValPeers(valset)
+	}
 }
 
 // SetP2PServer implements consensus.Handler.SetP2PServer

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -190,14 +190,6 @@ func (sb *Backend) SubscribeNewDelegateSignEvent(ch chan<- istanbul.MessageEvent
 // SetBroadcaster implements consensus.Handler.SetBroadcaster
 func (sb *Backend) SetBroadcaster(broadcaster consensus.Broadcaster) {
 	sb.broadcaster = broadcaster
-
-	// If this is a proxy, then refresh the val peers.  Note that this will be done within Backend.Start
-	// for non proxied validators
-	if sb.config.Proxy {
-		headBlock := sb.GetCurrentHeadBlock()
-		valset := sb.getValidators(headBlock.Number().Uint64(), headBlock.Hash())
-		sb.RefreshValPeers(valset)
-	}
 }
 
 // SetP2PServer implements consensus.Handler.SetP2PServer

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -245,6 +245,11 @@ func (pm *ProtocolManager) Start(maxPeers int) {
 	// start sync handlers
 	go pm.syncer()
 	go pm.txsyncLoop()
+
+	// Reconnect all the peer connections from the on-disk val enode table
+	if handler, ok := pm.engine.(consensus.Handler); ok {
+		handler.ConnectToVals()
+	}
 }
 
 func (pm *ProtocolManager) Stop() {


### PR DESCRIPTION
### Description

This PR has changes so that the proxy and standalone validators will attempt to establish validator peers from the on-disk val enode table on startup

### Tested

Ran the e2e proxy tests and at the end of it, started up a standalone validator and proxy and verified it started up fine.

### Other changes

- Fixes https://github.com/celo-org/celo-blockchain/issues/722

### Related issues

### Backwards compatibility

Is backward compatible