### PR TITLE
create validator conns on startup

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1271,6 +1271,9 @@ func SetProxyConfig(ctx *cli.Context, nodeCfg *node.Config, ethCfg *eth.Config) 
 			Fatalf("Option --%s must be used if option --%s is used", ProxyEnodeURLPairFlag.Name, ProxiedFlag.Name)
 		} else {
 			proxyEnodeURLPair := strings.Split(ctx.String(ProxyEnodeURLPairFlag.Name), ";")
+			if len(proxyEnodeURLPair) != 2 {
+				Fatalf("Invalid usage for option --%s", ProxyEnodeURLPairFlag.Name)
+			}
 
 			var err error
 			if ethCfg.Istanbul.ProxyInternalFacingNode, err = enode.ParseV4(proxyEnodeURLPair[0]); err != nil {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -151,6 +151,9 @@ type Handler interface {
 
 	// UnregisterPeer will notify the consensus engine that a new peer has been removed
 	UnregisterPeer(peer Peer, fromProxiedNode bool)
+
+	// ConnectToVals
+	ConnectToVals()
 }
 
 // PoW is a consensus engine based on proof-of-work.

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -712,3 +712,13 @@ func (sb *Backend) ValidatorAddress() common.Address {
 	}
 	return localAddress
 }
+
+func (sb *Backend) ConnectToVals() {
+	// If this is a proxy, then refresh the val peers.  Note that this will be done within Backend.Start
+	// for non proxied validators
+	if sb.config.Proxy {
+		headBlock := sb.GetCurrentHeadBlock()
+		valset := sb.getValidators(headBlock.Number().Uint64(), headBlock.Hash())
+		sb.RefreshValPeers(valset)
+	}
+}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -658,6 +658,10 @@ func (sb *Backend) Start(hasBadBlock func(common.Hash) bool,
 		}
 
 		go sb.sendValEnodesShareMsgs()
+	} else {
+		headBlock := sb.GetCurrentHeadBlock()
+		valset := sb.getValidators(headBlock.Number().Uint64(), headBlock.Hash())
+		sb.RefreshValPeers(valset)
 	}
 
 	return nil

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -245,6 +245,11 @@ func (pm *ProtocolManager) Start(maxPeers int) {
 	// start sync handlers
 	go pm.syncer()
 	go pm.txsyncLoop()
+
+	// Reconnect all the peer connections from the on-disk val enode table
+	if handler, ok := pm.engine.(consensus.Handler); ok {
+		handler.ConnectToVals()
+	}
 }
 
 func (pm *ProtocolManager) Stop() {


### PR DESCRIPTION
### Description

This PR has changes so that the proxy and standalone validators will attempt to establish validator peers from the on-disk val enode table on startup.

### Tested

1) Restarted a proxy against a stalled network and it established Validator peers on startup
2) Restarted a standalone validator against stalled network and it established Validator peers on startup

### Other changes

Fixes #722

### Related issues


### Backwards compatibility

Is backwards compatible.