### PR TITLE
validators SBAT handle clock drift for announce messages

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -148,7 +148,7 @@ var (
 		utils.ProxiedValidatorAddressFlag,
 		utils.ProxiedFlag,
 		utils.ProxyEnodeURLPairFlag,
-		utils.ProxyOverrideAnnounceIPCheckFlag,
+		utils.ProxyAllowExternalPrivateIPFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -148,6 +148,7 @@ var (
 		utils.ProxiedValidatorAddressFlag,
 		utils.ProxiedFlag,
 		utils.ProxyEnodeURLPairFlag,
+		utils.ProxyOverrideAnnounceIPCheckFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -249,7 +249,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.ProxiedValidatorAddressFlag,
 			utils.ProxiedFlag,
 			utils.ProxyEnodeURLPairFlag,
-			utils.ProxyOverrideAnnounceIPCheckFlag,
+			utils.ProxyAllowExternalPrivateIPFlag,
 		},
 	},
 	{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -249,6 +249,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.ProxiedValidatorAddressFlag,
 			utils.ProxiedFlag,
 			utils.ProxyEnodeURLPairFlag,
+			utils.ProxyOverrideAnnounceIPCheckFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -696,9 +696,9 @@ var (
 		Name:  "proxy.proxyenodeurlpair",
 		Usage: "proxy enode URL pair separated by a semicolon.  The format should be \"<internal facing enode URL>;<external facing enode URL>\"",
 	}
-	ProxyOverrideAnnounceIPCheckFlag = cli.BoolFlag{
-		Name:  "proxy.override-announced-ip-check",
-		Usage: "Specifies whether to override the internal IP check for the announced IP address.  WARNING: This option should only be used for testing.",
+	ProxyAllowExternalPrivateIPFlag = cli.BoolFlag{
+		Name:  "proxy.allow-external-private-ip",
+		Usage: "Specifies whether to allow a private IP within the external enode URL.  WARNING: This option should only be used for testing.",
 	}
 )
 
@@ -1289,7 +1289,7 @@ func SetProxyConfig(ctx *cli.Context, nodeCfg *node.Config, ethCfg *eth.Config) 
 			}
 
 			// Check that external IP is not a private IP address.
-			if !ctx.GlobalIsSet(ProxyOverrideAnnounceIPCheckFlag.Name) && ethCfg.Istanbul.ProxyExternalFacingNode.IsPrivateIP() {
+			if !ctx.GlobalIsSet(ProxyAllowExternalPrivateIPFlag.Name) && ethCfg.Istanbul.ProxyExternalFacingNode.IsPrivateIP() {
 				Fatalf("Proxy external facing enodeURL (%s) cannot be private IP.", proxyEnodeURLPair[1])
 			}
 		}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -698,7 +698,7 @@ var (
 	}
 	ProxyOverrideAnnounceIPCheckFlag = cli.BoolFlag{
 		Name:  "proxy.override-announced-ip-check",
-		Usage: "Specifies whether to override the internal IP check for the announced IP address",
+		Usage: "Specifies whether to override the internal IP check for the announced IP address.  WARNING: This option should only be used for testing.",
 	}
 )
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -696,6 +696,10 @@ var (
 		Name:  "proxy.proxyenodeurlpair",
 		Usage: "proxy enode URL pair separated by a semicolon.  The format should be \"<internal facing enode URL>;<external facing enode URL>\"",
 	}
+	OverrideAnnounceIPCheckFlag = cli.BoolFlag{
+		Name:  "proxy.override-announced-ip-check",
+		Usage: "Specifies whether to override the internal IP check for the announced IP address",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1285,7 +1289,7 @@ func SetProxyConfig(ctx *cli.Context, nodeCfg *node.Config, ethCfg *eth.Config) 
 			}
 
 			// Check that external IP is not a private IP address.
-			if ethCfg.Istanbul.ProxyExternalFacingNode.IsPrivateIP() {
+			if !ctx.GlobalIsSet(OverrideAnnounceIPCheckFlag.Name) && ethCfg.Istanbul.ProxyExternalFacingNode.IsPrivateIP() {
 				Fatalf("Proxy external facing enodeURL (%s) cannot be private IP.", proxyEnodeURLPair[1])
 			}
 		}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -696,7 +696,7 @@ var (
 		Name:  "proxy.proxyenodeurlpair",
 		Usage: "proxy enode URL pair separated by a semicolon.  The format should be \"<internal facing enode URL>;<external facing enode URL>\"",
 	}
-	OverrideAnnounceIPCheckFlag = cli.BoolFlag{
+	ProxyOverrideAnnounceIPCheckFlag = cli.BoolFlag{
 		Name:  "proxy.override-announced-ip-check",
 		Usage: "Specifies whether to override the internal IP check for the announced IP address",
 	}
@@ -1289,7 +1289,7 @@ func SetProxyConfig(ctx *cli.Context, nodeCfg *node.Config, ethCfg *eth.Config) 
 			}
 
 			// Check that external IP is not a private IP address.
-			if !ctx.GlobalIsSet(OverrideAnnounceIPCheckFlag.Name) && ethCfg.Istanbul.ProxyExternalFacingNode.IsPrivateIP() {
+			if !ctx.GlobalIsSet(ProxyOverrideAnnounceIPCheckFlag.Name) && ethCfg.Istanbul.ProxyExternalFacingNode.IsPrivateIP() {
 				Fatalf("Proxy external facing enodeURL (%s) cannot be private IP.", proxyEnodeURLPair[1])
 			}
 		}

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -118,9 +118,7 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 	backend.core = istanbulCore.New(backend, backend.config)
 
 	vph := &validatorPeerHandler{sb: backend}
-	// Don't set the val enode table entry ctime and mtimes if this node is a proxy.  Use those field's values from
-	// the shared val enode table from the proxied validator.
-	table, err := enodes.OpenValidatorEnodeDB(config.ValidatorEnodeDBPath, vph, !backend.IsProxy())
+	table, err := enodes.OpenValidatorEnodeDB(config.ValidatorEnodeDBPath, vph)
 	if err != nil {
 		logger.Crit("Can't open ValidatorEnodeDB", "err", err, "dbpath", config.ValidatorEnodeDBPath)
 	}

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -118,7 +118,9 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 	backend.core = istanbulCore.New(backend, backend.config)
 
 	vph := &validatorPeerHandler{sb: backend}
-	table, err := enodes.OpenValidatorEnodeDB(config.ValidatorEnodeDBPath, vph)
+	// Don't set the val enode table entry ctime and mtimes if this node is a proxy.  Use those field's values from
+	// the shared val enode table from the proxied validator.
+	table, err := enodes.OpenValidatorEnodeDB(config.ValidatorEnodeDBPath, vph, !backend.IsProxy())
 	if err != nil {
 		logger.Crit("Can't open ValidatorEnodeDB", "err", err, "dbpath", config.ValidatorEnodeDBPath)
 	}

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -67,6 +67,9 @@ var (
 	// errOldAnnounceMessage is returned when the received announce message's block number is earlier
 	// than a previous received message
 	errOldAnnounceMessage = errors.New("old announce message")
+
+	// errTSDiffOverThresholdAnnounceMessage is returned when the received announce message's timestamp diff is over threshold
+	errTSDiffOverThresholdAnnounceMessage = errors.New("timestamp diff over threshold announce message")
 )
 
 // Entries for the recent announce messages

--- a/consensus/istanbul/backend/internal/enodes/val_enode_db.go
+++ b/consensus/istanbul/backend/internal/enodes/val_enode_db.go
@@ -293,6 +293,12 @@ func (vet *ValidatorEnodeDB) Upsert(valEnodeEntries map[common.Address]*AddressE
 			return err
 		}
 
+		// new entry
+		rawEntry, err := rlp.EncodeToBytes(addressEntry)
+		if err != nil {
+			return err
+		}
+
 		// If it's an old message, ignore it
 		if !isNew && addressEntry.Timestamp.Cmp(currentEntry.Timestamp) < 0 {
 			vet.logger.Trace("Ignoring the entry because its timestamp is older than what is stored in the val enode db",
@@ -309,12 +315,6 @@ func (vet *ValidatorEnodeDB) Upsert(valEnodeEntries map[common.Address]*AddressE
 		} else if isNew {
 			batch.Put(nodeIDKey(addressEntry.Node.ID()), remoteAddress.Bytes())
 		}
-
-		rawEntry, err := rlp.EncodeToBytes(addressEntry)
-		if err != nil {
-			return err
-		}
-
 		batch.Put(addressKey(remoteAddress), rawEntry)
 		peersToAdd[remoteAddress] = addressEntry.Node
 

--- a/consensus/istanbul/backend/internal/enodes/val_enode_db_test.go
+++ b/consensus/istanbul/backend/internal/enodes/val_enode_db_test.go
@@ -26,12 +26,12 @@ func (ml *mockListener) ReplaceValidatorPeers(nodeNodes []*enode.Node)          
 func (ml *mockListener) ClearValidatorPeers()                                      {}
 
 func TestSimpleCase(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("", &mockListener{})
+	vet, err := OpenValidatorEnodeDB("", &mockListener{}, false)
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
 
-	addressEntry := &AddressEntry{Node: nodeA, Timestamp: 1}
+	addressEntry := &AddressEntry{Node: nodeA, Timestamp: common.Big1}
 
 	err = vet.Upsert(map[common.Address]*AddressEntry{addressA: addressEntry})
 	if err != nil {
@@ -56,12 +56,12 @@ func TestSimpleCase(t *testing.T) {
 }
 
 func TestDeleteEntry(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("", &mockListener{})
+	vet, err := OpenValidatorEnodeDB("", &mockListener{}, false)
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
 
-	addressEntry := &AddressEntry{Node: nodeA, Timestamp: 2}
+	addressEntry := &AddressEntry{Node: nodeA, Timestamp: common.Big2}
 
 	err = vet.Upsert(map[common.Address]*AddressEntry{addressA: addressEntry})
 	if err != nil {
@@ -84,15 +84,15 @@ func TestDeleteEntry(t *testing.T) {
 }
 
 func TestPruneEntries(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("", &mockListener{})
+	vet, err := OpenValidatorEnodeDB("", &mockListener{}, false)
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
 
 	batch := make(map[common.Address]*AddressEntry)
 
-	batch[addressA] = &AddressEntry{Node: nodeA, Timestamp: 2}
-	batch[addressB] = &AddressEntry{Node: nodeB, Timestamp: 2}
+	batch[addressA] = &AddressEntry{Node: nodeA, Timestamp: common.Big2}
+	batch[addressB] = &AddressEntry{Node: nodeB, Timestamp: common.Big2}
 
 	vet.Upsert(batch)
 
@@ -113,7 +113,7 @@ func TestPruneEntries(t *testing.T) {
 }
 
 func TestRLPEntries(t *testing.T) {
-	original := AddressEntry{Node: nodeA, Timestamp: 1}
+	original := AddressEntry{Node: nodeA, Timestamp: common.Big1}
 
 	rawEntry, err := rlp.EncodeToBytes(&original)
 	if err != nil {
@@ -128,25 +128,25 @@ func TestRLPEntries(t *testing.T) {
 	if result.Node.String() != original.Node.String() {
 		t.Errorf("node doesn't match: got: %s expected: %s", result.Node.String(), original.Node.String())
 	}
-	if result.Timestamp != original.Timestamp {
+	if result.Timestamp.Cmp(original.Timestamp) != 0 {
 		t.Errorf("timestamp doesn't match: got: %v expected: %v", result.Timestamp, original.Timestamp)
 	}
 }
 
 func TestTableToString(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("", &mockListener{})
+	vet, err := OpenValidatorEnodeDB("", &mockListener{}, false)
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
 
 	batch := make(map[common.Address]*AddressEntry)
 
-	batch[addressA] = &AddressEntry{Node: nodeA, Timestamp: 2}
-	batch[addressB] = &AddressEntry{Node: nodeB, Timestamp: 2}
+	batch[addressA] = &AddressEntry{Node: nodeA, Timestamp: common.Big2}
+	batch[addressB] = &AddressEntry{Node: nodeB, Timestamp: common.Big2}
 
 	vet.Upsert(batch)
 
-	expected := "ValEnodeTable: [0x00Ce0d46d924CC8437c806721496599FC3FFA268 => {enodeURL: enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:52150, timestamp: 2}] [0xfFFFff46D924CCfffFc806721496599fC3FFffff => {enodeURL: enode://38b219b54ed49cf7d802e8add586fc75b531ed2c31e43b5da71c35982b2e6f5c56fa9cfbe39606fe71fbee2566b94c2874e950b1ec88323103c835246e3d0023@127.0.0.1:37303, timestamp: 2}]"
+	expected := "ValEnodeTable: [0x00Ce0d46d924CC8437c806721496599FC3FFA268 => {enodeURL: enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:52150, timestamp: 2, ctime: 0, mtime: 0}] [0xfFFFff46D924CCfffFc806721496599fC3FFffff => {enodeURL: enode://38b219b54ed49cf7d802e8add586fc75b531ed2c31e43b5da71c35982b2e6f5c56fa9cfbe39606fe71fbee2566b94c2874e950b1ec88323103c835246e3d0023@127.0.0.1:37303, timestamp: 2, ctime: 0, mtime: 0}]"
 
 	if vet.String() != expected {
 		t.Errorf("String() error: got: %s", vet.String())

--- a/consensus/istanbul/backend/internal/enodes/val_enode_db_test.go
+++ b/consensus/istanbul/backend/internal/enodes/val_enode_db_test.go
@@ -146,7 +146,7 @@ func TestTableToString(t *testing.T) {
 
 	vet.Upsert(batch)
 
-	expected := "ValEnodeTable: [0x00Ce0d46d924CC8437c806721496599FC3FFA268 => {enodeURL: enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:52150, timestamp: 2, ctime: 0, mtime: 0}] [0xfFFFff46D924CCfffFc806721496599fC3FFffff => {enodeURL: enode://38b219b54ed49cf7d802e8add586fc75b531ed2c31e43b5da71c35982b2e6f5c56fa9cfbe39606fe71fbee2566b94c2874e950b1ec88323103c835246e3d0023@127.0.0.1:37303, timestamp: 2, ctime: 0, mtime: 0}]"
+	expected := "ValEnodeTable: [0x00Ce0d46d924CC8437c806721496599FC3FFA268 => {enodeURL: enode://1dd9d65c4552b5eb43d5ad55a2ee3f56c6cbc1c64a5c8d659f51fcd51bace24351232b8d7821617d2b29b54b81cdefb9b3e9c37d7fd5f63270bcc9e1a6f6a439@127.0.0.1:52150, timestamp: 2}] [0xfFFFff46D924CCfffFc806721496599fC3FFffff => {enodeURL: enode://38b219b54ed49cf7d802e8add586fc75b531ed2c31e43b5da71c35982b2e6f5c56fa9cfbe39606fe71fbee2566b94c2874e950b1ec88323103c835246e3d0023@127.0.0.1:37303, timestamp: 2}]"
 
 	if vet.String() != expected {
 		t.Errorf("String() error: got: %s", vet.String())

--- a/consensus/istanbul/backend/internal/enodes/val_enode_db_test.go
+++ b/consensus/istanbul/backend/internal/enodes/val_enode_db_test.go
@@ -26,7 +26,7 @@ func (ml *mockListener) ReplaceValidatorPeers(nodeNodes []*enode.Node)          
 func (ml *mockListener) ClearValidatorPeers()                                      {}
 
 func TestSimpleCase(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("", &mockListener{}, false)
+	vet, err := OpenValidatorEnodeDB("", &mockListener{})
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
@@ -56,7 +56,7 @@ func TestSimpleCase(t *testing.T) {
 }
 
 func TestDeleteEntry(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("", &mockListener{}, false)
+	vet, err := OpenValidatorEnodeDB("", &mockListener{})
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
@@ -84,7 +84,7 @@ func TestDeleteEntry(t *testing.T) {
 }
 
 func TestPruneEntries(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("", &mockListener{}, false)
+	vet, err := OpenValidatorEnodeDB("", &mockListener{})
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
@@ -134,7 +134,7 @@ func TestRLPEntries(t *testing.T) {
 }
 
 func TestTableToString(t *testing.T) {
-	vet, err := OpenValidatorEnodeDB("", &mockListener{}, false)
+	vet, err := OpenValidatorEnodeDB("", &mockListener{})
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}

--- a/consensus/istanbul/backend/val_enodes_share.go
+++ b/consensus/istanbul/backend/val_enodes_share.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -37,7 +38,7 @@ import (
 type sharedValidatorEnode struct {
 	Address   common.Address
 	EnodeURL  string
-	Timestamp uint
+	Timestamp *big.Int
 }
 
 type valEnodesShareData struct {

--- a/consensus/istanbul/backend/val_enodes_share_test.go
+++ b/consensus/istanbul/backend/val_enodes_share_test.go
@@ -52,7 +52,7 @@ func TestHandleValEnodeShareMsg(t *testing.T) {
 	// being inserted into the valEnodeTable
 	b.valEnodeTable.Upsert(map[common.Address]*vet.AddressEntry{testAddress: {
 		Node:      testNode,
-		Timestamp: 0,
+		Timestamp: common.Big0,
 	}})
 	senderAddress = b.Address()
 	newMsg, err := b.generateValEnodesShareMsg()


### PR DESCRIPTION
### Description

When the announce message is sent, it uses the sender's computer's local timestamp.  That timestamp may not necessarily always increase (e.g. NTP could make it earlier).

This change will modify the validators so that they only accept announce messages with timestamps that are within a time range of it's own local timestamp.

### Tested

* Ran e2e proxy tests
* Ran geth unit tests

### Other changes

- Added the flag `proxy.override-announced-ip-check` to be used for the proxy e2e test
- Converted the timestamp field to be type big.Int instead of uint

### Related issues

### Backwards compatibility

Yes
