### PR TITLE
Add block number to validator election log

### DIFF
--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -228,7 +228,7 @@ func (sb *Backend) NewChainHead(newBlock *types.Block) {
 		// new epoch's validator set
 		if sb.coreStarted {
 			_, val := valset.GetByAddress(sb.ValidatorAddress())
-			sb.logger.Info("Validator Election Results", "address", sb.ValidatorAddress(), "elected", (val != nil))
+			sb.logger.Info("Validator Election Results", "address", sb.ValidatorAddress(), "elected", (val != nil), "number", newBlock.Number().Uint64())
 
 			sb.newEpochCh <- struct{}{}
 		}


### PR DESCRIPTION
### Description

Shows exact block number in addition to validator election result in log on every epoch.

### Tested

Tested on Baklava.
```
INFO [12-16|15:29:59.601] Validator Election Results               address=0x355ecA0d3C48c4b8A3359644c7c83Db01c6Ac594 elected=true number=66960
```

### Related issues
- Closes #762 
