### PR TITLE
Add bootnodes to celo-node image

### DIFF
--- a/Dockerfile.celo-node
+++ b/Dockerfile.celo-node
@@ -19,3 +19,5 @@ RUN mkdir /celo
 RUN curl https://www.googleapis.com/storage/v1/b/genesis_blocks/o/${celo_env}?alt=media > /celo/genesis.json
 
 RUN curl https://www.googleapis.com/storage/v1/b/static_nodes/o/${celo_env}?alt=media > /celo/static-nodes.json
+
+RUN curl https://www.googleapis.com/storage/v1/b/env_bootnodes/o/${celo_env}?alt=media > /celo/bootnodes


### PR DESCRIPTION
### Description

Adds a file with the enode url of the bootnode

### Tested

Ran the built image, used the bootnode enode URL

### Other changes

n/a

### Related issues

Partner monorepo PR: https://github.com/celo-org/celo-monorepo/pull/2289

### Backwards compatibility

Backwards compatible
