### PR TITLE
Loop until IBFT core catches up so that signatures can be added to block

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -417,7 +417,8 @@ func (sb *Backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 						return seq
 					}
 				case <-timeout:
-					log.Warn("Timed out while waiting for core to sequence change, unable to combine commit messages with ParentAggregatedSeal", "cur_seq", sb.core.Sequence())
+					// TODO(asa): Why is this logged by full nodes?
+					log.Trace("Timed out while waiting for core to sequence change, unable to combine commit messages with ParentAggregatedSeal", "cur_seq", sb.core.Sequence())
 					return nil
 				}
 			}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -422,7 +422,8 @@ func (sb *Backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 		}
 		parentAggregatedSeal := parentExtra.AggregatedSeal
 
-		logger.Trace("Got ParentAggregatedSeal", "parentAggregatedSeal", parentAggregatedSeal.String())
+		logger = logger.New("parentAggregatedSeal", parentAggregatedSeal.String())
+		logger.Trace("Got ParentAggregatedSeal")
 		if sb.core.Sequence().Cmp(header.Number) == 0 {
 			parentCommits := sb.core.ParentCommits()
 			logger = logger.New("cur_seq", sb.core.Sequence())
@@ -442,11 +443,11 @@ func (sb *Backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 						logger.Error("Failed to verify combined ParentAggregatedSeal", "err", err)
 					} else {
 						parentAggregatedSeal = unionAggregatedSeal
-						logger.Trace("Succeeded in verifying combined ParentAggregatedSeal", "combinedParentAggregatedSeal", parentAggregatedSeal.String())
+						logger.Debug("Succeeded in verifying combined ParentAggregatedSeal", "combinedParentAggregatedSeal", parentAggregatedSeal.String())
 					}
 				}
 			} else {
-				logger.Trace("No additional seals to combine with ParentAggregatedSeal")
+				logger.Debug("No additional seals to combine with ParentAggregatedSeal")
 			}
 			return writeAggregatedSeal(header, parentAggregatedSeal, true)
 		}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -366,7 +366,6 @@ func (sb *Backend) VerifySeal(chain consensus.ChainReader, header *types.Header)
 // Prepare initializes the consensus fields of a block header according to the
 // rules of a particular engine. The changes are executed inline.
 func (sb *Backend) Prepare(chain consensus.ChainReader, header *types.Header) error {
-	sb.logger.Info("Entered Backend.Prepare()")
 	// unused fields, force to set to empty
 	header.Coinbase = sb.address
 	header.Nonce = emptyNonce
@@ -394,7 +393,6 @@ func (sb *Backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 	// wait for the timestamp of header, use this to adjust the block period
 	delay := time.Unix(header.Time.Int64(), 0).Sub(now())
 	time.Sleep(delay)
-	sb.logger.Info("Done sleeping")
 
 	logger := sb.logger.New("func", "Backend.Prepare()", "number", number)
 	// modify the block header to include all the ParentCommits

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -412,7 +412,7 @@ func (sb *Backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 			default:
 				stay = sb.core.Sequence().Cmp(header.Number) < 0
 				if !stay {
-					logger.Debug("Current sequence matches header", "cur_seq", sb.core.Sequence())
+					logger.Trace("Current sequence matches header", "cur_seq", sb.core.Sequence())
 				}
 			}
 		}
@@ -422,13 +422,13 @@ func (sb *Backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 		}
 		parentAggregatedSeal := parentExtra.AggregatedSeal
 
-		logger.Debug("Got ParentAggregatedSeal", "parentAggregatedSeal", parentAggregatedSeal.String())
+		logger.Trace("Got ParentAggregatedSeal", "parentAggregatedSeal", parentAggregatedSeal.String())
 		if sb.core.Sequence().Cmp(header.Number) == 0 {
 			parentCommits := sb.core.ParentCommits()
 			logger = logger.New("cur_seq", sb.core.Sequence())
 			if parentCommits != nil && parentCommits.Size() != 0 {
 				logger = logger.New("numParentCommits", parentCommits.Size())
-				logger.Debug("Found commit messages from previous sequence to combine with ParentAggregatedSeal")
+				logger.Trace("Found commit messages from previous sequence to combine with ParentAggregatedSeal")
 				// if we had any seals gossiped to us, proceed to add them to the
 				// already aggregated signature
 				if unionAggregatedSeal, err := istanbulCore.UnionOfSeals(parentExtra.AggregatedSeal, parentCommits); err != nil {
@@ -442,7 +442,7 @@ func (sb *Backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 						logger.Error("Failed to verify combined ParentAggregatedSeal", "err", err)
 					} else {
 						parentAggregatedSeal = unionAggregatedSeal
-						logger.Debug("Succeeded in verifying combined ParentAggregatedSeal", "combinedParentAggregatedSeal", parentAggregatedSeal.String())
+						logger.Trace("Succeeded in verifying combined ParentAggregatedSeal", "combinedParentAggregatedSeal", parentAggregatedSeal.String())
 					}
 				}
 			} else {

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -46,7 +46,7 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 	c := &core{
 		config:             config,
 		address:            backend.Address(),
-		logger:             log.New("address", backend.Address()),
+		logger:             log.New(),
 		selectProposer:     validator.GetProposerSelector(config.ProposerPolicy),
 		handlerWg:          new(sync.WaitGroup),
 		backend:            backend,
@@ -537,4 +537,18 @@ func PrepareCommittedSeal(hash common.Hash, round *big.Int) []byte {
 	buf.Write(round.Bytes())
 	buf.Write([]byte{byte(istanbul.MsgCommit)})
 	return buf.Bytes()
+}
+
+func (c *core) ParentCommits() MessageSet {
+	if c.current == nil {
+		return nil
+	}
+	return c.current.ParentCommits()
+}
+
+func (c *core) Sequence() *big.Int {
+	if c.current == nil {
+		return nil
+	}
+	return c.current.Sequence()
 }

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -23,13 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
-func (c *core) ParentCommits() MessageSet {
-	if c.current == nil {
-		return nil
-	}
-	return c.current.ParentCommits()
-}
-
 // Start implements core.Engine.Start
 func (c *core) Start() error {
 

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"math/big"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/log"
@@ -247,6 +248,7 @@ func (s *roundStateImpl) StartNewRound(nextRound *big.Int, validatorSet istanbul
 }
 
 func (s *roundStateImpl) StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet) error {
+	time.Sleep(time.Second)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	logger := s.newLogger()

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"math/big"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/log"
@@ -248,7 +247,6 @@ func (s *roundStateImpl) StartNewRound(nextRound *big.Int, validatorSet istanbul
 }
 
 func (s *roundStateImpl) StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet) error {
-	time.Sleep(time.Second)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	logger := s.newLogger()

--- a/consensus/istanbul/core/types.go
+++ b/consensus/istanbul/core/types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/rlp"
+	"math/big"
 )
 
 type Engine interface {
@@ -29,6 +30,7 @@ type Engine interface {
 	SetAddress(common.Address)
 	// Validator -> CommittedSeal from Parent Block
 	ParentCommits() MessageSet
+	Sequence() *big.Int
 }
 
 // State represents the IBFT state

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1845,7 +1845,7 @@ func (d *Downloader) qosTuner() {
 		atomic.StoreUint64(&d.rttConfidence, conf)
 
 		// Log the new QoS values and sleep until the next RTT
-		log.Debug("Recalculated downloader QoS values", "rtt", rtt, "confidence", float64(conf)/1000000.0, "ttl", d.requestTTL())
+		log.Trace("Recalculated downloader QoS values", "rtt", rtt, "confidence", float64(conf)/1000000.0, "ttl", d.requestTTL())
 		select {
 		case <-d.quitCh:
 			return

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -911,7 +911,6 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		}
 		header.Coinbase = w.coinbase
 	}
-	log.Info("Calling engine.Prepare()")
 	if err := w.engine.Prepare(w.chain, header); err != nil {
 		log.Error("Failed to prepare header for mining", "err", err)
 		return

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -910,6 +910,9 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			return
 		}
 		header.Coinbase = w.coinbase
+	} else {
+		// No need to continue if the worker is not running
+		return
 	}
 	if err := w.engine.Prepare(w.chain, header); err != nil {
 		log.Error("Failed to prepare header for mining", "err", err)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -447,10 +447,6 @@ func (w *worker) mainLoop() {
 		case req := <-w.newWorkCh:
 			if h, ok := w.engine.(consensus.Handler); ok {
 				h.NewWork()
-				// Wait a minimal amount of time so that the FinalizeCommittedEvent gets picked up by
-				// the engine and a new sequence gets started, so that we get the correct
-				// `ParentCommits` in `backend.Prepare`
-				time.Sleep(100 * time.Millisecond)
 			}
 			w.commitNewWork(req.interrupt, req.noempty, req.timestamp)
 
@@ -915,6 +911,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		}
 		header.Coinbase = w.coinbase
 	}
+	log.Info("Calling engine.Prepare()")
 	if err := w.engine.Prepare(w.chain, header); err != nil {
 		log.Error("Failed to prepare header for mining", "err", err)
 		return

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -910,9 +910,6 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			return
 		}
 		header.Coinbase = w.coinbase
-	} else {
-		// No need to continue if the worker is not running
-		return
 	}
 	if err := w.engine.Prepare(w.chain, header); err != nil {
 		log.Error("Failed to prepare header for mining", "err", err)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -265,7 +265,7 @@ func testPendingStateAndBlock(t *testing.T, chainConfig *params.ChainConfig, eng
 	defer w.close()
 
 	// Ensure snapshot has been updated.
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	block, state := w.pending()
 	if block.NumberU64() != 1 {
 		t.Errorf("block number mismatch: have %d, want %d", block.NumberU64(), 1)
@@ -276,7 +276,7 @@ func testPendingStateAndBlock(t *testing.T, chainConfig *params.ChainConfig, eng
 	b.txPool.AddLocals(newTxs)
 
 	// Ensure the new tx events has been processed
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	block, state = w.pending()
 	if balance := state.GetBalance(testUserAddress); balance.Cmp(big.NewInt(2000)) != 0 {
 		t.Errorf("account balance mismatch: have %d, want %d", balance, 2000)


### PR DESCRIPTION
### Description

This PR addresses a race condition that rarely occurs after blocks are created in round > 0, in which `Backend.Prepare()` is called before the IBFT core sequence changes, resulting in an attempt to aggregate signatures from two different blocks.

### Tested

Added a sleep of 200ms and 1s in `RoundState.StartNewSequence()` and confirmed that we saw the error message in master but not in this implementation, where we succeeded and timed out, respectively.

 
### Other changes
- Revert previous attempt to fix this race condition (https://github.com/celo-org/celo-blockchain/pull/670)
- Minor changes to logging

### Related issues

- Fixes #758 

### Backwards compatibility

Compatible