### PR TITLE
Add garbage collection for RoundStateDB

### DIFF
--- a/common/task/task.go
+++ b/common/task/task.go
@@ -5,7 +5,7 @@ import "time"
 type StopFn func()
 
 func RunTaskRepeateadly(task func(), period time.Duration) StopFn {
-	// Setup the ticket and the channel to signal
+	// Setup the ticker and the channel to signal
 	// the ending of the interval
 	ticker := time.NewTicker(period)
 	stop := make(chan struct{})
@@ -23,6 +23,7 @@ func RunTaskRepeateadly(task func(), period time.Duration) StopFn {
 	}()
 
 	return func() {
+		// stop <- struct{}{}
 		close(stop)
 	}
 }

--- a/common/task/task.go
+++ b/common/task/task.go
@@ -1,0 +1,28 @@
+package task
+
+import "time"
+
+type StopFn func()
+
+func RunTaskRepeateadly(task func(), period time.Duration) StopFn {
+	// Setup the ticket and the channel to signal
+	// the ending of the interval
+	ticker := time.NewTicker(period)
+	stop := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				task()
+			case <-stop:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	return func() {
+		close(stop)
+	}
+}

--- a/common/task/task.go
+++ b/common/task/task.go
@@ -23,7 +23,6 @@ func RunTaskRepeateadly(task func(), period time.Duration) StopFn {
 	}()
 
 	return func() {
-		// stop <- struct{}{}
-		close(stop)
+		stop <- struct{}{}
 	}
 }

--- a/common/task/task_test.go
+++ b/common/task/task_test.go
@@ -15,6 +15,6 @@ func TestRunTaskRepeateadly(t *testing.T) {
 	time.Sleep(25 * time.Millisecond)
 
 	if counter != 3 {
-		t.Errorf("Expect taskt to run 3 times but got %d", counter)
+		t.Errorf("Expect task to run 3 times but got %d", counter)
 	}
 }

--- a/common/task/task_test.go
+++ b/common/task/task_test.go
@@ -1,0 +1,20 @@
+package task
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRunTaskRepeateadly(t *testing.T) {
+	counter := 0
+	ping := func() { counter++ }
+
+	stopTask := RunTaskRepeateadly(ping, 7*time.Millisecond)
+	time.Sleep(25 * time.Millisecond)
+	stopTask()
+	time.Sleep(25 * time.Millisecond)
+
+	if counter != 3 {
+		t.Errorf("Expect taskt to run 3 times but got %d", counter)
+	}
+}

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -38,7 +38,7 @@ import (
 
 // New creates an Istanbul consensus core
 func New(backend istanbul.Backend, config *istanbul.Config) Engine {
-	rsdb, err := newRoundStateDB(config.RoundStateDBPath)
+	rsdb, err := newRoundStateDB(config.RoundStateDBPath, nil)
 	if err != nil {
 		log.Crit("Failed to open RoundStateDB", "err", err)
 	}

--- a/consensus/istanbul/core/roundstate_db_test.go
+++ b/consensus/istanbul/core/roundstate_db_test.go
@@ -92,7 +92,7 @@ func TestRSDBDeleteEntriesOlderThan(t *testing.T) {
 func TestRSDBKeyEncodingOrder(t *testing.T) {
 	iterations := 1000
 
-	t.Run("ViewKey Enconding should decode the same view", func(t *testing.T) {
+	t.Run("ViewKey enconding should decode the same view", func(t *testing.T) {
 		for i := 0; i < iterations; i++ {
 			view := newView(rand.Uint64(), rand.Uint64())
 			key := view2Key(view)
@@ -103,7 +103,7 @@ func TestRSDBKeyEncodingOrder(t *testing.T) {
 		}
 	})
 
-	t.Run("ViewKey Enconding should maintain sort order", func(t *testing.T) {
+	t.Run("ViewKey enconding should maintain sort order", func(t *testing.T) {
 		for i := 0; i < iterations; i++ {
 			viewA := newView(rand.Uint64(), rand.Uint64())
 			keyA := view2Key(viewA)

--- a/consensus/istanbul/core/testutils_test.go
+++ b/consensus/istanbul/core/testutils_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
-func newView(seq, round int64) *istanbul.View {
-	return &istanbul.View{Round: big.NewInt(seq), Sequence: big.NewInt(round)}
+func newView(seq, round uint64) *istanbul.View {
+	return &istanbul.View{Round: new(big.Int).SetUint64(round), Sequence: new(big.Int).SetUint64(seq)}
 }
 
 func newTestRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet) RoundState {


### PR DESCRIPTION
### Description

To implement this we had to change the key format on levelDB; so that
Range queries over istanbul.View are possible.

To do so, a View is serialized to a byte[] as 2 uint64 (pair sequence,
round)

Also, garbage collection is optional and is turned on using constructor
options within the newRoundStateDB()

Finally, to implement a recurrent task, a new common/task package was
created. This makes it easy to test the recurrent task logic and it can
be also used in many other places since it's a quite common patter
within geth.

**Notes for the Reviewers**: 
  * pls check the view2key() serialization. It's limited to uint64 and will completely break if negative number for round/seq are used.
  * on calling task.stop() this won't interrupt the current run if it's already running, nor stop() will wait for that run to finish... probably i need a WaitGroup for that.

### Tested

 * unit tests

### Other changes

* Adds common/task package to launch recurring tasks

### Related issues

- Fixes #764 

### Backwards compatibility

New rounddbVersion. It will automatically delete and create a new roundstateDB