### PR TITLE
build: gomobile automaticall adds the ios tag, don't duplicate

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -947,7 +947,7 @@ func doXCodeFramework(cmdline []string) {
 	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile", "golang.org/x/mobile/cmd/gobind"))
 	// Patch gomobile to disable bitcode for now (rust generated bls lib output is not compatible)
 	build.MustRunCommand("sed", "-i", "", `/^[[:space:]]*cflags += \" -fembed-bitcode\"$/s/^/\/\//`, filepath.Join(build.GOPATH(), "src/golang.org/x/mobile/cmd/gomobile/env.go"))
-	bind := gomobileTool("bind", "-ldflags", "-s -w", "--target", "ios", "--tags", "ios", "-v", "github.com/ethereum/go-ethereum/mobile")
+	bind := gomobileTool("bind", "-ldflags", "-s -w", "--target", "ios", "-v", "github.com/ethereum/go-ethereum/mobile")
 
 	if *local {
 		// If we're building locally, use the build folder and stop afterwards


### PR DESCRIPTION
### Description

Cherry-pick https://github.com/ethereum/go-ethereum/commit/4ef5e9746b6f235d007b61a30276fe897cc9be8b to fix iOS build.

`make ios` was failing with go 1.11.3 with the following error:

```
[...]
>>> /Users/jean/src/github.com/celo-org/celo-blockchain/build/_workspace/src/github.com/ethereum/go-ethereum/build/bin/gomobile bind -ldflags -s -w --target ios --tags ios -v github.com/ethereum/go-ethereum/mobile
/Users/jean/src/github.com/celo-org/celo-blockchain/build/_workspace/src/github.com/ethereum/go-ethereum/build/bin/gomobile: go [list -e -json -compiled=true -test=false -export=false -deps=false -find=true -tags=ios,ios -- github.com/ethereum/go-ethereum/mobile]: exit status 2: cmd/go: -tags space-separated list contains comma

util.go:45: Command failed "/Users/jean/src/github.com/celo-org/celo-blockchain/build/_workspace/src/github.com/ethereum/go-ethereum/build/bin/gomobile bind -ldflags -s -w --target ios --tags ios -v github.com/ethereum/go-ethereum/mobile", err: "exit status 1"
util.go:46: Command failed "/Users/jean/src/github.com/celo-org/celo-blockchain/build/_workspace/src/github.com/ethereum/go-ethereum/build/bin/gomobile bind -ldflags -s -w --target ios --tags ios -v github.com/ethereum/go-ethereum/mobile", err: "exit status 1"
exit status 1
make: *** [ios] Error 1
```

Note sure why I'm only seeing this now. Might be because I was using go 1.13 until now.

### Tested

Tested that `make ios` succeeds with go 1.11.3.

### Other changes

N/A

### Related issues

N/A

### Backwards compatibility

Yes.