### PR TITLE
add istanbul_getProposer rpc method and remove a few others

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	vet "github.com/ethereum/go-ethereum/consensus/istanbul/backend/internal/enodes"
+	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -35,66 +36,62 @@ type API struct {
 	istanbul *Backend
 }
 
-// GetSnapshot retrieves the state snapshot at a given block.
-func (api *API) GetSnapshot(number *rpc.BlockNumber) (*Snapshot, error) {
-	// Retrieve the requested block number (or current if none requested)
-	var header *types.Header
-	if number == nil || *number == rpc.LatestBlockNumber {
-		header = api.chain.CurrentHeader()
+// getHeaderByNumber retrieves the header requested block or current if unspecified.
+func (api *API) getParentHeaderByNumber(number *rpc.BlockNumber) (*types.Header, error) {
+	var parent uint64
+	if number == nil || *number == rpc.LatestBlockNumber || *number == rpc.PendingBlockNumber {
+		head := api.chain.CurrentHeader()
+		if head == nil {
+			return nil, errUnknownBlock
+		}
+		if number == nil || *number == rpc.LatestBlockNumber {
+			parent = head.Number.Uint64() - 1
+		} else {
+			parent = head.Number.Uint64()
+		}
+	} else if *number == rpc.EarliestBlockNumber {
+		return nil, errUnknownBlock
 	} else {
-		header = api.chain.GetHeaderByNumber(uint64(number.Int64()))
+		parent = uint64(*number - 1)
 	}
-	// Ensure we have an actually valid block and return its snapshot
+
+	header := api.chain.GetHeaderByNumber(parent)
 	if header == nil {
 		return nil, errUnknownBlock
 	}
-	return api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	return header, nil
 }
 
-// GetSnapshotAtHash retrieves the state snapshot at a given block.
-func (api *API) GetSnapshotAtHash(hash common.Hash) (*Snapshot, error) {
-	header := api.chain.GetHeaderByHash(hash)
-	if header == nil {
-		return nil, errUnknownBlock
-	}
-	return api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
-}
-
-// GetValidators retrieves the list of authorized validators at the specified block.
+// GetValidators retrieves the list validators that must sign a given block.
 func (api *API) GetValidators(number *rpc.BlockNumber) ([]common.Address, error) {
-	// Retrieve the requested block number (or current if none requested)
-	var header *types.Header
-	if number == nil || *number == rpc.LatestBlockNumber {
-		header = api.chain.CurrentHeader()
-	} else {
-		header = api.chain.GetHeaderByNumber(uint64(number.Int64()))
-	}
-	// Ensure we have an actually valid block and return the validators from its snapshot
-	if header == nil {
-		return nil, errUnknownBlock
-	}
-	snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+	header, err := api.getParentHeaderByNumber(number)
 	if err != nil {
 		return nil, err
 	}
-	validators := snap.validators()
-	validatorsAddresses, _ := istanbul.SeparateValidatorDataIntoIstanbulExtra(validators)
-	return validatorsAddresses, nil
+	validators := api.istanbul.GetValidators(header.Number, header.Hash())
+	return istanbul.GetAddressesFromValidatorList(validators), nil
 }
 
-// GetValidatorsAtHash retrieves the state snapshot at a given block.
-func (api *API) GetValidatorsAtHash(hash common.Hash) ([]common.Address, error) {
-	header := api.chain.GetHeaderByHash(hash)
-	if header == nil {
-		return nil, errUnknownBlock
-	}
-	snap, err := api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+// GetProposer retrieves the proposer for a given block number (i.e. sequence) and round.
+func (api *API) GetProposer(sequence *rpc.BlockNumber, round *uint64) (common.Address, error) {
+	header, err := api.getParentHeaderByNumber(sequence)
 	if err != nil {
-		return nil, err
+		return common.Address{}, err
 	}
-	validators := snap.validators()
-	validatorsAddresses, _ := istanbul.SeparateValidatorDataIntoIstanbulExtra(validators)
-	return validatorsAddresses, nil
+
+	valSet := api.istanbul.getOrderedValidators(header.Number.Uint64(), header.Hash())
+	if valSet == nil {
+		return common.Address{}, err
+	}
+	previousProposer, err := api.istanbul.Author(header)
+	if err != nil {
+		return common.Address{}, err
+	}
+	if round == nil {
+		round = new(uint64)
+	}
+	proposer := validator.GetProposerSelector(api.istanbul.config.ProposerPolicy)(valSet, previousProposer, *round)
+	return proposer.Address(), nil
 }
 
 // AddProxy peers with a remote node that acts as a proxy, even if slots are full

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -62,6 +62,22 @@ func (api *API) getParentHeaderByNumber(number *rpc.BlockNumber) (*types.Header,
 	return header, nil
 }
 
+// GetSnapshot retrieves the state snapshot at a given block.
+func (api *API) GetSnapshot(number *rpc.BlockNumber) (*Snapshot, error) {
+	// Retrieve the requested block number (or current if none requested)
+	var header *types.Header
+	if number == nil || *number == rpc.LatestBlockNumber {
+		header = api.chain.CurrentHeader()
+	} else {
+		header = api.chain.GetHeaderByNumber(uint64(number.Int64()))
+	}
+	// Ensure we have an actually valid block and return its snapshot
+	if header == nil {
+		return nil, errUnknownBlock
+	}
+	return api.istanbul.snapshot(api.chain, header.Number.Uint64(), header.Hash(), nil)
+}
+
 // GetValidators retrieves the list validators that must sign a given block.
 func (api *API) GetValidators(number *rpc.BlockNumber) ([]common.Address, error) {
 	header, err := api.getParentHeaderByNumber(number)

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -249,7 +249,7 @@ func (sb *Backend) Validators(proposal istanbul.Proposal) istanbul.ValidatorSet 
 	return sb.getOrderedValidators(proposal.Number().Uint64(), proposal.Hash())
 }
 
-// ParentBlockValidators implements istanbul.Backend.GetParentValidators
+// ParentBlockValidators implements istanbul.Backend.ParentBlockValidators
 func (sb *Backend) ParentBlockValidators(proposal istanbul.Proposal) istanbul.ValidatorSet {
 	return sb.getOrderedValidators(proposal.Number().Uint64()-1, proposal.ParentHash())
 }

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -237,7 +237,7 @@ func GetAggregatedSeal(seals MessageSet, round *big.Int) (types.IstanbulAggregat
 func UnionOfSeals(aggregatedSignature types.IstanbulAggregatedSeal, seals MessageSet) (types.IstanbulAggregatedSeal, error) {
 	// TODO(asa): Check for round equality...
 	// Check who already has signed the message
-	newBitmap := aggregatedSignature.Bitmap
+	newBitmap := new(big.Int).Set(aggregatedSignature.Bitmap)
 	committedSeals := [][]byte{}
 	committedSeals = append(committedSeals, aggregatedSignature.Signature)
 	for _, v := range seals.Values() {
@@ -254,7 +254,7 @@ func UnionOfSeals(aggregatedSignature types.IstanbulAggregatedSeal, seals Messag
 
 		// if the bit was not set, this means we should add this signature to
 		// the batch
-		if aggregatedSignature.Bitmap.Bit(int(valIndex)) == 0 {
+		if newBitmap.Bit(int(valIndex)) == 0 {
 			newBitmap.SetBit(newBitmap, (int(valIndex)), 1)
 			committedSeals = append(committedSeals, commit.CommittedSeal)
 		}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -761,6 +761,12 @@ web3._extend({
 	methods:
 	[
 		new web3._extend.Method({
+			name: 'getSnapshot',
+			call: 'istanbul_getSnapshot',
+			params: 1,
+			inputFormatter: [null]
+		}),
+		new web3._extend.Method({
 			name: 'getValidators',
 			call: 'istanbul_getValidators',
 			params: 1,

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -761,26 +761,16 @@ web3._extend({
 	methods:
 	[
 		new web3._extend.Method({
-			name: 'getSnapshot',
-			call: 'istanbul_getSnapshot',
-			params: 1,
-			inputFormatter: [null]
-		}),
-		new web3._extend.Method({
-			name: 'getSnapshotAtHash',
-			call: 'istanbul_getSnapshotAtHash',
-			params: 1
-		}),
-		new web3._extend.Method({
 			name: 'getValidators',
 			call: 'istanbul_getValidators',
 			params: 1,
 			inputFormatter: [null]
 		}),
 		new web3._extend.Method({
-			name: 'getValidatorsAtHash',
-			call: 'istanbul_getValidatorsAtHash',
-			params: 1
+			name: 'getProposer',
+			call: 'istanbul_getProposer',
+			params: 2,
+			inputFormatter: [null, null]
 		}),
 		new web3._extend.Method({
 			name: 'addProxy',


### PR DESCRIPTION
### Description

This PR makes the following changes to the Istanbul RPC API to make accessible new information about the proposer for each sequence. Additionally methods for retrieving validator set and snapshot information by hash are removed because they are equivalent to looking up the block by hash then calling the respective method with the block number because the hash is not actually used in snapshot retrieval.

* Add `GetProposer(sequence *rpc.BlockNumber, round *uint64)`
* Remove `GetValidatorsAtHash` and `GetSnapshotAtHash`
* Change `GetValidators` to return the validators that must sign the given block.

### Tested

Manually testing on a testnet which `geth attach` and executing the changes RPC methods.

### Other changes

* Remove a mutability bug in `consensus/istanbul/core/core.go` which could result in building a block proposal with invalid parent seal.
* Fix an outdated comment in `consensus/istanbul/backend/backend.go`

### Backwards compatibility

Breaks usage of the `istanbul_getSnapshotAtHash` and `istanbul_getValidatorsAtHash` RPC methods, which are not known to be in use.
