### PR TITLE
changed announce message frequency

### DIFF
--- a/consensus/consensustest/mockprotocol.go
+++ b/consensus/consensustest/mockprotocol.go
@@ -17,8 +17,13 @@
 package consensustest
 
 import (
+	"crypto/ecdsa"
+	"net"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
@@ -34,6 +39,19 @@ func (b *MockBroadcaster) FindPeers(targets map[enode.ID]bool, purpose p2p.Purpo
 
 type MockP2PServer struct {
 	Node *enode.Node
+}
+
+func NewMockP2PServer() *MockP2PServer {
+	mockNode := enode.NewV4(
+		&ecdsa.PublicKey{
+			Curve: crypto.S256(),
+			X:     hexutil.MustDecodeBig("0x760c4460e5336ac9bbd87952a3c7ec4363fc0a97bd31c86430806e287b437fd1"),
+			Y:     hexutil.MustDecodeBig("0xb01abc6e1db640cf3106b520344af1d58b00b57823db3e1407cbc433e1b6d04d")},
+		net.IP{192, 168, 0, 1},
+		30303,
+		30303)
+
+	return &MockP2PServer{Node: mockNode}
 }
 
 func (serv *MockP2PServer) Self() *enode.Node {

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -109,7 +109,10 @@ func (sb *Backend) sendAnnounceMsgs() {
 	sb.announceWg.Add(1)
 	defer sb.announceWg.Done()
 
-	ticker := time.NewTicker(time.Minute)
+	// Send out an announce message when this thread starts
+	go sb.sendIstAnnounce()
+
+	ticker := time.NewTicker(10 * time.Minute)
 
 	for {
 		select {

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -117,7 +117,7 @@ func (sb *Backend) sendAnnounceMsgs() {
 		HIGH_FREQ_BEFORE_FIRST_PEER_STATE = iota
 
 		// In this state, send out an announce message every 1 minute for the first 10 announce messages after the first peer is established.
-		// This is on the assumption that when this node first establishes a peer, the sub p2p network centered on this peer may
+		// This is on the assumption that when this node first establishes a peer, the p2p network that this node is in may
 		// be partitioned with the broader p2p network. We want to give that p2p network some time to connect to the broader p2p network.
 		HIGH_FREQ_AFTER_FIRST_PEER_STATE
 

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -123,7 +123,7 @@ func newBlockChain(n int, isFullChain bool) (*core.BlockChain, *Backend) {
 
 	b.SetChain(blockchain, blockchain.CurrentBlock)
 	b.SetBroadcaster(&consensustest.MockBroadcaster{})
-	b.SetP2PServer(&consensustest.MockP2PServer{})
+	b.SetP2PServer(consensustest.NewMockP2PServer())
 
 	b.Start(blockchain.HasBadBlock,
 		func(parentHash common.Hash) (*state.StateDB, error) {

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -249,7 +249,7 @@ func getAuthorizedIstanbulEngine() consensus.Istanbul {
 
 	engine := istanbulBackend.New(istanbul.DefaultConfig, ethdb.NewMemDatabase())
 	engine.(*istanbulBackend.Backend).SetBroadcaster(&consensustest.MockBroadcaster{})
-	engine.(*istanbulBackend.Backend).SetP2PServer(&consensustest.MockP2PServer{})
+	engine.(*istanbulBackend.Backend).SetP2PServer(consensustest.NewMockP2PServer())
 	engine.(*istanbulBackend.Backend).Authorize(crypto.PubkeyToAddress(testBankKey.PublicKey), signerFn, signHashBLSFn, signMessageBLSFn)
 	return engine
 }


### PR DESCRIPTION
### Description

This PR changes the frequency of when announce messages are sent.  Also, it will now send an announce message on istanbul engine start.

The exact times when the message is sent is described here:  https://github.com/celo-org/celo-blockchain/issues/790

### Tested

Created a testnet and verified that the announce messages are only sent on the intended events.

### Other changes

None

### Related issues

- Fixes #790 

### Backwards compatibility

Yes
