### PR TITLE
Istanbul Core Cleanup & Testing

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -1039,14 +1039,14 @@ func waitCoreToReachSequence(core istanbulCore.Engine, expectedSequence *big.Int
 	for {
 		select {
 		case <-ticker.C:
-			seq := core.Sequence()
-			if seq != nil && seq.Cmp(expectedSequence) == 0 {
-				logger.Trace("Current sequence matches header", "cur_seq", seq)
-				return seq
+			view := core.CurrentView()
+			if view != nil && view.Sequence != nil && view.Sequence.Cmp(expectedSequence) == 0 {
+				logger.Trace("Current sequence matches header", "cur_seq", view.Sequence)
+				return view.Sequence
 			}
 		case <-timeout:
 			// TODO(asa): Why is this logged by full nodes?
-			log.Trace("Timed out while waiting for core to sequence change, unable to combine commit messages with ParentAggregatedSeal", "cur_seq", core.Sequence())
+			log.Trace("Timed out while waiting for core to sequence change, unable to combine commit messages with ParentAggregatedSeal", "cur_view", core.CurrentView())
 			return nil
 		}
 	}

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -63,10 +63,6 @@ func (c *core) Stop() error {
 	return nil
 }
 
-func (c *core) CurrentView() *istanbul.View {
-	return c.current.View()
-}
-
 // ----------------------------------------------------------------------------
 
 // Subscribe both internal and external events

--- a/consensus/istanbul/core/types.go
+++ b/consensus/istanbul/core/types.go
@@ -20,17 +20,16 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/rlp"
-	"math/big"
 )
 
 type Engine interface {
 	Start() error
 	Stop() error
 	CurrentView() *istanbul.View
+	CurrentRoundState() RoundState
 	SetAddress(common.Address)
 	// Validator -> CommittedSeal from Parent Block
 	ParentCommits() MessageSet
-	Sequence() *big.Int
 }
 
 // State represents the IBFT state

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -63,6 +63,8 @@ type Proposal interface {
 	DecodeRLP(s *rlp.Stream) error
 }
 
+// ## Request ##############################################################
+
 type Request struct {
 	Proposal Proposal
 }
@@ -86,6 +88,8 @@ func (b *Request) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
+// ## View ##############################################################
+
 // View includes a round number and a sequence number.
 // Sequence is the block number we'd like to commit.
 // Each round has a number and is composed by 3 steps: preprepare, prepare and commit.
@@ -95,25 +99,6 @@ func (b *Request) DecodeRLP(s *rlp.Stream) error {
 type View struct {
 	Round    *big.Int
 	Sequence *big.Int
-}
-
-// EncodeRLP serializes b into the Ethereum RLP format.
-func (v *View) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{v.Round, v.Sequence})
-}
-
-// DecodeRLP implements rlp.Decoder, and load the consensus fields from a RLP stream.
-func (v *View) DecodeRLP(s *rlp.Stream) error {
-	var view struct {
-		Round    *big.Int
-		Sequence *big.Int
-	}
-
-	if err := s.Decode(&view); err != nil {
-		return err
-	}
-	v.Round, v.Sequence = view.Round, view.Sequence
-	return nil
 }
 
 func (v *View) String() string {
@@ -137,6 +122,8 @@ func (v *View) Cmp(y *View) int {
 	return 0
 }
 
+// ## RoundChangeCertificate ##############################################################
+
 type RoundChangeCertificate struct {
 	RoundChangeMessages []Message
 }
@@ -145,24 +132,7 @@ func (b *RoundChangeCertificate) IsEmpty() bool {
 	return len(b.RoundChangeMessages) == 0
 }
 
-// EncodeRLP serializes b into the Ethereum RLP format.
-func (b *RoundChangeCertificate) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{b.RoundChangeMessages})
-}
-
-// DecodeRLP implements rlp.Decoder, and load the consensus fields from a RLP stream.
-func (b *RoundChangeCertificate) DecodeRLP(s *rlp.Stream) error {
-	var roundChangeCertificate struct {
-		RoundChangeMessages []Message
-	}
-
-	if err := s.Decode(&roundChangeCertificate); err != nil {
-		return err
-	}
-	b.RoundChangeMessages = roundChangeCertificate.RoundChangeMessages
-
-	return nil
-}
+// ## Preprepare ##############################################################
 
 type Preprepare struct {
 	View                   *View
@@ -170,33 +140,50 @@ type Preprepare struct {
 	RoundChangeCertificate RoundChangeCertificate
 }
 
-func (b *Preprepare) HasRoundChangeCertificate() bool {
-	return !b.RoundChangeCertificate.IsEmpty()
+type PreprepareData struct {
+	View                   *View
+	Proposal               *types.Block
+	RoundChangeCertificate RoundChangeCertificate
 }
 
+func (pp *Preprepare) HasRoundChangeCertificate() bool {
+	return !pp.RoundChangeCertificate.IsEmpty()
+}
+
+func (pp *Preprepare) AsData() *PreprepareData {
+	return &PreprepareData{
+		View:                   pp.View,
+		Proposal:               pp.Proposal.(*types.Block),
+		RoundChangeCertificate: pp.RoundChangeCertificate,
+	}
+}
+
+// RLP Encoding ---------------------------------------------------------------
+
 // EncodeRLP serializes b into the Ethereum RLP format.
-func (b *Preprepare) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{b.View, b.Proposal, &b.RoundChangeCertificate})
+func (pp *Preprepare) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, pp.AsData())
 }
 
 // DecodeRLP implements rlp.Decoder, and load the consensus fields from a RLP stream.
-func (b *Preprepare) DecodeRLP(s *rlp.Stream) error {
-	var preprepare struct {
-		View                   *View
-		Proposal               *types.Block
-		RoundChangeCertificate RoundChangeCertificate
-	}
-
-	if err := s.Decode(&preprepare); err != nil {
+func (pp *Preprepare) DecodeRLP(s *rlp.Stream) error {
+	var data PreprepareData
+	if err := s.Decode(&data); err != nil {
 		return err
 	}
-	b.View, b.Proposal, b.RoundChangeCertificate = preprepare.View, preprepare.Proposal, preprepare.RoundChangeCertificate
-
+	pp.View, pp.Proposal, pp.RoundChangeCertificate = data.View, data.Proposal, data.RoundChangeCertificate
 	return nil
 }
 
+// ## PreparedCertificate #####################################################
+
 type PreparedCertificate struct {
 	Proposal                Proposal
+	PrepareOrCommitMessages []Message
+}
+
+type PreparedCertificateData struct {
+	Proposal                *types.Block
 	PrepareOrCommitMessages []Message
 }
 
@@ -217,29 +204,36 @@ func EmptyPreparedCertificate() PreparedCertificate {
 	}
 }
 
-func (b *PreparedCertificate) IsEmpty() bool {
-	return len(b.PrepareOrCommitMessages) == 0
+func (pc *PreparedCertificate) IsEmpty() bool {
+	return len(pc.PrepareOrCommitMessages) == 0
 }
 
+func (pc *PreparedCertificate) AsData() *PreparedCertificateData {
+	return &PreparedCertificateData{
+		Proposal:                pc.Proposal.(*types.Block),
+		PrepareOrCommitMessages: pc.PrepareOrCommitMessages,
+	}
+}
+
+// RLP Encoding ---------------------------------------------------------------
+
 // EncodeRLP serializes b into the Ethereum RLP format.
-func (b *PreparedCertificate) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{b.Proposal, b.PrepareOrCommitMessages})
+func (pc *PreparedCertificate) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, pc.AsData())
 }
 
 // DecodeRLP implements rlp.Decoder, and load the consensus fields from a RLP stream.
-func (b *PreparedCertificate) DecodeRLP(s *rlp.Stream) error {
-	var preparedCertificate struct {
-		Proposal                *types.Block
-		PrepareOrCommitMessages []Message
-	}
-
-	if err := s.Decode(&preparedCertificate); err != nil {
+func (pc *PreparedCertificate) DecodeRLP(s *rlp.Stream) error {
+	var data PreparedCertificateData
+	if err := s.Decode(&data); err != nil {
 		return err
 	}
-
-	b.Proposal, b.PrepareOrCommitMessages = preparedCertificate.Proposal, preparedCertificate.PrepareOrCommitMessages
+	pc.PrepareOrCommitMessages, pc.Proposal = data.PrepareOrCommitMessages, data.Proposal
 	return nil
+
 }
+
+// ## RoundChange #############################################################
 
 type RoundChange struct {
 	View                *View
@@ -269,81 +263,32 @@ func (b *RoundChange) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
+// ## Subject #################################################################
+
 type Subject struct {
 	View   *View
 	Digest common.Hash
 }
 
-// EncodeRLP serializes b into the Ethereum RLP format.
-func (b *Subject) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{b.View, b.Digest})
+func (s *Subject) String() string {
+	return fmt.Sprintf("{View: %v, Digest: %v}", s.View, s.Digest.String())
 }
 
-// DecodeRLP implements rlp.Decoder, and load the consensus fields from a RLP stream.
-func (b *Subject) DecodeRLP(s *rlp.Stream) error {
-	var subject struct {
-		View   *View
-		Digest common.Hash
-	}
-
-	if err := s.Decode(&subject); err != nil {
-		return err
-	}
-	b.View, b.Digest = subject.View, subject.Digest
-	return nil
-}
-
-func (b *Subject) String() string {
-	return fmt.Sprintf("{View: %v, Digest: %v}", b.View, b.Digest.String())
-}
+// ## CommittedSubject #################################################################
 
 type CommittedSubject struct {
 	Subject       *Subject
 	CommittedSeal []byte
 }
 
-// EncodeRLP serializes b into the Ethereum RLP format.
-func (cs *CommittedSubject) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{cs.Subject, cs.CommittedSeal})
-}
-
-// DecodeRLP implements rlp.Decoder, and load the consensus fields from a RLP stream.
-func (cs *CommittedSubject) DecodeRLP(s *rlp.Stream) error {
-	var committedSubject struct {
-		Subject       *Subject
-		CommittedSeal []byte
-	}
-
-	if err := s.Decode(&committedSubject); err != nil {
-		return err
-	}
-	cs.Subject, cs.CommittedSeal = committedSubject.Subject, committedSubject.CommittedSeal
-	return nil
-}
+// ## ForwardMessage #################################################################
 
 type ForwardMessage struct {
 	Msg           []byte
 	DestAddresses []common.Address
 }
 
-// EncodeRLP serializes fm into the Ethereum RLP format.
-func (fm *ForwardMessage) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{fm.Msg, fm.DestAddresses})
-}
-
-// DecodeRLP implements rlp.Decoder, and load the consensus fields from a RLP stream.
-func (fm *ForwardMessage) DecodeRLP(s *rlp.Stream) error {
-	var forwardMessage struct {
-		Msg           []byte
-		DestAddresses []common.Address
-	}
-
-	if err := s.Decode(&forwardMessage); err != nil {
-		return err
-	}
-	fm.Msg, fm.DestAddresses = forwardMessage.Msg, forwardMessage.DestAddresses
-	return nil
-}
+// ## Message #################################################################
 
 const (
 	MsgPreprepare uint64 = iota
@@ -359,33 +304,6 @@ type Message struct {
 	Signature []byte         // Signature of the Message using the private key associated with the "Address" field
 }
 
-// ==============================================
-//
-// define the functions that needs to be provided for rlp Encoder/Decoder.
-
-// EncodeRLP serializes m into the Ethereum RLP format.
-func (m *Message) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{m.Code, m.Msg, m.Address, m.Signature})
-}
-
-// DecodeRLP implements rlp.Decoder, and load the consensus fields from a RLP stream.
-func (m *Message) DecodeRLP(s *rlp.Stream) error {
-	var msg struct {
-		Code      uint64
-		Msg       []byte
-		Address   common.Address
-		Signature []byte
-	}
-
-	if err := s.Decode(&msg); err != nil {
-		return err
-	}
-	m.Code, m.Msg, m.Address, m.Signature = msg.Code, msg.Msg, msg.Address, msg.Signature
-	return nil
-}
-
-// ==============================================
-//
 // define the functions that needs to be provided for core.
 
 func (m *Message) Sign(signingFn func(data []byte) ([]byte, error)) error {

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -18,7 +18,12 @@ package istanbul
 
 import (
 	"math/big"
+	"reflect"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 func TestViewCompare(t *testing.T) {
@@ -67,5 +72,237 @@ func TestViewCompare(t *testing.T) {
 	}
 	if r := srvView.Cmp(tarView); r != -1 {
 		t.Errorf("source(%v) should be smaller than target(%v): have %v, want %v", srvView, tarView, r, -1)
+	}
+}
+
+func dummyView() *View {
+	return &View{
+		Round:    big.NewInt(15),
+		Sequence: big.NewInt(42),
+	}
+}
+func dummySubject() *Subject {
+	return &Subject{
+		View:   dummyView(),
+		Digest: common.HexToHash("1234567890"),
+	}
+}
+
+func dummyBlock(number int64) *types.Block {
+	header := &types.Header{
+		Difficulty: big.NewInt(5),
+		Number:     big.NewInt(number),
+		GasLimit:   1002121,
+		GasUsed:    123213,
+		Time:       big.NewInt(100),
+		Extra:      []byte{01, 02},
+	}
+	feeCurrencyAddr := common.HexToAddress("02")
+	gatewayFeeRecipientAddr := common.HexToAddress("03")
+	tx := types.NewTransaction(1, common.HexToAddress("01"), big.NewInt(1), 10000, big.NewInt(10), &feeCurrencyAddr, &gatewayFeeRecipientAddr, big.NewInt(34), []byte{04})
+	return types.NewBlock(header, []*types.Transaction{tx}, nil, nil, nil)
+
+}
+func dummyMessage(code uint64) *Message {
+	return &Message{
+		Code:      code,
+		Address:   common.HexToAddress("AABB"),
+		Msg:       []byte{10, 20, 42},
+		Signature: []byte{30, 40, 52},
+	}
+}
+func dummyRoundChangeCertificate() *RoundChangeCertificate {
+	return &RoundChangeCertificate{
+		RoundChangeMessages: []Message{*dummyMessage(42), *dummyMessage(32), *dummyMessage(15)},
+	}
+}
+
+func dummyPreparedCertificate() *PreparedCertificate {
+	return &PreparedCertificate{
+		PrepareOrCommitMessages: []Message{*dummyMessage(42), *dummyMessage(32), *dummyMessage(15)},
+		Proposal:                dummyBlock(1),
+	}
+}
+
+func assertEqual(t *testing.T, prefix string, o, r interface{}) {
+	if !reflect.DeepEqual(o, r) {
+		t.Errorf("%s:  Got %#v, expected %#v", prefix, r, o)
+	}
+}
+
+func TestViewRLPEncoding(t *testing.T) {
+	var result, original *View
+	original = dummyView()
+
+	rawVal, err := rlp.EncodeToBytes(original)
+	if err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if !reflect.DeepEqual(original, result) {
+		t.Fatalf("RLP Encode/Decode mismatch. Got %v, expected %v", result, original)
+	}
+}
+
+func TestMessageRLPEncoding(t *testing.T) {
+	var result, original *Message
+	original = dummyMessage(42)
+
+	rawVal, err := rlp.EncodeToBytes(original)
+	if err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if !reflect.DeepEqual(original, result) {
+		t.Fatalf("RLP Encode/Decode mismatch. Got %v, expected %v", result, original)
+	}
+}
+
+func TestRoundChangeCertificateRLPEncoding(t *testing.T) {
+	var result, original *RoundChangeCertificate
+	original = dummyRoundChangeCertificate()
+
+	rawVal, err := rlp.EncodeToBytes(original)
+	if err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if !reflect.DeepEqual(original, result) {
+		t.Fatalf("RLP Encode/Decode mismatch. Got %v, expected %v", result, original)
+	}
+}
+
+func TestPreprepareRLPEncoding(t *testing.T) {
+	var result, original *Preprepare
+	original = &Preprepare{
+		View:                   dummyView(),
+		RoundChangeCertificate: *dummyRoundChangeCertificate(),
+		Proposal:               dummyBlock(1),
+	}
+
+	rawVal, err := rlp.EncodeToBytes(original)
+	if err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	// decoded Blocks don't equal Original ones so we need to check equality differently
+	assertEqual(t, "RLP Encode/Decode mismatch: View", result.View, original.View)
+	assertEqual(t, "RLP Encode/Decode mismatch: RoundChangeCertificate", result.RoundChangeCertificate, original.RoundChangeCertificate)
+	assertEqual(t, "RLP Encode/Decode mismatch: BlockHash", result.Proposal.Hash(), original.Proposal.Hash())
+}
+
+func TestPreparedCertificateRLPEncoding(t *testing.T) {
+	var result, original *PreparedCertificate
+	original = dummyPreparedCertificate()
+
+	rawVal, err := rlp.EncodeToBytes(original)
+	if err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	// decoded Blocks don't equal Original ones so we need to check equality differently
+	assertEqual(t, "RLP Encode/Decode mismatch: PrepareOrCommitMessages", result.PrepareOrCommitMessages, original.PrepareOrCommitMessages)
+	assertEqual(t, "RLP Encode/Decode mismatch: BlockHash", result.Proposal.Hash(), original.Proposal.Hash())
+}
+
+func TestRoundChangeRLPEncoding(t *testing.T) {
+	var result, original *RoundChange
+	original = &RoundChange{
+		View:                dummyView(),
+		PreparedCertificate: *dummyPreparedCertificate(),
+	}
+
+	rawVal, err := rlp.EncodeToBytes(original)
+	if err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	// decoded Blocks don't equal Original ones so we need to check equality differently
+	assertEqual(t, "RLP Encode/Decode mismatch: View", result.View, original.View)
+	assertEqual(t, "RLP Encode/Decode mismatch: PreparedCertificate.PrepareOrCommitMessages", result.PreparedCertificate.PrepareOrCommitMessages, original.PreparedCertificate.PrepareOrCommitMessages)
+	assertEqual(t, "RLP Encode/Decode mismatch: PreparedCertificate.BlockHash", result.PreparedCertificate.Proposal.Hash(), original.PreparedCertificate.Proposal.Hash())
+}
+
+func TestSubjectRLPEncoding(t *testing.T) {
+	var result, original *Subject
+	original = dummySubject()
+
+	rawVal, err := rlp.EncodeToBytes(original)
+	if err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if !reflect.DeepEqual(original, result) {
+		t.Fatalf("RLP Encode/Decode mismatch. Got %v, expected %v", result, original)
+	}
+}
+
+func TestCommittedSubjectRLPEncoding(t *testing.T) {
+	var result, original *CommittedSubject
+	original = &CommittedSubject{
+		Subject:       dummySubject(),
+		CommittedSeal: []byte{12, 13, 23},
+	}
+
+	rawVal, err := rlp.EncodeToBytes(original)
+	if err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if !reflect.DeepEqual(original, result) {
+		t.Fatalf("RLP Encode/Decode mismatch. Got %v, expected %v", result, original)
+	}
+}
+
+func TestForwardMessageRLPEncoding(t *testing.T) {
+	var result, original *ForwardMessage
+	original = &ForwardMessage{
+		DestAddresses: []common.Address{common.HexToAddress("123123")},
+		Msg:           []byte{23, 23, 12, 3},
+	}
+
+	rawVal, err := rlp.EncodeToBytes(original)
+	if err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if err = rlp.DecodeBytes(rawVal, &result); err != nil {
+		t.Fatalf("Error %v", err)
+	}
+
+	if !reflect.DeepEqual(original, result) {
+		t.Fatalf("RLP Encode/Decode mismatch. Got %v, expected %v", result, original)
 	}
 }

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -71,6 +71,9 @@ type Validator interface {
 	// Serialize returns binary reprenstation of the Validator
 	// can be use used to instantiate a validator with DeserializeValidator()
 	Serialize() ([]byte, error)
+
+	// AsData returns Validator representation as ValidatorData
+	AsData() *ValidatorData
 }
 
 func GetAddressesFromValidatorList(validators []Validator) []common.Address {
@@ -128,10 +131,17 @@ type ValidatorSet interface {
 	RemoveValidators(removedValidators *big.Int) bool
 	// Copy validator set
 	Copy() ValidatorSet
+	// AsData returns the ValidatorSetData representation
+	AsData() *ValidatorSetData
 
 	// Serialize returns binary reprentation of the ValidatorSet
 	// can be use used to instantiate a validator with DeserializeValidatorSet()
 	Serialize() ([]byte, error)
+}
+
+type ValidatorSetData struct {
+	Validators []ValidatorData
+	Randomness common.Hash
 }
 
 // ----------------------------------------------------------------------------

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -19,6 +19,7 @@ package istanbul
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -60,13 +61,12 @@ type ValidatorData struct {
 }
 
 type Validator interface {
+	fmt.Stringer
+
 	// Address returns address
 	Address() common.Address
 
 	BLSPublicKey() []byte
-
-	// String representation of Validator
-	String() string
 
 	// Serialize returns binary reprenstation of the Validator
 	// can be use used to instantiate a validator with DeserializeValidator()
@@ -131,8 +131,6 @@ type ValidatorSet interface {
 	RemoveValidators(removedValidators *big.Int) bool
 	// Copy validator set
 	Copy() ValidatorSet
-	// AsData returns the ValidatorSetData representation
-	AsData() *ValidatorSetData
 
 	// Serialize returns binary reprentation of the ValidatorSet
 	// can be use used to instantiate a validator with DeserializeValidatorSet()

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -33,10 +33,6 @@ type defaultValidator struct {
 	blsPublicKey []byte
 }
 
-func NewValidatorFromData(data *istanbul.ValidatorData) istanbul.Validator {
-	return newValidatorFromData(data)
-}
-
 func newValidatorFromData(data *istanbul.ValidatorData) *defaultValidator {
 	return &defaultValidator{
 		address:      data.Address,
@@ -95,17 +91,6 @@ type defaultSet struct {
 func newDefaultSet(validators []istanbul.ValidatorData) *defaultSet {
 	return &defaultSet{
 		validators: mapDataToValidators(validators),
-	}
-}
-
-func NewValidatorSetFromData(data *istanbul.ValidatorSetData) istanbul.ValidatorSet {
-	return newValidatorSetFromData(data)
-}
-
-func newValidatorSetFromData(data *istanbul.ValidatorSetData) *defaultSet {
-	return &defaultSet{
-		validators: mapDataToValidators(data.Validators),
-		randomness: data.Randomness,
 	}
 }
 
@@ -262,7 +247,7 @@ func mapValidatorsToData(validators []istanbul.Validator) []istanbul.ValidatorDa
 func mapDataToValidators(data []istanbul.ValidatorData) []istanbul.Validator {
 	validators := make([]istanbul.Validator, len(data))
 	for i, v := range data {
-		validators[i] = NewValidatorFromData(&v)
+		validators[i] = newValidatorFromData(&v)
 	}
 	return validators
 }

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -17,6 +17,7 @@
 package validator
 
 import (
+	"encoding/json"
 	"io"
 	"math"
 	"math/big"
@@ -32,42 +33,52 @@ type defaultValidator struct {
 	blsPublicKey []byte
 }
 
-func (val *defaultValidator) Address() common.Address {
-	return val.address
+func NewValidatorFromData(data *istanbul.ValidatorData) istanbul.Validator {
+	return newValidatorFromData(data)
 }
 
-func (val *defaultValidator) BLSPublicKey() []byte {
-	return val.blsPublicKey
-}
-
-func (val *defaultValidator) String() string {
-	return val.Address().String()
-}
-
-type defaultValidatorRLP struct {
-	Address      common.Address
-	BlsPublicKey []byte
-}
-
-func (val *defaultValidator) Serialize() ([]byte, error) {
-	return rlp.EncodeToBytes(val)
-}
-
-func (val *defaultValidator) EncodeRLP(w io.Writer) error {
-	entry := defaultValidatorRLP{
-		Address:      val.address,
-		BlsPublicKey: val.blsPublicKey,
+func newValidatorFromData(data *istanbul.ValidatorData) *defaultValidator {
+	return &defaultValidator{
+		address:      data.Address,
+		blsPublicKey: data.BLSPublicKey,
 	}
-	return rlp.Encode(w, entry)
 }
 
+func (val *defaultValidator) AsData() *istanbul.ValidatorData {
+	return &istanbul.ValidatorData{
+		Address:      val.address,
+		BLSPublicKey: val.blsPublicKey,
+	}
+}
+
+func (val *defaultValidator) Address() common.Address { return val.address }
+func (val *defaultValidator) BLSPublicKey() []byte    { return val.blsPublicKey }
+func (val *defaultValidator) String() string          { return val.Address().String() }
+
+func (val *defaultValidator) Serialize() ([]byte, error) { return rlp.EncodeToBytes(val) }
+
+// JSON Encoding -----------------------------------------------------------------------
+
+func (val *defaultValidator) MarshalJSON() ([]byte, error) { return json.Marshal(val.AsData()) }
+func (val *defaultValidator) UnmarshalJSON(b []byte) error {
+	var data istanbul.ValidatorData
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+	*val = *newValidatorFromData(&data)
+	return nil
+}
+
+// RLP Encoding -----------------------------------------------------------------------
+
+func (val *defaultValidator) EncodeRLP(w io.Writer) error { return rlp.Encode(w, val.AsData()) }
 func (val *defaultValidator) DecodeRLP(stream *rlp.Stream) error {
-	var v defaultValidatorRLP
+	var v istanbul.ValidatorData
 	if err := stream.Decode(&v); err != nil {
 		return err
 	}
 
-	*val = defaultValidator{v.Address, v.BlsPublicKey}
+	*val = *newValidatorFromData(&v)
 	return nil
 }
 
@@ -81,51 +92,28 @@ type defaultSet struct {
 	randomness common.Hash
 }
 
-type defaultSetRLP struct {
-	Validators []*defaultValidator
-	Randomness common.Hash
-}
-
-func (val *defaultSet) DecodeRLP(stream *rlp.Stream) error {
-	var v defaultSetRLP
-	if err := stream.Decode(&v); err != nil {
-		return err
-	}
-
-	validators := make([]istanbul.Validator, len(v.Validators))
-	for i := range v.Validators {
-		validators[i] = v.Validators[i]
-	}
-
-	*val = defaultSet{
-		validators: validators,
-		randomness: v.Randomness,
-	}
-	return nil
-}
-
-func (val *defaultSet) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{
-		val.validators,
-		val.randomness,
-	})
-}
-
-func (val *defaultSet) Serialize() ([]byte, error) {
-	return rlp.EncodeToBytes(val)
-}
-
 func newDefaultSet(validators []istanbul.ValidatorData) *defaultSet {
-	valSet := &defaultSet{}
-
-	// init validators
-	valSet.validators = make([]istanbul.Validator, len(validators))
-	for i, validator := range validators {
-		valSet.validators[i] = New(validator.Address, validator.BLSPublicKey)
+	return &defaultSet{
+		validators: mapDataToValidators(validators),
 	}
-
-	return valSet
 }
+
+func NewValidatorSetFromData(data *istanbul.ValidatorSetData) istanbul.ValidatorSet {
+	return newValidatorSetFromData(data)
+}
+
+func newValidatorSetFromData(data *istanbul.ValidatorSetData) *defaultSet {
+	return &defaultSet{
+		validators: mapDataToValidators(data.Validators),
+		randomness: data.Randomness,
+	}
+}
+
+func (val *defaultSet) Serialize() ([]byte, error)        { return rlp.EncodeToBytes(val) }
+func (valSet *defaultSet) F() int                         { return int(math.Ceil(float64(valSet.Size())/3)) - 1 }
+func (valSet *defaultSet) MinQuorumSize() int             { return int(math.Ceil(float64(2*valSet.Size()) / 3)) }
+func (valSet *defaultSet) SetRandomness(seed common.Hash) { valSet.randomness = seed }
+func (valSet *defaultSet) GetRandomness() common.Hash     { return valSet.randomness }
 
 func (valSet *defaultSet) Size() int {
 	valSet.validatorMu.RLock()
@@ -159,32 +147,21 @@ func (valSet *defaultSet) GetByAddress(addr common.Address) (int, istanbul.Valid
 }
 
 func (valSet *defaultSet) ContainsByAddress(addr common.Address) bool {
-	for _, val := range valSet.List() {
-		if addr == val.Address() {
-			return true
-		}
-	}
-	return false
+	i, _ := valSet.GetByAddress(addr)
+	return i != -1
 }
 
 func (valSet *defaultSet) GetIndex(addr common.Address) int {
-	for i, val := range valSet.List() {
-		if addr == val.Address() {
-			return i
-		}
-	}
-	return -1
+	i, _ := valSet.GetByAddress(addr)
+	return i
 }
 
 func (valSet *defaultSet) AddValidators(validators []istanbul.ValidatorData) bool {
 	newValidators := make([]istanbul.Validator, 0, len(validators))
 	newAddressesMap := make(map[common.Address]bool)
 	for i := range validators {
-		address := validators[i].Address
-		blsPublicKey := validators[i].BLSPublicKey
-
-		newAddressesMap[address] = true
-		newValidators = append(newValidators, New(address, blsPublicKey))
+		newAddressesMap[validators[i].Address] = true
+		newValidators = append(newValidators, newValidatorFromData(&validators[i]))
 	}
 
 	valSet.validatorMu.Lock()
@@ -217,41 +194,75 @@ func (valSet *defaultSet) RemoveValidators(removedValidators *big.Int) bool {
 	// Using this method to filter the validators list: https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating, so that no
 	// new memory will be allocated
 	tempList := valSet.validators[:0]
-	defer func() {
-		valSet.validators = tempList
-	}()
-
 	for i, v := range valSet.validators {
 		if removedValidators.Bit(i) == 0 {
 			tempList = append(tempList, v)
 		}
 	}
 
+	valSet.validators = tempList
 	return true
 }
 
 func (valSet *defaultSet) Copy() istanbul.ValidatorSet {
 	valSet.validatorMu.RLock()
 	defer valSet.validatorMu.RUnlock()
-
-	validators := make([]istanbul.ValidatorData, 0, len(valSet.validators))
-	for _, v := range valSet.validators {
-		validators = append(validators, istanbul.ValidatorData{
-			v.Address(),
-			v.BLSPublicKey(),
-		})
-	}
-
-	newValSet := NewSet(validators)
-	newValSet.SetRandomness(valSet.GetRandomness())
+	newValSet := NewSet(mapValidatorsToData(valSet.validators))
+	newValSet.SetRandomness(valSet.randomness)
 	return newValSet
 }
 
-func (valSet *defaultSet) F() int { return int(math.Ceil(float64(valSet.Size())/3)) - 1 }
-
-func (valSet *defaultSet) MinQuorumSize() int {
-	return int(math.Ceil(float64(2*valSet.Size()) / 3))
+func (valSet *defaultSet) AsData() *istanbul.ValidatorSetData {
+	valSet.validatorMu.RLock()
+	defer valSet.validatorMu.RUnlock()
+	return &istanbul.ValidatorSetData{
+		Validators: mapValidatorsToData(valSet.validators),
+		Randomness: valSet.randomness,
+	}
 }
 
-func (valSet *defaultSet) SetRandomness(seed common.Hash) { valSet.randomness = seed }
-func (valSet *defaultSet) GetRandomness() common.Hash     { return valSet.randomness }
+// JSON Encoding -----------------------------------------------------------------------
+
+func (val *defaultSet) MarshalJSON() ([]byte, error) { return json.Marshal(val.AsData()) }
+
+func (val *defaultSet) UnmarshalJSON(b []byte) error {
+	var data istanbul.ValidatorSetData
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+	*val = *newDefaultSet(data.Validators)
+	val.SetRandomness(data.Randomness)
+	return nil
+}
+
+// RLP Encoding -----------------------------------------------------------------------
+
+func (val *defaultSet) EncodeRLP(w io.Writer) error { return rlp.Encode(w, val.AsData()) }
+
+func (val *defaultSet) DecodeRLP(stream *rlp.Stream) error {
+	var data istanbul.ValidatorSetData
+	if err := stream.Decode(&data); err != nil {
+		return err
+	}
+	*val = *newDefaultSet(data.Validators)
+	val.SetRandomness(data.Randomness)
+	return nil
+}
+
+// Utility Functions
+
+func mapValidatorsToData(validators []istanbul.Validator) []istanbul.ValidatorData {
+	validatorsData := make([]istanbul.ValidatorData, len(validators))
+	for i, v := range validators {
+		validatorsData[i] = *v.AsData()
+	}
+	return validatorsData
+}
+
+func mapDataToValidators(data []istanbul.ValidatorData) []istanbul.Validator {
+	validators := make([]istanbul.Validator, len(data))
+	for i, v := range data {
+		validators[i] = NewValidatorFromData(&v)
+	}
+	return validators
+}


### PR DESCRIPTION
### Description

Side work while adding the RPC for Istanbul RoundState.

#### Validator

* Add `AsData()` and Json Encode/Decode
* Cleanup Methods
* Reorder methods in file

#### Istanbul Core Types

In  `istanbul/core/types.go`

 * Add test for RLP encode/decode for each type
 * Remove unnecessary custom RLP encode/decode functions
 * Comments to separate types / interface implementations

#### Cleanup on istanbul/core. CurrentRoundState

 * Add `CurrentRoundState()` to engine (will be used for the RPC)
 * Remove `Sequence()` form engine. Replace with existing `CurrentView()` call
 * Move getter method from `handler.go` to `core.go` where all others live
 * Reorder methods in `core.go`. First public methods, then private methods.

### Tested

Unit tests, CI