### PR TITLE
Log all levels if round > 1

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -128,7 +128,7 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 					return backend.core.CurrentView().Round
 				}
 			}
-			return big.NewInt(0)
+			return common.Big0
 		},
 	)
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -118,15 +118,11 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 	}
 	backend.core = istanbulCore.New(backend, backend.config)
 
-	istanbulLogger, err := istanbul.NewIstLogger(
+	backend.logger = istanbul.NewIstLogger(
 		func() *big.Int {
 			return backend.core.CurrentView().Round
 		},
 	)
-	if err != nil {
-		logger.Crit("Failed to create Istanbul Logger", "err", err)
-	}
-	backend.logger = istanbulLogger
 
 	vph := &validatorPeerHandler{sb: backend}
 	table, err := enodes.OpenValidatorEnodeDB(config.ValidatorEnodeDBPath, vph)

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -123,10 +123,8 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 
 	backend.logger = istanbul.NewIstLogger(
 		func() *big.Int {
-			if backend.core != nil {
-				if backend.core.CurrentView() != nil {
-					return backend.core.CurrentView().Round
-				}
+			if backend.core != nil && backend.core.CurrentView() != nil {
+				return backend.core.CurrentView().Round
 			}
 			return common.Big0
 		},

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -120,7 +120,10 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 
 	backend.logger = istanbul.NewIstLogger(
 		func() *big.Int {
-			return backend.core.CurrentView().Round
+			if backend.core != nil {
+				return backend.core.CurrentView().Round
+			}
+			return big.NewInt(0)
 		},
 	)
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -124,7 +124,9 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 	backend.logger = istanbul.NewIstLogger(
 		func() *big.Int {
 			if backend.core != nil {
-				return backend.core.CurrentView().Round
+				if backend.core.CurrentView() != nil {
+					return backend.core.CurrentView().Round
+				}
 			}
 			return big.NewInt(0)
 		},

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -50,7 +50,8 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 				log.Crit("Failed to fetch last view")
 			}
 			return view.Round
-		})
+		},
+	)
 
 	c := &core{
 		config:             config,

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -43,7 +43,7 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 	if err != nil {
 		log.Crit("Failed to open RoundStateDB", "err", err)
 	}
-	istanbulLogger, err := istanbul.NewIstLogger(
+	istanbulLogger := istanbul.NewIstLogger(
 		func() *big.Int {
 			view, err := rsdb.GetLastView()
 			if err != nil {
@@ -51,9 +51,6 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 			}
 			return view.Round
 		})
-	if err != nil {
-		log.Crit("Failed to instantiate Istanbul Logger", "err", err)
-	}
 
 	c := &core{
 		config:             config,

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -69,7 +69,7 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 	c.validateFn = c.checkValidatorSignature
 	c.logger = istanbul.NewIstLogger(
 		func() *big.Int {
-			if c != nil {
+			if c != nil && c.current != nil {
 				return c.current.Round()
 			}
 			return big.NewInt(0)

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -109,7 +109,7 @@ func New(backend istanbul.Backend, config *istanbul.Config) Engine {
 			if c != nil && c.current != nil {
 				return c.current.Round()
 			}
-			return big.NewInt(0)
+			return common.Big0
 		},
 	)
 	return c

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -63,15 +63,6 @@ func (c *core) Stop() error {
 	return nil
 }
 
-func (c *core) CurrentView() *istanbul.View {
-	if c.current != nil {
-		return c.current.View()
-	}
-	return &istanbul.View{
-		Round:    big.NewInt(0),
-		Sequence: big.NewInt(0),
-	}
-}
 // ----------------------------------------------------------------------------
 
 // Subscribe both internal and external events

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -68,7 +68,7 @@ func (c *core) CurrentView() *istanbul.View {
 		return c.current.View()
 	}
 	return &istanbul.View{
-		Round: big.NewInt(0),
+		Round:    big.NewInt(0),
 		Sequence: big.NewInt(0),
 	}
 }

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -61,7 +61,13 @@ func (c *core) Stop() error {
 }
 
 func (c *core) CurrentView() *istanbul.View {
-	return c.current.View()
+	if c.current != nil {
+		return c.current.View()
+	}
+	return &istanbul.View{
+		Round: big.NewInt(0),
+		Sequence: big.NewInt(0),
+	}
 }
 
 // ----------------------------------------------------------------------------

--- a/consensus/istanbul/logger.go
+++ b/consensus/istanbul/logger.go
@@ -28,8 +28,8 @@ type istLogger struct {
 }
 
 // NewIstLogger creates an Istanbul Logger with custom logic for exposing logs
-func NewIstLogger(fn func() *big.Int, ctx ...interface{}) (log.Logger, error) {
-	return &istLogger{logger: log.New(ctx[1:]...), round: fn}, nil
+func NewIstLogger(fn func() *big.Int, ctx ...interface{}) log.Logger {
+	return &istLogger{logger: log.New(ctx[1:]...), round: fn}
 }
 
 func (l *istLogger) New(ctx ...interface{}) log.Logger {

--- a/consensus/istanbul/logger.go
+++ b/consensus/istanbul/logger.go
@@ -42,7 +42,7 @@ func (l *istLogger) Trace(msg string, ctx ...interface{}) {
 	if l.round().Cmp(common.Big1) > 0 {
 		l.Info(msg, ctx...)
 	} else {
-		l.Trace(msg, ctx)
+		l.Trace(msg, ctx...)
 	}
 }
 
@@ -51,7 +51,7 @@ func (l *istLogger) Debug(msg string, ctx ...interface{}) {
 	if l.round().Cmp(common.Big1) > 0 {
 		l.Info(msg, ctx...)
 	} else {
-		l.Debug(msg, ctx)
+		l.Debug(msg, ctx...)
 	}
 }
 

--- a/consensus/istanbul/logger.go
+++ b/consensus/istanbul/logger.go
@@ -39,7 +39,7 @@ func (l *istLogger) New(ctx ...interface{}) log.Logger {
 
 func (l *istLogger) Trace(msg string, ctx ...interface{}) {
 	// If the current round > 1, then upgrade this message to Info
-	if l.round().Cmp(common.Big1) > 0 {
+	if l.round != nil && l.round() != nil && l.round().Cmp(common.Big1) > 0 {
 		l.Info(msg, ctx...)
 	} else {
 		l.logger.Trace(msg, ctx...)
@@ -48,7 +48,7 @@ func (l *istLogger) Trace(msg string, ctx ...interface{}) {
 
 func (l *istLogger) Debug(msg string, ctx ...interface{}) {
 	// If the current round > 1, then upgrade this message to Info
-	if l.round().Cmp(common.Big1) > 0 {
+	if l.round != nil && l.round() != nil && l.round().Cmp(common.Big1) > 0 {
 		l.Info(msg, ctx...)
 	} else {
 		l.logger.Debug(msg, ctx...)

--- a/consensus/istanbul/logger.go
+++ b/consensus/istanbul/logger.go
@@ -1,0 +1,95 @@
+// Copyright 2017 The celo Authors
+// This file is part of the celo library.
+//
+// The celo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The celo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the celo library. If not, see <http://www.gnu.org/licenses/>.
+
+package istanbul
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type Rounder interface {
+	Round() *big.Int
+}
+
+type istLogger struct {
+	logger     log.Logger
+	roundState Rounder
+}
+
+func NewIstLogger(ctx ...interface{}) (log.Logger, error) {
+	// The first parameter must have a RoundState interface
+	if len(ctx) == 0 {
+		return nil, errors.New("First parameter of istanbul.NewIstLogger must have RoundState interface")
+	}
+
+	roundState, ok := ctx[0].(Rounder)
+	if !ok {
+		return nil, errors.New("First parameter of istanbul.NewIstLogger must have RoundState interface")
+	}
+
+	return &istLogger{logger: log.New(ctx[1:]...), roundState: roundState}, nil
+}
+
+func (l *istLogger) New(ctx ...interface{}) log.Logger {
+	childLogger := l.logger.New(ctx)
+	return &istLogger{logger: childLogger, roundState: l.roundState}
+}
+
+func (l *istLogger) Trace(msg string, ctx ...interface{}) {
+	// If the current round > 1, then upgrade this message to Info
+	if l.roundState.Round().Cmp(common.Big1) > 0 {
+		l.Info(msg, ctx...)
+	} else {
+		l.Trace(msg, ctx)
+	}
+}
+
+func (l *istLogger) Debug(msg string, ctx ...interface{}) {
+	// If the current round > 1, then upgrade this message to Info
+	if l.roundState.Round().Cmp(common.Big1) > 0 {
+		l.Info(msg, ctx...)
+	} else {
+		l.Debug(msg, ctx)
+	}
+}
+
+func (l *istLogger) Info(msg string, ctx ...interface{}) {
+	l.logger.Info(msg, ctx...)
+}
+
+func (l *istLogger) Warn(msg string, ctx ...interface{}) {
+	l.logger.Warn(msg, ctx...)
+}
+
+func (l *istLogger) Error(msg string, ctx ...interface{}) {
+	l.logger.Error(msg, ctx...)
+}
+
+func (l *istLogger) Crit(msg string, ctx ...interface{}) {
+	l.logger.Crit(msg, ctx...)
+}
+
+func (l *istLogger) GetHandler() log.Handler {
+	return l.logger.GetHandler()
+}
+
+func (l *istLogger) SetHandler(h log.Handler) {
+	l.logger.SetHandler(h)
+}

--- a/consensus/istanbul/logger.go
+++ b/consensus/istanbul/logger.go
@@ -29,11 +29,11 @@ type istLogger struct {
 
 // NewIstLogger creates an Istanbul Logger with custom logic for exposing logs
 func NewIstLogger(fn func() *big.Int, ctx ...interface{}) log.Logger {
-	return &istLogger{logger: log.New(ctx[1:]...), round: fn}
+	return &istLogger{logger: log.New(ctx...), round: fn}
 }
 
 func (l *istLogger) New(ctx ...interface{}) log.Logger {
-	childLogger := l.logger.New(ctx)
+	childLogger := l.logger.New(ctx...)
 	return &istLogger{logger: childLogger, round: l.round}
 }
 
@@ -42,7 +42,7 @@ func (l *istLogger) Trace(msg string, ctx ...interface{}) {
 	if l.round().Cmp(common.Big1) > 0 {
 		l.Info(msg, ctx...)
 	} else {
-		l.Trace(msg, ctx...)
+		l.logger.Trace(msg, ctx...)
 	}
 }
 
@@ -51,7 +51,7 @@ func (l *istLogger) Debug(msg string, ctx ...interface{}) {
 	if l.round().Cmp(common.Big1) > 0 {
 		l.Info(msg, ctx...)
 	} else {
-		l.Debug(msg, ctx...)
+		l.logger.Debug(msg, ctx...)
 	}
 }
 


### PR DESCRIPTION
### Description

Implements new logger wrapper to log all messages if `round > 1` , specifically high verbosity `trace` and `debug`.

### Tested

Running CI

### Other changes

Changed instances within `istanbul.backend.backend.go` and `istanbul.core.core.go` that were using `log.{log_level}` rather than `sb.log.{log_level}` or `c.log.{log_level}`

### Related Issues 
* Fixes #799 
