### PR TITLE
Periodically resend RoundChanges for same round 

### DIFF
--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -62,7 +62,7 @@ func (sb *Backend) HandleMsg(addr common.Address, msg p2p.Msg, peer consensus.Pe
 	sb.coreMu.Lock()
 	defer sb.coreMu.Unlock()
 
-	sb.logger.Trace("HandleMsg called", "address", addr, "m", msg, "peer.Node()", peer.Node())
+	sb.logger.Trace("HandleMsg called", "address", addr, "m", msg, "peer", peer.Node())
 
 	if sb.isIstanbulMsg(msg) {
 		if (!sb.coreStarted && !sb.config.Proxy) && (msg.Code == istanbulConsensusMsg) {

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -30,13 +30,16 @@ const (
 )
 
 type Config struct {
-	RequestTimeout       uint64         `toml:",omitempty"` // The timeout for each Istanbul round in milliseconds.
-	BlockPeriod          uint64         `toml:",omitempty"` // Default minimum difference between two consecutive block's timestamps in second
-	ProposerPolicy       ProposerPolicy `toml:",omitempty"` // The policy for proposer selection
-	Epoch                uint64         `toml:",omitempty"` // The number of blocks after which to checkpoint and reset the pending votes
-	LookbackWindow       uint64         `toml:",omitempty"` // The window of blocks in which a validator is forgived from voting
-	ValidatorEnodeDBPath string         `toml:",omitempty"` // The location for the validator enodes DB
-	RoundStateDBPath     string         `toml:",omitempty"` // The location for the round states DB
+	RequestTimeout              uint64         `toml:",omitempty"` // The timeout for each Istanbul round in milliseconds.
+	TimeoutBackoffFactor        uint64         `toml:",omitempty"` // Timeout at subsequent rounds is: RequestTimeout + 2**round * TimeoutBackoffFactor (in milliseconds)
+	MinResendRoundChangeTimeout uint64         `toml:",omitempty"` // Minimum interval with which to resend RoundChange messages for same round
+	MaxResendRoundChangeTimeout uint64         `toml:",omitempty"` // Maximum interval with which to resend RoundChange messages for same round
+	BlockPeriod                 uint64         `toml:",omitempty"` // Default minimum difference between two consecutive block's timestamps in second
+	ProposerPolicy              ProposerPolicy `toml:",omitempty"` // The policy for proposer selection
+	Epoch                       uint64         `toml:",omitempty"` // The number of blocks after which to checkpoint and reset the pending votes
+	LookbackWindow              uint64         `toml:",omitempty"` // The window of blocks in which a validator is forgived from voting
+	ValidatorEnodeDBPath        string         `toml:",omitempty"` // The location for the validator enodes DB
+	RoundStateDBPath            string         `toml:",omitempty"` // The location for the round states DB
 
 	// Proxy Configs
 	Proxy                   bool           `toml:",omitempty"` // Specifies if this node is a proxy
@@ -49,13 +52,16 @@ type Config struct {
 }
 
 var DefaultConfig = &Config{
-	RequestTimeout:       3000,
-	BlockPeriod:          1,
-	ProposerPolicy:       ShuffledRoundRobin,
-	Epoch:                30000,
-	LookbackWindow:       12,
-	ValidatorEnodeDBPath: "validatorenodes",
-	RoundStateDBPath:     "roundstates",
-	Proxy:                false,
-	Proxied:              false,
+	RequestTimeout:              3000,
+	TimeoutBackoffFactor:        1000,
+	MinResendRoundChangeTimeout: 15 * 1000,
+	MaxResendRoundChangeTimeout: 2 * 60 * 1000,
+	BlockPeriod:                 1,
+	ProposerPolicy:              ShuffledRoundRobin,
+	Epoch:                       30000,
+	LookbackWindow:              12,
+	ValidatorEnodeDBPath:        "validatorenodes",
+	RoundStateDBPath:            "roundstates",
+	Proxy:                       false,
+	Proxied:                     false,
 }

--- a/consensus/istanbul/core/events.go
+++ b/consensus/istanbul/core/events.go
@@ -24,6 +24,9 @@ type backlogEvent struct {
 	msg *istanbul.Message
 }
 
-type timeoutEvent struct {
+type resendRoundChangeEvent struct {
+	view *istanbul.View
+}
+type timeoutAndMoveToNextRoundEvent struct {
 	view *istanbul.View
 }

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -34,7 +34,7 @@ func (c *core) Start() error {
 	c.current = roundState
 	c.roundChangeSet = newRoundChangeSet(c.current.ValidatorSet())
 
-	c.newRoundChangeTimer()
+	c.resetRoundChangeTimer()
 
 	// Process backlog
 	c.processPendingRequests()

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -28,15 +28,10 @@ import (
 )
 
 // sendRoundChange sends the ROUND CHANGE message with the given round
-func (c *core) sendRoundChange(round *big.Int) {
-	logger := c.newLogger("func", "sendRoundChange", "target_round", round)
+func (c *core) sendRoundChange() {
+	logger := c.newLogger("func", "sendRoundChange")
 
-	if c.current.View().Round.Cmp(round) >= 0 {
-		logger.Warn("Cannot send round change for previous round")
-		return
-	}
-
-	msg, err := c.buildRoundChangeMsg(round)
+	msg, err := c.buildRoundChangeMsg(c.current.DesiredRound())
 	if err != nil {
 		logger.Error("Could not build round change message", "err", msg)
 		return
@@ -47,7 +42,7 @@ func (c *core) sendRoundChange(round *big.Int) {
 
 // sendRoundChange sends a ROUND CHANGE message for the current round back to a single address
 func (c *core) sendRoundChangeAgain(addr common.Address) {
-	logger := c.newLogger("func", "sendRoundChange", "desired_round", c.current.DesiredRound(), "to", addr)
+	logger := c.newLogger("func", "sendRoundChangeAgain", "to", addr)
 
 	msg, err := c.buildRoundChangeMsg(c.current.DesiredRound())
 	if err != nil {

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -27,7 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
-// sendRoundChange sends the ROUND CHANGE message with the given round
+// sendRoundChange broadcasts a ROUND CHANGE message with the current desired round.
 func (c *core) sendRoundChange() {
 	logger := c.newLogger("func", "sendRoundChange")
 
@@ -40,7 +40,7 @@ func (c *core) sendRoundChange() {
 	c.broadcast(msg)
 }
 
-// sendRoundChange sends a ROUND CHANGE message for the current round back to a single address
+// sendRoundChange sends a ROUND CHANGE message for the current desired round back to a single address
 func (c *core) sendRoundChangeAgain(addr common.Address) {
 	logger := c.newLogger("func", "sendRoundChangeAgain", "to", addr)
 

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -440,7 +440,7 @@ func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 	newBlocks := sys.backends[3].EventMux().Subscribe(istanbul.FinalCommittedEvent{})
 	defer newBlocks.Unsubscribe()
 
-	timeout := sys.backends[3].EventMux().Subscribe(timeoutEvent{})
+	timeout := sys.backends[3].EventMux().Subscribe(timeoutAndMoveToNextRoundEvent{})
 	defer timeout.Unsubscribe()
 
 	istMsgDistribution := map[uint64]map[int]bool{}
@@ -507,7 +507,7 @@ func TestPreparedCertificatePersistsThroughRoundChanges(t *testing.T) {
 	newBlocks := sys.backends[3].EventMux().Subscribe(istanbul.FinalCommittedEvent{})
 	defer newBlocks.Unsubscribe()
 
-	timeout := sys.backends[3].EventMux().Subscribe(timeoutEvent{})
+	timeout := sys.backends[3].EventMux().Subscribe(timeoutAndMoveToNextRoundEvent{})
 	defer timeout.Unsubscribe()
 
 	istMsgDistribution := map[uint64]map[int]bool{}

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -557,7 +557,7 @@ func TestPreparedCertificatePersistsThroughRoundChanges(t *testing.T) {
 
 	// Manually open and close b/c hijacking sys.listen
 	for _, b := range sys.backends {
-		b.engine.Stop() // start Istanbul core
+		b.engine.Stop() // stop Istanbul core
 	}
 	close(sys.quit)
 }
@@ -639,7 +639,7 @@ loop:
 
 	// Manually open and close b/c hijacking sys.listen
 	for _, b := range sys.backends {
-		b.engine.Stop() // start Istanbul core
+		b.engine.Stop() // stop Istanbul core
 	}
 	close(sys.quit)
 }

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -105,6 +105,7 @@ func (self *testSystemBackend) BroadcastConsensusMsg(validators []common.Address
 	}
 	return nil
 }
+
 func (self *testSystemBackend) Gossip(validators []common.Address, message []byte, msgCode uint64, ignoreCache bool) error {
 	return nil
 }
@@ -368,6 +369,10 @@ func NewTestSystemWithBackend(n, f uint64) *testSystem {
 	config := *istanbul.DefaultConfig
 	config.ProposerPolicy = istanbul.RoundRobin
 	config.RoundStateDBPath = ""
+	config.RequestTimeout = 300
+	config.TimeoutBackoffFactor = 100
+	config.MinResendRoundChangeTimeout = 1000
+	config.MaxResendRoundChangeTimeout = 10000
 
 	for i := uint64(0); i < n; i++ {
 		vset := validator.NewSet(validators)


### PR DESCRIPTION
### Description

Separates the IBFT round change timer into two: one that moves into `StateWaitingForRoundChange` and advances to to the next desired round; and one that while in  in `StateWaitingForRoundChange` periodically resends RoundChange messages for the same current desired round if the other timeout exceeds `MinResendRoundChangeTimeout`. 

Add hard-coded config options to control timeout parameters:
* `TimeoutBackoffFactor` - Timeout at subsequent rounds is: `RequestTimeout + 2**round * TimeoutBackoffFactor` (in milliseconds)
* `MinResendRoundChangeTimeout` - Minimum interval with which to resend RoundChange messages for same round
* `MaxResendRoundChangeTimeout` -Maximum interval with which to resend RoundChange messages for same round

### Tested

New test in `core_test.go`.

TODO - on a fault-injection network.

### Other changes

* Fix logging typo. 
* Speed up IBFT tests by setting lower timeouts.

### Backwards compatibility

For networks with same timeouts, additional `RoundChange` messages do not break backwards-compatibility.
