### PR TITLE
Add RPC to query RoundState information

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	vet "github.com/ethereum/go-ethereum/consensus/istanbul/backend/internal/enodes"
+	"github.com/ethereum/go-ethereum/consensus/istanbul/core"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -85,7 +86,7 @@ func (api *API) GetValidators(number *rpc.BlockNumber) ([]common.Address, error)
 		return nil, err
 	}
 	validators := api.istanbul.GetValidators(header.Number, header.Hash())
-	return istanbul.GetAddressesFromValidatorList(validators), nil
+	return istanbul.MapValidatorsToAddresses(validators), nil
 }
 
 // GetProposer retrieves the proposer for a given block number (i.e. sequence) and round.
@@ -145,6 +146,11 @@ func (api *API) RemoveProxy(url string) (bool, error) {
 // Retrieve the Validator Enode Table
 func (api *API) GetValEnodeTable() (map[string]*vet.ValEnodeEntryInfo, error) {
 	return api.istanbul.valEnodeTable.ValEnodeTableInfo()
+}
+
+// GetCurrentRoundState retrieves the current IBFT RoundState
+func (api *API) GetCurrentRoundState() (*core.RoundStateSummary, error) {
+	return api.istanbul.core.CurrentRoundState().Summary(), nil
 }
 
 // TODO(kevjue) - implement this

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -248,7 +248,7 @@ func (c *core) finalizeMessage(msg *istanbul.Message) ([]byte, error) {
 
 // Send message to all current validators
 func (c *core) broadcast(msg *istanbul.Message) {
-	c.sendMsgTo(msg, istanbul.GetAddressesFromValidatorList(c.current.ValidatorSet().List()))
+	c.sendMsgTo(msg, istanbul.MapValidatorsToAddresses(c.current.ValidatorSet().List()))
 }
 
 // Send message to a specific address

--- a/consensus/istanbul/core/message_set.go
+++ b/consensus/istanbul/core/message_set.go
@@ -37,7 +37,7 @@ type MessageSet interface {
 	Values() (result []*istanbul.Message)
 	Size() int
 	Get(addr common.Address) *istanbul.Message
-	ListAddresses() []common.Address
+	Addresses() []common.Address
 	Serialize() ([]byte, error)
 }
 
@@ -122,7 +122,7 @@ func (ms *messageSetImpl) Get(addr common.Address) *istanbul.Message {
 	return ms.messages[addr]
 }
 
-func (ms *messageSetImpl) ListAddresses() []common.Address {
+func (ms *messageSetImpl) Addresses() []common.Address {
 	ms.messagesMu.Lock()
 	defer ms.messagesMu.Unlock()
 	returnList := make([]common.Address, len(ms.messages))

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -441,11 +441,11 @@ func (rs *roundStateImpl) Summary() *RoundStateSummary {
 		DesiredRound: rs.desiredRound,
 
 		Proposer:     rs.proposer.Address(),
-		ValidatorSet: rs.validatorSet.ListAddresses(),
+		ValidatorSet: istanbul.MapValidatorsToAddresses(rs.validatorSet.List()),
 
-		Prepares:      rs.prepares.ListAddresses(),
-		Commits:       rs.commits.ListAddresses(),
-		ParentCommits: rs.parentCommits.ListAddresses(),
+		Prepares:      rs.prepares.Addresses(),
+		Commits:       rs.commits.Addresses(),
+		ParentCommits: rs.parentCommits.Addresses(),
 	}
 
 	if rs.pendingRequest != nil {

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -70,6 +70,7 @@ type RoundState interface {
 	View() *istanbul.View
 	PreparedCertificate() istanbul.PreparedCertificate
 	GetProposalVerificationStatus(proposalHash common.Hash) (verificationStatus error, isCached bool)
+	Summary() *RoundStateSummary
 }
 
 // RoundState stores the consensus state
@@ -101,6 +102,24 @@ type roundStateImpl struct {
 	logger log.Logger
 }
 
+type RoundStateSummary struct {
+	State              string       `json:"state"`
+	Sequence           *big.Int     `json:"sequence"`
+	Round              *big.Int     `json:"round"`
+	DesiredRound       *big.Int     `json:"desiredRound"`
+	PendingRequestHash *common.Hash `json:"pendingRequestHash"`
+
+	ValidatorSet []common.Address `json:"validatorSet"`
+	Proposer     common.Address   `json:"proposer"`
+
+	Prepares      []common.Address `json:"prepares"`
+	Commits       []common.Address `json:"commits"`
+	ParentCommits []common.Address `json:"parentCommits"`
+
+	Preprepare          *istanbul.PreprepareSummary          `json:"preprepare"`
+	PreparedCertificate *istanbul.PreparedCertificateSummary `json:"preparedCertificate"`
+}
+
 func newRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, proposer istanbul.Validator) RoundState {
 	return &roundStateImpl{
 		state:        StateAcceptRequest,
@@ -125,200 +144,200 @@ func newRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, prop
 	}
 }
 
-func (s *roundStateImpl) Commits() MessageSet       { return s.commits }
-func (s *roundStateImpl) Prepares() MessageSet      { return s.prepares }
-func (s *roundStateImpl) ParentCommits() MessageSet { return s.parentCommits }
+func (rs *roundStateImpl) Commits() MessageSet       { return rs.commits }
+func (rs *roundStateImpl) Prepares() MessageSet      { return rs.prepares }
+func (rs *roundStateImpl) ParentCommits() MessageSet { return rs.parentCommits }
 
-func (s *roundStateImpl) State() State {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.state
+func (rs *roundStateImpl) State() State {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+	return rs.state
 }
 
-func (s *roundStateImpl) View() *istanbul.View {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) View() *istanbul.View {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
 	return &istanbul.View{
-		Sequence: new(big.Int).Set(s.sequence),
-		Round:    new(big.Int).Set(s.round),
+		Sequence: new(big.Int).Set(rs.sequence),
+		Round:    new(big.Int).Set(rs.round),
 	}
 }
 
-func (s *roundStateImpl) GetPrepareOrCommitSize() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) GetPrepareOrCommitSize() int {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	result := s.prepares.Size() + s.commits.Size()
+	result := rs.prepares.Size() + rs.commits.Size()
 
 	// find duplicate one
-	for _, m := range s.prepares.Values() {
-		if s.commits.Get(m.Address) != nil {
+	for _, m := range rs.prepares.Values() {
+		if rs.commits.Get(m.Address) != nil {
 			result--
 		}
 	}
 	return result
 }
 
-func (s *roundStateImpl) Subject() *istanbul.Subject {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) Subject() *istanbul.Subject {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	if s.preprepare == nil {
+	if rs.preprepare == nil {
 		return nil
 	}
 
 	return &istanbul.Subject{
 		View: &istanbul.View{
-			Round:    new(big.Int).Set(s.round),
-			Sequence: new(big.Int).Set(s.sequence),
+			Round:    new(big.Int).Set(rs.round),
+			Sequence: new(big.Int).Set(rs.sequence),
 		},
-		Digest: s.preprepare.Proposal.Hash(),
+		Digest: rs.preprepare.Proposal.Hash(),
 	}
 }
 
-func (s *roundStateImpl) IsProposer(address common.Address) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) IsProposer(address common.Address) bool {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	return s.proposer.Address() == address
+	return rs.proposer.Address() == address
 }
 
-func (s *roundStateImpl) Proposer() istanbul.Validator {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) Proposer() istanbul.Validator {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	return s.proposer
+	return rs.proposer
 }
 
-func (s *roundStateImpl) ValidatorSet() istanbul.ValidatorSet {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) ValidatorSet() istanbul.ValidatorSet {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	return s.validatorSet
+	return rs.validatorSet
 }
 
-func (s *roundStateImpl) GetValidatorByAddress(address common.Address) istanbul.Validator {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) GetValidatorByAddress(address common.Address) istanbul.Validator {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	_, validator := s.validatorSet.GetByAddress(address)
+	_, validator := rs.validatorSet.GetByAddress(address)
 	return validator
 }
 
-func (s *roundStateImpl) Preprepare() *istanbul.Preprepare {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) Preprepare() *istanbul.Preprepare {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	return s.preprepare
+	return rs.preprepare
 }
 
-func (s *roundStateImpl) Proposal() istanbul.Proposal {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) Proposal() istanbul.Proposal {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	if s.preprepare != nil {
-		return s.preprepare.Proposal
+	if rs.preprepare != nil {
+		return rs.preprepare.Proposal
 	}
 
 	return nil
 }
 
-func (s *roundStateImpl) Round() *big.Int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) Round() *big.Int {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	return s.round
+	return rs.round
 }
 
-func (s *roundStateImpl) changeRound(nextRound *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator) {
-	s.state = StateAcceptRequest
-	s.round = nextRound
-	s.desiredRound = nextRound
+func (rs *roundStateImpl) changeRound(nextRound *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator) {
+	rs.state = StateAcceptRequest
+	rs.round = nextRound
+	rs.desiredRound = nextRound
 
 	// TODO MC use old valset
-	s.prepares = newMessageSet(validatorSet)
-	s.commits = newMessageSet(validatorSet)
-	s.proposer = nextProposer
+	rs.prepares = newMessageSet(validatorSet)
+	rs.commits = newMessageSet(validatorSet)
+	rs.proposer = nextProposer
 
 	// ??
-	s.preprepare = nil
+	rs.preprepare = nil
 }
 
-func (s *roundStateImpl) StartNewRound(nextRound *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	logger := s.newLogger()
-	s.changeRound(nextRound, validatorSet, nextProposer)
+func (rs *roundStateImpl) StartNewRound(nextRound *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	logger := rs.newLogger()
+	rs.changeRound(nextRound, validatorSet, nextProposer)
 	logger.Debug("Starting new round", "next_round", nextRound, "next_proposer", nextProposer.Address().Hex())
 	return nil
 }
 
-func (s *roundStateImpl) StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	logger := s.newLogger()
+func (rs *roundStateImpl) StartNewSequence(nextSequence *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator, parentCommits MessageSet) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	logger := rs.newLogger()
 
-	s.validatorSet = validatorSet
+	rs.validatorSet = validatorSet
 
-	s.changeRound(big.NewInt(0), validatorSet, nextProposer)
+	rs.changeRound(big.NewInt(0), validatorSet, nextProposer)
 
-	s.sequence = nextSequence
-	s.preparedCertificate = istanbul.EmptyPreparedCertificate()
-	s.pendingRequest = nil
-	s.parentCommits = parentCommits
-	s.proposalVerificationStatus = nil
+	rs.sequence = nextSequence
+	rs.preparedCertificate = istanbul.EmptyPreparedCertificate()
+	rs.pendingRequest = nil
+	rs.parentCommits = parentCommits
+	rs.proposalVerificationStatus = nil
 
 	logger.Debug("Starting new sequence", "next_sequence", nextSequence, "next_proposer", nextProposer.Address().Hex())
 	return nil
 }
 
-func (s *roundStateImpl) TransitionToCommitted() error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (rs *roundStateImpl) TransitionToCommitted() error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
 
-	s.state = StateCommitted
+	rs.state = StateCommitted
 	return nil
 }
 
-func (s *roundStateImpl) TransitionToPreprepared(preprepare *istanbul.Preprepare) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (rs *roundStateImpl) TransitionToPreprepared(preprepare *istanbul.Preprepare) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
 
-	s.preprepare = preprepare
-	s.state = StatePreprepared
+	rs.preprepare = preprepare
+	rs.state = StatePreprepared
 	return nil
 }
 
-func (s *roundStateImpl) TransitionToWaitingForNewRound(r *big.Int, nextProposer istanbul.Validator) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (rs *roundStateImpl) TransitionToWaitingForNewRound(r *big.Int, nextProposer istanbul.Validator) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
 
-	s.desiredRound = new(big.Int).Set(r)
-	s.proposer = nextProposer
-	s.state = StateWaitingForNewRound
+	rs.desiredRound = new(big.Int).Set(r)
+	rs.proposer = nextProposer
+	rs.state = StateWaitingForNewRound
 	return nil
 }
 
 // TransitionToPrepared will create a PreparedCertificate and change state to Prepared
-func (s *roundStateImpl) TransitionToPrepared(quorumSize int) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (rs *roundStateImpl) TransitionToPrepared(quorumSize int) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
 
 	messages := make([]istanbul.Message, quorumSize)
 	i := 0
-	for _, message := range s.prepares.Values() {
+	for _, message := range rs.prepares.Values() {
 		if i == quorumSize {
 			break
 		}
 		messages[i] = *message
 		i++
 	}
-	for _, message := range s.commits.Values() {
+	for _, message := range rs.commits.Values() {
 		if i == quorumSize {
 			break
 		}
-		if s.prepares.Get(message.Address) == nil {
+		if rs.prepares.Get(message.Address) == nil {
 			messages[i] = *message
 			i++
 		}
@@ -326,94 +345,128 @@ func (s *roundStateImpl) TransitionToPrepared(quorumSize int) error {
 	if i != quorumSize {
 		return errFailedCreatePreparedCertificate
 	}
-	s.preparedCertificate = istanbul.PreparedCertificate{
-		Proposal:                s.preprepare.Proposal,
+	rs.preparedCertificate = istanbul.PreparedCertificate{
+		Proposal:                rs.preprepare.Proposal,
 		PrepareOrCommitMessages: messages,
 	}
 
-	s.state = StatePrepared
+	rs.state = StatePrepared
 	return nil
 }
 
-func (s *roundStateImpl) AddCommit(msg *istanbul.Message) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.commits.Add(msg)
+func (rs *roundStateImpl) AddCommit(msg *istanbul.Message) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.commits.Add(msg)
 }
 
-func (s *roundStateImpl) AddPrepare(msg *istanbul.Message) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.prepares.Add(msg)
+func (rs *roundStateImpl) AddPrepare(msg *istanbul.Message) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.prepares.Add(msg)
 }
 
-func (s *roundStateImpl) AddParentCommit(msg *istanbul.Message) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.parentCommits.Add(msg)
+func (rs *roundStateImpl) AddParentCommit(msg *istanbul.Message) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.parentCommits.Add(msg)
 }
 
-func (s *roundStateImpl) DesiredRound() *big.Int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) DesiredRound() *big.Int {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	return s.desiredRound
+	return rs.desiredRound
 }
 
-func (s *roundStateImpl) SetPendingRequest(pendingRequest *istanbul.Request) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (rs *roundStateImpl) SetPendingRequest(pendingRequest *istanbul.Request) error {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
 
-	s.pendingRequest = pendingRequest
+	rs.pendingRequest = pendingRequest
 	return nil
 }
 
-func (s *roundStateImpl) PendingRequest() *istanbul.Request {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.pendingRequest
+func (rs *roundStateImpl) PendingRequest() *istanbul.Request {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+	return rs.pendingRequest
 }
 
-func (s *roundStateImpl) Sequence() *big.Int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) Sequence() *big.Int {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	return s.sequence
+	return rs.sequence
 }
 
-func (s *roundStateImpl) PreparedCertificate() istanbul.PreparedCertificate {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.preparedCertificate
+func (rs *roundStateImpl) PreparedCertificate() istanbul.PreparedCertificate {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+	return rs.preparedCertificate
 }
 
-func (s *roundStateImpl) SetProposalVerificationStatus(proposalHash common.Hash, verificationStatus error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func (rs *roundStateImpl) SetProposalVerificationStatus(proposalHash common.Hash, verificationStatus error) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
 
-	if s.proposalVerificationStatus == nil {
-		s.proposalVerificationStatus = make(map[common.Hash]error)
+	if rs.proposalVerificationStatus == nil {
+		rs.proposalVerificationStatus = make(map[common.Hash]error)
 	}
 
-	s.proposalVerificationStatus[proposalHash] = verificationStatus
+	rs.proposalVerificationStatus[proposalHash] = verificationStatus
 }
 
-func (s *roundStateImpl) GetProposalVerificationStatus(proposalHash common.Hash) (verificationStatus error, isCached bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) GetProposalVerificationStatus(proposalHash common.Hash) (verificationStatus error, isCached bool) {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
 	verificationStatus, isCached = nil, false
 
-	if s.proposalVerificationStatus != nil {
-		verificationStatus, isCached = s.proposalVerificationStatus[proposalHash]
+	if rs.proposalVerificationStatus != nil {
+		verificationStatus, isCached = rs.proposalVerificationStatus[proposalHash]
 	}
 
 	return
 }
 
-func (s *roundStateImpl) newLogger(ctx ...interface{}) log.Logger {
-	logger := s.logger.New(ctx...)
-	return logger.New("cur_seq", s.sequence, "cur_round", s.round, "state", s.state)
+func (rs *roundStateImpl) Summary() *RoundStateSummary {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+
+	summary := &RoundStateSummary{
+		State:        rs.state.String(),
+		Sequence:     rs.sequence,
+		Round:        rs.round,
+		DesiredRound: rs.desiredRound,
+
+		Proposer:     rs.proposer.Address(),
+		ValidatorSet: rs.validatorSet.ListAddresses(),
+
+		Prepares:      rs.prepares.ListAddresses(),
+		Commits:       rs.commits.ListAddresses(),
+		ParentCommits: rs.parentCommits.ListAddresses(),
+	}
+
+	if rs.pendingRequest != nil {
+		hash := rs.pendingRequest.Proposal.Hash()
+		summary.PendingRequestHash = &hash
+	}
+
+	if rs.preprepare != nil {
+		summary.Preprepare = rs.preprepare.Summary()
+	}
+
+	if !rs.preparedCertificate.IsEmpty() {
+		summary.PreparedCertificate = rs.preparedCertificate.Summary()
+	}
+
+	return summary
+}
+
+func (rs *roundStateImpl) newLogger(ctx ...interface{}) log.Logger {
+	logger := rs.logger.New(ctx...)
+	return logger.New("cur_seq", rs.sequence, "cur_round", rs.round, "state", rs.state)
 }
 
 type roundStateRLP struct {
@@ -441,59 +494,59 @@ type roundStateRLP struct {
 // not verified at the moment, but a future version might. It is
 // recommended to write only a single value but writing multiple
 // values or no value at all is also permitted.
-func (s *roundStateImpl) EncodeRLP(w io.Writer) error {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+func (rs *roundStateImpl) EncodeRLP(w io.Writer) error {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
 
-	serializedValSet, err := s.validatorSet.Serialize()
+	serializedValSet, err := rs.validatorSet.Serialize()
 	if err != nil {
 		return err
 	}
-	serializedProposer, err := s.proposer.Serialize()
+	serializedProposer, err := rs.proposer.Serialize()
 	if err != nil {
 		return err
 	}
 
-	serializedParentCommits, err := s.parentCommits.Serialize()
+	serializedParentCommits, err := rs.parentCommits.Serialize()
 	if err != nil {
 		return err
 	}
-	serializedPrepares, err := s.prepares.Serialize()
+	serializedPrepares, err := rs.prepares.Serialize()
 	if err != nil {
 		return err
 	}
-	serializedCommits, err := s.commits.Serialize()
+	serializedCommits, err := rs.commits.Serialize()
 	if err != nil {
 		return err
 	}
 
 	// handle nullable field. Serialized them to rlp.EmptyList or the rlp version of them
 	var serializedPendingRequest []byte
-	if s.pendingRequest == nil {
+	if rs.pendingRequest == nil {
 		serializedPendingRequest = rlp.EmptyList
 	} else {
-		serializedPendingRequest, err = rlp.EncodeToBytes(s.pendingRequest)
+		serializedPendingRequest, err = rlp.EncodeToBytes(rs.pendingRequest)
 		if err != nil {
 			return err
 		}
 	}
 
 	var serializedPreprepare []byte
-	if s.preprepare == nil {
+	if rs.preprepare == nil {
 		serializedPreprepare = rlp.EmptyList
 	} else {
-		serializedPreprepare, err = rlp.EncodeToBytes(s.preprepare)
+		serializedPreprepare, err = rlp.EncodeToBytes(rs.preprepare)
 		if err != nil {
 			return err
 		}
 	}
 
 	entry := roundStateRLP{
-		State:               s.state,
-		Round:               s.round,
-		DesiredRound:        s.desiredRound,
-		Sequence:            s.sequence,
-		PreparedCertificate: &s.preparedCertificate,
+		State:               rs.state,
+		Round:               rs.round,
+		DesiredRound:        rs.desiredRound,
+		Sequence:            rs.sequence,
+		PreparedCertificate: &rs.preparedCertificate,
 
 		SerializedValSet:         serializedValSet,
 		SerializedProposer:       serializedProposer,
@@ -509,38 +562,38 @@ func (s *roundStateImpl) EncodeRLP(w io.Writer) error {
 // The DecodeRLP method should read one value from the given
 // Stream. It is not forbidden to read less or more, but it might
 // be confusing.
-func (s *roundStateImpl) DecodeRLP(stream *rlp.Stream) error {
+func (rs *roundStateImpl) DecodeRLP(stream *rlp.Stream) error {
 	var data roundStateRLP
 	err := stream.Decode(&data)
 	if err != nil {
 		return err
 	}
 
-	s.logger = log.New()
-	s.mu = new(sync.RWMutex)
-	s.state = data.State
-	s.round = data.Round
-	s.desiredRound = data.DesiredRound
-	s.sequence = data.Sequence
-	s.preparedCertificate = *data.PreparedCertificate
+	rs.logger = log.New()
+	rs.mu = new(sync.RWMutex)
+	rs.state = data.State
+	rs.round = data.Round
+	rs.desiredRound = data.DesiredRound
+	rs.sequence = data.Sequence
+	rs.preparedCertificate = *data.PreparedCertificate
 
-	s.prepares, err = deserializeMessageSet(data.SerializedPrepares)
+	rs.prepares, err = deserializeMessageSet(data.SerializedPrepares)
 	if err != nil {
 		return err
 	}
-	s.parentCommits, err = deserializeMessageSet(data.SerializedParentCommits)
+	rs.parentCommits, err = deserializeMessageSet(data.SerializedParentCommits)
 	if err != nil {
 		return err
 	}
-	s.commits, err = deserializeMessageSet(data.SerializedCommits)
+	rs.commits, err = deserializeMessageSet(data.SerializedCommits)
 	if err != nil {
 		return err
 	}
-	s.validatorSet, err = validator.DeserializeValidatorSet(data.SerializedValSet)
+	rs.validatorSet, err = validator.DeserializeValidatorSet(data.SerializedValSet)
 	if err != nil {
 		return err
 	}
-	s.proposer, err = validator.DeserializeValidator(data.SerializedProposer)
+	rs.proposer, err = validator.DeserializeValidator(data.SerializedProposer)
 	if err != nil {
 		return err
 	}
@@ -551,7 +604,7 @@ func (s *roundStateImpl) DecodeRLP(stream *rlp.Stream) error {
 		if err != nil {
 			return err
 		}
-		s.pendingRequest = &value
+		rs.pendingRequest = &value
 
 	}
 
@@ -561,7 +614,7 @@ func (s *roundStateImpl) DecodeRLP(stream *rlp.Stream) error {
 		if err != nil {
 			return err
 		}
-		s.preprepare = &value
+		rs.preprepare = &value
 	}
 
 	return nil

--- a/consensus/istanbul/core/roundstate_save_decorator.go
+++ b/consensus/istanbul/core/roundstate_save_decorator.go
@@ -143,3 +143,6 @@ func (rsp *rsSaveDecorator) IsProposer(address common.Address) bool { return rsp
 func (rsp *rsSaveDecorator) PreparedCertificate() istanbul.PreparedCertificate {
 	return rsp.rs.PreparedCertificate()
 }
+
+// Summary implements RoundState.Summary
+func (rsp *rsSaveDecorator) Summary() *RoundStateSummary { return rsp.rs.Summary() }

--- a/consensus/istanbul/core/roundstate_test.go
+++ b/consensus/istanbul/core/roundstate_test.go
@@ -1,7 +1,11 @@
 package core
 
 import (
+	"encoding/json"
 	"math/big"
+	"reflect"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -13,8 +17,8 @@ import (
 func TestRoundStateRLPEncoding(t *testing.T) {
 	dummyRoundState := func() RoundState {
 		valSet := validator.NewSet([]istanbul.ValidatorData{
-			{Address: common.BytesToAddress([]byte(string(2))), BLSPublicKey: []byte{1, 2, 3}},
-			{Address: common.BytesToAddress([]byte(string(4))), BLSPublicKey: []byte{3, 1, 4}},
+			{Address: common.HexToAddress("2"), BLSPublicKey: []byte{1, 2, 3}},
+			{Address: common.HexToAddress("4"), BLSPublicKey: []byte{3, 1, 4}},
 		})
 		view := &istanbul.View{Round: big.NewInt(1), Sequence: big.NewInt(2)}
 		return newRoundState(view, valSet, valSet.GetByIndex(0))
@@ -75,6 +79,200 @@ func TestRoundStateRLPEncoding(t *testing.T) {
 		}
 
 		assertEqualRoundState(t, rs, result)
+	})
+
+}
+
+func TestRoundStateSummary(t *testing.T) {
+	view := &istanbul.View{Round: big.NewInt(2), Sequence: big.NewInt(2)}
+
+	validatorAddresses := []common.Address{
+		common.HexToAddress("1"),
+		common.HexToAddress("2"),
+		common.HexToAddress("3"),
+		common.HexToAddress("4"),
+		common.HexToAddress("5"),
+		common.HexToAddress("6"),
+	}
+
+	dummyRoundState := func() RoundState {
+
+		valData := make([]istanbul.ValidatorData, len(validatorAddresses))
+		for i, addr := range validatorAddresses {
+			valData[i] = istanbul.ValidatorData{Address: addr, BLSPublicKey: []byte{1, 2, 3}}
+		}
+		valSet := validator.NewSet(valData)
+
+		rs := newRoundState(view, valSet, valSet.GetByIndex(0))
+
+		// Add a few prepares
+		rs.AddPrepare(&istanbul.Message{
+			Code:    istanbul.MsgPrepare,
+			Address: validatorAddresses[1],
+		})
+		rs.AddPrepare(&istanbul.Message{
+			Code:    istanbul.MsgPrepare,
+			Address: validatorAddresses[2],
+		})
+		rs.AddPrepare(&istanbul.Message{
+			Code:    istanbul.MsgPrepare,
+			Address: validatorAddresses[3],
+		})
+		rs.AddPrepare(&istanbul.Message{
+			Code:    istanbul.MsgPrepare,
+			Address: validatorAddresses[4],
+		})
+
+		// Add a few commits
+		rs.AddCommit(&istanbul.Message{
+			Code:    istanbul.MsgCommit,
+			Address: validatorAddresses[1],
+		})
+		rs.AddCommit(&istanbul.Message{
+			Code:    istanbul.MsgCommit,
+			Address: validatorAddresses[2],
+		})
+		rs.AddCommit(&istanbul.Message{
+			Code:    istanbul.MsgCommit,
+			Address: validatorAddresses[3],
+		})
+
+		// Add a few parent commits
+		rs.AddParentCommit(&istanbul.Message{
+			Code:    istanbul.MsgCommit,
+			Address: validatorAddresses[3],
+		})
+		rs.AddParentCommit(&istanbul.Message{
+			Code:    istanbul.MsgCommit,
+			Address: validatorAddresses[4],
+		})
+		rs.AddParentCommit(&istanbul.Message{
+			Code:    istanbul.MsgCommit,
+			Address: validatorAddresses[5],
+		})
+
+		return rs
+	}
+
+	assertEqualAddressSet := func(t *testing.T, name string, got, expected []common.Address) {
+		gotStrings := make([]string, len(got))
+		for i, addr := range got {
+			gotStrings[i] = addr.Hex()
+		}
+
+		expectedStrings := make([]string, len(expected))
+		for i, addr := range expected {
+			expectedStrings[i] = addr.Hex()
+		}
+
+		sort.StringSlice(expectedStrings).Sort()
+		sort.StringSlice(gotStrings).Sort()
+
+		if !reflect.DeepEqual(expectedStrings, gotStrings) {
+			t.Errorf("%s: Got %v expected %v", name, gotStrings, expectedStrings)
+		}
+	}
+
+	t.Run("With nil fields", func(t *testing.T) {
+		rs := dummyRoundState()
+		rsSummary := rs.Summary()
+
+		if strings.Compare(rsSummary.State, rs.State().String()) != 0 {
+			t.Errorf("State: Mismatch got %v expected %v", rsSummary.State, rs.State().String())
+		}
+
+		if rsSummary.Sequence.Cmp(rs.Sequence()) != 0 {
+			t.Errorf("Sequence: Mismatch got %v expected %v", rsSummary.Sequence, rs.Sequence())
+		}
+		if rsSummary.Round.Cmp(rs.Round()) != 0 {
+			t.Errorf("Round: Mismatch got %v expected %v", rsSummary.Round, rs.Round())
+		}
+		if rsSummary.DesiredRound.Cmp(rs.DesiredRound()) != 0 {
+			t.Errorf("DesiredRound: Mismatch got %v expected %v", rsSummary.DesiredRound, rs.DesiredRound())
+		}
+
+		if rsSummary.PendingRequestHash != nil {
+			t.Errorf("PendingRequestHash: Mismatch got %v expected %v", rsSummary.PendingRequestHash, nil)
+		}
+
+		if !reflect.DeepEqual(rsSummary.ValidatorSet, validatorAddresses) {
+			t.Errorf("ValidatorSet: Mismatch got %v expected %v", rsSummary.ValidatorSet, validatorAddresses)
+		}
+
+		if !reflect.DeepEqual(rsSummary.Proposer, validatorAddresses[0]) {
+			t.Errorf("Proposer: Mismatch got %v expected %v", rsSummary.Proposer, validatorAddresses[0])
+		}
+
+		assertEqualAddressSet(t, "Prepares", rsSummary.Prepares, validatorAddresses[1:5])
+		assertEqualAddressSet(t, "Commits", rsSummary.Commits, validatorAddresses[1:4])
+		assertEqualAddressSet(t, "ParentCommits", rsSummary.ParentCommits, validatorAddresses[3:6])
+
+		if rsSummary.Preprepare != nil {
+			t.Errorf("Preprepare: Mismatch got %v expected %v", rsSummary.Preprepare, nil)
+		}
+
+		if rsSummary.PreparedCertificate != nil {
+			t.Errorf("PreparedCertificate: Mismatch got %v expected %v", rsSummary.PreparedCertificate, nil)
+		}
+
+		_, err := json.Marshal(rsSummary)
+		if err != nil {
+			t.Errorf("Error %v", err)
+		}
+	})
+
+	t.Run("With a Pending Request", func(t *testing.T) {
+		rs := dummyRoundState()
+		block := makeBlock(1)
+		rs.SetPendingRequest(&istanbul.Request{
+			Proposal: block,
+		})
+
+		rsSummary := rs.Summary()
+
+		if rsSummary.PendingRequestHash == nil || !reflect.DeepEqual(*rsSummary.PendingRequestHash, block.Hash()) {
+			t.Errorf("PendingRequestHash: Mismatch got %v expected %v", rsSummary.PendingRequestHash, block.Hash())
+		}
+
+		_, err := json.Marshal(rsSummary)
+		if err != nil {
+			t.Errorf("Error %v", err)
+		}
+	})
+
+	t.Run("With a Preprepare", func(t *testing.T) {
+		rs := dummyRoundState()
+		block := makeBlock(1)
+		preprepare := &istanbul.Preprepare{
+			Proposal: block,
+			View:     rs.View(),
+			RoundChangeCertificate: istanbul.RoundChangeCertificate{
+				RoundChangeMessages: []istanbul.Message{
+					{Code: istanbul.MsgRoundChange, Address: validatorAddresses[3]},
+				},
+			},
+		}
+
+		rs.TransitionToPreprepared(preprepare)
+
+		rsSummary := rs.Summary()
+
+		if rsSummary.Preprepare == nil {
+			t.Fatalf("Got nil Preprepare")
+		}
+		if !reflect.DeepEqual(rsSummary.Preprepare.View, rs.View()) {
+			t.Errorf("Preprepare.View: Mismatch got %v expected %v", rsSummary.Preprepare.View, rs.View())
+		}
+		if !reflect.DeepEqual(rsSummary.Preprepare.ProposalHash, block.Hash()) {
+			t.Errorf("Preprepare.ProposalHash: Mismatch got %v expected %v", rsSummary.Preprepare.ProposalHash, block.Hash())
+		}
+
+		assertEqualAddressSet(t, "Preprepare.RoundChangeCertificateSenders", rsSummary.Preprepare.RoundChangeCertificateSenders, validatorAddresses[3:4])
+
+		_, err := json.Marshal(rsSummary)
+		if err != nil {
+			t.Errorf("Error %v", err)
+		}
 	})
 
 }

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -29,32 +29,6 @@ var (
 	errInvalidValidatorSetDiffSize = errors.New("istanbul extra validator set data has different size")
 )
 
-func CombineIstanbulExtraToValidatorData(addrs []common.Address, blsPublicKeys [][]byte) ([]ValidatorData, error) {
-	if len(addrs) != len(blsPublicKeys) {
-		return nil, errInvalidValidatorSetDiffSize
-	}
-	validators := []ValidatorData{}
-	for i := range addrs {
-		validators = append(validators, ValidatorData{
-			Address:      addrs[i],
-			BLSPublicKey: blsPublicKeys[i],
-		})
-	}
-
-	return validators, nil
-}
-
-func SeparateValidatorDataIntoIstanbulExtra(validators []ValidatorData) ([]common.Address, [][]byte) {
-	addrs := []common.Address{}
-	pubKeys := [][]byte{}
-	for i := range validators {
-		addrs = append(addrs, validators[i].Address)
-		pubKeys = append(pubKeys, validators[i].BLSPublicKey)
-	}
-
-	return addrs, pubKeys
-}
-
 type ValidatorData struct {
 	Address      common.Address
 	BLSPublicKey []byte
@@ -76,7 +50,8 @@ type Validator interface {
 	AsData() *ValidatorData
 }
 
-func GetAddressesFromValidatorList(validators []Validator) []common.Address {
+// MapValidatorsToAddresses maps a slice of validator to a slice of addresses
+func MapValidatorsToAddresses(validators []Validator) []common.Address {
 	returnList := make([]common.Address, len(validators))
 
 	for i, val := range validators {
@@ -87,8 +62,6 @@ func GetAddressesFromValidatorList(validators []Validator) []common.Address {
 }
 
 // ----------------------------------------------------------------------------
-
-type Validators []Validator
 
 type ValidatorsDataByAddress []ValidatorData
 
@@ -114,8 +87,10 @@ type ValidatorSet interface {
 	// Get the minimum quorum size
 	MinQuorumSize() int
 
-	// Return the validator array
+	// List returns all the validators
 	List() []Validator
+	// ListAddresses returns all the validators addresses
+	ListAddresses() []common.Address
 	// Return the validator index
 	GetIndex(addr common.Address) int
 	// Get validator by index
@@ -146,3 +121,31 @@ type ValidatorSetData struct {
 
 // ProposerSelector returns the block proposer for a round given the last proposer, round number, and randomness.
 type ProposerSelector func(validatorSet ValidatorSet, lastBlockProposer common.Address, currentRound uint64) Validator
+
+// ----------------------------------------------------------------------------
+
+func CombineIstanbulExtraToValidatorData(addrs []common.Address, blsPublicKeys [][]byte) ([]ValidatorData, error) {
+	if len(addrs) != len(blsPublicKeys) {
+		return nil, errInvalidValidatorSetDiffSize
+	}
+	validators := []ValidatorData{}
+	for i := range addrs {
+		validators = append(validators, ValidatorData{
+			Address:      addrs[i],
+			BLSPublicKey: blsPublicKeys[i],
+		})
+	}
+
+	return validators, nil
+}
+
+func SeparateValidatorDataIntoIstanbulExtra(validators []ValidatorData) ([]common.Address, [][]byte) {
+	addrs := []common.Address{}
+	pubKeys := [][]byte{}
+	for i := range validators {
+		addrs = append(addrs, validators[i].Address)
+		pubKeys = append(pubKeys, validators[i].BLSPublicKey)
+	}
+
+	return addrs, pubKeys
+}

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -89,8 +89,6 @@ type ValidatorSet interface {
 
 	// List returns all the validators
 	List() []Validator
-	// ListAddresses returns all the validators addresses
-	ListAddresses() []common.Address
 	// Return the validator index
 	GetIndex(addr common.Address) int
 	// Get validator by index

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -113,10 +113,6 @@ func (valSet *defaultSet) List() []istanbul.Validator {
 	return valSet.validators
 }
 
-func (valSet *defaultSet) ListAddresses() []common.Address {
-	return istanbul.MapValidatorsToAddresses(valSet.List())
-}
-
 func (valSet *defaultSet) GetByIndex(i uint64) istanbul.Validator {
 	valSet.validatorMu.RLock()
 	defer valSet.validatorMu.RUnlock()

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -81,7 +81,7 @@ func (val *defaultValidator) DecodeRLP(stream *rlp.Stream) error {
 // ----------------------------------------------------------------------------
 
 type defaultSet struct {
-	validators  istanbul.Validators
+	validators  []istanbul.Validator
 	validatorMu sync.RWMutex
 	// This is set when we call `getOrderedValidators`
 	// TODO Rename to `EpochState` that has validators & randomness
@@ -111,6 +111,10 @@ func (valSet *defaultSet) List() []istanbul.Validator {
 	valSet.validatorMu.RLock()
 	defer valSet.validatorMu.RUnlock()
 	return valSet.validators
+}
+
+func (valSet *defaultSet) ListAddresses() []common.Address {
+	return istanbul.MapValidatorsToAddresses(valSet.List())
 }
 
 func (valSet *defaultSet) GetByIndex(i uint64) istanbul.Validator {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -791,11 +791,11 @@ web3._extend({
 		new web3._extend.Property({
 			name: 'valEnodeTableInfo',
 			getter: 'istanbul_getValEnodeTable',
-		}),		
+		}),				
 		new web3._extend.Property({
-			name: 'proxyInfo',
-			getter: 'istanbul_proxyInfo'
-		}),		
+			name: 'currentRoundState',
+			getter: 'istanbul_getCurrentRoundState',
+		}),				
 	],
 	properties:
 	[


### PR DESCRIPTION
### Description

Add RPC to query RoundState information

A few clean ups: 

 * Change "self" variable to a sensible name on a few types
 * Rename GetAddressesFromValidatorList to MapValidatorsToAddresses
 * Remove istanbul.Validators type (almost not used)

### Tested

 * Tested Summary generation and Json Marshalling. 
 * Need to test the actual RPC call on an living environment
