### PR TITLE
Add metrics timers to block finalization and evm execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,12 @@
 # docker exec -t -i geth_container /bin/sh
 #
 # Once you are satisfied, build the image using
-# TAG is the git commit hash of the geth repo.
-# docker build -f Dockerfile -t gcr.io/celo-testnet/geth:$TAG .
+# export COMMIT_SHA=$(git rev-parse HEAD)
+# docker build -f Dockerfile --build-arg COMMIT_SHA=$COMMIT_SHA -t gcr.io/celo-testnet/geth:$COMMIT_SHA .
+#
 # push the image to the cloud
-# docker push gcr.io/celo-testnet/geth:$TAG
+# docker push gcr.io/celo-testnet/geth:$COMMIT_SHA
+#
 # To use this image for testing, modify GETH_NODE_DOCKER_IMAGE_TAG in celo-monorepo/.env file
 
 FROM ubuntu:16.04 as rustbuilder

--- a/cloudbuild-branchname.yaml
+++ b/cloudbuild-branchname.yaml
@@ -1,9 +1,9 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'us.gcr.io/$PROJECT_ID/geth:$BRANCH_NAME', '.' ]
+  args: [ 'build', '-t', 'us.gcr.io/$PROJECT_ID/geth:$BRANCH_NAME', '--build-arg', 'COMMIT_SHA=$COMMIT_SHA', '.' ]
   waitFor: ["-"]
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'us.gcr.io/$PROJECT_ID/geth-all:$BRANCH_NAME', '-f', 'Dockerfile.alltools', '.' ]
+  args: [ 'build', '-t', 'us.gcr.io/$PROJECT_ID/geth-all:$BRANCH_NAME', '--build-arg', 'COMMIT_SHA=$COMMIT_SHA', '-f', 'Dockerfile.alltools', '.' ]
   waitFor: ["-"]
 images:
 - 'us.gcr.io/$PROJECT_ID/geth:$BRANCH_NAME'

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -445,6 +445,8 @@ func (sb *Backend) LookbackWindow() uint64 {
 // Note, the block header and state database might be updated to reflect any
 // consensus rules that happen at finalization (e.g. block rewards).
 func (sb *Backend) Finalize(chain consensus.ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, uncles []*types.Header, receipts []*types.Receipt, randomness *types.Randomness) (*types.Block, error) {
+	start := time.Now()
+	defer sb.finalizationTimer.UpdateSince(start)
 
 	snapshot := state.Snapshot()
 	err := sb.setInitialGoldTokenTotalSupplyIfUnset(header, state)

--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
@@ -38,6 +39,9 @@ import (
 )
 
 func (sb *Backend) distributeEpochPaymentsAndRewards(header *types.Header, state *state.StateDB) error {
+	start := time.Now()
+	defer sb.rewardDistributionTimer.UpdateSince(start)
+
 	err := epoch_rewards.UpdateTargetVotingYield(header, state)
 	if err != nil {
 		return err

--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -19,6 +19,7 @@ package contract_comm
 import (
 	"math/big"
 	"reflect"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -27,11 +28,15 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 )
 
 var (
 	emptyMessage                = types.NewMessage(common.HexToAddress("0x0"), nil, 0, common.Big0, 0, common.Big0, nil, nil, common.Big0, []byte{}, false)
 	internalEvmHandlerSingleton *InternalEVMHandler
+
+	// Metrics timers to track the execution time of calls made from the system to core contracts.
+	systemCallTimers = make(map[string]metrics.Timer)
 )
 
 // An EVM handler to make calls to smart contracts from within geth
@@ -94,6 +99,15 @@ func createEVM(header *types.Header, state vm.StateDB) (*vm.EVM, error) {
 }
 
 func makeCallFromSystem(scAddress common.Address, abi abi.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int, header *types.Header, state vm.StateDB, static bool) (uint64, error) {
+	// Record a metrics data point about execution time.
+	start := time.Now()
+	timer, ok := systemCallTimers[funcName]
+	if !ok {
+		timer = metrics.NewRegisteredTimer("contract_comm/systemcall/"+funcName, nil)
+		systemCallTimers[funcName] = timer
+	}
+	defer timer.UpdateSince(start)
+
 	vmevm, err := createEVM(header, state)
 	if err != nil {
 		return 0, err
@@ -107,7 +121,7 @@ func makeCallFromSystem(scAddress common.Address, abi abi.ABI, funcName string, 
 		gasLeft, err = vmevm.CallFromSystem(scAddress, abi, funcName, args, returnObj, gas, value)
 	}
 	if err != nil {
-		log.Error("Error when invoking evm function", "err", err, "funcName", funcName, "static", static, "address", scAddress, "args", args)
+		log.Error("Error when invoking evm function", "err", err, "funcName", funcName, "static", static, "address", scAddress, "args", args, "gas", gas, "gasLeft", gasLeft, "value", value)
 		return gasLeft, err
 	}
 


### PR DESCRIPTION
### Description

With the goal of helping to track down issues with execution time, especially in epoch finalization, this PR adds timers to the Istanbul backend and `contract_comm` to track execution times as metrics.

### Other Changes

* Pass `$COMMIT_SHA` to docker in cloud build from branches to ensure the `version.txt` file is populated correctly.
* Update the build instructions in `Dockerfile` to make sure `version.txt` gets populated

### Tested

Manually via `geth attach` on local testnet

### Backwards compatibility

It is