### PR TITLE
Add ProxyAllowPrivateIPFlag

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -148,6 +148,7 @@ var (
 		utils.ProxiedValidatorAddressFlag,
 		utils.ProxiedFlag,
 		utils.ProxyEnodeURLPairFlag,
+		utils.ProxyAllowPrivateIPFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -249,6 +249,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.ProxiedValidatorAddressFlag,
 			utils.ProxiedFlag,
 			utils.ProxyEnodeURLPairFlag,
+			utils.ProxyAllowPrivateIPFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -696,6 +696,10 @@ var (
 		Name:  "proxy.proxyenodeurlpair",
 		Usage: "proxy enode URL pair separated by a semicolon.  The format should be \"<internal facing enode URL>;<external facing enode URL>\"",
 	}
+	ProxyAllowPrivateIPFlag = cli.BoolFlag{
+		Name:  "proxy.allowprivateip",
+		Usage: "Specifies whether private IP is allowed for external facing proxy enodeURL",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1286,7 +1290,11 @@ func SetProxyConfig(ctx *cli.Context, nodeCfg *node.Config, ethCfg *eth.Config) 
 
 			// Check that external IP is not a private IP address.
 			if ethCfg.Istanbul.ProxyExternalFacingNode.IsPrivateIP() {
-				Fatalf("Proxy external facing enodeURL (%s) cannot be private IP.", proxyEnodeURLPair[1])
+				if ctx.GlobalBool(ProxyAllowPrivateIPFlag.Name) {
+					log.Warn("Proxy external facing enodeURL (%s) is private IP.", proxyEnodeURLPair[1])
+				} else {
+					Fatalf("Proxy external facing enodeURL (%s) cannot be private IP.", proxyEnodeURLPair[1])
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description

Adds ProxyAllowPrivateIPFlag, which specifies whether private IP is allowed for external facing proxy enodeURL.

### Tested

Tested that celotool deployed testnet comes up rather than fatal "Proxy external facing enodeURL (%s) cannot be private IP.".
