### PR TITLE
Proxies should ignore consensus messages from non validators

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -195,9 +195,11 @@ type Backend struct {
 	valEnodesShareWg   *sync.WaitGroup
 	valEnodesShareQuit chan struct{}
 
+	// Validator's proxy
 	proxyNode *proxyInfo
 
 	// Right now, we assume that there is at most one proxied peer for a proxy
+	// Proxy's validator
 	proxiedPeer consensus.Peer
 
 	newEpochCh chan struct{}

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -133,6 +133,11 @@ func (sb *Backend) handleConsensusMsg(peer consensus.Peer, payload []byte) error
 			return nil
 		}
 
+		if _, err := sb.valEnodeTable.GetAddressFromNodeID(peer.Node().ID()); err != nil {
+			sb.logger.Trace("Got a consensus message from a non validator.  Ignoring it")
+			return nil
+		}
+
 		// Need to forward the message to the proxied validator
 		sb.logger.Trace("Forwarding consensus message to proxied validator")
 		if sb.proxiedPeer != nil {

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -41,6 +41,9 @@ const (
 var (
 	// errDecodeFailed is returned when decode message fails
 	errDecodeFailed = errors.New("fail to decode istanbul message")
+	// errNonValidatorMessage is returned when `handleConsensusMsg` receives
+	// a message with a signature from a non validator
+	errNonValidatorMessage = errors.New("proxy received consensus message of a non validator")
 )
 
 // Protocol implements consensus.Engine.Protocol
@@ -135,15 +138,15 @@ func (sb *Backend) handleConsensusMsg(peer consensus.Peer, payload []byte) error
 
 		msg := new(istanbul.Message)
 
-		// Verify that this message is coming from a legitimate validator before forwarding.
+		// Verify that this message is created by a legitimate validator before forwarding.
 		checkValidatorSignature := func(data []byte, sig []byte) (common.Address, error) {
 			block := sb.currentBlock()
 			valSet := sb.getValidators(block.Number().Uint64(), block.Hash())
 			return istanbul.CheckValidatorSignature(valSet, data, sig)
 		}
 		if err := msg.FromPayload(payload, checkValidatorSignature); err != nil {
-			sb.logger.Trace("Got a consensus message from a non validator.  Ignoring it")
-			return nil
+			sb.logger.Error("Got a consensus message signed by a non validator.")
+			return errNonValidatorMessage
 		}
 
 		// Need to forward the message to the proxied validator

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -77,6 +77,41 @@ func TestIstanbulMessage(t *testing.T) {
 	}
 }
 
+func TestProxyConsensusForwarding(t *testing.T) {
+	_, backend := newBlockChain(1, true)
+	backend.config.Proxy = true
+
+	// generate one msg
+	data := []byte("data1")
+	bytes, err := rlp.EncodeToBytes(data)
+	if err != nil {
+		t.Fatalf("Error encoding consensus message bytes: %v", err)
+	}
+
+	msg := &istanbul.Message{
+		Code:      istanbulConsensusMsg,
+		Msg:       bytes,
+		Address:   backend.Address(),
+		Signature: []byte{},
+	}
+
+	// Test sending a message with no validator signature.
+	// Should fail because proxy expects consensus messages from validators.
+	payloadNoSig, _ := msg.Payload()
+	err = backend.handleConsensusMsg(&MockPeer{}, payloadNoSig)
+	if err != errNonValidatorMessage {
+		t.Errorf("Expected error sending message from non validator")
+	}
+
+	// Test sending a message with a legitimate validator signature.
+	// Should succeed now.
+	msg.Sign(backend.Sign)
+	payloadWithSig, _ := msg.Payload()
+	if err = backend.handleConsensusMsg(&MockPeer{}, payloadWithSig); err != nil {
+		t.Errorf("error %v", err)
+	}
+}
+
 func makeMsg(msgcode uint64, data interface{}) p2p.Msg {
 	size, r, _ := rlp.EncodeToReader(data)
 	return p2p.Msg{Code: msgcode, Size: uint32(size), Payload: r}


### PR DESCRIPTION
### Description

Proxies that receive a consensus message from a non validator now return an error. 

### Tested

Added unit testing to verify that messages not signed by a validator are ignored, whereas those that are signed are properly forwarded to the proxies' validator.

### Other changes

Added comments to present more context on proxy setup (will be removed with multiproxy).

### Related issues

- Fixes #651

### Backwards compatibility

Yes
