### PR TITLE
Use contract historical randomness

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -648,15 +648,12 @@ func (sb *Backend) validatorRandomnessAtBlockNumber(number uint64, hash common.H
 	if number > 0 {
 		lastBlockInPreviousEpoch = number - istanbul.GetNumberWithinEpoch(number, sb.config.Epoch)
 	}
-	header := sb.chain.GetHeaderByNumber(lastBlockInPreviousEpoch)
-	if header == nil {
-		return common.Hash{}, errNoBlockHeader
-	}
+	header := sb.chain.CurrentHeader()
 	state, err := sb.stateAt(header.Hash())
 	if err != nil {
 		return common.Hash{}, err
 	}
-	return random.Random(header, state)
+	return random.HistoricalRandom(header, state, lastBlockInPreviousEpoch)
 }
 
 func (sb *Backend) getOrderedValidators(number uint64, hash common.Hash) istanbul.ValidatorSet {

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -649,11 +649,14 @@ func (sb *Backend) validatorRandomnessAtBlockNumber(number uint64, hash common.H
 		lastBlockInPreviousEpoch = number - istanbul.GetNumberWithinEpoch(number, sb.config.Epoch)
 	}
 	header := sb.chain.CurrentHeader()
+	if header == nil {
+		return common.Hash{}, errNoBlockHeader
+	}
 	state, err := sb.stateAt(header.Hash())
 	if err != nil {
 		return common.Hash{}, err
 	}
-	return random.HistoricalRandom(header, state, lastBlockInPreviousEpoch)
+	return random.BlockRandomness(header, state, lastBlockInPreviousEpoch)
 }
 
 func (sb *Backend) getOrderedValidators(number uint64, hash common.Hash) istanbul.ValidatorSet {

--- a/contract_comm/random/random.go
+++ b/contract_comm/random/random.go
@@ -220,12 +220,12 @@ func RevealAndCommit(randomness, newCommitment common.Hash, proposer common.Addr
 // Random performs an internal call to the EVM to retrieve the current randomness from the official Random contract.
 func Random(header *types.Header, state vm.StateDB) (common.Hash, error) {
 	randomness := common.Hash{}
-	_, err := contract_comm.MakeStaticCall(params.RandomRegistryId, randomFuncABI, "random", []interface{}{}, &randomness, params.MaxGasForComputeCommitment, header, state)
+	_, err := contract_comm.MakeStaticCall(params.RandomRegistryId, randomFuncABI, "random", []interface{}{}, &randomness, params.MaxGasForBlockRandomness, header, state)
 	return randomness, err
 }
 
-func HistoricalRandom(header *types.Header, state vm.StateDB, blockNumber uint64) (common.Hash, error) {
+func BlockRandomness(header *types.Header, state vm.StateDB, blockNumber uint64) (common.Hash, error) {
 	randomness := common.Hash{}
-	_, err := contract_comm.MakeStaticCall(params.RandomRegistryId, historicRandomFuncABI, "getBlockRandomness", []interface{}{big.NewInt(int64(blockNumber))}, &randomness, params.MaxGasForComputeCommitment, header, state)
+	_, err := contract_comm.MakeStaticCall(params.RandomRegistryId, historicRandomFuncABI, "getBlockRandomness", []interface{}{big.NewInt(int64(blockNumber))}, &randomness, params.MaxGasForBlockRandomness, header, state)
 	return randomness, err
 }

--- a/contract_comm/random/random.go
+++ b/contract_comm/random/random.go
@@ -1,6 +1,7 @@
 package random
 
 import (
+	"math/big"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -101,6 +102,28 @@ const (
       "type": "function"
     }
 ]`
+
+	historicRandomAbi = `[
+    {
+      "constant": true,
+      "inputs": [
+		{
+			"name": "blockNumber",
+			"type": "uint256"
+		}
+	  ],
+      "name": "getBlockRandomness",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+]`
 )
 
 var (
@@ -108,6 +131,7 @@ var (
 	commitmentsFuncABI, _       = abi.JSON(strings.NewReader(commitmentsAbi))
 	computeCommitmentFuncABI, _ = abi.JSON(strings.NewReader(computeCommitmentAbi))
 	randomFuncABI, _            = abi.JSON(strings.NewReader(randomAbi))
+	historicRandomFuncABI, _    = abi.JSON(strings.NewReader(historicRandomAbi))
 	zeroValue                   = common.Big0
 	dbRandomnessPrefix          = []byte("db-randomness-prefix")
 )
@@ -197,5 +221,11 @@ func RevealAndCommit(randomness, newCommitment common.Hash, proposer common.Addr
 func Random(header *types.Header, state vm.StateDB) (common.Hash, error) {
 	randomness := common.Hash{}
 	_, err := contract_comm.MakeStaticCall(params.RandomRegistryId, randomFuncABI, "random", []interface{}{}, &randomness, params.MaxGasForComputeCommitment, header, state)
+	return randomness, err
+}
+
+func HistoricalRandom(header *types.Header, state vm.StateDB, blockNumber uint64) (common.Hash, error) {
+	randomness := common.Hash{}
+	_, err := contract_comm.MakeStaticCall(params.RandomRegistryId, historicRandomFuncABI, "getBlockRandomness", []interface{}{big.NewInt(int64(blockNumber))}, &randomness, params.MaxGasForComputeCommitment, header, state)
 	return randomness, err
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -201,6 +201,7 @@ const (
 	MaxGasForCalculateTargetEpochPaymentAndRewards uint64 = 2000000
 	MaxGasForCommitments                           uint64 = 2000000
 	MaxGasForComputeCommitment                     uint64 = 2000000
+	MaxGasForBlockRandomness                       uint64 = 2000000
 	MaxGasForCreditToTransactions                  uint64 = 100000
 	MaxGasForDebitFromTransactions                 uint64 = 100000
 	MaxGasForDistributeEpochPayment                uint64 = 1 * 1000000


### PR DESCRIPTION
### Description

Currently, we are trying to fetch the randomness of the last epoch block to determine the validator set order (to know who is supposed to propose). However, we only store the last 128 tries by default, which causes us not to be able to retrieve the state of the epoch block, and thus not be able to fetch the randomness.

This PR suggests one solution to this problem. It actually uses the state of the current block and takes advantage of that fact that we are storing historical randomness on the contract itself. The window on baklava is 720 blocks right now, and the epoch size is 720. To avoid off-by-one error, we'll probably need to run a governance proposal to set it to something higher.

The alternate solution to this would be to increase the `TriesInMemory` default to something larger than the epoch size.

### Tested

- Deployed it to `nammissingtrie`, so the error pop up only until historical randomness on the contract was no longer available with the current block (since epoch lengths are 1000 by default on testnets)

