### PR TITLE
Higher trie limit

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -84,7 +84,7 @@ const (
 	maxFutureBlocks     = 256
 	maxTimeFutureBlocks = 30
 	badBlockLimit       = 10
-	TriesInMemory       = 128
+	TriesInMemory       = 1024
 
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	//

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1846,7 +1846,7 @@ func TestLowDiffLongChain(t *testing.T) {
 
 	// We must use a pretty long chain to ensure that the fork doesn't overtake us
 	// until after at least 128 blocks post tip
-	blocks, _ := GenerateChain(params.TestChainConfig, genesis, engine, db, 6*TriesInMemory, func(i int, b *BlockGen) {
+	blocks, _ := GenerateChain(params.TestChainConfig, genesis, engine, db, 6*128, func(i int, b *BlockGen) {
 		b.SetCoinbase(common.Address{1})
 		b.OffsetTime(-9)
 	})
@@ -1864,7 +1864,7 @@ func TestLowDiffLongChain(t *testing.T) {
 	}
 	// Generate fork chain, starting from an early block
 	parent := blocks[10]
-	fork, _ := GenerateChain(params.TestChainConfig, parent, engine, db, 8*TriesInMemory, func(i int, b *BlockGen) {
+	fork, _ := GenerateChain(params.TestChainConfig, parent, engine, db, 8*128, func(i int, b *BlockGen) {
 		b.SetCoinbase(common.Address{2})
 	})
 


### PR DESCRIPTION
### Description

I'm seeing a weird off-by-one error in https://github.com/celo-org/celo-blockchain/pull/844, so to move on, this PR just increases the TrieInMemory Limit to exceed the epoch size for now. This is meant as a temporary solution and should be fixed with https://github.com/celo-org/celo-monorepo/issues/2625

### Tested

- [x] on https://nammissingtrie-celostats.celo-networks-dev.org/


