### PR TITLE
p2p: ensure Server.loop is ticking even if discovery hangs

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -746,9 +746,12 @@ func (srv *Server) run(dialstate dialer) {
 		inboundCount = 0
 		trusted      = make(map[enode.ID]*PurposeFlag, len(srv.TrustedNodes))
 		taskdone     = make(chan task, maxActiveDialTasks)
+		tick         = time.NewTicker(30 * time.Second)
 		runningTasks []task
 		queuedTasks  []task // tasks that can't run yet
 	)
+	defer tick.Stop()
+
 	// Put trusted nodes into a map to speed up checks.
 	// Trusted peers are loaded on startup or added via AddTrustedPeer RPC.
 	for _, n := range srv.TrustedNodes {
@@ -865,6 +868,9 @@ running:
 		scheduleTasks()
 
 		select {
+		case <-tick.C:
+			// This is just here to ensure the dial scheduler runs occasionally.
+
 		case <-srv.quit:
 			// The server was stopped. Run the cleanup logic.
 			break running


### PR DESCRIPTION
### Description

This is a cherry-pick of https://github.com/ethereum/go-ethereum/pull/20573, which fixes an issue where discovery queries would hang indefinitely if the connection was refused, resulting in future discovery queries never happening. This adds a timer to ensure discovery queries still happen every 30 seconds.

### Tested

I ran without this commit and added some log messages, and saw that a discovery query to an inaccessible bootnode only happened at node startup and never again (I let it run ~10 min). I then ran with this commit and saw discovery queries to the inaccessible bootnode would occur every ~30 seconds.

### Other changes

n/a

### Related issues

n/a

### Backwards compatibility

This is backwards compatible with the rest of 1.9