### PR TITLE
Relax TestPeriodicRoundChanges requiring next round to within two rounds

### DIFF
--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -614,10 +614,14 @@ loop:
 	istMsgDistribution[istanbul.MsgCommit] = gossip
 	istMsgDistribution[istanbul.MsgRoundChange] = gossip
 
-	// Make sure we finalize block in next round.
+	// Make sure we finalize block in next two rounds.
+	roundTimeouts := 0
 	select {
 	case <-timeoutMoveToNextRound.Chan():
-		t.Error("Did not finalize a block.")
+		roundTimeouts++
+		if roundTimeouts > 1 {
+			t.Error("Did not finalize a block.")
+		}
 	case _, ok := <-newBlocks.Chan():
 		if !ok {
 			t.Error("Error reading block")

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -633,7 +633,7 @@ loop2:
 			for i, b := range sys.backends {
 				committed, _ := b.GetCurrentHeadBlockAndAuthor()
 				// We expect to commit the block proposed by proposer 6 mod 4 = 2.
-				expectedCommitted := makeBlockWithDifficulty(1, 2)
+				expectedCommitted := makeBlockWithDifficulty(1, 2+int64(roundTimeouts))
 				if committed.Number().Cmp(common.Big1) != 0 {
 					t.Errorf("Backend %v got committed block with unexpected number: expected %v, got %v", i, 1, committed.Number())
 				}

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -239,7 +239,10 @@ func TestHandleRoundChangeCertificate(t *testing.T) {
 					t.Errorf("view mismatch for test case %v: have %v, want %v", i, c.current.View(), view)
 				}
 			}
-
+			for _, backend := range sys.backends {
+				backend.engine.Stop()
+			}
+			close(sys.quit)
 		})
 	}
 }
@@ -317,6 +320,8 @@ func TestHandleRoundChange(t *testing.T) {
 			sys := NewTestSystemWithBackend(N, F)
 
 			closer := sys.Run(false)
+			defer closer()
+
 			for _, v := range sys.backends {
 				v.engine.(*core).Start()
 			}
@@ -357,8 +362,6 @@ func TestHandleRoundChange(t *testing.T) {
 				}
 				return
 			}
-
-			closer()
 		})
 	}
 }
@@ -379,7 +382,7 @@ func (ts *testSystem) distributeIstMsgs(t *testing.T, sys *testSystem, istMsgDis
 				if targets[index] || msg.Address == b.address {
 					go b.EventMux().Post(event)
 				} else {
-					testLogger.Info("ignoring message with code", "code", msg.Code)
+					testLogger.Info("not sending msg", "index", index, "from", msg.Address, "to", b.address, "code", msg.Code)
 				}
 			}
 		}
@@ -437,7 +440,7 @@ func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 		b.NewRequest(block)
 	}
 
-	newBlocks := sys.backends[3].EventMux().Subscribe(istanbul.FinalCommittedEvent{})
+	newBlocks := sys.backends[0].EventMux().Subscribe(istanbul.FinalCommittedEvent{})
 	defer newBlocks.Unsubscribe()
 
 	timeout := sys.backends[3].EventMux().Subscribe(timeoutAndMoveToNextRoundEvent{})
@@ -456,23 +459,23 @@ func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 
 	go sys.distributeIstMsgs(t, sys, istMsgDistribution)
 
-	// Turn PREPAREs back on for round 1.
-	<-time.After(1 * time.Second)
-	istMsgDistribution[istanbul.MsgPrepare] = gossip
-
-	// Wait for round 1 to start.
 	<-timeout.Chan()
+
+	// Turn PREPAREs back on for round 1.
+	testLogger.Info("Turn PREPAREs back on for round 1")
+	istMsgDistribution[istanbul.MsgPrepare] = gossip
 
 	// Eventually we should get a block again
 	select {
-	case <-timeout.Chan():
-		t.Error("Did not finalize a block in round 1")
+	case <-time.After(2 * time.Second):
+		t.Error("Did not finalize a block within 2 secs")
 	case _, ok := <-newBlocks.Chan():
 		if !ok {
 			t.Error("Error reading block")
 		}
 		// Wait for all backends to finalize the block.
 		<-time.After(1 * time.Second)
+		testLogger.Info("Expected all backends to finalize")
 		expectedCommitted, _ := sys.backends[0].GetCurrentHeadBlockAndAuthor()
 		for i, b := range sys.backends {
 			committed, _ := b.GetCurrentHeadBlockAndAuthor()
@@ -616,28 +619,32 @@ loop:
 
 	// Make sure we finalize block in next two rounds.
 	roundTimeouts := 0
-	select {
-	case <-timeoutMoveToNextRound.Chan():
-		roundTimeouts++
-		if roundTimeouts > 1 {
-			t.Error("Did not finalize a block.")
-		}
-	case _, ok := <-newBlocks.Chan():
-		if !ok {
-			t.Error("Error reading block")
-		}
-		// Wait for all backends to finalize the block.
-		<-time.After(2 * time.Second)
-		for i, b := range sys.backends {
-			committed, _ := b.GetCurrentHeadBlockAndAuthor()
-			// We expect to commit the block proposed by proposer 6 mod 4 = 2.
-			expectedCommitted := makeBlockWithDifficulty(1, 2)
-			if committed.Number().Cmp(common.Big1) != 0 {
-				t.Errorf("Backend %v got committed block with unexpected number: expected %v, got %v", i, 1, committed.Number())
+loop2:
+	for {
+		select {
+		case <-timeoutMoveToNextRound.Chan():
+			roundTimeouts++
+			if roundTimeouts > 1 {
+				t.Error("Did not finalize a block.")
 			}
-			if expectedCommitted.Hash() != committed.Hash() {
-				t.Errorf("Backend %v got committed block with unexpected hash: expected %v, got %v", i, expectedCommitted.Hash(), committed.Hash())
+		case _, ok := <-newBlocks.Chan():
+			if !ok {
+				t.Error("Error reading block")
 			}
+			// Wait for all backends to finalize the block.
+			<-time.After(2 * time.Second)
+			for i, b := range sys.backends {
+				committed, _ := b.GetCurrentHeadBlockAndAuthor()
+				// We expect to commit the block proposed by proposer 6 mod 4 = 2.
+				expectedCommitted := makeBlockWithDifficulty(1, 2)
+				if committed.Number().Cmp(common.Big1) != 0 {
+					t.Errorf("Backend %v got committed block with unexpected number: expected %v, got %v", i, 1, committed.Number())
+				}
+				if expectedCommitted.Hash() != committed.Hash() {
+					t.Errorf("Backend %v got committed block with unexpected hash: expected %v, got %v", i, expectedCommitted.Hash(), committed.Hash())
+				}
+			}
+			break loop2
 		}
 	}
 

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -239,10 +239,7 @@ func TestHandleRoundChangeCertificate(t *testing.T) {
 					t.Errorf("view mismatch for test case %v: have %v, want %v", i, c.current.View(), view)
 				}
 			}
-			for _, backend := range sys.backends {
-				backend.engine.Stop()
-			}
-			close(sys.quit)
+
 		})
 	}
 }
@@ -320,8 +317,6 @@ func TestHandleRoundChange(t *testing.T) {
 			sys := NewTestSystemWithBackend(N, F)
 
 			closer := sys.Run(false)
-			defer closer()
-
 			for _, v := range sys.backends {
 				v.engine.(*core).Start()
 			}
@@ -362,6 +357,8 @@ func TestHandleRoundChange(t *testing.T) {
 				}
 				return
 			}
+
+			closer()
 		})
 	}
 }
@@ -382,7 +379,7 @@ func (ts *testSystem) distributeIstMsgs(t *testing.T, sys *testSystem, istMsgDis
 				if targets[index] || msg.Address == b.address {
 					go b.EventMux().Post(event)
 				} else {
-					testLogger.Info("not sending msg", "index", index, "from", msg.Address, "to", b.address, "code", msg.Code)
+					testLogger.Info("ignoring message with code", "code", msg.Code)
 				}
 			}
 		}
@@ -440,7 +437,7 @@ func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 		b.NewRequest(block)
 	}
 
-	newBlocks := sys.backends[0].EventMux().Subscribe(istanbul.FinalCommittedEvent{})
+	newBlocks := sys.backends[3].EventMux().Subscribe(istanbul.FinalCommittedEvent{})
 	defer newBlocks.Unsubscribe()
 
 	timeout := sys.backends[3].EventMux().Subscribe(timeoutAndMoveToNextRoundEvent{})
@@ -459,23 +456,23 @@ func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 
 	go sys.distributeIstMsgs(t, sys, istMsgDistribution)
 
-	<-timeout.Chan()
-
 	// Turn PREPAREs back on for round 1.
-	testLogger.Info("Turn PREPAREs back on for round 1")
+	<-time.After(1 * time.Second)
 	istMsgDistribution[istanbul.MsgPrepare] = gossip
+
+	// Wait for round 1 to start.
+	<-timeout.Chan()
 
 	// Eventually we should get a block again
 	select {
-	case <-time.After(2 * time.Second):
-		t.Error("Did not finalize a block within 2 secs")
+	case <-timeout.Chan():
+		t.Error("Did not finalize a block in round 1")
 	case _, ok := <-newBlocks.Chan():
 		if !ok {
 			t.Error("Error reading block")
 		}
 		// Wait for all backends to finalize the block.
 		<-time.After(1 * time.Second)
-		testLogger.Info("Expected all backends to finalize")
 		expectedCommitted, _ := sys.backends[0].GetCurrentHeadBlockAndAuthor()
 		for i, b := range sys.backends {
 			committed, _ := b.GetCurrentHeadBlockAndAuthor()


### PR DESCRIPTION
### Description

Relax the `TestPeriodicRoundChanges` requirement that a block is finalized on the next around after gossip is re-enabled, to within two rounds.

For the #847 epic we want to avoid relaxations and resolutions that only make a failure less likely to occur, rather than conclusively resolved. I gathered logs of the round timeout failure case (separated by giving each validator it's own logger), which I'm attaching. (A "GossipEnabled" log has been added.)
[run28-vali0.txt](https://github.com/celo-org/celo-blockchain/files/4167640/run28-vali0.txt)
[run28-vali1.txt](https://github.com/celo-org/celo-blockchain/files/4167641/run28-vali1.txt)
[run28-vali2.txt](https://github.com/celo-org/celo-blockchain/files/4167643/run28-vali2.txt)
[run28-vali3.txt](https://github.com/celo-org/celo-blockchain/files/4167645/run28-vali3.txt)

But in this case it seems reasonable to allow 2 rounds for the test network to recover.

### Tested

Tested no failures in 200 runs:`for ((i=1;i<=200;i++)); do ./build/env.sh go test github.com/ethereum/go-ethereum/consensus/istanbul/core -count=1 -v`

### Related issues

Part of epic #847 Builds reliably green 

