### PR TITLE
Reintroduce Wallet.SignHash

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -118,6 +118,14 @@ type Wallet interface {
 	// the account in a keystore).
 	SignData(account Account, mimeType string, data []byte) ([]byte, error)
 
+	// SignHash is like SignData but doesn't hash the given data
+	//
+	// NOTE: DEPRACATED, use SignData for future releases.
+	// This is needed for backwards compatibility on a network where validators
+	// started on celo-blockchain 1.8. 1.9 removed the SignHash function,
+	// replacing it with SignData, which always hashes the input before signing.
+	SignHash(account Account, hash []byte) ([]byte, error)
+
 	// SignDataWithPassphrase is identical to SignData, but also takes a password
 	// NOTE: there's an chance that an erroneous call might mistake the two strings, and
 	// supply password in the mimetype field, or vice versa. Thus, an implementation

--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -169,6 +169,13 @@ func (api *ExternalSigner) SignData(account accounts.Account, mimeType string, d
 	return res, nil
 }
 
+// SignHash is not implemented for the external signer
+//
+// DEPRECATED, use SignData in future releases.
+func (api *ExternalSigner) SignHash(account accounts.Account, hash []byte) ([]byte, error) {
+	panic("SignHash not implemented for the external signer")
+}
+
 func (api *ExternalSigner) SignText(account accounts.Account, text []byte) ([]byte, error) {
 	var res hexutil.Bytes
 	var signAddress = common.NewMixedcaseAddress(account.Address)

--- a/accounts/keystore/wallet.go
+++ b/accounts/keystore/wallet.go
@@ -166,6 +166,16 @@ func (w *keystoreWallet) SignData(account accounts.Account, mimeType string, dat
 	return w.signHash(account, crypto.Keccak256(data))
 }
 
+// SignHash implements accounts.Wallet, attempting to sign the given hash with
+// the given account. If the wallet does not wrap this particular account, an
+// error is returned to avoid account leakage (even though in theory we may be
+// able to sign via our shared keystore backend).
+//
+// DEPRECATED, use SignData in future releases.
+func (w *keystoreWallet) SignHash(account accounts.Account, hash []byte) ([]byte, error) {
+	return w.signHash(account, hash)
+}
+
 // SignDataWithPassphrase signs keccak256(data). The mimetype parameter describes the type of data being signed
 func (w *keystoreWallet) SignDataWithPassphrase(account accounts.Account, passphrase, mimeType string, data []byte) ([]byte, error) {
 	// Make sure the requested account is contained within

--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -700,6 +700,16 @@ func (w *Wallet) SignData(account accounts.Account, mimeType string, data []byte
 	return w.signHash(account, crypto.Keccak256(data))
 }
 
+// SignHash implements accounts.Wallet, attempting to sign the given hash with
+// the given account. If the wallet does not wrap this particular account, an
+// error is returned to avoid account leakage (even though in theory we may be
+// able to sign via our shared keystore backend).
+//
+// DEPRECATED, use SignData in future releases.
+func (w *Wallet) SignHash(account accounts.Account, hash []byte) ([]byte, error) {
+	return w.signHash(account, hash)
+}
+
 func (w *Wallet) signHash(account accounts.Account, hash []byte) ([]byte, error) {
 	w.lock.Lock()
 	defer w.lock.Unlock()

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -548,6 +548,16 @@ func (w *wallet) SignData(account accounts.Account, mimeType string, data []byte
 	return w.signHash(account, crypto.Keccak256(data))
 }
 
+// SignHash implements accounts.Wallet, attempting to sign the given hash with
+// the given account. If the wallet does not wrap this particular account, an
+// error is returned to avoid account leakage (even though in theory we may be
+// able to sign via our shared keystore backend).
+//
+// DEPRECATED, use SignData in future releases.
+func (w *wallet) SignHash(account accounts.Account, hash []byte) ([]byte, error) {
+	return w.signHash(account, hash)
+}
+
 // SignDataWithPassphrase implements accounts.Wallet, attempting to sign the given
 // data with the given account using passphrase as extra authentication.
 // Since USB wallets don't rely on passphrases, these are silently ignored.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -994,7 +994,8 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			account := accounts.Account{Address: w.coinbase}
 			wallet, err := w.eth.AccountManager().Find(account)
 			if err == nil {
-				randomSeed, err = wallet.SignData(account, accounts.MimetypeTextPlain, randomSeedString)
+				// TODO: Use SignData instead
+				randomSeed, err = wallet.SignHash(account, common.BytesToHash(randomSeedString).Bytes())
 			}
 			if err != nil {
 				log.Error("Unable to create random seed", "err", err)


### PR DESCRIPTION
### Description

*Note*: this is merging to Tim's 1.9 branch

Geth 1.9 removed `SignHash` from the `Wallet` interface, breaking our deterministic randomness scheme used in case a validator looses their data. Since there is a network running on which it is expected that validators will upgrade from 1.8 to 1.9, we need a temporary fix that will reintroduce the same randomness generation scheme.

### Tested

Ran a local testnet with 1.8 instances, restarted validator0 with current Tim's 1.9 branch and successfully reproduced the randomness issue, restarted validator0 again with this branch and successfully mined blocks.

### Related issues

- Fixes #859 

### Backwards compatibility

Fixes a backwards incompatibility introduced by `timmoreton/geth_1.9`.