### PR TITLE
Increase MaxPeers to be greater than light client MaxPeers

### DIFF
--- a/node/defaults.go
+++ b/node/defaults.go
@@ -50,7 +50,7 @@ var DefaultConfig = Config{
 	Proxy:               false,
 	P2P: p2p.Config{
 		ListenAddr: ":30303",
-		MaxPeers:   50,
+		MaxPeers:   175,
 		NAT:        nat.Any(),
 		NetworkId:  1,
 	},


### PR DESCRIPTION
### Description

Folks on Discord were running into an issue when starting the node where the node would refuse to start with the default MaxPeers (50) being less than the default light client MaxPeers (99).

### Tested

Ran geth with default values & node started up

### Other changes

n/a

### Related issues

n/a

### Backwards compatibility

Yes :)