### PR TITLE
Fix mobile build for geth 1.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,13 @@ jobs:
       - checkout
       - run:
           name: Setup Go language
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install go
+          command: |
+            HOMEBREW_NO_AUTO_UPDATE=1 brew install go
+            # Check that homebrew installed the expected go version
+            if [[ "$(go version)" != "go version go1.13"* ]]; then 
+              echo "go1.13 is required"
+              exit 1
+            fi
       - run:
           name: Setup Rust language
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,21 +105,13 @@ jobs:
 
   android:
     docker:
-      - image: celohq/android-client
-        user: circleci
+      - image: celohq/circleci:android-v1
     working_directory: ~/repos/geth
     steps:
       - checkout
       - run:
           name: Compile android client
-          command: |
-            # TODO(jeanregisser): Fix docker image so build works directly with circleci user
-            sudo chown -R circleci:circleci $HOME/.rustup $HOME/.cargo
-            export PATH=$PATH:$HOME/.cargo/bin
-            export NDK_VERSION=android-ndk-r19c
-            export ANDROID_NDK=/opt/android/${NDK_VERSION}
-            export ANDROID_HOME=/opt/android/sdk
-            make android
+          command: make android
       - persist_to_workspace:
           root: ~/repos
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,13 +248,9 @@ workflows:
             - build-geth
       - coverage:
           requires:
-            - build-geth            
-      - android:
-          requires:
-            - build-geth                  
-      - ios:
-          requires:
-            - build-geth                  
+            - build-geth
+      - android
+      - ios
       - publish-mobile-client:
           requires:
             - android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,16 +134,10 @@ jobs:
             fi
       - run:
           name: Setup Rust language
-          command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            export PATH=$PATH:$HOME/.cargo/bin
-            rustup install 1.37.0
-            rustup default 1.37.0
+          command: curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.37.0
       - run:
           name: Compile ios client
-          command: |
-            # export PATH="/usr/local/opt/go@1.11/bin:$HOME/.cargo/bin:$PATH"
-            make ios
+          command: make ios
       - persist_to_workspace:
           root: ~/repos
           paths:

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -1,15 +1,13 @@
-# celohq/android-client
+# celohq/circleci:android-v1
 
 FROM circleci/android:api-28-alpha
-
-USER root
 
 # NDK see also: https://github.com/CircleCI-Public/circleci-dockerfiles/blob/cb8bda793023d3e919ea5553e2f2c04b71f53c49/android/images/api-28-ndk/Dockerfile#L181
 
 ARG ndk_version=android-ndk-r19c
 ARG android_ndk_home=/opt/android/${ndk_version}
 
-# install NDK
+# Install NDK
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/${ndk_version}.zip \
         https://dl.google.com/android/repository/${ndk_version}-linux-x86_64.zip && \
     sudo unzip -q /tmp/${ndk_version}.zip -d /opt/android && \
@@ -19,20 +17,22 @@ RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/${ndk_v
 ENV ANDROID_NDK_HOME ${android_ndk_home}
 ENV ANDROID_NDK ${android_ndk_home}
 
-RUN curl https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz | tar -xz
-ENV PATH=/go/bin:$PATH
-ENV GOROOT=/go
-ENV GOPATH=$HOME/go
+# Install rust
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.37.0
 ENV PATH=$PATH:$HOME/.cargo/bin
-RUN rustup install 1.37.0
-RUN rustup default 1.37.0
 RUN rustup target add aarch64-linux-android
 RUN rustup target add armv7-linux-androideabi
 RUN rustup target add i686-linux-android
 RUN rustup target add x86_64-linux-android
 
+# go and node installations command expect to run as root
+USER root
+
+RUN curl https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz | tar -xz
+ENV PATH=/go/bin:$PATH
+ENV GOROOT=/go
+ENV GOPATH=$HOME/go
 
 ## Using node installation from https://raw.githubusercontent.com/nodejs/docker-node/170ed2092d4925971f9cd3ad5dfc416e820f90fd/10/stretch/Dockerfile
 
@@ -100,3 +100,5 @@ RUN set -ex \
 
 # Basic smoke test
 RUN node --version
+
+USER circleci

--- a/build/ci.go
+++ b/build/ci.go
@@ -985,8 +985,6 @@ func doXCodeFramework(cmdline []string) {
 
 	// Build the iOS XCode framework
 	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile", "golang.org/x/mobile/cmd/gobind"))
-	// Patch gomobile to disable bitcode for now (rust generated bls lib output is not compatible)
-	build.MustRunCommand("sed", "-i", "", `/^[[:space:]]*cflags += \" -fembed-bitcode\"$/s/^/\/\//`, filepath.Join(build.GOPATH(), "src/golang.org/x/mobile/cmd/gomobile/env.go"))
 	bind := gomobileTool("bind", "-ldflags", "-s -w", "--target", "ios", "-v", "github.com/ethereum/go-ethereum/mobile")
 
 	if *local {

--- a/go.mod
+++ b/go.mod
@@ -76,3 +76,6 @@ require (
 )
 
 replace github.com/celo-org/bls-zexe/go => ./crypto/bls/bls-zexe/go
+
+// Use our fork which contains the fix to build on iOS
+replace github.com/elastic/gosigar => github.com/celo-org/gosigar v0.10.5-celo1

--- a/mobile/bind.go
+++ b/mobile/bind.go
@@ -34,7 +34,7 @@ import (
 // Signer is an interface defining the callback when a contract requires a
 // method to sign the transaction before submission.
 type Signer interface {
-	Sign(*Address, *Transaction) (tx *Transaction, _ error)
+	Sign(addr *Address, unsignedTx *Transaction) (tx *Transaction, _ error)
 }
 
 type MobileSigner struct {


### PR DESCRIPTION
### Description

The work here to fix mobile build (iOS/Android) was done on top of https://github.com/celo-org/celo-blockchain/pull/511

- Use Go 1.13 on mobile
- Remove bitcode patch, bitcode is now disabled in gomobile for Go < 1.14
- Fix `gosigar` build on iOS https://github.com/elastic/gosigar/compare/master...celo-org:jeanregisser/fix-ios-build
- Fix gobind build error on iOS due to different parameter names in the generated ObjC code of the `Sign` method between `Signer` and `MobileSigner`
- Don't wait for `build-geth` step to to build `ios` and `android`, this is so we don't have to wait unnecessarily when we need to debug them

### Tested

- iOS and Android compile again locally and on CircleCI
- was able to sync, redeem invite, verify number, send money using geth 1.9 connected to alfajores on iOS

### Other changes

- Updated the Dockerfile for building Geth on Android and pushed it to Docker hub as `celohq/circleci:android-v1`
