### PR TITLE
Use exec in geth start script to pass signals correctly

### DIFF
--- a/scripts/run_geth_in_docker.sh
+++ b/scripts/run_geth_in_docker.sh
@@ -1,11 +1,5 @@
-# allow exiting using CTRL + C
-exit_func() {
-        echo "Exiting..."
-        exit 1
-}
-trap exit_func SIGTERM SIGINT
-
+# Prevent error related to running geth without a tty
 # 150 is an arbitrary choice, which seems good enough
 stty cols 150
 sleep 1
-geth "$@"
+exec geth "$@"


### PR DESCRIPTION
### Description

As discussed in  https://github.com/celo-org/celo-blockchain/issues/857, the run script used in the Docker container prevent SIGINT from being passed through correctly. This PR uses `exec` when starting geth to ensure signals are passed correctly, and to conform to the "one process per container" best practice.

### Tested

Built and ran the docker container locally. Confirmed it starts, and receives SIGINT as desired.

### Related issues

- Fixes https://github.com/celo-org/celo-blockchain/issues/857

### Backwards compatibility

100%