### PR TITLE
Add gosec as a linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,8 +15,8 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    # - staticcheck
-    # - unused
+    - staticcheck
+    - unused
     - varcheck
 
     - goconst
@@ -37,10 +37,15 @@ linters-settings:
 
 issues:
   exclude-rules:
-    # Exclude some linters from running on tests files.
+    # ignore deprecation warnings for now
+    - linters:
+        - staticcheck
+      text: "SA1019:"
+    # genesis has a really long string
     - path: core/genesis_alloc.go
       linters:
         - misspell
+    # Exclude some linters from running on tests files.
     - path: _test\.go
       linters:
         - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
 
     - goconst
     - goimports
-    # - gosec
+    - gosec
     - misspell
     # - prealloc
     - unconvert

--- a/accounts/abi/event_test.go
+++ b/accounts/abi/event_test.go
@@ -173,7 +173,7 @@ func TestEventTupleUnpack(t *testing.T) {
 	type EventTransferWithTag struct {
 		// this is valid because `value` is not exportable,
 		// so value is only unmarshalled into `Value1`.
-		value  *big.Int //lint:ignore U1000 unused field is part of test
+		value  *big.Int //nolint:unused // field is part of test
 		Value1 *big.Int `abi:"value"`
 	}
 

--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -149,10 +149,6 @@ func (api *ExternalSigner) SelfDerive(bases []accounts.DerivationPath, chain eth
 	log.Error("operation SelfDerive not supported on external signers")
 }
 
-func (api *ExternalSigner) signHash(account accounts.Account, hash []byte) ([]byte, error) {
-	return []byte{}, fmt.Errorf("operation not supported on external signers")
-}
-
 // SignData signs keccak256(data). The mimetype parameter describes the type of data being signed
 func (api *ExternalSigner) SignData(account accounts.Account, mimeType string, data []byte) ([]byte, error) {
 	var res hexutil.Bytes

--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -915,7 +915,7 @@ func (s *Session) walletStatus() (*walletStatus, error) {
 }
 
 // derivationPath fetches the wallet's current derivation path from the card.
-func (s *Session) derivationPath() (accounts.DerivationPath, error) {
+func (s *Session) derivationPath() (accounts.DerivationPath, error) { //nolint:unused
 	response, err := s.Channel.transmitEncrypted(claSCWallet, insStatus, statusP1Path, 0, nil)
 	if err != nil {
 		return nil, err
@@ -1029,13 +1029,13 @@ func (s *Session) derive(path accounts.DerivationPath) (accounts.Account, error)
 }
 
 // keyExport contains information on an exported keypair.
-type keyExport struct {
+type keyExport struct { //nolint:unused
 	PublicKey  []byte `asn1:"tag:0"`
 	PrivateKey []byte `asn1:"tag:1,optional"`
 }
 
 // publicKey returns the public key for the current derivation path.
-func (s *Session) publicKey() ([]byte, error) {
+func (s *Session) publicKey() ([]byte, error) { //nolint:unused
 	response, err := s.Channel.transmitEncrypted(claSCWallet, insExportKey, exportP1Any, exportP2Pubkey, nil)
 	if err != nil {
 		return nil, err

--- a/accounts/usbwallet/ledger.go
+++ b/accounts/usbwallet/ledger.go
@@ -162,7 +162,7 @@ func (w *ledgerDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 		return common.Address{}, nil, accounts.ErrWalletClosed
 	}
 	// Ensure the wallet is capable of signing the given transaction
-	if chainID != nil && w.version[0] <= 1 && w.version[1] <= 0 && w.version[2] <= 2 {
+	if chainID != nil && w.version[0] <= 1 && w.version[1] == 0 && w.version[2] <= 2 {
 		return common.Address{}, nil, fmt.Errorf("Ledger v%d.%d.%d doesn't support signing this transaction, please update to v1.0.3 at least", w.version[0], w.version[1], w.version[2])
 	}
 	// All infos gathered and metadata checks out, request signing

--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -687,6 +687,7 @@ func authTwitter(url string) (string, string, common.Address, error) {
 	// Twitter's API isn't really friendly with direct links. Still, we don't
 	// want to do ask read permissions from users, so just load the public posts and
 	// scrape it for the Ethereum address and profile URL.
+	// #nosec (we don't use faucet)
 	res, err := http.Get(url)
 	if err != nil {
 		return "", "", common.Address{}, err
@@ -728,6 +729,7 @@ func authFacebook(url string) (string, string, common.Address, error) {
 	// Facebook's Graph API isn't really friendly with direct links. Still, we don't
 	// want to do ask read permissions from users, so just load the public posts and
 	// scrape it for the Ethereum address and profile URL.
+	// #nosec (we don't use this)
 	res, err := http.Get(url)
 	if err != nil {
 		return "", "", common.Address{}, err

--- a/cmd/faucet/website.go
+++ b/cmd/faucet/website.go
@@ -105,14 +105,14 @@ func Asset(name string) ([]byte, error) {
 }
 
 // AssetString returns the asset contents as a string (instead of a []byte).
-func AssetString(name string) (string, error) {
+func AssetString(name string) (string, error) { //nolint:unused
 	data, err := Asset(name)
 	return string(data), err
 }
 
 // MustAsset is like Asset but panics when Asset would return an error.
 // It simplifies safe initialization of global variables.
-func MustAsset(name string) []byte {
+func MustAsset(name string) []byte { //nolint:unused
 	a, err := Asset(name)
 	if err != nil {
 		panic("asset: Asset(" + name + "): " + err.Error())
@@ -123,14 +123,14 @@ func MustAsset(name string) []byte {
 
 // MustAssetString is like AssetString but panics when Asset would return an
 // error. It simplifies safe initialization of global variables.
-func MustAssetString(name string) string {
+func MustAssetString(name string) string { //nolint:unused
 	return string(MustAsset(name))
 }
 
 // AssetInfo loads and returns the asset info for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
-func AssetInfo(name string) (os.FileInfo, error) {
+func AssetInfo(name string) (os.FileInfo, error) { //nolint:unused
 	canonicalName := strings.Replace(name, "\\", "/", -1)
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
@@ -144,7 +144,7 @@ func AssetInfo(name string) (os.FileInfo, error) {
 
 // AssetDigest returns the digest of the file with the given name. It returns an
 // error if the asset could not be found or the digest could not be loaded.
-func AssetDigest(name string) ([sha256.Size]byte, error) {
+func AssetDigest(name string) ([sha256.Size]byte, error) { //nolint:unused
 	canonicalName := strings.Replace(name, "\\", "/", -1)
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
@@ -157,7 +157,7 @@ func AssetDigest(name string) ([sha256.Size]byte, error) {
 }
 
 // Digests returns a map of all known files and their checksums.
-func Digests() (map[string][sha256.Size]byte, error) {
+func Digests() (map[string][sha256.Size]byte, error) { //nolint:unused
 	mp := make(map[string][sha256.Size]byte, len(_bindata))
 	for name := range _bindata {
 		a, err := _bindata[name]()
@@ -170,7 +170,7 @@ func Digests() (map[string][sha256.Size]byte, error) {
 }
 
 // AssetNames returns the names of the assets.
-func AssetNames() []string {
+func AssetNames() []string { //nolint:unused
 	names := make([]string, 0, len(_bindata))
 	for name := range _bindata {
 		names = append(names, name)
@@ -196,7 +196,7 @@ var _bindata = map[string]func() (*asset, error){
 // AssetDir("data/img") would return []string{"a.png", "b.png"},
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error, and
 // AssetDir("") will return []string{"data"}.
-func AssetDir(name string) ([]string, error) {
+func AssetDir(name string) ([]string, error) { //nolint:unused
 	node := _bintree
 	if len(name) != 0 {
 		canonicalName := strings.Replace(name, "\\", "/", -1)
@@ -223,12 +223,13 @@ type bintree struct {
 	Children map[string]*bintree
 }
 
+//nolint:unused
 var _bintree = &bintree{nil, map[string]*bintree{
 	"faucet.html": {faucetHtml, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.
-func RestoreAsset(dir, name string) error {
+func RestoreAsset(dir, name string) error { //nolint:unused
 	data, err := Asset(name)
 	if err != nil {
 		return err
@@ -249,7 +250,7 @@ func RestoreAsset(dir, name string) error {
 }
 
 // RestoreAssets restores an asset under the given directory recursively.
-func RestoreAssets(dir, name string) error {
+func RestoreAssets(dir, name string) error { //nolint:unused
 	children, err := AssetDir(name)
 	// File
 	if err != nil {
@@ -265,7 +266,7 @@ func RestoreAssets(dir, name string) error {
 	return nil
 }
 
-func _filePath(dir, name string) string {
+func _filePath(dir, name string) string { //nolint:unused
 	canonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(canonicalName, "/")...)...)
 }

--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -505,7 +505,6 @@ func (api *RetestethAPI) mineBlock() error {
 	txCount := 0
 	var txs []*types.Transaction
 	var receipts []*types.Receipt
-	var coalescedLogs []*types.Log
 	var blockFull = gasPool.Gas() < params.TxGas
 	for address := range api.txSenders {
 		if blockFull {
@@ -533,7 +532,6 @@ func (api *RetestethAPI) mineBlock() error {
 				}
 				txs = append(txs, tx)
 				receipts = append(receipts, receipt)
-				coalescedLogs = append(coalescedLogs, receipt.Logs...)
 				delete(m, nonce)
 				if len(m) == 0 {
 					// Last tx for the sender
@@ -694,7 +692,7 @@ func (api *RetestethAPI) AccountRange(ctx context.Context,
 		if preimage := accountTrie.GetKey(it.Key); preimage != nil {
 			result.AddressMap[common.BytesToHash(it.Key)] = common.BytesToAddress(preimage)
 			//fmt.Printf("%x: %x\n", it.Key, preimage)
-		} else {
+			// } else {
 			//fmt.Printf("could not find preimage for %x\n", it.Key)
 		}
 	}
@@ -820,7 +818,7 @@ func (api *RetestethAPI) StorageRangeAt(ctx context.Context,
 				Value: string(vs),
 			}
 			//fmt.Printf("Key: %s, Value: %s\n", ks, vs)
-		} else {
+			// } else {
 			//fmt.Printf("Did not find preimage for %x\n", it.Key)
 		}
 	}
@@ -900,7 +898,8 @@ func retesteth(ctx *cli.Context) error {
 		log.Info("HTTP endpoint closed", "url", httpEndpoint)
 	}()
 
-	abortChan := make(chan os.Signal)
+	// the channel used with signal.Notify should be buffered
+	abortChan := make(chan os.Signal, 5)
 	signal.Notify(abortChan, os.Interrupt)
 
 	sig := <-abortChan

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1453,15 +1453,6 @@ func setIstanbul(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	cfg.Istanbul.RoundStateDBPath = stack.ResolvePath(cfg.Istanbul.RoundStateDBPath)
 }
 
-func setAnnounce(ctx *cli.Context, cfg *eth.Config) {
-	cfg.Istanbul.AnnounceGossipPeriod = ctx.GlobalUint64(AnnounceGossipPeriodFlag.Name)
-	if ctx.GlobalIsSet(AnnounceAggressiveGossipOnEnablementFlag.Name) {
-		cfg.Istanbul.AnnounceAggressiveGossipOnEnablement = true
-	} else {
-		cfg.Istanbul.AnnounceAggressiveGossipOnEnablement = istanbul.DefaultConfig.AnnounceAggressiveGossipOnEnablement
-	}
-}
-
 func setProxyP2PConfig(ctx *cli.Context, proxyCfg *p2p.Config) {
 	setNodeKey(ctx, proxyCfg)
 	setNAT(ctx, proxyCfg)

--- a/common/compiler/solidity.go
+++ b/common/compiler/solidity.go
@@ -95,6 +95,7 @@ func CompileSolidityString(solc, source string) (map[string]*Contract, error) {
 		return nil, err
 	}
 	args := append(s.makeArgs(), "--")
+	// #nosec (only used in testing)
 	cmd := exec.Command(s.Path, append(args, "-")...)
 	cmd.Stdin = strings.NewReader(source)
 	return s.run(cmd, source)
@@ -114,6 +115,7 @@ func CompileSolidity(solc string, sourcefiles ...string) (map[string]*Contract, 
 		return nil, err
 	}
 	args := append(s.makeArgs(), "--")
+	// #nosec (used for abigen)
 	cmd := exec.Command(s.Path, append(args, sourcefiles...)...)
 	return s.run(cmd, source)
 }

--- a/common/compiler/vyper.go
+++ b/common/compiler/vyper.go
@@ -83,6 +83,7 @@ func CompileVyper(vyper string, sourcefiles ...string) (map[string]*Contract, er
 		return nil, err
 	}
 	args := s.makeArgs()
+	// #nosec (only used in abigen locally)
 	cmd := exec.Command(s.Path, append(args, sourcefiles...)...)
 	return s.run(cmd, source)
 }

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -115,6 +115,7 @@ func memoryMapAndGenerate(path string, size uint64, generator func(buffer []uint
 		return nil, nil, nil, err
 	}
 	// Create a huge temporary empty file to fill with data
+	// #nosec (we don't use this)
 	temp := path + "." + strconv.Itoa(rand.Int())
 
 	dump, err := os.Create(temp)

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -297,19 +297,6 @@ type announceMsgCachedEntry struct {
 	MsgPayload []byte
 }
 
-// This function will request announce messages from a set of validator addresses from a peer
-func (sb *Backend) sendGetAnnounces(peer consensus.Peer, valAddresses []common.Address) error {
-	logger := sb.logger.New("func", "sendGetAnnounces")
-	valAddressesBytes, err := rlp.EncodeToBytes(valAddresses)
-	if err != nil {
-		logger.Error("Error encoding valAddresses", "valAddresses", common.ConvertToStringSlice(valAddresses), "err", err)
-		return err
-	}
-
-	go peer.Send(istanbulGetAnnouncesMsg, valAddressesBytes)
-	return nil
-}
-
 // This function will reply from a GetAnnounce message.  It will retrieve the requested announce messages
 // from it's announceMsgCache.
 func (sb *Backend) handleGetAnnouncesMsg(peer consensus.Peer, payload []byte) error {

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -449,7 +449,6 @@ func (sb *Backend) Multicast(destAddresses []common.Address, payload []byte, eth
 // Commit implements istanbul.Backend.Commit
 func (sb *Backend) Commit(proposal istanbul.Proposal, aggregatedSeal types.IstanbulAggregatedSeal, aggregatedEpochValidatorSetSeal types.IstanbulEpochValidatorSetSeal) error {
 	// Check if the proposal is a valid block
-	block := &types.Block{}
 	block, ok := proposal.(*types.Block)
 	if !ok {
 		sb.logger.Error("Invalid proposal, %v", proposal)
@@ -495,7 +494,6 @@ func (sb *Backend) EventMux() *event.TypeMux {
 // Verify implements istanbul.Backend.Verify
 func (sb *Backend) Verify(proposal istanbul.Proposal) (time.Duration, error) {
 	// Check if the proposal is a valid block
-	block := &types.Block{}
 	block, ok := proposal.(*types.Block)
 	if !ok {
 		sb.logger.Error("Invalid proposal, %v", proposal)

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -367,11 +367,6 @@ func (rcs *roundChangeSet) String() string {
 		msgsForRoundStr = append(msgsForRoundStr, fmt.Sprintf("%v: %v", r, rms.String()))
 	}
 
-	latestRoundForValStr := make([]string, 0, len(rcs.latestRoundForVal))
-	for addr, r := range rcs.latestRoundForVal {
-		latestRoundForValStr = append(latestRoundForValStr, fmt.Sprintf("%v: %v", addr.String(), r))
-	}
-
 	return fmt.Sprintf("RCS len=%v mode_round=%v mode_round_len=%v unique_rounds=%v %v",
 		len(rcs.latestRoundForVal),
 		modeRound,

--- a/consensus/istanbul/validator/default_test.go
+++ b/consensus/istanbul/validator/default_test.go
@@ -43,7 +43,6 @@ func TestValidatorSet(t *testing.T) {
 }
 
 func testNewValidatorSet(t *testing.T) {
-	var validators []istanbul.Validator
 	const ValCnt = 100
 
 	// Create 100 validators with random addresses
@@ -54,7 +53,6 @@ func testNewValidatorSet(t *testing.T) {
 		blsPublicKey, _ := blscrypto.PrivateToPublic(blsPrivateKey)
 		addr := crypto.PubkeyToAddress(key.PublicKey)
 		val := New(addr, blsPublicKey)
-		validators = append(validators, val)
 		b = append(b, val.Address().Bytes()...)
 		b = append(b, blsPublicKey[:]...)
 	}

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -150,7 +150,7 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 				}
 				// Database contains only older data than the freezer, this happens if the
 				// state was wiped and reinited from an existing freezer.
-			} else {
+				// } else {
 				// Key-value store continues where the freezer left off, all is fine. We might
 				// have duplicate blocks (crash after freezer write but before kay-value store
 				// deletion, but that's fine).
@@ -167,7 +167,7 @@ func NewDatabaseWithFreezer(db ethdb.KeyValueStore, freezer string, namespace st
 					return nil, errors.New("ancient chain segments already extracted, please set --datadir.ancient to the correct path")
 				}
 				// Block #1 is still in the database, we're allowed to init a new feezer
-			} else {
+				// } else {
 				// The head header is still the genesis, we're allowed to init a new feezer
 			}
 		}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -188,10 +188,6 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 		log.Warn("Sanitizing invalid txpool journal time", "provided", conf.Rejournal, "updated", time.Second)
 		conf.Rejournal = time.Second
 	}
-	if conf.PriceLimit < 0 {
-		log.Warn("Sanitizing invalid txpool price limit", "provided", conf.PriceLimit, "updated", DefaultTxPoolConfig.PriceLimit)
-		conf.PriceLimit = DefaultTxPoolConfig.PriceLimit
-	}
 	if conf.PriceBump < 1 {
 		log.Warn("Sanitizing invalid txpool price bump", "provided", conf.PriceBump, "updated", DefaultTxPoolConfig.PriceBump)
 		conf.PriceBump = DefaultTxPoolConfig.PriceBump

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -133,7 +133,6 @@ var mockEVM = &EVM{
 // precompiledTest defines the input/output pairs for precompiled contract tests.
 type precompiledTest struct {
 	input, expected string
-	gas             uint64
 	name            string
 	noBenchmark     bool // Benchmark primarily the worst-cases
 	errorExpected   bool

--- a/core/vm/stack.go
+++ b/core/vm/stack.go
@@ -74,13 +74,6 @@ func (st *Stack) Back(n int) *big.Int {
 	return st.data[st.len()-n-1]
 }
 
-func (st *Stack) require(n int) error {
-	if st.len() < n {
-		return fmt.Errorf("stack underflow (%d <=> %d)", len(st.data), n)
-	}
-	return nil
-}
-
 // Print dumps the content of the stack
 func (st *Stack) Print() {
 	fmt.Println("### stack ###")

--- a/crypto/blake2b/blake2b.go
+++ b/crypto/blake2b/blake2b.go
@@ -302,7 +302,7 @@ func appendUint64(b []byte, x uint64) []byte {
 	return append(b, a[:]...)
 }
 
-func appendUint32(b []byte, x uint32) []byte {
+func appendUint32(b []byte, x uint32) []byte { //nolint:unused
 	var a [4]byte
 	binary.BigEndian.PutUint32(a[:], x)
 	return append(b, a[:]...)
@@ -313,7 +313,7 @@ func consumeUint64(b []byte) ([]byte, uint64) {
 	return b[8:], x
 }
 
-func consumeUint32(b []byte) ([]byte, uint32) {
+func consumeUint32(b []byte) ([]byte, uint32) { //nolint:unused
 	x := binary.BigEndian.Uint32(b)
 	return b[4:], x
 }

--- a/crypto/blake2b/blake2b_generic.go
+++ b/crypto/blake2b/blake2b_generic.go
@@ -25,7 +25,7 @@ var precomputed = [10][16]byte{
 	{10, 8, 7, 1, 2, 4, 6, 5, 15, 9, 3, 13, 11, 14, 12, 0},
 }
 
-func hashBlocksGeneric(h *[8]uint64, c *[2]uint64, flag uint64, blocks []byte) {
+func hashBlocksGeneric(h *[8]uint64, c *[2]uint64, flag uint64, blocks []byte) { //nolint:unused
 	var m [16]uint64
 	c0, c1 := c[0], c[1]
 

--- a/crypto/blake2b/blake2b_test.go
+++ b/crypto/blake2b/blake2b_test.go
@@ -14,14 +14,6 @@ import (
 	"testing"
 )
 
-func fromHex(s string) []byte {
-	b, err := hex.DecodeString(s)
-	if err != nil {
-		panic(err)
-	}
-	return b
-}
-
 func TestHashes(t *testing.T) {
 	defer func(sse4, avx, avx2 bool) {
 		useSSE4, useAVX, useAVX2 = sse4, avx, avx2

--- a/crypto/bn256/cloudflare/gfp_decl.go
+++ b/crypto/bn256/cloudflare/gfp_decl.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/sys/cpu"
 )
 
-//nolint:varcheck
+//nolint:varcheck,unused
 var hasBMI2 = cpu.X86.HasBMI2
 
 // go:noescape

--- a/crypto/bn256/cloudflare/optate.go
+++ b/crypto/bn256/cloudflare/optate.go
@@ -199,9 +199,8 @@ func miller(q *twistPoint, p *curvePoint) *gfP12 {
 	r = newR
 
 	r2.Square(&minusQ2.y)
-	a, b, c, newR = lineFunctionAdd(r, minusQ2, bAffine, r2)
+	a, b, c, _ = lineFunctionAdd(r, minusQ2, bAffine, r2)
 	mulLine(ret, a, b, c)
-	r = newR
 
 	return ret
 }

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -375,7 +375,6 @@ func (dl *downloadTester) dropPeer(id string) {
 type downloadTesterPeer struct {
 	dl            *downloadTester
 	id            string
-	lock          sync.RWMutex
 	chain         *testChain
 	missingStates map[common.Hash]bool // State entries that fast sync should not return
 }

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -54,7 +54,6 @@ type filter struct {
 type PublicFilterAPI struct {
 	backend   Backend
 	mux       *event.TypeMux
-	quit      chan struct{}
 	chainDb   ethdb.Database
 	events    *EventSystem
 	filtersMu sync.Mutex

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -83,20 +83,6 @@ var makeTest = function(tx, rewind) {
 }
 */
 
-// callTrace is the result of a callTracer run.
-type callTrace struct {
-	Type    string          `json:"type"`
-	From    common.Address  `json:"from"`
-	To      common.Address  `json:"to"`
-	Input   hexutil.Bytes   `json:"input"`
-	Output  hexutil.Bytes   `json:"output"`
-	Gas     *hexutil.Uint64 `json:"gas,omitempty"`
-	GasUsed *hexutil.Uint64 `json:"gasUsed,omitempty"`
-	Value   *hexutil.Big    `json:"value,omitempty"`
-	Error   string          `json:"error,omitempty"`
-	Calls   []callTrace     `json:"calls,omitempty"`
-}
-
 func TestPrestateTracerCreate2(t *testing.T) {
 	unsignedTx := types.NewTransaction(1, common.HexToAddress("0x00000000000000000000000000000000deadbeef"), new(big.Int), 5000000, big.NewInt(1), nil, nil, nil, []byte{})
 

--- a/internal/build/download.go
+++ b/internal/build/download.go
@@ -82,7 +82,7 @@ func (db *ChecksumDB) DownloadFile(url, dstPath string) error {
 	fmt.Printf("%s is stale\n", dstPath)
 	fmt.Printf("downloading from %s\n", url)
 
-	// #nosec (internal tool nothing to worry about)
+	// #nosec (Ignoring sanitization warning. Intended to be an arbitrary url.)
 	resp, err := http.Get(url)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download error: code %d, err %v", resp.StatusCode, err)

--- a/internal/build/download.go
+++ b/internal/build/download.go
@@ -82,6 +82,7 @@ func (db *ChecksumDB) DownloadFile(url, dstPath string) error {
 	fmt.Printf("%s is stale\n", dstPath)
 	fmt.Printf("downloading from %s\n", url)
 
+	// #nosec (internal tool nothing to worry about)
 	resp, err := http.Get(url)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download error: code %d, err %v", resp.StatusCode, err)

--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -129,6 +129,7 @@ func render(tpl *template.Template, outputFile string, outputPerm os.FileMode, x
 // because runtime.Version checks on the host should match the tools that are run.
 func GoTool(tool string, args ...string) *exec.Cmd {
 	args = append([]string{tool}, args...)
+	// #nosec (Internal tool. nothing to worry about)
 	return exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"), args...)
 }
 

--- a/internal/build/util.go
+++ b/internal/build/util.go
@@ -129,7 +129,7 @@ func render(tpl *template.Template, outputFile string, outputPerm os.FileMode, x
 // because runtime.Version checks on the host should match the tools that are run.
 func GoTool(tool string, args ...string) *exec.Cmd {
 	args = append([]string{tool}, args...)
-	// #nosec (Internal tool. nothing to worry about)
+	// #nosec (Ignoring sanitization warning. Build tool is intended to take arbitrary arguments.)
 	return exec.Command(filepath.Join(runtime.GOROOT(), "bin", "go"), args...)
 }
 

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	_ "net/http/pprof"
+	_ "net/http/pprof" // #nosec TODO?
 	"os"
 	"runtime"
 

--- a/les/benchmark.go
+++ b/les/benchmark.go
@@ -116,6 +116,7 @@ func (b *benchmarkProofsOrCode) init(h *serverHandler, count int) error {
 
 func (b *benchmarkProofsOrCode) request(peer *peer, index int) error {
 	key := make([]byte, 32)
+	// #nosec (not important)
 	rand.Read(key)
 	if b.code {
 		return peer.RequestCode(0, 0, []CodeReq{{BHash: b.headHash, AccKey: key}})
@@ -179,6 +180,7 @@ func (b *benchmarkTxSend) init(h *serverHandler, count int) error {
 
 	for i := range b.txs {
 		data := make([]byte, txSizeCostLimit)
+		// #nosec (not important)
 		rand.Read(data)
 		tx, err := types.SignTx(types.NewTransaction(0, addr, new(big.Int), 0, new(big.Int), nil, nil, nil, data), signer, key)
 		if err != nil {
@@ -203,6 +205,7 @@ func (b *benchmarkTxStatus) init(h *serverHandler, count int) error {
 
 func (b *benchmarkTxStatus) request(peer *peer, index int) error {
 	var hash common.Hash
+	// #nosec (not important)
 	rand.Read(hash[:])
 	return peer.RequestTxStatus(0, 0, []common.Hash{hash})
 }
@@ -281,6 +284,7 @@ func (h *serverHandler) measure(setup *benchmarkSetup, count int) error {
 	clientMeteredPipe := &meteredPipe{rw: clientPipe}
 	serverMeteredPipe := &meteredPipe{rw: serverPipe}
 	var id enode.ID
+	// #nosec (not important)
 	rand.Read(id[:])
 
 	clientPeer := newPeer(lpv2, NetworkId, false, p2p.NewPeer(id, "client", nil), clientMeteredPipe)

--- a/les/clientpool.go
+++ b/les/clientpool.go
@@ -546,7 +546,7 @@ func (c *clientInfo) updatePriceFactors() {
 }
 
 // getPosBalance retrieves a single positive balance entry from cache or the database
-func (f *clientPool) getPosBalance(id enode.ID) posBalance {
+func (f *clientPool) getPosBalance(id enode.ID) posBalance { //nolint:unused
 	f.lock.Lock()
 	defer f.lock.Unlock()
 

--- a/les/flowcontrol/manager.go
+++ b/les/flowcontrol/manager.go
@@ -58,10 +58,9 @@ var (
 // corrigated buffer value and usually allows a higher remaining buffer value
 // to be returned with each reply.
 type ClientManager struct {
-	clock     mclock.Clock
-	lock      sync.Mutex
-	enabledCh chan struct{}
-	stop      chan chan struct{}
+	clock mclock.Clock
+	lock  sync.Mutex
+	stop  chan chan struct{}
 
 	curve                                      PieceWiseLinear
 	sumRecharge, totalRecharge, totalConnected uint64

--- a/les/peer.go
+++ b/les/peer.go
@@ -311,11 +311,6 @@ func (p *peer) updateCapacity(cap uint64) {
 	p.queueSend(func() { p.SendAnnounce(announceData{Update: kvList}) })
 }
 
-func (p *peer) responseID() uint64 {
-	p.responseCount += 1
-	return p.responseCount
-}
-
 func sendRequest(w p2p.MsgWriter, msgcode, reqID, cost uint64, data interface{}) error {
 	type req struct {
 		ReqID uint64

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -667,7 +667,6 @@ const (
 // poolEntry represents a server node and stores its current state and statistics.
 type poolEntry struct {
 	peer                  *peer
-	pubkey                [64]byte // secp256k1 key of the node
 	addr                  map[string]*poolEntryAddress
 	node                  *enode.Node
 	lastConnected, dialed *poolEntryAddress

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -110,7 +110,6 @@ type testWorkerBackend struct {
 	db             ethdb.Database
 	txPool         *core.TxPool
 	chain          *core.BlockChain
-	testTxFeed     event.Feed
 	genesis        *core.Genesis
 	uncleBlock     *types.Block
 }

--- a/node/config.go
+++ b/node/config.go
@@ -195,7 +195,6 @@ type Config struct {
 
 	staticNodesWarning     bool
 	trustedNodesWarning    bool
-	proxiedNodesWarning    bool
 	oldGethResourceWarning bool
 }
 

--- a/p2p/discover/table.go
+++ b/p2p/discover/table.go
@@ -77,9 +77,8 @@ type Table struct {
 	refreshReq chan chan struct{}
 	initDone   chan struct{}
 
-	closeOnce sync.Once
-	closeReq  chan struct{}
-	closed    chan struct{}
+	closeReq chan struct{}
+	closed   chan struct{}
 
 	nodeAddedHook func(*node) // for testing
 }

--- a/p2p/discover/table_util_test.go
+++ b/p2p/discover/table_util_test.go
@@ -130,7 +130,6 @@ func (t *pingRecorder) updateRecord(n *enode.Node) {
 func (t *pingRecorder) Self() *enode.Node           { return nullNode }
 func (t *pingRecorder) lookupSelf() []*enode.Node   { return nil }
 func (t *pingRecorder) lookupRandom() []*enode.Node { return nil }
-func (t *pingRecorder) close()                      {}
 
 // ping simulates a ping request.
 func (t *pingRecorder) ping(n *enode.Node) (seq uint64, err error) {

--- a/p2p/discv5/ticket.go
+++ b/p2p/discv5/ticket.go
@@ -697,6 +697,7 @@ func globalRandRead(b []byte) {
 	val := 0
 	for n := 0; n < len(b); n++ {
 		if pos == 0 {
+			// #nosec TODO?
 			val = rand.Int()
 			pos = 7
 		}

--- a/p2p/simulations/adapters/exec.go
+++ b/p2p/simulations/adapters/exec.go
@@ -386,6 +386,7 @@ func execP2PNode() {
 
 	// Send status to the host.
 	statusJSON, _ := json.Marshal(status)
+	// #nosec (we don't use this)
 	if _, err := http.Post(statusURL, "application/json", bytes.NewReader(statusJSON)); err != nil {
 		log.Crit("Can't post startup info", "url", statusURL, "err", err)
 	}

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -354,7 +354,7 @@ type tailUint struct {
 type tailPrivateFields struct {
 	A    uint
 	Tail []uint `rlp:"tail"`
-	x, y bool   //lint:ignore U1000 unused fields required for testing purposes.
+	x, y bool   //nolint:unused // fields required for testing purposes
 }
 
 type nilListUint struct {

--- a/trie/database.go
+++ b/trie/database.go
@@ -278,7 +278,7 @@ func expandNode(hash hashNode, n node) node {
 //
 // Since trie keys are already hashes, we can just use the key directly to
 // map shard id.
-type trienodeHasher struct{}
+type trienodeHasher struct{} //nolint:unused
 
 // Sum64 implements the bigcache.Hasher interface.
 func (t trienodeHasher) Sum64(key string) uint64 {

--- a/whisper/whisperv6/message.go
+++ b/whisper/whisperv6/message.go
@@ -218,6 +218,7 @@ func generateSecureRandomData(length int) ([]byte, error) {
 	} else if !validateDataIntegrity(x, length) {
 		return nil, errors.New("crypto/rand failed to generate secure random data")
 	}
+	// #nosec (we don't use this)
 	_, err = mrand.Read(y)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description

Adds gosec as a linter. For now we ignore all current issues seems they don't seem important for our current usage.

Still is useful to add it, so we can't check future code

### Tested

* CI

### Related issues

- Related to #848 

### Backwards compatibility

Yes