### PR TITLE
Fix dumpconfig

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -160,7 +160,7 @@ type TxPoolConfig struct {
 
 	Lifetime time.Duration // Maximum amount of time non-executable transaction are queued
 
-	CurrencyAddresses *[]common.Address // The addresses of all the currencies that are accepted by the node
+	CurrencyAddresses *[]common.Address `toml:",omitempty"` // The addresses of all the currencies that are accepted by the node
 }
 
 // DefaultTxPoolConfig contains the default configurations for the transaction


### PR DESCRIPTION
### Description

Running dumpconfig on any configuration was failing with the error
message: `toml: cannot marshal nil *[]common.Address`. 

This commit fixes the issue by simply adding the `omitempty` flag, which skips
the field if it is empty. With this commit, `dumpconfig` successfully outputs a TOML
file specifying the current geth config.

There have been several similar issues in the upstream go-ethereum repository: https://github.com/ethereum/go-ethereum/issues/19824, solved by commits https://github.com/ethereum/go-ethereum/pull/19825/commits/66a6cbe4a4e63da4801f7f3927d17f142f85c204 and https://github.com/ethereum/go-ethereum/commit/226aef18c888049b5e82e05f0c063c91cc3dfc45 in a very similar way to what is done here. 

### Tested

- Build from source (`make geth`)
- `./build/bin/geth dumpconfig` successfully outputs TOML