### PR TITLE
Continue to distribute rewards if a single validator fails

### DIFF
--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -153,7 +153,8 @@ func (sb *Backend) distributeValidatorRewards(header *types.Header, state *state
 		sb.logger.Debug("Distributing epoch reward for validator", "address", val.Address())
 		validatorReward, err := validators.DistributeEpochReward(header, state, val.Address(), maxReward)
 		if err != nil {
-			return totalValidatorRewards, nil
+			sb.logger.Error("Error in distributing rewards to validator", "address", val.Address(), "err", err)
+			continue
 		}
 		totalValidatorRewards.Add(totalValidatorRewards, validatorReward)
 	}


### PR DESCRIPTION
### Description

Currently if distributing rewards to an individual validator fails, reward distribution to other validators stops, without error. This PR changes that to log an error and continue instead.

### Tested

E2e tests

### Related issues

- Related https://github.com/celo-org/celo-labs/issues/306

### Backwards compatibility

Potentially a hard-fork
