### PR TITLE
Decrease announce validator set size

### DIFF
--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -472,7 +472,7 @@ func (sb *Backend) handleAnnounceMsg(peer consensus.Peer, payload []byte) error 
 		return err
 	}
 
-	// If this is a registered or elected validator, then process the announce message
+	// If this is an elected or nearly elected validator, then process the announce message
 	shouldProcessAnnounce, err := sb.shouldGenerateAndProcessAnnounce()
 	if err != nil {
 		logger.Warn("Error in checking if should process announce", err)

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -828,6 +828,8 @@ func (sb *Backend) ConnectToVals() {
 }
 
 func (sb *Backend) retrieveValidatorConnSet() (map[common.Address]bool, error) {
+	logger := sb.logger.New("func", "retrieveValidatorConnSet")
+
 	sb.cachedValidatorConnSetMu.Lock()
 	defer sb.cachedValidatorConnSetMu.Unlock()
 
@@ -850,10 +852,9 @@ func (sb *Backend) retrieveValidatorConnSet() (map[common.Address]bool, error) {
 	// The validator contract may not be deployed yet.
 	// Even if it is deployed, it may not have any registered validators yet.
 	if err == comm_errors.ErrSmartContractNotDeployed || err == comm_errors.ErrRegistryContractNotDeployed {
-		sb.logger.Trace("Can't elect N validators.  Only allowing the initial validator set to send announce messages", "err", err)
+		logger.Trace("Can't elect N validators because smart contract not deployed. Setting validator conn set to current elected validators.", "err", err)
 	} else if err != nil {
-		sb.logger.Error("Error in electing N validators", "err", err)
-		return validatorsSet, err
+		logger.Error("Error in electing N validators. Setting validator conn set to current elected validators", "err", err)
 	}
 
 	for _, address := range electNValidators {
@@ -868,6 +869,8 @@ func (sb *Backend) retrieveValidatorConnSet() (map[common.Address]bool, error) {
 
 	sb.cachedValidatorConnSet = validatorsSet
 	sb.cachedValidatorConnSetTimestamp = time.Now()
+
+	logger.Trace("Returning validator conn set", "validatorsSet", validatorsSet)
 
 	return validatorsSet, nil
 }

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -849,7 +849,7 @@ func (sb *Backend) retrieveValidatorConnSet() (map[common.Address]bool, error) {
 
 	// The validator contract may not be deployed yet.
 	// Even if it is deployed, it may not have any registered validators yet.
-	if err == comm_errors.ErrSmartContractNotDeployed {
+	if err == comm_errors.ErrSmartContractNotDeployed || err == comm_errors.ErrRegistryContractNotDeployed {
 		sb.logger.Trace("Can't elect N validators.  Only allowing the initial validator set to send announce messages", "err", err)
 	} else if err != nil {
 		sb.logger.Error("Error in electing N validators", "err", err)

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	// Announce Configs
 	AnnounceGossipPeriod                 uint64 `toml:",omitempty"` // Time duration (in seconds) between gossiped announce messages
 	AnnounceAggressiveGossipOnEnablement bool   `toml:",omitempty"` // Specifies if this node should do aggressive gossip on announce enablement
+	AnnounceAdditionalValidatorsToGossip int64  `toml:",omitempty"` // Specifies the number of additional non-elected validators to gossip an announce
 }
 
 var DefaultConfig = &Config{
@@ -70,4 +71,5 @@ var DefaultConfig = &Config{
 	Proxied:                              false,
 	AnnounceGossipPeriod:                 600,
 	AnnounceAggressiveGossipOnEnablement: false,
+	AnnounceAdditionalValidatorsToGossip: 10,
 }

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -451,8 +451,6 @@ func (c *core) startNewRound(round *big.Int) error {
 		c.roundChangeSet = newRoundChangeSet(valSet)
 	}
 
-	logger = logger.New("old_proposer", c.current.Proposer())
-
 	// Calculate new proposer
 	nextProposer := c.selectProposer(valSet, headAuthor, newView.Round.Uint64())
 	err := c.resetRoundState(newView, valSet, nextProposer, roundChange)
@@ -471,7 +469,7 @@ func (c *core) startNewRound(round *big.Int) error {
 	c.resetRoundChangeTimer()
 
 	// Some round info will have changed.
-	logger = c.newLogger("func", "startNewRound", "tag", "stateTransition")
+	logger = c.newLogger("func", "startNewRound", "tag", "stateTransition", "old_proposer", c.current.Proposer())
 	logger.Debug("New round", "new_round", newView.Round, "new_seq", newView.Sequence, "new_proposer", c.current.Proposer(), "valSet", c.current.ValidatorSet().List(), "size", c.current.ValidatorSet().Size(), "isProposer", c.isProposer())
 	return nil
 }

--- a/contract_comm/election/election.go
+++ b/contract_comm/election/election.go
@@ -179,6 +179,7 @@ func ElectNValidatorSigners(header *types.Header, state vm.StateDB, additionalAb
 	if err != nil {
 		return nil, err
 	}
+	log.Info("getElectableValidators called", "minElectableValidators", minElectableValidators, "maxElectableValidators", maxElectableValidators)
 
 	var electedValidators []common.Address
 	// Run the validator election for up to maxElectable + getTotalVotesForEligibleValidatorGroups
@@ -186,6 +187,7 @@ func ElectNValidatorSigners(header *types.Header, state vm.StateDB, additionalAb
 	if err != nil {
 		return nil, err
 	}
+	log.Info("electNValidatorSigners called", "electedValidators length", len(electedValidators))
 
 	return electedValidators, nil
 

--- a/contract_comm/election/election.go
+++ b/contract_comm/election/election.go
@@ -114,7 +114,48 @@ const electionABIString string = `[
       "payable": false,
       "stateMutability": "view",
       "type": "function"
-    }
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "minElectableValidators",
+          "type": "uint256"
+        },
+        {
+          "name": "maxElectableValidators",
+          "type": "uint256"
+        }
+      ],
+      "name": "electNValidatorSigners",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address[]"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "getElectableValidators",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },    
 ]`
 
 var electionABI, _ = abi.JSON(strings.NewReader(electionABIString))
@@ -127,6 +168,27 @@ func GetElectedValidators(header *types.Header, state vm.StateDB) ([]common.Addr
 		return nil, err
 	}
 	return newValSet, nil
+}
+
+func ElectNValidatorSigners(header *types.Header, state vm.StateDB, additionalAboveMaxElectable int64) ([]common.Address, error) {
+        var minElectableValidators *big.Int
+        var maxElectableValidators *big.Int
+
+	// Get the electable min and max
+	_, err := contract_comm.MakeStaticCall(params.ElectionRegistryId, electionABI, "getElectableValidators", []interface{}{}, &[]interface{}{&minElectableValidators, &maxElectableValidators}, params.MaxGasForGetElectableValidators, header, state)
+	if err != nil {
+	        return nil, err
+	}
+
+	var electedValidators []common.Address
+	// Run the validator election for up to maxElectable + getTotalVotesForEligibleValidatorGroups
+	_, err = contract_comm.MakeStaticCall(params.ElectionRegistryId, electionABI, "electNValidatorSigners", []interface{}{minElectableValidators, maxElectableValidators.Add(maxElectableValidators, big.NewInt(additionalAboveMaxElectable))}, &electedValidators, params.MaxGasForElectNValidatorSigners, header, state)
+	if err != nil {
+	        return nil, err
+	}
+
+	return electedValidators, nil
+	
 }
 
 type voteTotal struct {

--- a/contract_comm/election/election.go
+++ b/contract_comm/election/election.go
@@ -182,7 +182,8 @@ func ElectNValidatorSigners(header *types.Header, state vm.StateDB, additionalAb
 	log.Info("getElectableValidators called", "minElectableValidators", minElectableValidators, "maxElectableValidators", maxElectableValidators)
 
 	var electedValidators []common.Address
-	// Run the validator election for up to maxElectable + getTotalVotesForEligibleValidatorGroups
+	// Run the validator election for up to maxElectable + getTotalVotesForEligibleValidatorGroup
+	log.Info("calling electNValidatorSigners", "minElectableValidators", minElectableValidators.Int64(), "maxElectableValidator", maxElectableValidators.Add(maxElectableValidators, big.NewInt(additionalAboveMaxElectable)).Int64())
 	_, err = contract_comm.MakeStaticCall(params.ElectionRegistryId, electionABI, "electNValidatorSigners", []interface{}{minElectableValidators, maxElectableValidators.Add(maxElectableValidators, big.NewInt(additionalAboveMaxElectable))}, &electedValidators, params.MaxGasForElectNValidatorSigners, header, state)
 	if err != nil {
 		return nil, err

--- a/contract_comm/election/election.go
+++ b/contract_comm/election/election.go
@@ -179,16 +179,13 @@ func ElectNValidatorSigners(header *types.Header, state vm.StateDB, additionalAb
 	if err != nil {
 		return nil, err
 	}
-	log.Info("getElectableValidators called", "minElectableValidators", minElectableValidators, "maxElectableValidators", maxElectableValidators)
 
 	var electedValidators []common.Address
 	// Run the validator election for up to maxElectable + getTotalVotesForEligibleValidatorGroup
-	log.Info("calling electNValidatorSigners", "minElectableValidators", minElectableValidators.Int64(), "maxElectableValidator", maxElectableValidators.Add(maxElectableValidators, big.NewInt(additionalAboveMaxElectable)).Int64())
 	_, err = contract_comm.MakeStaticCall(params.ElectionRegistryId, electionABI, "electNValidatorSigners", []interface{}{minElectableValidators, maxElectableValidators.Add(maxElectableValidators, big.NewInt(additionalAboveMaxElectable))}, &electedValidators, params.MaxGasForElectNValidatorSigners, header, state)
 	if err != nil {
 		return nil, err
 	}
-	log.Info("electNValidatorSigners called", "electedValidators length", len(electedValidators))
 
 	return electedValidators, nil
 

--- a/contract_comm/election/election.go
+++ b/contract_comm/election/election.go
@@ -171,24 +171,24 @@ func GetElectedValidators(header *types.Header, state vm.StateDB) ([]common.Addr
 }
 
 func ElectNValidatorSigners(header *types.Header, state vm.StateDB, additionalAboveMaxElectable int64) ([]common.Address, error) {
-        var minElectableValidators *big.Int
-        var maxElectableValidators *big.Int
+	var minElectableValidators *big.Int
+	var maxElectableValidators *big.Int
 
 	// Get the electable min and max
 	_, err := contract_comm.MakeStaticCall(params.ElectionRegistryId, electionABI, "getElectableValidators", []interface{}{}, &[]interface{}{&minElectableValidators, &maxElectableValidators}, params.MaxGasForGetElectableValidators, header, state)
 	if err != nil {
-	        return nil, err
+		return nil, err
 	}
 
 	var electedValidators []common.Address
 	// Run the validator election for up to maxElectable + getTotalVotesForEligibleValidatorGroups
 	_, err = contract_comm.MakeStaticCall(params.ElectionRegistryId, electionABI, "electNValidatorSigners", []interface{}{minElectableValidators, maxElectableValidators.Add(maxElectableValidators, big.NewInt(additionalAboveMaxElectable))}, &electedValidators, params.MaxGasForElectNValidatorSigners, header, state)
 	if err != nil {
-	        return nil, err
+		return nil, err
 	}
 
 	return electedValidators, nil
-	
+
 }
 
 type voteTotal struct {

--- a/contract_comm/election/election.go
+++ b/contract_comm/election/election.go
@@ -155,7 +155,7 @@ const electionABIString string = `[
       "payable": false,
       "stateMutability": "view",
       "type": "function"
-    },    
+    }
 ]`
 
 var electionABI, _ = abi.JSON(strings.NewReader(electionABIString))

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -207,7 +207,9 @@ const (
 	MaxGasForDistributeEpochPayment                uint64 = 1 * 1000000
 	MaxGasForDistributeEpochRewards                uint64 = 1 * 1000000
 	MaxGasForElectValidators                       uint64 = 50 * 1000000
+	MaxGasForElectNValidatorSigners                uint64 = 50 * 1000000
 	MaxGasForGetAddressFor                         uint64 = 1 * 100000
+	MaxGasForGetElectableValidators                uint64 = 1 * 100000
 	MaxGasForGetEligibleValidatorGroupsVoteTotals  uint64 = 1 * 1000000
 	MaxGasForGetGasPriceMinimum                    uint64 = 2000000
 	MaxGasForGetGroupEpochRewards                  uint64 = 500 * 1000


### PR DESCRIPTION
### Description

Currently, all registered validators will broadcast their enodeURL to all other registered validators and currently elected validators.

To decrease the exposure of those enodeURLs, this PR contains changes so that the enodeURL is broadcast to the next threshold's elected validators + 10 validators that are just below the election cutoff.

### Tested

* e2e CI tests.
* Ran a testnet with 10 elected validators and 30 registered validators, and verified that the enodeURL is shared with only 20 nodes.

### Other changes

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Yes.