### PR TITLE
Pay epoch rewards to carbon offsetting partner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
       GO_VERSION: "1.13.7"
-      CELO_MONOREPO_BRANCH_TO_TEST: jfoutts/carbon-offsetting-fund
+      CELO_MONOREPO_BRANCH_TO_TEST: master
 jobs:
   build-bls-zexe:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
       GO_VERSION: "1.13.7"
-      CELO_MONOREPO_BRANCH_TO_TEST: master
+      CELO_MONOREPO_BRANCH_TO_TEST: jfoutts/carbon-offsetting-fund
 jobs:
   build-bls-zexe:
     docker:

--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -46,7 +46,7 @@ func (sb *Backend) distributeEpochRewards(header *types.Header, state *state.Sta
 	if err != nil {
 		return err
 	}
-	validatorReward, totalVoterRewards, communityReward, err := epoch_rewards.CalculateTargetEpochRewards(header, state)
+	validatorReward, totalVoterRewards, communityReward, carbonOffsettingPartnerReward, err := epoch_rewards.CalculateTargetEpochRewards(header, state)
 	if err != nil {
 		return err
 	}
@@ -100,8 +100,19 @@ func (sb *Backend) distributeEpochRewards(header *types.Header, state *state.Sta
 		return errors.New("Unable to fetch reserve address for epoch rewards distribution")
 	}
 
+	carbonOffsettingPartnerAddress, err := epoch_rewards.GetCarbonOffsettingPartnerAddress(header, state)
+	if err != nil {
+		return err
+	}
+	if carbonOffsettingPartnerAddress != common.ZeroAddress {
+		state.AddBalance(carbonOffsettingPartnerAddress, carbonOffsettingPartnerReward)
+	} else {
+		carbonOffsettingPartnerReward = big.NewInt(0)
+	}
+
 	mintedGold := big.NewInt(0).Add(totalDistributedVoterRewards, totalValidatorRewardsConvertedToGold)
 	mintedGold.Add(mintedGold, totalCommunityRewards)
+	mintedGold.Add(mintedGold, carbonOffsettingPartnerReward)
 	return sb.increaseGoldTokenTotalSupply(header, state, mintedGold)
 }
 

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -451,8 +451,6 @@ func (c *core) startNewRound(round *big.Int) error {
 		c.roundChangeSet = newRoundChangeSet(valSet)
 	}
 
-	logger = logger.New("old_proposer", c.current.Proposer())
-
 	// Calculate new proposer
 	nextProposer := c.selectProposer(valSet, headAuthor, newView.Round.Uint64())
 	err := c.resetRoundState(newView, valSet, nextProposer, roundChange)

--- a/contract_comm/epoch_rewards/epoch_rewards.go
+++ b/contract_comm/epoch_rewards/epoch_rewards.go
@@ -45,6 +45,24 @@ const epochRewardsABIString string = `[
         {
           "name": "",
           "type": "uint256"
+        },
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    { 
+      "constant": true,
+      "inputs": [],
+      "name": "carbonOffsettingPartner",
+      "outputs": [
+        { 
+          "name": "",
+          "type": "address"
         }
       ],
       "payable": false,
@@ -84,17 +102,18 @@ func UpdateTargetVotingYield(header *types.Header, state vm.StateDB) error {
 	return err
 }
 
-// Returns the per validator epoch reward, the total voter reward, and the total community reward
-// for the epoch.
-func CalculateTargetEpochRewards(header *types.Header, state vm.StateDB) (*big.Int, *big.Int, *big.Int, error) {
+// Returns the per validator epoch reward, the total voter reward, the total community reward, and
+// the total carbon offsetting partner award, for the epoch.
+func CalculateTargetEpochRewards(header *types.Header, state vm.StateDB) (*big.Int, *big.Int, *big.Int, *big.Int, error) {
 	var validatorEpochReward *big.Int
 	var totalVoterRewards *big.Int
 	var totalCommunityReward *big.Int
-	_, err := contract_comm.MakeStaticCall(params.EpochRewardsRegistryId, epochRewardsABI, "calculateTargetEpochRewards", []interface{}{}, &[]interface{}{&validatorEpochReward, &totalVoterRewards, &totalCommunityReward}, params.MaxGasForCalculateTargetEpochPaymentAndRewards, header, state)
+	var totalCarbonOffsettingPartnerReward *big.Int
+	_, err := contract_comm.MakeStaticCall(params.EpochRewardsRegistryId, epochRewardsABI, "calculateTargetEpochRewards", []interface{}{}, &[]interface{}{&validatorEpochReward, &totalVoterRewards, &totalCommunityReward, &totalCarbonOffsettingPartnerReward}, params.MaxGasForCalculateTargetEpochPaymentAndRewards, header, state)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
-	return validatorEpochReward, totalVoterRewards, totalCommunityReward, nil
+	return validatorEpochReward, totalVoterRewards, totalCommunityReward, totalCarbonOffsettingPartnerReward, nil
 }
 
 // Determines if the reserve is below it's critical threshold
@@ -105,4 +124,14 @@ func IsReserveLow(header *types.Header, state vm.StateDB) (bool, error) {
 		return false, err
 	}
 	return isLow, nil
+}
+
+// Returns the address of the carbon offsetting partner
+func GetCarbonOffsettingPartnerAddress(header *types.Header, state vm.StateDB) (common.Address, error) {
+	var carbonOffsettingPartner common.Address
+	_, err := contract_comm.MakeStaticCall(params.EpochRewardsRegistryId, epochRewardsABI, "carbonOffsettingPartner", []interface{}{}, &carbonOffsettingPartner, params.MaxGasForIsReserveLow, header, state)
+	if err != nil {
+		return common.ZeroAddress, err
+	}
+	return carbonOffsettingPartner, nil
 }

--- a/contract_comm/epoch_rewards/epoch_rewards.go
+++ b/contract_comm/epoch_rewards/epoch_rewards.go
@@ -129,7 +129,7 @@ func IsReserveLow(header *types.Header, state vm.StateDB) (bool, error) {
 // Returns the address of the carbon offsetting partner
 func GetCarbonOffsettingPartnerAddress(header *types.Header, state vm.StateDB) (common.Address, error) {
 	var carbonOffsettingPartner common.Address
-	_, err := contract_comm.MakeStaticCall(params.EpochRewardsRegistryId, epochRewardsABI, "carbonOffsettingPartner", []interface{}{}, &carbonOffsettingPartner, params.MaxGasForIsReserveLow, header, state)
+	_, err := contract_comm.MakeStaticCall(params.EpochRewardsRegistryId, epochRewardsABI, "carbonOffsettingPartner", []interface{}{}, &carbonOffsettingPartner, params.MaxGasForGetCarbonOffsettingPartner, header, state)
 	if err != nil {
 		return common.ZeroAddress, err
 	}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -230,4 +230,5 @@ const (
 	MaxGasForTotalSupply                           uint64 = 50 * 1000
 	MaxGasToReadErc20Balance                       uint64 = 100000
 	MaxGasForIsReserveLow                          uint64 = 1000000
+	MaxGasForGetCarbonOffsettingPartner            uint64 = 20000
 )


### PR DESCRIPTION
### Description

Adds epoch payments to carbon offsetting partner as described in design doc.

### Tested

Added e2e test for carbon offsetting partner payment.

### Related issues

- Part of Epic #2670 Epoch rewards implementation matches design doc

### Backwards compatibility

No, changes the expectation of the smart contract interface.
