### PR TITLE
fixed double connect on node start

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -274,7 +274,7 @@ func (s *Service) loop() {
 			wallet, err := s.eth.AccountManager().Find(accounts.Account{Address: s.etherBase})
 			if err != nil {
 				break
-			}]
+			}
 
 			if status, _ := wallet.Status(); status == "Unlocked" {
 				// Resolve the URL, defaulting to TLS, but falling back to none too


### PR DESCRIPTION
### Description

When a node is started it will start connecting to celostats, if it connects to celostats with an locked account it will fail to connect. Therefore every nodes does two connection attempts which creates a lot of noise on celostats.

### Tested

Tested by running a local testnet with celotool and celostats locally

### Backwards compatibility

It should not. break anything
