### PR TITLE
Benchmarking precompiles, setting other parameters

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"math"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -361,7 +362,12 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 	} else {
 		// Increment the nonce for the next transaction
 		st.state.SetNonce(msg.From(), st.state.GetNonce(sender.Address())+1)
+		start := time.Now()
+		gas := st.gas
 		ret, st.gas, vmerr = evm.Call(sender, st.to(), st.data, st.gas, st.value)
+		t := time.Now()
+		elapsed := t.Sub(start)
+		log.Warn("Call took", "time", elapsed, "gas", gas-st.gas, "gasPerTime", float64(gas-st.gas)/elapsed.Seconds())
 	}
 	if vmerr != nil {
 		log.Debug("VM returned with error", "err", vmerr)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"math"
 	"math/big"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -362,12 +361,7 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 	} else {
 		// Increment the nonce for the next transaction
 		st.state.SetNonce(msg.From(), st.state.GetNonce(sender.Address())+1)
-		start := time.Now()
-		gas := st.gas
 		ret, st.gas, vmerr = evm.Call(sender, st.to(), st.data, st.gas, st.value)
-		t := time.Now()
-		elapsed := t.Sub(start)
-		log.Warn("Call took", "time", elapsed, "gas", gas-st.gas, "gasPerTime", float64(gas-st.gas)/elapsed.Seconds())
 	}
 	if vmerr != nil {
 		log.Debug("VM returned with error", "err", vmerr)

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -564,13 +564,16 @@ func (c *transfer) Run(input []byte, caller common.Address, evm *EVM, gas uint64
 type fractionMulExp struct{}
 
 func max(x, y int64) int64 {
-    if x < y {
-        return y
-    }
-    return x
+	if x < y {
+		return y
+	}
+	return x
 }
 
 func (c *fractionMulExp) RequiredGas(input []byte) uint64 {
+	if len(input) < 192 {
+		return params.FractionMulExpGas
+	}
 	exponent, parsed := math.ParseBig256(hexutil.Encode(input[128:160]))
 	if !parsed {
 		return params.FractionMulExpGas
@@ -591,9 +594,9 @@ func (c *fractionMulExp) RequiredGas(input []byte) uint64 {
 
 	gas := params.FractionMulExpGas
 
-	for ; numbers > 10 ; {
+	for numbers > 10 {
 		gas = gas * 3
-		numbers = numbers/2
+		numbers = numbers / 2
 	}
 
 	return gas

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -563,8 +563,40 @@ func (c *transfer) Run(input []byte, caller common.Address, evm *EVM, gas uint64
 // computes a * (b ^ exponent) to `decimals` places of precision, where a and b are fractions
 type fractionMulExp struct{}
 
+func max(x, y int64) int64 {
+    if x < y {
+        return y
+    }
+    return x
+}
+
 func (c *fractionMulExp) RequiredGas(input []byte) uint64 {
-	return params.FractionMulExpGas
+	exponent, parsed := math.ParseBig256(hexutil.Encode(input[128:160]))
+	if !parsed {
+		return params.FractionMulExpGas
+	}
+	decimals, parsed := math.ParseBig256(hexutil.Encode(input[160:192]))
+	if !parsed {
+		return params.FractionMulExpGas
+	}
+	if !decimals.IsInt64() || !exponent.IsInt64() {
+		return params.FractionMulExpGas
+	}
+
+	numbers := max(decimals.Int64(), exponent.Int64())
+
+	if numbers > 100000 {
+		return params.FractionMulExpGas
+	}
+
+	gas := params.FractionMulExpGas
+
+	for ; numbers > 10 ; {
+		gas = gas * 3
+		numbers = numbers/2
+	}
+
+	return gas
 }
 
 func (c *fractionMulExp) Run(input []byte, caller common.Address, evm *EVM, gas uint64) ([]byte, uint64, error) {
@@ -621,6 +653,10 @@ func (c *fractionMulExp) Run(input []byte, caller common.Address, evm *EVM, gas 
 	// Handle passing of zero denominators
 	if aDenominator == big.NewInt(0) || bDenominator == big.NewInt(0) {
 		return nil, gas, fmt.Errorf("Input Error: Denominator of zero provided!")
+	}
+
+	if !decimals.IsInt64() || !exponent.IsInt64() || max(decimals.Int64(), exponent.Int64()) > 100000 {
+		return nil, gas, fmt.Errorf("Input Error: Decimals or exponent too large")
 	}
 
 	numeratorExp := new(big.Int).Mul(aNumerator, new(big.Int).Exp(bNumerator, exponent, nil))

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -138,14 +138,13 @@ const (
 	// Celo precompiled contracts
 	// TODO: make this cost variable- https://github.com/celo-org/geth/issues/250
 	FractionMulExpGas uint64 = 1050 // Cost of performing multiplication and exponentiation of fractions to an exponent of up to 10^3.
-	// TODO(kobigurk):  Figure out what the actual gas cost of this contract should be.
-	ProofOfPossessionGas        uint64 = 50000 // Cost of verifying a BLS proof of possession.
-	GetValidatorGas             uint64 = 5000  // Cost of reading a validator's address.
-	GetEpochSizeGas             uint64 = 1000  // Cost of querying the number of blocks in an epoch.
-	GetBlockNumberFromHeaderGas uint64 = 10000 // Cost of decoding a block header.
-	HashHeaderGas               uint64 = 20000 // Cost of hashing a block header.
-	GetParentSealBitmapGas      uint64 = 500   // Cost of reading the parent seal bitmap from the chain.
-	GetVerifiedSealBitmapGas    uint64 = 55000 // Cost of verifying the seal on a given RLP encoded header.
+	ProofOfPossessionGas        uint64 = 350000 // Cost of verifying a BLS proof of possession.
+	GetValidatorGas             uint64 = 10     // Cost of reading a validator's address.
+	GetEpochSizeGas             uint64 = 10     // Cost of querying the number of blocks in an epoch.
+	GetBlockNumberFromHeaderGas uint64 = 10000  // Cost of decoding a block header.
+	HashHeaderGas               uint64 = 20000  // Cost of hashing a block header.
+	GetParentSealBitmapGas      uint64 = 100    // Cost of reading the parent seal bitmap from the chain.
+	GetVerifiedSealBitmapGas    uint64 = 55000  // Cost of verifying the seal on a given RLP encoded header.
 )
 
 var (

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -136,7 +136,7 @@ const (
 	Bn256PairingPerPointGasIstanbul  uint64 = 34000  // Per-point price for an elliptic curve pairing check
 
 	// Celo precompiled contracts
-	FractionMulExpGas           uint64 = 50   // Cost of performing multiplication and exponentiation of fractions to an exponent of up to 10^3.
+	FractionMulExpGas           uint64 = 50     // Cost of performing multiplication and exponentiation of fractions to an exponent of up to 10^3.
 	FractionMulExpExtraGas      uint64 = 1050   // Cost for extra bits
 	ProofOfPossessionGas        uint64 = 350000 // Cost of verifying a BLS proof of possession.
 	GetValidatorGas             uint64 = 10     // Cost of reading a validator's address.
@@ -145,7 +145,7 @@ const (
 	HashHeaderGas               uint64 = 10     // Cost of hashing a block header.
 	GetParentSealBitmapGas      uint64 = 100    // Cost of reading the parent seal bitmap from the chain.
 	// May take a bit more time with 100 validators, need to bench that
-	GetVerifiedSealBitmapGas    uint64 = 350000 // Cost of verifying the seal on a given RLP encoded header.
+	GetVerifiedSealBitmapGas uint64 = 350000 // Cost of verifying the seal on a given RLP encoded header.
 )
 
 var (

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -138,7 +138,7 @@ const (
 	// Celo precompiled contracts
 	FractionMulExpGas           uint64 = 50     // Cost of performing multiplication and exponentiation of fractions to an exponent of up to 10^3.
 	ProofOfPossessionGas        uint64 = 350000 // Cost of verifying a BLS proof of possession.
-	GetValidatorGas             uint64 = 10     // Cost of reading a validator's address.
+	GetValidatorGas             uint64 = 1000     // Cost of reading a validator's address.
 	GetEpochSizeGas             uint64 = 10     // Cost of querying the number of blocks in an epoch.
 	GetBlockNumberFromHeaderGas uint64 = 10     // Cost of decoding a block header.
 	HashHeaderGas               uint64 = 10     // Cost of hashing a block header.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -137,7 +137,6 @@ const (
 
 	// Celo precompiled contracts
 	FractionMulExpGas           uint64 = 50     // Cost of performing multiplication and exponentiation of fractions to an exponent of up to 10^3.
-	FractionMulExpExtraGas      uint64 = 1050   // Cost for extra bits
 	ProofOfPossessionGas        uint64 = 350000 // Cost of verifying a BLS proof of possession.
 	GetValidatorGas             uint64 = 10     // Cost of reading a validator's address.
 	GetEpochSizeGas             uint64 = 10     // Cost of querying the number of blocks in an epoch.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -138,7 +138,7 @@ const (
 	// Celo precompiled contracts
 	FractionMulExpGas           uint64 = 50     // Cost of performing multiplication and exponentiation of fractions to an exponent of up to 10^3.
 	ProofOfPossessionGas        uint64 = 350000 // Cost of verifying a BLS proof of possession.
-	GetValidatorGas             uint64 = 1000     // Cost of reading a validator's address.
+	GetValidatorGas             uint64 = 1000   // Cost of reading a validator's address.
 	GetEpochSizeGas             uint64 = 10     // Cost of querying the number of blocks in an epoch.
 	GetBlockNumberFromHeaderGas uint64 = 10     // Cost of decoding a block header.
 	HashHeaderGas               uint64 = 10     // Cost of hashing a block header.

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -136,15 +136,16 @@ const (
 	Bn256PairingPerPointGasIstanbul  uint64 = 34000  // Per-point price for an elliptic curve pairing check
 
 	// Celo precompiled contracts
-	// TODO: make this cost variable- https://github.com/celo-org/geth/issues/250
-	FractionMulExpGas uint64 = 1050 // Cost of performing multiplication and exponentiation of fractions to an exponent of up to 10^3.
+	FractionMulExpGas           uint64 = 50   // Cost of performing multiplication and exponentiation of fractions to an exponent of up to 10^3.
+	FractionMulExpExtraGas      uint64 = 1050   // Cost for extra bits
 	ProofOfPossessionGas        uint64 = 350000 // Cost of verifying a BLS proof of possession.
 	GetValidatorGas             uint64 = 10     // Cost of reading a validator's address.
 	GetEpochSizeGas             uint64 = 10     // Cost of querying the number of blocks in an epoch.
-	GetBlockNumberFromHeaderGas uint64 = 10000  // Cost of decoding a block header.
-	HashHeaderGas               uint64 = 20000  // Cost of hashing a block header.
+	GetBlockNumberFromHeaderGas uint64 = 10     // Cost of decoding a block header.
+	HashHeaderGas               uint64 = 10     // Cost of hashing a block header.
 	GetParentSealBitmapGas      uint64 = 100    // Cost of reading the parent seal bitmap from the chain.
-	GetVerifiedSealBitmapGas    uint64 = 55000  // Cost of verifying the seal on a given RLP encoded header.
+	// May take a bit more time with 100 validators, need to bench that
+	GetVerifiedSealBitmapGas    uint64 = 350000 // Cost of verifying the seal on a given RLP encoded header.
 )
 
 var (

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -219,11 +219,11 @@ const (
 	MaxGasForGetOrComputeTobinTax                  uint64 = 1000000
 	MaxGasForGetRegisteredValidators               uint64 = 2000000
 	MaxGasForGetValidator                          uint64 = 100 * 1000
-	MaxGasForGetWhiteList                          uint64 = 20000
-	MaxGasForGetTransferWhitelist                  uint64 = 1000000
+	MaxGasForGetWhiteList                          uint64 = 200000
+	MaxGasForGetTransferWhitelist                  uint64 = 2000000
 	MaxGasForIncreaseSupply                        uint64 = 50 * 1000
 	MaxGasForIsFrozen                              uint64 = 20000
-	MaxGasForMedianRate                            uint64 = 20000
+	MaxGasForMedianRate                            uint64 = 100000
 	MaxGasForReadBlockchainParameter               uint64 = 20000
 	MaxGasForRevealAndCommit                       uint64 = 2000000
 	MaxGasForUpdateGasPriceMinimum                 uint64 = 2000000


### PR DESCRIPTION
### Description

Hopefully the precompile gas costs are now good enough. Many of them have basically no cost (calling precompiles costs anyway). The cost of verifying aggregated seals should be checked later when we have a new network running.

### Tested


### Other changes

### Related issues

- Fixes #901

### Backwards compatibility

