### PR TITLE
Adds Ledger ECDSA proof of possession

### DIFF
--- a/accounts/usbwallet/ledger.go
+++ b/accounts/usbwallet/ledger.go
@@ -53,7 +53,7 @@ const (
 	ledgerOpRetrieveAddress  ledgerOpcode = 0x02 // Returns the public key and Celo address for a given BIP 32 path
 	ledgerOpSignTransaction  ledgerOpcode = 0x04 // Signs a Celo transaction after having the user validate the parameters
 	ledgerOpGetConfiguration ledgerOpcode = 0x06 // Returns specific wallet application configuration
-	ledgerOpSignMessage      ledgerOpcode = 0x08 // Signs a Celo transaction after having the user validate the parameters
+	ledgerOpSignMessage      ledgerOpcode = 0x08 // Signs a Celo message after having the user validate the parameters
 
 	ledgerP1DirectlyFetchAddress    ledgerParam1 = 0x00 // Return address directly from the wallet
 	ledgerP1InitTransactionData     ledgerParam1 = 0x00 // First transaction data block for signing
@@ -101,7 +101,7 @@ func (w *ledgerDriver) Status() (string, error) {
 	return fmt.Sprintf("Celo app v%d.%d.%d online", w.version[0], w.version[1], w.version[2]), w.failure
 }
 
-// offline returns whether the wallet and the Ethereum app is offline or not.
+// offline returns whether the wallet and the Celo app is offline or not.
 //
 // The method assumes that the state lock is held!
 func (w *ledgerDriver) offline() bool {
@@ -116,13 +116,13 @@ func (w *ledgerDriver) Open(device io.ReadWriter, passphrase string) error {
 
 	_, err := w.ledgerDerive(accounts.DefaultBaseDerivationPath)
 	if err != nil {
-		// Ethereum app is not running or in browser mode, nothing more to do, return
+		// Celo app is not running or in browser mode, nothing more to do, return
 		if err == errLedgerReplyInvalidHeader {
 			w.browser = true
 		}
 		return nil
 	}
-	// Try to resolve the Ethereum app's version, will fail prior to v1.0.2
+	// Try to resolve the Celo app's version, will fail prior to v1.0.2
 	if w.version, err = w.ledgerVersion(); err != nil {
 		w.version = [3]byte{1, 0, 0} // Assume worst case, can't verify if v1.0.0 or v1.0.1
 	}
@@ -147,7 +147,7 @@ func (w *ledgerDriver) Heartbeat() error {
 }
 
 // Derive implements usbwallet.driver, sending a derivation request to the Ledger
-// and returning the Ethereum address located on that derivation path.
+// and returning the Celo address located on that derivation path.
 func (w *ledgerDriver) Derive(path accounts.DerivationPath) (common.Address, error) {
 	return w.ledgerDerive(path)
 }
@@ -155,11 +155,11 @@ func (w *ledgerDriver) Derive(path accounts.DerivationPath) (common.Address, err
 // SignTx implements usbwallet.driver, sending the transaction to the Ledger and
 // waiting for the user to confirm or deny the transaction.
 //
-// Note, if the version of the Ethereum application running on the Ledger wallet is
+// Note, if the version of the Celo application running on the Ledger wallet is
 // too old to sign EIP-155 transactions, but such is requested nonetheless, an error
 // will be returned opposed to silently signing in Homestead mode.
 func (w *ledgerDriver) SignTx(path accounts.DerivationPath, tx *types.Transaction, chainID *big.Int) (common.Address, *types.Transaction, error) {
-	// If the Ethereum app doesn't run, abort
+	// If the Celo app doesn't run, abort
 	if w.offline() {
 		return common.Address{}, nil, accounts.ErrWalletClosed
 	}
@@ -174,7 +174,7 @@ func (w *ledgerDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 // SignPersonalMessage implements usbwallet.driver, sending the message to the Ledger and
 // waiting for the user to confirm or deny the message.
 func (w *ledgerDriver) SignPersonalMessage(path accounts.DerivationPath, message []byte) (common.Address, []byte, []byte, error) {
-	// If the Ethereum app doesn't run, abort
+	// If the Celo app doesn't run, abort
 	if w.offline() {
 		return common.Address{}, nil, nil, accounts.ErrWalletClosed
 	}
@@ -183,7 +183,7 @@ func (w *ledgerDriver) SignPersonalMessage(path accounts.DerivationPath, message
 	return w.ledgerSignData(path, message)
 }
 
-// ledgerVersion retrieves the current version of the Ethereum wallet app running
+// ledgerVersion retrieves the current version of the Celo wallet app running
 // on the Ledger wallet.
 //
 // The version retrieval protocol is defined as follows:
@@ -215,7 +215,7 @@ func (w *ledgerDriver) ledgerVersion() ([3]byte, error) {
 	return version, nil
 }
 
-// ledgerDerive retrieves the currently active Ethereum address from a Ledger
+// ledgerDerive retrieves the currently active Celo address from a Ledger
 // wallet at the specified derivation path.
 //
 // The address derivation protocol is defined as follows:
@@ -243,8 +243,8 @@ func (w *ledgerDriver) ledgerVersion() ([3]byte, error) {
 //   ------------------------+-------------------
 //   Public Key length       | 1 byte
 //   Uncompressed Public Key | arbitrary
-//   Ethereum address length | 1 byte
-//   Ethereum address        | 40 bytes hex ascii
+//   Celo address length     | 1 byte
+//   Celo address            | 40 bytes hex ascii
 //   Chain code if requested | 32 bytes
 func (w *ledgerDriver) ledgerDerive(derivationPath []uint32) (common.Address, error) {
 	// Flatten the derivation path into the Ledger request
@@ -264,13 +264,13 @@ func (w *ledgerDriver) ledgerDerive(derivationPath []uint32) (common.Address, er
 	}
 	reply = reply[1+int(reply[0]):]
 
-	// Extract the Ethereum hex address string
+	// Extract the Celo hex address string
 	if len(reply) < 1 || len(reply) < 1+int(reply[0]) {
 		return common.Address{}, errors.New("reply lacks address entry")
 	}
 	hexstr := reply[1 : 1+int(reply[0])]
 
-	// Decode the hex sting into an Ethereum address and return
+	// Decode the hex sting into an Celo address and return
 	var address common.Address
 	if _, err = hex.Decode(address[:], hexstr); err != nil {
 		return common.Address{}, err
@@ -356,7 +356,7 @@ func (w *ledgerDriver) ledgerSign(derivationPath []uint32, tx *types.Transaction
 		payload = payload[chunk:]
 		op = ledgerP1ContTransactionData
 	}
-	// Extract the Ethereum signature and do a sanity validation
+	// Extract the Celo signature and do a sanity validation
 	if len(reply) != crypto.SignatureLength {
 		return common.Address{}, nil, errors.New("reply lacks signature")
 	}
@@ -452,7 +452,7 @@ func (w *ledgerDriver) ledgerSignData(derivationPath []uint32, data []byte) (com
 		payload = payload[chunk:]
 		op = ledgerP1ContTransactionData
 	}
-	// Extract the Ethereum signature and do a sanity validation
+	// Extract the Celo signature and do a sanity validation
 	if len(reply) != crypto.SignatureLength {
 		return common.Address{}, nil, nil, errors.New("reply lacks signature")
 	}

--- a/accounts/usbwallet/ledger.go
+++ b/accounts/usbwallet/ledger.go
@@ -21,6 +21,7 @@
 package usbwallet
 
 import (
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -49,9 +50,10 @@ type ledgerParam1 byte
 type ledgerParam2 byte
 
 const (
-	ledgerOpRetrieveAddress  ledgerOpcode = 0x02 // Returns the public key and Ethereum address for a given BIP 32 path
-	ledgerOpSignTransaction  ledgerOpcode = 0x04 // Signs an Ethereum transaction after having the user validate the parameters
+	ledgerOpRetrieveAddress  ledgerOpcode = 0x02 // Returns the public key and Celo address for a given BIP 32 path
+	ledgerOpSignTransaction  ledgerOpcode = 0x04 // Signs a Celo transaction after having the user validate the parameters
 	ledgerOpGetConfiguration ledgerOpcode = 0x06 // Returns specific wallet application configuration
+	ledgerOpSignMessage      ledgerOpcode = 0x08 // Signs a Celo transaction after having the user validate the parameters
 
 	ledgerP1DirectlyFetchAddress    ledgerParam1 = 0x00 // Return address directly from the wallet
 	ledgerP1InitTransactionData     ledgerParam1 = 0x00 // First transaction data block for signing
@@ -91,12 +93,12 @@ func (w *ledgerDriver) Status() (string, error) {
 		return fmt.Sprintf("Failed: %v", w.failure), w.failure
 	}
 	if w.browser {
-		return "Ethereum app in browser mode", w.failure
+		return "Celo app in browser mode", w.failure
 	}
 	if w.offline() {
-		return "Ethereum app offline", w.failure
+		return "Celo app offline", w.failure
 	}
-	return fmt.Sprintf("Ethereum app v%d.%d.%d online", w.version[0], w.version[1], w.version[2]), w.failure
+	return fmt.Sprintf("Celo app v%d.%d.%d online", w.version[0], w.version[1], w.version[2]), w.failure
 }
 
 // offline returns whether the wallet and the Ethereum app is offline or not.
@@ -167,6 +169,18 @@ func (w *ledgerDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 	}
 	// All infos gathered and metadata checks out, request signing
 	return w.ledgerSign(path, tx, chainID)
+}
+
+// SignPersonalMessage implements usbwallet.driver, sending the message to the Ledger and
+// waiting for the user to confirm or deny the message.
+func (w *ledgerDriver) SignPersonalMessage(path accounts.DerivationPath, message []byte) (common.Address, []byte, []byte, error) {
+	// If the Ethereum app doesn't run, abort
+	if w.offline() {
+		return common.Address{}, nil, nil, accounts.ErrWalletClosed
+	}
+
+	// All infos gathered and metadata checks out, request signing
+	return w.ledgerSignData(path, message)
 }
 
 // ledgerVersion retrieves the current version of the Ethereum wallet app running
@@ -365,6 +379,97 @@ func (w *ledgerDriver) ledgerSign(derivationPath []uint32, tx *types.Transaction
 		return common.Address{}, nil, err
 	}
 	return sender, signed, nil
+}
+
+// ledgerSignData sends the message to the Ledger wallet, and waits for the user
+// to confirm or deny the message.
+//
+// The message signing protocol is defined as follows:
+//
+//   CLA | INS | P1 | P2 | Lc  | Le
+//   ----+-----+----+----+-----+---
+//    E0 | 08  | 00: first message data block
+//               80: subsequent message data block
+//                  | 00 | variable | variable
+//
+// Where the input for the first message block (first 255 bytes) is:
+//
+//   Description                                      | Length
+//   -------------------------------------------------+----------
+//   Number of BIP 32 derivations to perform (max 10) | 1 byte
+//   First derivation index (big endian)              | 4 bytes
+//   ...                                              | 4 bytes
+//   Last derivation index (big endian)               | 4 bytes
+//   data chunk                                       | arbitrary
+//
+// And the input for subsequent message blocks (first 255 bytes) are:
+//
+//   Description           | Length
+//   ----------------------+----------
+//   data chunk | arbitrary
+//
+// And the output data is:
+//
+//   Description | Length
+//   ------------+---------
+//   signature V | 1 byte
+//   signature R | 32 bytes
+//   signature S | 32 bytes
+func (w *ledgerDriver) ledgerSignData(derivationPath []uint32, data []byte) (common.Address, []byte, []byte, error) {
+	hashMessage := sha256.Sum256(data)
+	w.log.Info("Signing message on Ledger with hash", "message", hex.EncodeToString(data), "hash", hex.EncodeToString(hashMessage[:]))
+
+	// Flatten the derivation path into the Ledger request
+	path := make([]byte, 1+4*len(derivationPath))
+	path[0] = byte(len(derivationPath))
+	for i, component := range derivationPath {
+		binary.BigEndian.PutUint32(path[1+4*i:], component)
+	}
+
+	dataLen := make([]byte, 4)
+	binary.BigEndian.PutUint32(dataLen, uint32(len(data)))
+	payload := append(path, dataLen...)
+	payload = append(payload, data...)
+
+	// Send the request and wait for the response
+	var (
+		op    = ledgerP1InitTransactionData
+		reply []byte
+		err   error
+	)
+	for len(payload) > 0 {
+		// Calculate the size of the next data chunk
+		chunk := 255
+		if chunk > len(payload) {
+			chunk = len(payload)
+		}
+		// Send the chunk over, ensuring it's processed correctly
+		reply, err = w.ledgerExchange(ledgerOpSignMessage, op, 0, payload[:chunk])
+		if err != nil {
+			return common.Address{}, nil, nil, err
+		}
+		// Shift the payload and ensure subsequent chunks are marked as such
+		payload = payload[chunk:]
+		op = ledgerP1ContTransactionData
+	}
+	// Extract the Ethereum signature and do a sanity validation
+	if len(reply) != crypto.SignatureLength {
+		return common.Address{}, nil, nil, errors.New("reply lacks signature")
+	}
+	signature := append(reply[1:], reply[0])
+
+	msg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(data), data)
+	hash := crypto.Keccak256([]byte(msg))
+	hashFixedLength := common.Hash{}
+	copy(hashFixedLength[:], hash)
+
+	signer := new(types.HomesteadSigner)
+	addr, pubkey, err := signer.SenderData(hashFixedLength, signature)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+
+	return addr, pubkey, signature, nil
 }
 
 // ledgerExchange performs a data exchange with the Ledger wallet, sending it a

--- a/accounts/usbwallet/trezor.go
+++ b/accounts/usbwallet/trezor.go
@@ -185,6 +185,12 @@ func (w *trezorDriver) SignTx(path accounts.DerivationPath, tx *types.Transactio
 	return w.trezorSign(path, tx, chainID)
 }
 
+// SignPersonalMessage implements usbwallet.driver, sending the message to the Trezor and
+// waiting for the user to confirm or deny the message.
+func (w *trezorDriver) SignPersonalMessage(path accounts.DerivationPath, message []byte) (common.Address, []byte, []byte, error) {
+	return common.Address{}, nil, nil, accounts.ErrNotSupported
+}
+
 // trezorDerive sends a derivation request to the Trezor device and returns the
 // Ethereum address located on that path.
 func (w *trezorDriver) trezorDerive(derivationPath []uint32) (common.Address, error) {

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -70,6 +70,10 @@ type driver interface {
 	// SignTx sends the transaction to the USB device and waits for the user to confirm
 	// or deny the transaction.
 	SignTx(path accounts.DerivationPath, tx *types.Transaction, chainID *big.Int) (common.Address, *types.Transaction, error)
+
+	// SignPersonalMessage sends the message to the USB device and waits for the user to confirm
+	// or deny the message.
+	SignPersonalMessage(path accounts.DerivationPath, message []byte) (common.Address, []byte, []byte, error)
 }
 
 // wallet represents the common functionality shared by all USB hardware
@@ -538,7 +542,47 @@ func (w *wallet) SignMessageBLS(account accounts.Account, msg []byte, extraData 
 }
 
 func (w *wallet) GenerateProofOfPossession(account accounts.Account, address common.Address) ([]byte, []byte, error) {
-	return nil, nil, accounts.ErrNotSupported
+	message := address.Bytes()
+	return w.signText(account, message)
+}
+
+func (w *wallet) signText(account accounts.Account, text []byte) ([]byte, []byte, error) {
+	w.stateLock.RLock() // Comms have own mutex, this is for the state fields
+	defer w.stateLock.RUnlock()
+
+	// If the wallet is closed, abort
+	if w.device == nil {
+		return nil, nil, accounts.ErrWalletClosed
+	}
+	// Make sure the requested account is contained within
+	path, ok := w.paths[account.Address]
+	if !ok {
+		return nil, nil, accounts.ErrUnknownAccount
+	}
+	// All infos gathered and metadata checks out, request signing
+	<-w.commsLock
+	defer func() { w.commsLock <- struct{}{} }()
+
+	// Ensure the device isn't screwed with while user confirmation is pending
+	// TODO(karalabe): remove if hotplug lands on Windows
+	w.hub.commsLock.Lock()
+	w.hub.commsPend++
+	w.hub.commsLock.Unlock()
+
+	defer func() {
+		w.hub.commsLock.Lock()
+		w.hub.commsPend--
+		w.hub.commsLock.Unlock()
+	}()
+	// Sign the message and verify the sender to avoid hardware fault surprises
+	sender, pubkey, signed, err := w.driver.SignPersonalMessage(path, text)
+	if err != nil {
+		return nil, nil, err
+	}
+	if sender != account.Address {
+		return nil, nil, fmt.Errorf("signer mismatch: expected %s, got %s", account.Address.Hex(), sender.Hex())
+	}
+	return pubkey, signed, nil
 }
 
 func (w *wallet) GenerateProofOfPossessionBLS(account accounts.Account, address common.Address) ([]byte, []byte, error) {
@@ -568,7 +612,8 @@ func (w *wallet) SignDataWithPassphrase(account accounts.Account, passphrase, mi
 }
 
 func (w *wallet) SignText(account accounts.Account, text []byte) ([]byte, error) {
-	return w.signHash(account, accounts.TextHash(text))
+	_, signature, err := w.signText(account, text)
+	return signature, err
 }
 
 // SignTx implements accounts.Wallet. It sends the transaction over to the Ledger
@@ -621,7 +666,7 @@ func (w *wallet) SignTx(account accounts.Account, tx *types.Transaction, chainID
 // data is not supported for Ledger wallets, so this method will always return
 // an error.
 func (w *wallet) SignTextWithPassphrase(account accounts.Account, passphrase string, text []byte) ([]byte, error) {
-	return w.SignText(account, accounts.TextHash(text))
+	return w.SignText(account, text)
 }
 
 // SignTxWithPassphrase implements accounts.Wallet, attempting to sign the given

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -244,38 +244,38 @@ func accountProofOfPossession(ctx *cli.Context) error {
 	message := common.HexToAddress(ctx.Args()[1])
 
 	var err error
-  var wallet accounts.Wallet
-  account := accounts.Account{ Address: signer }
-  foundAccount := false
+	var wallet accounts.Wallet
+	account := accounts.Account{Address: signer}
+	foundAccount := false
 
-  for _, wallet = range am.Wallets() {
-    if wallet.URL().Scheme == keystore.KeyStoreScheme {
-      if wallet.Contains(account) {
-        foundAccount = true
-        break
-      }
-    } else if wallet.URL().Scheme == usbwallet.LedgerScheme {
-      if err := wallet.Open(""); err != nil {
-        if err != accounts.ErrWalletAlreadyOpen {
-          utils.Fatalf("Could not open Ledger wallet: %v", err)
-        }
-      } else {
-        defer wallet.Close()
-      }
+	for _, wallet = range am.Wallets() {
+		if wallet.URL().Scheme == keystore.KeyStoreScheme {
+			if wallet.Contains(account) {
+				foundAccount = true
+				break
+			}
+		} else if wallet.URL().Scheme == usbwallet.LedgerScheme {
+			if err := wallet.Open(""); err != nil {
+				if err != accounts.ErrWalletAlreadyOpen {
+					utils.Fatalf("Could not open Ledger wallet: %v", err)
+				}
+			} else {
+				defer wallet.Close()
+			}
 
-      account, err = wallet.Derive(accounts.DefaultBaseDerivationPath, true)
-      if err != nil {
-        return err
-      }
-      if account.Address == signer {
-        foundAccount = true
-        break
-      }
-    }
-  }
-  if !foundAccount {
-    utils.Fatalf("Could not find signer account %x", signer)
-  }
+			account, err = wallet.Derive(accounts.DefaultBaseDerivationPath, true)
+			if err != nil {
+				return err
+			}
+			if account.Address == signer {
+				foundAccount = true
+				break
+			}
+		}
+	}
+	if !foundAccount {
+		utils.Fatalf("Could not find signer account %x", signer)
+	}
 
 	if wallet.URL().Scheme == keystore.KeyStoreScheme {
 		account, _ = unlockAccount(ks, signer.String(), 0, utils.MakePasswordList(ctx))
@@ -287,7 +287,7 @@ func accountProofOfPossession(ctx *cli.Context) error {
 		keyType = "BLS"
 		key, pop, err = ks.GenerateProofOfPossessionBLS(account, message)
 	} else {
-    key, pop, err = wallet.GenerateProofOfPossession(account, message)
+		key, pop, err = wallet.GenerateProofOfPossession(account, message)
 	}
 	if err != nil {
 		return err

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -133,7 +133,8 @@ func (s EIP155Signer) Sender(tx *Transaction) (common.Address, error) {
 	}
 	V := new(big.Int).Sub(tx.data.V, s.chainIdMul)
 	V.Sub(V, big8)
-	return recoverPlain(s.Hash(tx), tx.data.R, tx.data.S, V, true)
+	addr, _, err := recoverPlain(s.Hash(tx), tx.data.R, tx.data.S, V, true)
+	return addr, err
 }
 
 // SignatureValues returns signature values. This signature
@@ -183,7 +184,17 @@ func (hs HomesteadSigner) SignatureValues(tx *Transaction, sig []byte) (r, s, v 
 }
 
 func (hs HomesteadSigner) Sender(tx *Transaction) (common.Address, error) {
-	return recoverPlain(hs.Hash(tx), tx.data.R, tx.data.S, tx.data.V, true)
+	addr, _, err := recoverPlain(hs.Hash(tx), tx.data.R, tx.data.S, tx.data.V, true)
+	return addr, err
+}
+
+func (hs HomesteadSigner) SenderData(data common.Hash, sig []byte) (common.Address, []byte, error) {
+	r, s, v, err := hs.SignatureValues(nil, sig)
+	v = new(big.Int).Sub(v, big.NewInt(27))
+	if err != nil {
+		return common.Address{}, nil, err
+	}
+	return recoverPlain(data, r, s, v, true)
 }
 
 type FrontierSigner struct{}
@@ -222,16 +233,17 @@ func (fs FrontierSigner) Hash(tx *Transaction) common.Hash {
 }
 
 func (fs FrontierSigner) Sender(tx *Transaction) (common.Address, error) {
-	return recoverPlain(fs.Hash(tx), tx.data.R, tx.data.S, tx.data.V, false)
+	addr, _, err := recoverPlain(fs.Hash(tx), tx.data.R, tx.data.S, tx.data.V, false)
+	return addr, err
 }
 
-func recoverPlain(sighash common.Hash, R, S, Vb *big.Int, homestead bool) (common.Address, error) {
+func recoverPlain(sighash common.Hash, R, S, Vb *big.Int, homestead bool) (common.Address, []byte, error) {
 	if Vb.BitLen() > 8 {
-		return common.Address{}, ErrInvalidSig
+		return common.Address{}, nil, ErrInvalidSig
 	}
 	V := byte(Vb.Uint64() - 27)
 	if !crypto.ValidateSignatureValues(V, R, S, homestead) {
-		return common.Address{}, ErrInvalidSig
+		return common.Address{}, nil, ErrInvalidSig
 	}
 	// encode the signature in uncompressed format
 	r, s := R.Bytes(), S.Bytes()
@@ -242,14 +254,14 @@ func recoverPlain(sighash common.Hash, R, S, Vb *big.Int, homestead bool) (commo
 	// recover the public key from the signature
 	pub, err := crypto.Ecrecover(sighash[:], sig)
 	if err != nil {
-		return common.Address{}, err
+		return common.Address{}, nil, err
 	}
 	if len(pub) == 0 || pub[0] != 4 {
-		return common.Address{}, errors.New("invalid public key")
+		return common.Address{}, nil, errors.New("invalid public key")
 	}
 	var addr common.Address
 	copy(addr[:], crypto.Keccak256(pub[1:])[12:])
-	return addr, nil
+	return addr, pub, nil
 }
 
 // deriveChainId derives the chain id from the given v parameter


### PR DESCRIPTION
Tested using a Ledger Nano S, with the `proof-of-possession` command. Test cases:

1. Signer address on a Ledger
2. Signer address in keystore
3. Signer address nowhere