### PR TITLE
Change clientIdentifier to "celo" from "Celo"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
       - run: go get github.com/jstemmer/go-junit-report
       - run: 
           name: Run Tests
+          no_output_timeout: 15m
           command: |
             mkdir -p /tmp/test-results
             trap "go-junit-report < /tmp/test-results/go-test.out > /tmp/test-results/go-test-report.xml" EXIT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,6 @@ jobs:
       - run: go get github.com/jstemmer/go-junit-report
       - run: 
           name: Run Tests
-          no_output_timeout: 15m
           command: |
             mkdir -p /tmp/test-results
             trap "go-junit-report < /tmp/test-results/go-test.out > /tmp/test-results/go-test-report.xml" EXIT

--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -58,7 +58,7 @@ func TestConsoleWelcome(t *testing.T) {
 	geth.Expect(`
 Welcome to the Celo JavaScript console!
 
-instance: Celo/v{{gethver}}/{{goos}}-{{goarch}}/{{gover}}
+instance: celo/v{{gethver}}/{{goos}}-{{goarch}}/{{gover}}
 coinbase: {{.Etherbase}}
 at block: 0 ({{niltime}})
  datadir: {{.Datadir}}
@@ -146,7 +146,7 @@ func testAttachWelcome(t *testing.T, geth *testgeth, endpoint, apis string) {
 	attach.Expect(`
 Welcome to the Celo JavaScript console!
 
-instance: Celo/v{{gethver}}/{{goos}}-{{goarch}}/{{gover}}
+instance: celo/v{{gethver}}/{{goos}}-{{goarch}}/{{gover}}
 coinbase: {{etherbase}}
 at block: 0 ({{niltime}}){{if ipc}}
  datadir: {{datadir}}{{end}}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -47,7 +47,7 @@ import (
 )
 
 const (
-	clientIdentifier = "Celo" // Client identifier to advertise over the network
+	clientIdentifier = "celo" // Client identifier to advertise over the network
 )
 
 var (


### PR DESCRIPTION
### Description

During the Stake Off we released a new image based on 1.9 and one of the other changes we included was to change the client identifier of `geth` to `Celo`. Although not incorrect, the capital letter does not match the other client identifiers in use, namely `celoios` and `celoandroid`. This in itself is fairly inconsequential, but does have the side effect that the directory in which chain data is stored is set based on the client identifier. This means that the directory name was capital `Celo` rather than `celo` which would be more standard on Linux filesystems where casing matters. This led to confusion from Stake Off participants.

https://github.com/celo-org/celo-blockchain/blob/f4f8cf938fb28f7571d3c77cdcad9da4d5876b78/node/node.go#L299-L316

This PR changes the default client identifier from "Celo" to "celo"

### Backwards compatibility

Because the data director is different, upgrading in place would require moving the data directory.
