### PR TITLE
Add/fix metrics for consensus and block signing 

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -119,6 +119,9 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 		updatingCachedValidatorConnSetCond: sync.NewCond(&sync.Mutex{}),
 		finalizationTimer:                  metrics.NewRegisteredTimer("consensus/istanbul/backend/finalize", nil),
 		rewardDistributionTimer:            metrics.NewRegisteredTimer("consensus/istanbul/backend/rewards", nil),
+		blocksElectedMeter:                 metrics.NewRegisteredMeter("consensus/istanbul/blocks/elected", nil),
+		blocksSignedInSealMeter:            metrics.NewRegisteredMeter("consensus/istanbul/blocks/signed/quorum", nil),
+		blocksSignedInSealOrChildMeter:     metrics.NewRegisteredMeter("consensus/istanbul/blocks/signed/total", nil),
 	}
 	backend.core = istanbulCore.New(backend, backend.config)
 
@@ -234,6 +237,13 @@ type Backend struct {
 	finalizationTimer metrics.Timer
 	// Metric timer used to record epoch reward distribution times.
 	rewardDistributionTimer metrics.Timer
+
+	// Meters for number of blocks seen for which the current validator signer has been elected,
+	// has its signature included in the seal, and has its signature included in the subsequent block's
+	// 'parentSeal' (i.e. it doesn't count for consensus, but it does count for counting uptime)
+	blocksElectedMeter             metrics.Meter
+	blocksSignedInSealMeter        metrics.Meter
+	blocksSignedInSealOrChildMeter metrics.Meter
 
 	istanbulAnnounceMsgHandlers map[uint64]announceMsgHandler
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -122,6 +122,7 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 		blocksElectedMeter:                 metrics.NewRegisteredMeter("consensus/istanbul/blocks/elected", nil),
 		blocksSignedInSealMeter:            metrics.NewRegisteredMeter("consensus/istanbul/blocks/signed/quorum", nil),
 		blocksSignedInSealOrChildMeter:     metrics.NewRegisteredMeter("consensus/istanbul/blocks/signed/total", nil),
+		blocksElectedButNotSignedMeter:     metrics.NewRegisteredMeter("consensus/istanbul/blocks/signed/missed", nil),
 	}
 	backend.core = istanbulCore.New(backend, backend.config)
 
@@ -244,6 +245,7 @@ type Backend struct {
 	blocksElectedMeter             metrics.Meter
 	blocksSignedInSealMeter        metrics.Meter
 	blocksSignedInSealOrChildMeter metrics.Meter
+	blocksElectedButNotSignedMeter metrics.Meter
 
 	istanbulAnnounceMsgHandlers map[uint64]announceMsgHandler
 

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -227,7 +227,7 @@ func (sb *Backend) SetP2PServer(p2pserver consensus.P2PServer) {
 
 // This function is called by miner/worker.go whenever it's mainLoop gets a newWork event.
 func (sb *Backend) NewWork() error {
-	sb.logger.Debug("Posting FinalCommittedEvent 1", "func", "NewWork")
+	sb.logger.Debug("NewWork called, acquiring core lock", "func", "NewWork")
 
 	sb.coreMu.RLock()
 	defer sb.coreMu.RUnlock()

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -227,11 +227,15 @@ func (sb *Backend) SetP2PServer(p2pserver consensus.P2PServer) {
 
 // This function is called by miner/worker.go whenever it's mainLoop gets a newWork event.
 func (sb *Backend) NewWork() error {
+	sb.logger.Debug("Posting FinalCommittedEvent 1", "func", "NewWork")
+
 	sb.coreMu.RLock()
 	defer sb.coreMu.RUnlock()
 	if !sb.coreStarted {
 		return istanbul.ErrStoppedEngine
 	}
+
+	sb.logger.Debug("Posting FinalCommittedEvent 2", "func", "NewWork")
 
 	go sb.istanbulEventMux.Post(istanbul.FinalCommittedEvent{})
 	return nil

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -235,7 +235,7 @@ func (sb *Backend) NewWork() error {
 		return istanbul.ErrStoppedEngine
 	}
 
-	sb.logger.Debug("Posting FinalCommittedEvent 2", "func", "NewWork")
+	sb.logger.Debug("Posting FinalCommittedEvent", "func", "NewWork")
 
 	go sb.istanbulEventMux.Post(istanbul.FinalCommittedEvent{})
 	return nil

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -264,8 +264,7 @@ func (sb *Backend) ValidatorElectedAndSignedParentBlock(child *types.Block) (ele
 
 	// Check validator in grandparent valset.
 	gpValSet := sb.getValidators(number-2, parentHeader.ParentHash)
-	gpValSetIndex, _ := gpValSet.GetByAddress(sb.ValidatorAddress())
-	if gpValSetIndex < 0 {
+	if !gpValSet.ContainsByAddress(sb.ValidatorAddress()) {
 		return
 	}
 	elected = true

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -303,6 +303,9 @@ func (sb *Backend) NewChainHead(newBlock *types.Block) {
 	if inChildsParentSeal {
 		sb.blocksSignedInSealOrChildMeter.Mark(1)
 	}
+	if elected && !inSeal && !inChildsParentSeal {
+		sb.blocksElectedButNotSignedMeter.Mark(1)
+	}
 
 	// If this is the last block of the epoch:
 	// * Print an easy to find log message giving our address and whether we're elected in next epoch.

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -264,7 +264,8 @@ func (sb *Backend) ValidatorElectedAndSignedParentBlock(child *types.Block) (ele
 
 	// Check validator in grandparent valset.
 	gpValSet := sb.getValidators(number-2, parentHeader.ParentHash)
-	if !gpValSet.ContainsByAddress(sb.ValidatorAddress()) {
+	gpValSetIndex, _ := gpValSet.GetByAddress(sb.ValidatorAddress())
+	if gpValSetIndex < 0 {
 		return
 	}
 	elected = true

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -265,10 +265,7 @@ func (sb *Backend) ValidatorElectedAndSignedParentBlock(child *types.Block) (ele
 	// Check validator in grandparent valset.
 	gpValSet := sb.getValidators(number-2, parentHeader.ParentHash)
 	gpValSetIndex, _ := gpValSet.GetByAddress(sb.ValidatorAddress())
-	if gpValSetIndex < 0 {
-		return
-	}
-	elected = true
+	elected = gpValSetIndex >= 0
 
 	// Now check if in the "parent seal" (used for downtime calcs, on the child block)
 	childExtra, err := types.ExtractIstanbulExtra(child.Header())
@@ -276,10 +273,8 @@ func (sb *Backend) ValidatorElectedAndSignedParentBlock(child *types.Block) (ele
 		return
 	}
 
-	pValSet := sb.getValidators(number-1, childHeader.ParentHash)
-	pValSetIndex, _ := pValSet.GetByAddress(sb.ValidatorAddress())
-	if pValSetIndex >= 0 {
-		inParentSeal = childExtra.ParentAggregatedSeal.Bitmap.Bit(pValSetIndex) != 0
+	if elected {
+		inParentSeal = childExtra.ParentAggregatedSeal.Bitmap.Bit(gpValSetIndex) != 0
 	}
 
 	missedRounds = childExtra.ParentAggregatedSeal.Round.Int64()

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -237,29 +237,89 @@ func (sb *Backend) NewWork() error {
 	return nil
 }
 
-// This function is called by all nodes.
-// At the end of each epoch, this function will
-//    1)  Output if it is or isn't an elected validator if it has mining turned on.
-//    2)  Refresh the validator connections if it's a proxy or non proxied validator
+// Determine if this validator signed the parent of the supplied block:
+// First check the grandparent's validator set. If not elected, it didn't.
+// Then, check the seal on the parent block. Finally, check the parent seal on the supplied block.
+func (sb *Backend) ValidatorElectedAndSignedParentBlock(child *types.Block) (elected bool, inSeal bool, inParentSeal bool) {
+	sb.coreMu.RLock()
+	defer sb.coreMu.RUnlock()
+
+	// Check the parent is not the genesis block.
+	number := child.Number().Uint64()
+	if number <= 1 {
+		return
+	}
+
+	childHeader := child.Header()
+	parentHeader := sb.chain.GetHeader(childHeader.ParentHash, number-1)
+
+	// Check validator in grandparent valset.
+	gpValSet := sb.getValidators(number-2, parentHeader.ParentHash)
+	gpValSetIndex, _ := gpValSet.GetByAddress(sb.ValidatorAddress())
+	if gpValSetIndex < 0 {
+		return
+	}
+	elected = true
+
+	// Now check if in the actual seal (on the parent block, used for consensus).
+	parentExtra, err := types.ExtractIstanbulExtra(parentHeader)
+	if err != nil {
+		return
+	}
+	inSeal = parentExtra.AggregatedSeal.Bitmap.Bit(gpValSetIndex) != 0
+
+	// Now check if in the "parent seal" (used for downtime calcs, on the child block)
+	pValSet := sb.getValidators(number-1, childHeader.ParentHash)
+	pValSetIndex, _ := pValSet.GetByAddress(sb.ValidatorAddress())
+	if pValSetIndex < 0 {
+		return
+	}
+
+	childExtra, err := types.ExtractIstanbulExtra(child.Header())
+	if err != nil {
+		return
+	}
+	inParentSeal = childExtra.ParentAggregatedSeal.Bitmap.Bit(pValSetIndex) != 0
+	return
+}
+
+// Actions triggered by a new block being added to the chain.
 func (sb *Backend) NewChainHead(newBlock *types.Block) {
+
+	sb.logger.Trace("Start NewChainHead", "number", newBlock.Number().Uint64())
+
+	// Update metrics for whether we were elected and signed the parent of this block.
+	elected, inSeal, inChildsParentSeal := sb.ValidatorElectedAndSignedParentBlock(newBlock)
+	if elected {
+		sb.blocksElectedMeter.Mark(1)
+	}
+	if inSeal {
+		sb.blocksSignedInSealMeter.Mark(1)
+	}
+	if inChildsParentSeal {
+		sb.blocksSignedInSealOrChildMeter.Mark(1)
+	}
+
+	// If this is the last block of the epoch:
+	// * Print an easy to find log message giving our address and whether we're elected in next epoch.
+	// * if this is a proxy or a non proxied validator, refresh the validator enode table.
 	if istanbul.IsLastBlockOfEpoch(newBlock.Number().Uint64(), sb.config.Epoch) {
+
 		sb.coreMu.RLock()
 		defer sb.coreMu.RUnlock()
 
-		valset := sb.getValidators(newBlock.Number().Uint64(), newBlock.Hash())
+		valSet := sb.getValidators(newBlock.Number().Uint64(), newBlock.Hash())
+		valSetIndex, _ := valSet.GetByAddress(sb.ValidatorAddress())
 
-		// Output whether this validator was or wasn't elected for the
-		// new epoch's validator set
-		if sb.coreStarted {
-			_, val := valset.GetByAddress(sb.ValidatorAddress())
-			sb.logger.Info("Validator Election Results", "address", sb.ValidatorAddress(), "elected", (val != nil), "number", newBlock.Number().Uint64())
+		sb.logger.Info("Validator Election Results", "address", sb.ValidatorAddress(), "elected", valSetIndex >= 0, "number", newBlock.Number().Uint64())
+
+		if sb.announceRunning {
+			sb.logger.Trace("At end of epoch and going to refresh validator peers", "new_block_number", newBlock.Number().Uint64())
+			sb.RefreshValPeers(valSet)
 		}
-
-		// If this is a proxy or a non proxied validator and a
-		// new epoch just started, then refresh the validator enode table
-		sb.logger.Trace("At end of epoch and going to refresh validator peers", "new_block_number", newBlock.Number().Uint64())
-		sb.RefreshValPeers(valset)
 	}
+
+	sb.logger.Trace("End NewChainHead", "number", newBlock.Number().Uint64())
 }
 
 func (sb *Backend) RegisterPeer(peer consensus.Peer, isProxiedPeer bool) {

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -392,11 +392,12 @@ func (c *core) getPreprepareWithRoundChangeCertificate(round *big.Int) (*istanbu
 
 // startNewRound starts a new round. if round equals to 0, it means to starts a new sequence
 func (c *core) startNewRound(round *big.Int) error {
-	logger := c.newLogger("func", "startNewRound", "tag", "stateTransition")
 
 	roundChange := false
-	// Try to get last proposal
+	// Try to get most recent block
 	headBlock, headAuthor := c.backend.GetCurrentHeadBlockAndAuthor()
+
+	logger := c.newLogger("func", "startNewRound", "tag", "stateTransition", "head_block", headBlock.Number().Uint64(), "head_block_hash", headBlock.Hash())
 
 	if headBlock.Number().Cmp(c.current.Sequence()) >= 0 {
 		// Want to be working on the block 1 beyond the last committed block.
@@ -407,19 +408,19 @@ func (c *core) startNewRound(round *big.Int) error {
 			c.consensusTimer.UpdateSince(c.consensusTimestamp)
 			c.consensusTimestamp = time.Time{}
 		}
-		logger.Trace("Catch up to the latest proposal.", "number", headBlock.Number().Uint64(), "hash", headBlock.Hash())
+		logger.Trace("Catch up to the latest block.")
 	} else if headBlock.Number().Cmp(big.NewInt(c.current.Sequence().Int64()-1)) == 0 {
 		// Working on the block immediately after the last committed block.
 		if round.Cmp(c.current.Round()) == 0 {
 			logger.Trace("Already in the desired round.")
 			return nil
 		} else if round.Cmp(c.current.Round()) < 0 {
-			logger.Warn("New round should not be smaller than current round", "lastBlockNumber", headBlock.Number().Int64(), "new_round", round)
+			logger.Warn("New round should not be smaller than current round", "new_round", round)
 			return nil
 		}
 		roundChange = true
 	} else {
-		logger.Warn("New sequence should be larger than current sequence", "new_seq", headBlock.Number().Int64())
+		logger.Warn("New sequence should be larger than current sequence")
 		return nil
 	}
 
@@ -469,7 +470,7 @@ func (c *core) startNewRound(round *big.Int) error {
 	c.resetRoundChangeTimer()
 
 	// Some round info will have changed.
-	logger = c.newLogger("func", "startNewRound", "tag", "stateTransition", "old_proposer", c.current.Proposer())
+	logger = c.newLogger("func", "startNewRound", "tag", "stateTransition", "old_proposer", c.current.Proposer(), "head_block", headBlock.Number().Uint64(), "head_block_hash", headBlock.Hash())
 	logger.Debug("New round", "new_round", newView.Round, "new_seq", newView.Sequence, "new_proposer", c.current.Proposer(), "valSet", c.current.ValidatorSet().List(), "size", c.current.ValidatorSet().Size(), "isProposer", c.isProposer())
 	return nil
 }

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -594,6 +594,9 @@ func (rs *roundStateImpl) DecodeRLP(stream *rlp.Stream) error {
 
 	rs.logger = log.New()
 	rs.mu = new(sync.RWMutex)
+	rs.roundGauge = metrics.NewRegisteredGauge("consensus/istanbul/core/round", nil)
+	rs.desiredRoundGauge = metrics.NewRegisteredGauge("consensus/istanbul/core/desiredround", nil)
+	rs.sequenceGauge = metrics.NewRegisteredGauge("consensus/istanbul/core/sequence", nil)
 	rs.state = data.State
 	rs.round = data.Round
 	rs.desiredRound = data.DesiredRound

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -99,6 +100,11 @@ type roundStateImpl struct {
 
 	mu     *sync.RWMutex
 	logger log.Logger
+
+	// Gauges for current round, desiredRound, and sequence
+	roundGauge        metrics.Gauge
+	desiredRoundGauge metrics.Gauge
+	sequenceGauge     metrics.Gauge
 }
 
 type RoundStateSummary struct {
@@ -140,6 +146,10 @@ func newRoundState(view *istanbul.View, validatorSet istanbul.ValidatorSet, prop
 
 		mu:     new(sync.RWMutex),
 		logger: log.New(),
+
+		roundGauge:        metrics.NewRegisteredGauge("consensus/istanbul/core/round", nil),
+		desiredRoundGauge: metrics.NewRegisteredGauge("consensus/istanbul/core/desiredround", nil),
+		sequenceGauge:     metrics.NewRegisteredGauge("consensus/istanbul/core/sequence", nil),
 	}
 }
 
@@ -254,6 +264,10 @@ func (rs *roundStateImpl) changeRound(nextRound *big.Int, validatorSet istanbul.
 	rs.round = nextRound
 	rs.desiredRound = nextRound
 
+	// Update gauges
+	rs.roundGauge.Update(nextRound.Int64())
+	rs.desiredRoundGauge.Update(nextRound.Int64())
+
 	// TODO MC use old valset
 	rs.prepares = newMessageSet(validatorSet)
 	rs.commits = newMessageSet(validatorSet)
@@ -287,6 +301,9 @@ func (rs *roundStateImpl) StartNewSequence(nextSequence *big.Int, validatorSet i
 	rs.parentCommits = parentCommits
 	rs.proposalVerificationStatus = nil
 
+	// Update sequence gauge
+	rs.sequenceGauge.Update(nextSequence.Int64())
+
 	logger.Debug("Starting new sequence", "next_sequence", nextSequence, "next_proposer", nextProposer.Address().Hex())
 	return nil
 }
@@ -318,6 +335,10 @@ func (rs *roundStateImpl) TransitionToWaitingForNewRound(desiredRound *big.Int, 
 	rs.desiredRound = new(big.Int).Set(desiredRound)
 	rs.proposer = nextProposer
 	rs.state = StateWaitingForNewRound
+
+	// Update gauge
+	rs.desiredRoundGauge.Update(desiredRound.Int64())
+
 	return nil
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1356,7 +1356,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 			// Get the bitmap from the previous block
 			extra, err := types.ExtractIstanbulExtra(block.Header())
 			if err != nil {
-				log.Error("Unable to extrace istanbul extra", "func", "WriteBlockWithState", "blocknum", block.NumberU64(), "epoch", epochNum)
+				log.Error("Unable to extract istanbul extra", "func", "WriteBlockWithState", "blocknum", block.NumberU64(), "epoch", epochNum)
 				return NonStatTy, errors.New("could not extract block header extra")
 			}
 			signedValidatorsBitmap := extra.ParentAggregatedSeal.Bitmap


### PR DESCRIPTION
### Description

Add metrics to make it easier for Validators to monitor consensus progress, and when their validator is not signing blocks.

For the *parent* of the last sealed block received (i.e. this is always 2 fewer than the current consensus sequence):
* `consensus_istanbul_blocks_elected` - counts the blocks for which this validator was elected
* `consensus_istanbul_blocks_missedbyus` -  counts the blocks for which this validator was elected but not included in the child's parent seal (i.e. this block will count as "downtime") 
* `consensus_istanbul_blocks_signedbyus` -  counts the blocks for which this validator was elected and its signature was included in the seal (i.e. this validator completed consensus correctly, sent a COMMIT, its commit was received In time to make the seal of the parent received by the next proposer, or was received directly by the next proposer itself, and so the block will not count as "downtime") 
* `consensus_istanbul_blocks_totalsigs` - gauge of number of validators whose signatures were included in the child's parent seal. This can be used to determine how many validators are up and contributing to consensus.
* `consensus_istanbul_blocks_missedrounds` - sum of the `round` included in the parentAggregatedSeal for the blocks seen -- i.e the cumulative number of round changes these blocks needed to make to get to this agreed block.

prom output looks like this:

```
# TYPE consensus_istanbul_blocks_elected gauge
consensus_istanbul_blocks_elected 24

# TYPE consensus_istanbul_blocks_missedbyus gauge
consensus_istanbul_blocks_missedbyus 0

# TYPE consensus_istanbul_blocks_missedrounds gauge
consensus_istanbul_blocks_missedrounds 6

# TYPE consensus_istanbul_blocks_signedbyus gauge
consensus_istanbul_blocks_signedbyus 24

# TYPE consensus_istanbul_blocks_totalsigs gauge
consensus_istanbul_blocks_totalsigs 4
```

Existing block-to-block consensus time distribution:
 
```
# TYPE consensus_istanbul_core_consensus_count counter
consensus_istanbul_core_consensus_count 25

# TYPE consensus_istanbul_core_consensus summary
consensus_istanbul_core_consensus {quantile="0.5"} 6.717818e+07

# TYPE consensus_istanbul_core_consensus summary
consensus_istanbul_core_consensus {quantile="0.75"} 7.909872e+07

# TYPE consensus_istanbul_core_consensus summary
consensus_istanbul_core_consensus {quantile="0.95"} 4.5495920479999983e+08

# TYPE consensus_istanbul_core_consensus summary
consensus_istanbul_core_consensus {quantile="0.99"} 5.32398563e+08

# TYPE consensus_istanbul_core_consensus summary
consensus_istanbul_core_consensus {quantile="0.999"} 5.32398563e+08

# TYPE consensus_istanbul_core_consensus summary
consensus_istanbul_core_consensus {quantile="0.9999"} 5.32398563e+08
```

Gauages for current sequence (refactored), round (was broken - now works) and desired round (new) -- can be used to identify round change scenarios:

```
# TYPE consensus_istanbul_core_desiredround gauge
consensus_istanbul_core_desiredround 0

# TYPE consensus_istanbul_core_round gauge
consensus_istanbul_core_round 0

# TYPE consensus_istanbul_core_sequence gauge
consensus_istanbul_core_sequence 26
``` 
 
### Tested

e2e tests and testnet.

### Other changes

Logging consistency fixes and typos.

### Backwards compatibility

Yes
