### PR TITLE
Point CI back to monorepo master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
       GO_VERSION: "1.13.7"
-      CELO_MONOREPO_BRANCH_TO_TEST: victor/loose-ends
+      CELO_MONOREPO_BRANCH_TO_TEST: master
 jobs:
   build-bls-zexe:
     docker:


### PR DESCRIPTION
### Description

https://github.com/celo-org/celo-blockchain/pull/941 relied on changes to e2e tests in https://github.com/celo-org/celo-monorepo/pull/3216. Once that PR is merged, this PR may be merged to reset CI back to pointing at `master`