### PR TITLE
Fix error when using http2

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6 h1:Eey/GGQ/E5Xp1P2Lyx1qj007hLZfbi0+CoVeJruGCtI=
 github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6/go.mod h1:Dmm/EzmjnCiweXmzRIAiUWCInVmPgjkzgv5k4tVyXiQ=
 github.com/celo-org/bls-zexe v0.0.0-20200401181323-b507c9d2c729 h1:xoSRP5SWgvuqc8fbmTCz8dI1Ys8fm4CyhZ2VKPAqozA=
+github.com/celo-org/bls-zexe v0.0.0-20200402113626-6f9526d155b5 h1:8Z08tQ9m8bjxqyjSbH/KaiNuUYPjryK6hEyRtJaVLjM=
 github.com/celo-org/gosigar v0.10.5-celo1 h1:LbhCsvNot586MAVvGFVF4cekBAo1pAYfUxktl8VuPas=
 github.com/celo-org/gosigar v0.10.5-celo1/go.mod h1:/kPo9MOBSowZbtkqUg0tJ048OJJVjG8dpaHKwAgBLz4=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -175,6 +175,13 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	req.Body = ioutil.NopCloser(bytes.NewReader(body))
 	req.ContentLength = int64(len(body))
 
+	// And also add the same thing to `Request.GetBody`, which allows
+	// `net/http` to get a new body in cases like a redirect.
+	req.GetBody = func() (io.ReadCloser, error) {
+		reader := bytes.NewReader(body)
+		return ioutil.NopCloser(reader), nil
+	}
+
 	resp, err := hc.client.Do(req)
 	if err != nil {
 		return nil, err

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -171,16 +171,16 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	if err != nil {
 		return nil, err
 	}
+
+	getBodyReader := func() io.ReadCloser { return ioutil.NopCloser(bytes.NewReader(body)) }
+
 	req := hc.req.WithContext(ctx)
-	req.Body = ioutil.NopCloser(bytes.NewReader(body))
+	req.Body = getBodyReader()
 	req.ContentLength = int64(len(body))
 
 	// And also add the same thing to `Request.GetBody`, which allows
 	// `net/http` to get a new body in cases like a redirect.
-	req.GetBody = func() (io.ReadCloser, error) {
-		reader := bytes.NewReader(body)
-		return ioutil.NopCloser(reader), nil
-	}
+	req.GetBody = func() (io.ReadCloser, error) { return getBodyReader(), nil }
 
 	resp, err := hc.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
### Description

Found an error message like:

```
http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
```

So, this PR implements GetBody

### Tested

Discovered, fixed and tested while developing rosetta

