### PR TITLE
Ignore build output on Docker Context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 **/*_test.go
-
-build/_workspace
-build/_bin
+.git
+/build/_workspace
+/build/bin
 tests/testdata
-.git*
+
+/crypto/bls/bls-zexe/bls/target
+/crypto/bls/bls-zexe/target


### PR DESCRIPTION


### Description

Build output from geth & rust compiler are removed from the docker
context.
