### PR TITLE
Fix monorepo build now that walletkit has been removed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,8 +167,7 @@ jobs:
             yarn build --scope @celo/utils
             yarn build --scope @celo/protocol
             yarn build --scope docs
-            yarn build --scope @celo/walletkit
-            yarn build --ignore @celo/protocol --ignore docs --ignore @celo/walletkit --ignore @celo/web --ignore @celo/mobile --ignore @celo/react-components
+            yarn build --ignore @celo/protocol --ignore docs --ignore @celo/web --ignore @celo/mobile --ignore @celo/react-components
       - run:
           name: Setup Go language
           command: |


### PR DESCRIPTION
### Description

Walletkit has been removed from the monorepo, this PR fixes the `checkout-monorepo` step on CircleCI which was still referencing it.
