### PR TITLE
Use Gold.mint() instead of state.AddBalance() for epoch rewards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
       GO_VERSION: "1.13.7"
-      CELO_MONOREPO_BRANCH_TO_TEST: master
+      CELO_MONOREPO_BRANCH_TO_TEST: mc/gold-mint
 jobs:
   build-bls-zexe:
     docker:

--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -103,7 +103,7 @@ func (sb *Backend) distributeEpochRewards(header *types.Header, state *state.Sta
 		return err
 	}
 
-	// Validator rewards were payed in cUSD, convert that amount to cGLD and add it to the Reserve
+	// Validator rewards were paid in cUSD, convert that amount to cGLD and add it to the Reserve
 	totalValidatorRewardsConvertedToGold, err := currency.Convert(totalValidatorRewards, stableTokenAddress, nil)
 	if err != nil {
 		return err

--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -52,13 +52,33 @@ func (sb *Backend) distributeEpochRewards(header *types.Header, state *state.Sta
 		return nil
 	}
 
-	err := epoch_rewards.UpdateTargetVotingYield(header, state)
+	// Get necessary Addresses First
+	reserveAddress, err := contract_comm.GetRegisteredAddress(params.ReserveRegistryId, header, state)
 	if err != nil {
 		return err
 	}
+	stableTokenAddress, err := contract_comm.GetRegisteredAddress(params.StableTokenRegistryId, header, state)
+	if err != nil {
+		return err
+	}
+
+	carbonOffsettingPartnerAddress, err := epoch_rewards.GetCarbonOffsettingPartnerAddress(header, state)
+	if err != nil {
+		return err
+	}
+
+	err = epoch_rewards.UpdateTargetVotingYield(header, state)
+	if err != nil {
+		return err
+	}
+
 	validatorReward, totalVoterRewards, communityReward, carbonOffsettingPartnerReward, err := epoch_rewards.CalculateTargetEpochRewards(header, state)
 	if err != nil {
 		return err
+	}
+
+	if carbonOffsettingPartnerAddress == common.ZeroAddress {
+		carbonOffsettingPartnerReward = big.NewInt(0)
 	}
 
 	logger.Debug("Calculated target rewards", "validatorReward", validatorReward, "totalVoterRewards", totalVoterRewards, "communityReward", communityReward)
@@ -82,50 +102,32 @@ func (sb *Backend) distributeEpochRewards(header *types.Header, state *state.Sta
 	if err != nil {
 		return err
 	}
-	totalCommunityRewards, err := sb.distributeCommunityRewards(header, state, communityReward)
-	if err != nil {
-		return err
-	}
 
-	totalDistributedVoterRewards, err := sb.distributeVoterRewards(header, state, valSet, totalVoterRewards, uptimes)
-	if err != nil {
-		return err
-	}
-
-	stableTokenAddress, err := contract_comm.GetRegisteredAddress(params.StableTokenRegistryId, header, state)
-	if err != nil {
-		return err
-	}
-
+	// Validator rewards were payed in cUSD, convert that amount to cGLD and add it to the Reserve
 	totalValidatorRewardsConvertedToGold, err := currency.Convert(totalValidatorRewards, stableTokenAddress, nil)
 	if err != nil {
 		return err
 	}
 
-	reserveAddress, err := contract_comm.GetRegisteredAddress(params.ReserveRegistryId, header, state)
-	if err != nil {
+	if err = gold_token.Mint(header, state, *reserveAddress, totalValidatorRewardsConvertedToGold); err != nil {
 		return err
 	}
-	if reserveAddress != nil {
-		state.AddBalance(*reserveAddress, totalValidatorRewardsConvertedToGold)
-	} else {
-		return errors.New("Unable to fetch reserve address for epoch rewards distribution")
-	}
 
-	carbonOffsettingPartnerAddress, err := epoch_rewards.GetCarbonOffsettingPartnerAddress(header, state)
-	if err != nil {
+	if err := sb.distributeCommunityRewards(header, state, communityReward); err != nil {
 		return err
 	}
-	if carbonOffsettingPartnerAddress != common.ZeroAddress {
-		state.AddBalance(carbonOffsettingPartnerAddress, carbonOffsettingPartnerReward)
-	} else {
-		carbonOffsettingPartnerReward = big.NewInt(0)
+
+	if err := sb.distributeVoterRewards(header, state, valSet, totalVoterRewards, uptimes); err != nil {
+		return err
 	}
 
-	mintedGold := big.NewInt(0).Add(totalDistributedVoterRewards, totalValidatorRewardsConvertedToGold)
-	mintedGold.Add(mintedGold, totalCommunityRewards)
-	mintedGold.Add(mintedGold, carbonOffsettingPartnerReward)
-	return sb.increaseGoldTokenTotalSupply(header, state, mintedGold)
+	if carbonOffsettingPartnerReward.Cmp(new(big.Int)) != 0 {
+		if err = gold_token.Mint(header, state, carbonOffsettingPartnerAddress, carbonOffsettingPartnerReward); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (sb *Backend) updateValidatorScores(header *types.Header, state *state.StateDB, valSet []istanbul.Validator) ([]*big.Int, error) {
@@ -191,34 +193,37 @@ func (sb *Backend) distributeValidatorRewards(header *types.Header, state *state
 	return totalValidatorRewards, nil
 }
 
-func (sb *Backend) distributeCommunityRewards(header *types.Header, state *state.StateDB, communityReward *big.Int) (*big.Int, error) {
-	totalCommunityRewards := big.NewInt(0)
+func (sb *Backend) distributeCommunityRewards(header *types.Header, state *state.StateDB, communityReward *big.Int) error {
 	governanceAddress, err := contract_comm.GetRegisteredAddress(params.GovernanceRegistryId, header, state)
 	if err != nil {
-		return totalCommunityRewards, err
+		return err
 	}
 	reserveAddress, err := contract_comm.GetRegisteredAddress(params.ReserveRegistryId, header, state)
 	if err != nil {
-		return totalCommunityRewards, err
+		return err
 	}
 	lowReserve, err := epoch_rewards.IsReserveLow(header, state)
 	if err != nil {
-		return totalCommunityRewards, err
+		return err
 	}
+
 	if lowReserve && reserveAddress != nil {
-		state.AddBalance(*reserveAddress, communityReward)
-		totalCommunityRewards.Add(totalCommunityRewards, communityReward)
+		return gold_token.Mint(header, state, *reserveAddress, communityReward)
 	} else if governanceAddress != nil {
 		// TODO: How to split eco fund here
-		state.AddBalance(*governanceAddress, communityReward)
-		totalCommunityRewards.Add(totalCommunityRewards, communityReward)
+		return gold_token.Mint(header, state, *governanceAddress, communityReward)
 	}
-
-	return totalCommunityRewards, err
+	return nil
 }
 
-func (sb *Backend) distributeVoterRewards(header *types.Header, state *state.StateDB, valSet []istanbul.Validator, maxTotalRewards *big.Int, uptimes []*big.Int) (*big.Int, error) {
-	totalVoterRewards := big.NewInt(0)
+func (sb *Backend) distributeVoterRewards(header *types.Header, state *state.StateDB, valSet []istanbul.Validator, maxTotalRewards *big.Int, uptimes []*big.Int) error {
+
+	lockedGoldAddress, err := contract_comm.GetRegisteredAddress(params.LockedGoldRegistryId, header, state)
+	if err != nil {
+		return err
+	} else if lockedGoldAddress == nil {
+		return errors.New("Unable to fetch locked gold address for epoch rewards distribution")
+	}
 
 	// Select groups that elected at least one validator aggregate their uptimes.
 	var groups []common.Address
@@ -227,7 +232,7 @@ func (sb *Backend) distributeVoterRewards(header *types.Header, state *state.Sta
 	for i, val := range valSet {
 		group, err := validators.GetMembershipInLastEpoch(header, state, val.Address())
 		if err != nil {
-			return totalVoterRewards, err
+			return err
 		}
 		if _, ok := groupElectedValidator[group]; !ok {
 			groups = append(groups, group)
@@ -239,19 +244,10 @@ func (sb *Backend) distributeVoterRewards(header *types.Header, state *state.Sta
 
 	electionRewards, err := election.DistributeEpochRewards(header, state, groups, maxTotalRewards, groupUptimes)
 	if err != nil {
-		return totalVoterRewards, err
+		return err
 	}
-	lockedGoldAddress, err := contract_comm.GetRegisteredAddress(params.LockedGoldRegistryId, header, state)
-	if err != nil {
-		return totalVoterRewards, err
-	}
-	if lockedGoldAddress != nil {
-		state.AddBalance(*lockedGoldAddress, electionRewards)
-		totalVoterRewards.Add(totalVoterRewards, electionRewards)
-	} else {
-		return totalVoterRewards, errors.New("Unable to fetch locked gold address for epoch rewards distribution")
-	}
-	return totalVoterRewards, err
+
+	return gold_token.Mint(header, state, *lockedGoldAddress, electionRewards)
 }
 
 func (sb *Backend) setInitialGoldTokenTotalSupplyIfUnset(header *types.Header, state *state.StateDB) error {
@@ -269,17 +265,10 @@ func (sb *Backend) setInitialGoldTokenTotalSupplyIfUnset(header *types.Header, s
 		genesisSupply := new(big.Int)
 		genesisSupply.SetBytes(data)
 
-		err = sb.increaseGoldTokenTotalSupply(header, state, genesisSupply)
+		err = gold_token.IncreaseSupply(header, state, genesisSupply)
 		if err != nil {
 			return err
 		}
-	}
-	return nil
-}
-
-func (sb *Backend) increaseGoldTokenTotalSupply(header *types.Header, state *state.StateDB, increase *big.Int) error {
-	if increase.Cmp(common.Big0) > 0 {
-		return gold_token.IncreaseSupply(header, state, increase)
 	}
 	return nil
 }

--- a/contract_comm/gold_token/gold_token.go
+++ b/contract_comm/gold_token/gold_token.go
@@ -121,13 +121,17 @@ func IncreaseSupply(header *types.Header, state vm.StateDB, value *big.Int) erro
 }
 
 func Mint(header *types.Header, state vm.StateDB, benficiary common.Address, value *big.Int) error {
+	if value.Cmp(new(big.Int)) <= 0 {
+		return nil
+	}
+
 	_, err := contract_comm.MakeCall(
 		params.GoldTokenRegistryId,
 		mintFuncABI,
 		"mint",
 		[]interface{}{benficiary, value},
 		nil,
-		params.MaxGasForIncreaseSupply,
+		params.MaxGasForMintGas,
 		common.Big0,
 		header,
 		state,

--- a/contract_comm/gold_token/gold_token.go
+++ b/contract_comm/gold_token/gold_token.go
@@ -30,6 +30,31 @@ const (
 		}]`
 
 	// This is taken from celo-monorepo/packages/protocol/build/<env>/contracts/GoldToken.json
+	mintABI = `[{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "to",
+				"type": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256"
+			}
+		],
+		"name": "mint",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	}]`
+
+	// This is taken from celo-monorepo/packages/protocol/build/<env>/contracts/GoldToken.json
 	totalSupplyABI = `[{
 		"constant": true,
 		"inputs": [],
@@ -46,10 +71,23 @@ const (
 	  }]`
 )
 
-var (
-	increaseSupplyFuncABI, _ = abi.JSON(strings.NewReader(increaseSupplyABI))
-	totalSupplyFuncABI, _    = abi.JSON(strings.NewReader(totalSupplyABI))
-)
+var mintFuncABI, totalSupplyFuncABI, increaseSupplyFuncABI abi.ABI
+
+func init() {
+	var err error
+	increaseSupplyFuncABI, err = abi.JSON(strings.NewReader(increaseSupplyABI))
+	if err != nil {
+		panic(err)
+	}
+	mintFuncABI, err = abi.JSON(strings.NewReader(mintABI))
+	if err != nil {
+		panic(err)
+	}
+	totalSupplyFuncABI, err = abi.JSON(strings.NewReader(totalSupplyABI))
+	if err != nil {
+		panic(err)
+	}
+}
 
 func GetTotalSupply(header *types.Header, state vm.StateDB) (*big.Int, error) {
 	var totalSupply *big.Int
@@ -72,6 +110,22 @@ func IncreaseSupply(header *types.Header, state vm.StateDB, value *big.Int) erro
 		increaseSupplyFuncABI,
 		"increaseSupply",
 		[]interface{}{value},
+		nil,
+		params.MaxGasForIncreaseSupply,
+		common.Big0,
+		header,
+		state,
+		false,
+	)
+	return err
+}
+
+func Mint(header *types.Header, state vm.StateDB, benficiary common.Address, value *big.Int) error {
+	_, err := contract_comm.MakeCall(
+		params.GoldTokenRegistryId,
+		mintFuncABI,
+		"mint",
+		[]interface{}{benficiary, value},
 		nil,
 		params.MaxGasForIncreaseSupply,
 		common.Big0,

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -545,17 +545,24 @@ func (c *transfer) Run(input []byte, caller common.Address, evm *EVM, gas uint64
 	}
 	from := common.BytesToAddress(input[0:32])
 	to := common.BytesToAddress(input[32:64])
+
 	var parsed bool
 	value, parsed := math.ParseBig256(hexutil.Encode(input[64:96]))
 	if !parsed {
 		return nil, gas, fmt.Errorf("Error parsing transfer: unable to parse value from " + hexutil.Encode(input[64:96]))
 	}
-	// Fail if we're trying to transfer more than the available balance
-	if !evm.Context.CanTransfer(evm.StateDB, from, value) {
-		return nil, gas, ErrInsufficientBalance
-	}
 
-	gas, err = evm.TobinTransfer(evm.StateDB, from, to, gas, value)
+	if from == common.ZeroAddress {
+		// Mint case: Create cGLD out of thin air
+		evm.StateDB.AddBalance(to, value)
+	} else {
+		// Fail if we're trying to transfer more than the available balance
+		if !evm.Context.CanTransfer(evm.StateDB, from, value) {
+			return nil, gas, ErrInsufficientBalance
+		}
+
+		gas, err = evm.TobinTransfer(evm.StateDB, from, to, gas, value)
+	}
 
 	return input, gas, err
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -222,6 +222,7 @@ const (
 	MaxGasForUpdateTargetVotingYield               uint64 = 2000000
 	MaxGasForUpdateValidatorScore                  uint64 = 1 * 1000000
 	MaxGasForTotalSupply                           uint64 = 50 * 1000
+	MaxGasForMintGas                               uint64 = 50 * 100000
 	MaxGasToReadErc20Balance                       uint64 = 100000
 	MaxGasForIsReserveLow                          uint64 = 1000000
 	MaxGasForGetCarbonOffsettingPartner            uint64 = 20000


### PR DESCRIPTION
### Description

The rationale behind this, is the `Gold.mint()` emits an event, and thus
is traceable, while `state.AddBalance()` is not. Making it really hard
to figure out how much GoldToken was minted and to whom.

Companion PR https://github.com/celo-org/celo-monorepo/pull/3307

### Tested

CI e2e

