### PR TITLE
Elevate reorg log message and suppress innocuous side chain error message

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2017,15 +2017,9 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 			return fmt.Errorf("invalid new chain")
 		}
 	}
-	// Ensure the user sees large reorgs
+	// Reorgs should not happen with Istanbul consensus. Warn the user.
 	if len(oldChain) > 0 && len(newChain) > 0 {
-		logFn := log.Info
-		msg := "Chain reorg detected"
-		if len(oldChain) > 63 {
-			msg = "Large chain reorg detected"
-			logFn = log.Warn
-		}
-		logFn(msg, "number", commonBlock.Number(), "hash", commonBlock.Hash(),
+		log.Error("Chain reorg detected", "number", commonBlock.Number(), "hash", commonBlock.Hash(),
 			"drop", len(oldChain), "dropfrom", oldChain[0].Hash(), "add", len(newChain), "addfrom", newChain[0].Hash())
 		blockReorgAddMeter.Mark(int64(len(newChain)))
 		blockReorgDropMeter.Mark(int64(len(oldChain)))

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -18,7 +18,6 @@ package miner
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 	"sync"
 	"sync/atomic"
@@ -441,7 +440,8 @@ func (w *worker) mainLoop() {
 			w.commitNewWork(req.interrupt, req.noempty, req.timestamp)
 
 		case ev := <-w.chainSideCh:
-			log.Error(fmt.Sprintf("Unexpected message in chan chainSideCh: %v", ev))
+			// TOOO(nategraf): Remove this subcription, as there is no work to be done here.
+			log.Debug("Message in chan chainSideCh", "hash", ev.Block.Hash(), "number", ev.Block.Number(), "root", ev.Block.Root())
 
 		case ev := <-w.txsCh:
 			// Apply transactions to the pending state if we're not mining.


### PR DESCRIPTION
### Description

In 16e1c70f363451b66712a99540bc03716d93c565 the side chain event handling code, which dealt with uncle blocks, was removed from `miner/worker.go` and an error was put in its place, as we did not expect that code path to ever execute. It turns out, it does execute under an innocuous race condition in which a block is inserted via the `Blockchain.insertChain` and returned to the result channel of `miner/worker.go` simultaneously. This will result in the same block being written to the database twice, which the second being considered a side chain event, but it does not cause any further issues.

As a result, this PR reduces the log level on that error to a debug statement. I refrained from removing the channel because that could have unintended consequences while a logging change along is safe.

### Other changes

While poking around I noticed the reorg code path logs an info message, but now that the Celo client only supports Istanbul, this is always an error. (A very serious error). I've increased the logging level there.

### Backwards compatibility

100%
