### PR TITLE
Update version to v1.0.0-unstable

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	VersionMajor = 0          // Major version component of the current release
-	VersionMinor = 10         // Minor version component of the current release
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 0          // Minor version component of the current release
 	VersionPatch = 0          // Patch version component of the current release
 	VersionMeta  = "unstable" // Version metadata to append to the version string
 )


### PR DESCRIPTION
### Description

This PR updates the version number to `1.0.0-unstable` as version `0.10.0-stable` has been released and the new planned release is `1.0.0-stable`.
