### PR TITLE
Adds address confirmation to Ledger

### DIFF
--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -71,7 +71,7 @@ type Wallet interface {
 	// resources (especially important when working with hardware wallets).
 	Open(passphrase string) error
 
-  // ConfirmAddress shows the address of the given path on the wallet's display.
+	// ConfirmAddress shows the address of the given path on the wallet's display.
 	ConfirmAddress(path DerivationPath) (common.Address, error)
 
 	// Close releases any resources held by an open wallet instance.

--- a/accounts/accounts.go
+++ b/accounts/accounts.go
@@ -71,6 +71,9 @@ type Wallet interface {
 	// resources (especially important when working with hardware wallets).
 	Open(passphrase string) error
 
+  // ConfirmAddress shows the address of the given path on the wallet's display.
+	ConfirmAddress(path DerivationPath) (common.Address, error)
+
 	// Close releases any resources held by an open wallet instance.
 	Close() error
 

--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -145,6 +145,10 @@ func (api *ExternalSigner) Derive(path accounts.DerivationPath, pin bool) (accou
 	return accounts.Account{}, fmt.Errorf("operation not supported on external signers")
 }
 
+func (api *ExternalSigner) ConfirmAddress(path accounts.DerivationPath) (common.Address, error) {
+	return common.Address{}, fmt.Errorf("operation not supported on external signers")
+}
+
 func (api *ExternalSigner) SelfDerive(bases []accounts.DerivationPath, chain ethereum.ChainStateReader) {
 	log.Error("operation SelfDerive not supported on external signers")
 }

--- a/accounts/keystore/wallet.go
+++ b/accounts/keystore/wallet.go
@@ -94,6 +94,12 @@ func (w *keystoreWallet) Derive(path accounts.DerivationPath, pin bool) (account
 	return accounts.Account{}, accounts.ErrNotSupported
 }
 
+// ConfirmAddress implements accounts.Wallet, but is a noop for plain wallets since there
+// is no notion of address confirmation for plain keystore accounts.
+func (w *keystoreWallet) ConfirmAddress(path accounts.DerivationPath) (common.Address, error) {
+	return common.Address{}, accounts.ErrNotSupported
+}
+
 // SelfDerive implements accounts.Wallet, but is a noop for plain wallets since
 // there is no notion of hierarchical account derivation for plain keystore accounts.
 func (w *keystoreWallet) SelfDerive(bases []accounts.DerivationPath, chain ethereum.ChainStateReader) {

--- a/accounts/scwallet/wallet.go
+++ b/accounts/scwallet/wallet.go
@@ -410,6 +410,12 @@ func (w *Wallet) Open(passphrase string) error {
 	return nil
 }
 
+// ConfirmAddress implements accounts.Wallet, but is a noop for plain wallets since there
+// is no notion of address confirmation for smartcards.
+func (w *Wallet) ConfirmAddress(path accounts.DerivationPath) (common.Address, error) {
+	return common.Address{}, accounts.ErrNotSupported
+}
+
 // Close stops and closes the wallet, freeing any resources.
 func (w *Wallet) Close() error {
 	// Ensure the wallet was opened

--- a/accounts/usbwallet/ledger.go
+++ b/accounts/usbwallet/ledger.go
@@ -56,7 +56,7 @@ const (
 	ledgerOpSignMessage      ledgerOpcode = 0x08 // Signs a Celo message after having the user validate the parameters
 
 	ledgerP1DirectlyFetchAddress    ledgerParam1 = 0x00 // Return address directly from the wallet
-	ledgerP1ShowFetchAddress        ledgerParam1 = 0x01 // Return address from the wallet after showing it 
+	ledgerP1ShowFetchAddress        ledgerParam1 = 0x01 // Return address from the wallet after showing it
 	ledgerP1InitTransactionData     ledgerParam1 = 0x00 // First transaction data block for signing
 	ledgerP1ContTransactionData     ledgerParam1 = 0x80 // Subsequent transaction data block for signing
 	ledgerP2DiscardAddressChainCode ledgerParam2 = 0x00 // Do not return the chain code along with the address
@@ -266,10 +266,10 @@ func (w *ledgerDriver) ledgerDerive(derivationPath []uint32, showOnWallet bool) 
 		binary.BigEndian.PutUint32(path[1+4*i:], component)
 	}
 	// Send the request and wait for the response
-  p1 := ledgerP1DirectlyFetchAddress
-  if showOnWallet {
-    p1 = ledgerP1ShowFetchAddress
-  }
+	p1 := ledgerP1DirectlyFetchAddress
+	if showOnWallet {
+		p1 = ledgerP1ShowFetchAddress
+	}
 	reply, err := w.ledgerExchange(ledgerOpRetrieveAddress, p1, ledgerP2DiscardAddressChainCode, path)
 	if err != nil {
 		return common.Address{}, err
@@ -293,7 +293,6 @@ func (w *ledgerDriver) ledgerDerive(derivationPath []uint32, showOnWallet bool) 
 	}
 	return address, nil
 }
-
 
 // ledgerSign sends the transaction to the Ledger wallet, and waits for the user
 // to confirm or deny the transaction.

--- a/accounts/usbwallet/trezor.go
+++ b/accounts/usbwallet/trezor.go
@@ -153,6 +153,12 @@ func (w *trezorDriver) Open(device io.ReadWriter, passphrase string) error {
 	return nil
 }
 
+
+// ConfirmAddress implements usbwallet.driver, showing the address on the device.
+func (w *trezorDriver) ConfirmAddress(path accounts.DerivationPath) (common.Address, error) {
+	return common.Address{}, accounts.ErrNotSupported
+}
+
 // Close implements usbwallet.driver, cleaning up and metadata maintained within
 // the Trezor driver.
 func (w *trezorDriver) Close() error {

--- a/accounts/usbwallet/trezor.go
+++ b/accounts/usbwallet/trezor.go
@@ -153,7 +153,6 @@ func (w *trezorDriver) Open(device io.ReadWriter, passphrase string) error {
 	return nil
 }
 
-
 // ConfirmAddress implements usbwallet.driver, showing the address on the device.
 func (w *trezorDriver) ConfirmAddress(path accounts.DerivationPath) (common.Address, error) {
 	return common.Address{}, accounts.ErrNotSupported

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -56,7 +56,7 @@ type driver interface {
 	// or may not be used by the implementation of a particular wallet instance.
 	Open(device io.ReadWriter, passphrase string) error
 
-  // ConfirmAddress shows the address of the given path on the wallet's display.
+	// ConfirmAddress shows the address of the given path on the wallet's display.
 	ConfirmAddress(path accounts.DerivationPath) (common.Address, error)
 
 	// Close releases any resources held by an open wallet instance.
@@ -519,7 +519,7 @@ func (w *wallet) ConfirmAddress(path accounts.DerivationPath) (common.Address, e
 		return common.Address{}, err
 	}
 
-  return address, nil
+	return address, nil
 }
 
 // SelfDerive sets a base account derivation path from which the wallet attempts

--- a/accounts/usbwallet/wallet.go
+++ b/accounts/usbwallet/wallet.go
@@ -56,6 +56,9 @@ type driver interface {
 	// or may not be used by the implementation of a particular wallet instance.
 	Open(device io.ReadWriter, passphrase string) error
 
+  // ConfirmAddress shows the address of the given path on the wallet's display.
+	ConfirmAddress(path accounts.DerivationPath) (common.Address, error)
+
 	// Close releases any resources held by an open wallet instance.
 	Close() error
 
@@ -494,6 +497,29 @@ func (w *wallet) Derive(path accounts.DerivationPath, pin bool) (accounts.Accoun
 		copy(w.paths[address], path)
 	}
 	return account, nil
+}
+
+// ConfirmAddress implements accounts.Wallet, showing the address on the device.
+func (w *wallet) ConfirmAddress(path accounts.DerivationPath) (common.Address, error) {
+	// Try to derive the actual account and update its URL if successful
+	w.stateLock.RLock() // Avoid device disappearing during derivation
+
+	if w.device == nil {
+		w.stateLock.RUnlock()
+		return common.Address{}, accounts.ErrWalletClosed
+	}
+	<-w.commsLock // Avoid concurrent hardware access
+	address, err := w.driver.ConfirmAddress(path)
+	w.commsLock <- struct{}{}
+
+	w.stateLock.RUnlock()
+
+	// If an error occurred or no pinning was requested, return
+	if err != nil {
+		return common.Address{}, err
+	}
+
+  return address, nil
 }
 
 // SelfDerive sets a base account derivation path from which the wallet attempts

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -129,7 +129,7 @@ can then be used to prove possession of the signing key, for example to
 authorize a the signer to act as a validator in the Celo protocol.
 `,
 			},
-      {
+			{
 				Name:      "confirm-address",
 				Usage:     "Confirm the entered address appears on the hardware wallet.",
 				Action:    utils.MigrateFlags(accountConfirmHardwareAddress),
@@ -337,7 +337,7 @@ func accountConfirmHardwareAddress(ctx *cli.Context) error {
 	foundAccount := false
 
 	for _, wallet = range am.Wallets() {
-    if wallet.URL().Scheme == usbwallet.LedgerScheme {
+		if wallet.URL().Scheme == usbwallet.LedgerScheme {
 			if err := wallet.Open(""); err != nil {
 				if err != accounts.ErrWalletAlreadyOpen {
 					utils.Fatalf("Could not open Ledger wallet: %v", err)
@@ -352,13 +352,13 @@ func accountConfirmHardwareAddress(ctx *cli.Context) error {
 			}
 			if account.Address == address {
 				foundAccount = true
-        receivedAddress, err := wallet.ConfirmAddress(accounts.DefaultBaseDerivationPath)
-        if err != nil {
-          return err
-        }
-        if receivedAddress != address {
-          utils.Fatalf("Address %x is different in the ledger %x", address, receivedAddress)
-        }
+				receivedAddress, err := wallet.ConfirmAddress(accounts.DefaultBaseDerivationPath)
+				if err != nil {
+					return err
+				}
+				if receivedAddress != address {
+					utils.Fatalf("Address %x is different in the ledger %x", address, receivedAddress)
+				}
 				break
 			}
 		}


### PR DESCRIPTION
### Description

This allows users to confirm the address they receive from other commands are an address that exists on the Ledger, confirming the Ledger actually contains the address private key.

The command format is `geth account confirm-address ADDRESS`.

### Tested

Tested that normal transaction sending and proofs-of-possession are not affected and that when running the confirm-address command the address is displayed on the Ledger.

This is backwards compatible.