### PR TITLE
Fix missing reference to libbls_crypto causing linking errors on iOS

### DIFF
--- a/CeloBlockchain.podspec
+++ b/CeloBlockchain.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.summary         = package['description']
   s.source          = { :git => package['repository']['url'], :tag => s.version }
   s.source_files    = 'build/bin/Geth.framework/**/*.h', 'Empty.m'
-  s.vendored_libraries  = 'libGeth.a', 'crypto/bls/bls-zexe/target/universal/release/libepoch_snark.a'
+  s.vendored_libraries  = 'libGeth.a', 'crypto/bls/bls-zexe/target/universal/release/libbls_crypto.a', 'crypto/bls/bls-zexe/target/universal/release/libepoch_snark.a'
   s.pod_target_xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 end


### PR DESCRIPTION
### Description

Fix missing reference to libbls_crypto causing linking errors on iOS

### Tested

Compilation works again on iOS.

### Backwards compatibility

Yes.
