### PR TITLE
Run only primary EVM call with tracer

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -249,9 +249,10 @@ func (st *StateTransition) debitGas(address common.Address, amount *big.Int, fee
 	transactionData := common.GetEncodedAbi(functionSelector, [][]byte{common.AddressToAbi(address), common.AmountToAbi(amount)})
 
 	// Run only primary evm.Call() with tracer
-	debug := evm.GetDebug()
-	evm.SetDebug(false)
-	defer func() { evm.SetDebug(debug) }()
+	if evm.GetDebug() {
+		evm.SetDebug(false)
+		defer func() { evm.SetDebug(true) }()
+	}
 
 	rootCaller := vm.AccountRef(common.HexToAddress("0x0"))
 	// The caller was already charged for the cost of this operation via IntrinsicGas.
@@ -277,9 +278,10 @@ func (st *StateTransition) creditGasFees(
 	transactionData := common.GetEncodedAbi(functionSelector, [][]byte{common.AddressToAbi(from), common.AddressToAbi(feeRecipient), common.AddressToAbi(*gatewayFeeRecipient), common.AddressToAbi(*communityFund), common.AmountToAbi(refund), common.AmountToAbi(tipTxFee), common.AmountToAbi(gatewayFee), common.AmountToAbi(baseTxFee)})
 
 	// Run only primary evm.Call() with tracer
-	debug := evm.GetDebug()
-	evm.SetDebug(false)
-	defer func() { evm.SetDebug(debug) }()
+	if evm.GetDebug() {
+		evm.SetDebug(false)
+		defer func() { evm.SetDebug(true) }()
+	}
 
 	rootCaller := vm.AccountRef(common.HexToAddress("0x0"))
 	// The caller was already charged for the cost of this operation via IntrinsicGas.
@@ -395,6 +397,12 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 
 // distributeTxFees calculates the amounts and recipients of transaction fees and credits the accounts.
 func (st *StateTransition) distributeTxFees() error {
+	// Run only primary evm.Call() with tracer
+	if st.evm.GetDebug() {
+		st.evm.SetDebug(false)
+		defer func() { st.evm.SetDebug(true) }()
+	}
+
 	// Determine the refund and transaction fee to be distributed.
 	refund := new(big.Int).Mul(new(big.Int).SetUint64(st.gas), st.gasPrice)
 	gasUsed := new(big.Int).SetUint64(st.gasUsed())

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -185,7 +185,7 @@ func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmCon
 
 	// vmConfig.EVMInterpreter will be used by EVM-C, it won't be checked here
 	// as we always want to have the built-in EVM as the failover option.
-	evm.interpreters = append(evm.interpreters, NewEVMInterpreter(evm, vmConfig))
+	evm.interpreters = append(evm.interpreters, NewEVMInterpreter(evm, &evm.vmConfig))
 	evm.interpreter = evm.interpreters[0]
 
 	return evm
@@ -528,6 +528,11 @@ func (evm *EVM) ChainConfig() *params.ChainConfig { return evm.chainConfig }
 // If the calculation or transfer of the tax amount fails for any reason, the regular transfer goes ahead.
 // NB: Gas is not charged or accounted for this calculation.
 func (evm *EVM) TobinTransfer(db StateDB, sender, recipient common.Address, gas uint64, amount *big.Int) (leftOverGas uint64, err error) {
+	// Run only primary evm.Call() with tracer
+	if evm.GetDebug() {
+		evm.SetDebug(false)
+		defer func() { evm.SetDebug(true) }()
+	}
 
 	if amount.Cmp(big.NewInt(0)) != 0 {
 		reserveAddress, err := GetRegisteredAddressWithEvm(params.ReserveRegistryId, evm)

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -264,7 +264,7 @@ func opBenchmark(bench *testing.B, op func(pc *uint64, interpreter *EVMInterpret
 	var (
 		env            = NewEVM(Context{}, nil, params.DefaultChainConfig, Config{})
 		stack          = newstack()
-		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
+		evmInterpreter = NewEVMInterpreter(env, &env.vmConfig)
 	)
 
 	env.interpreter = evmInterpreter
@@ -500,7 +500,7 @@ func TestOpMstore(t *testing.T) {
 		env            = NewEVM(Context{}, nil, params.DefaultChainConfig, Config{})
 		stack          = newstack()
 		mem            = NewMemory()
-		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
+		evmInterpreter = NewEVMInterpreter(env, &env.vmConfig)
 	)
 
 	env.interpreter = evmInterpreter
@@ -526,7 +526,7 @@ func BenchmarkOpMstore(bench *testing.B) {
 		env            = NewEVM(Context{}, nil, params.DefaultChainConfig, Config{})
 		stack          = newstack()
 		mem            = NewMemory()
-		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
+		evmInterpreter = NewEVMInterpreter(env, &env.vmConfig)
 	)
 
 	env.interpreter = evmInterpreter
@@ -549,7 +549,7 @@ func BenchmarkOpSHA3(bench *testing.B) {
 		env            = NewEVM(Context{}, nil, params.DefaultChainConfig, Config{})
 		stack          = newstack()
 		mem            = NewMemory()
-		evmInterpreter = NewEVMInterpreter(env, env.vmConfig)
+		evmInterpreter = NewEVMInterpreter(env, &env.vmConfig)
 	)
 	env.interpreter = evmInterpreter
 	evmInterpreter.intPool = poolOfIntPools.get()

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -74,7 +74,7 @@ type keccakState interface {
 // EVMInterpreter represents an EVM interpreter
 type EVMInterpreter struct {
 	evm *EVM
-	cfg Config
+	cfg *Config
 
 	intPool *intPool
 
@@ -86,7 +86,7 @@ type EVMInterpreter struct {
 }
 
 // NewEVMInterpreter returns a new instance of the Interpreter.
-func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
+func NewEVMInterpreter(evm *EVM, cfg *Config) *EVMInterpreter {
 	// We use the STOP instruction whether to see
 	// the jump table was initialised. If it was not
 	// we'll set the default jump table.


### PR DESCRIPTION
## Description

Update `distributeTxFees()` and `TobinTransfer()` to filter their EVM operations from transaction trace when debugging is enabled.  The issue is similar to https://github.com/celo-org/celo-blockchain/pull/938 but occurring at EVM depth 1 instead of depth 0.

## Other changes

- Cosmetically updates idiom in `debitGas()` and `creditGasFees()`.
- Updates `EVMInterpreter` to use a pointer to `evm.config` instead of copying by value. 

## Tested

Unit and e2e tests.

## Related issues

- Fixes issue where Blockscout thinks normal transaction failed if associated Tobin tax transfer reverts.

## Backwards compatibility

Yes.
