### PR TITLE
Begin 1.1.0 release cycle

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 0          // Minor version component of the current release
+	VersionMinor = 1          // Minor version component of the current release
 	VersionPatch = 0          // Patch version component of the current release
 	VersionMeta  = "unstable" // Version metadata to append to the version string
 )


### PR DESCRIPTION
## Description

* Update master version to `1.1.0-unstable`
* Branch `rc0` is tracking `1.0.x`