### PR TITLE
Don't commit previous sequence while on seq 0

### DIFF
--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -19,6 +19,7 @@ package core
 import (
 	"reflect"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 )
@@ -121,7 +122,7 @@ func (c *core) handleCommit(msg *istanbul.Message) error {
 			return err
 		} else if commit.Subject.View.Cmp(lastSubject.View) != 0 {
 			return errOldMessage
-		} else if lastSubject.View.Sequence.Cmp(Common.Big0) == 0 {
+		} else if lastSubject.View.Sequence.Cmp(common.Big0) == 0 {
 			// Don't handle commits for the genesis block, will cause underflows
 			return errOldMessage
 		}

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -121,6 +121,9 @@ func (c *core) handleCommit(msg *istanbul.Message) error {
 			return err
 		} else if commit.Subject.View.Cmp(lastSubject.View) != 0 {
 			return errOldMessage
+		} else if lastSubject.View.Sequence.Cmp(Common.Big0) == 0 {
+			// Don't handle commits for the genesis block, will cause underflows
+			return errOldMessage
 		}
 		return c.handleCheckedCommitForPreviousSequence(msg, commit)
 	} else if err != nil {


### PR DESCRIPTION
## Description

Small fix for a potential issue that can really on crop up at the very start of the network.

When on the first round of consensus, sending an old commit message can cause an underflow when looking for the validators of the parent block of the current block. The parent block does not exist for the genesis block, therefore when this code path is triggered before the first commit, malicious nodes could send a commit for the n = 0 block.

## Tested

Not specifically tested.

## Related issues

- Fixes #[issue number here]

## Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

## Commit Message
Don't commit previous sequence while on seq 0

When on the first round of consensus, sending an old commit message can
cause an underflow when looking for the validators of the parent block
of the current block. The parent block does not exist for the genesis
block, therefore when this code path is triggered before the first
commit, malicious nodes could send a commit for the n = 0 block.
