### PR TITLE
Update mergify to use PR title and body as commit message

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,25 +1,20 @@
-## Description
+### Description
 
 _A few sentences describing the overall effects and goals of the pull request's commits.
 What is the current behavior, and what is the updated/expected behavior with this PR?_
 
-## Other changes
+### Other changes
 
 _Describe any minor or "drive-by" changes here._
 
-## Tested
+### Tested
 
 _An explanation of how the changes were tested or an explanation as to why they don't need to be._
 
-## Related issues
+### Related issues
 
 - Fixes #[issue number here]
 
-## Backwards compatibility
+### Backwards compatibility
 
 _Brief explanation of why these changes are/are not backwards compatible._
-
-## Commit Message
-_If using automerge, specify desired commit title_
-
-_And desired commit message body_

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,14 +11,16 @@ pull_request_rules:
       - "base=master"
       # List of all the tests that should pass.
       # Keep this in sync with the github branch protection settings
-      - "status-success=ci/circleci: unit-tests"
+      - "status-success=Build (253914576835)"
       - "status-success=ci/circleci: lint"
-      - "status-success=ci/circleci: end-to-end-geth-transfer-test"
-      - "status-success=ci/circleci: end-to-end-geth-sync-test"
-      - "status-success=ci/circleci: end-to-end-geth-slashing-test"
-      - "status-success=ci/circleci: end-to-end-geth-governance-test"
+      - "status-success=ci/circleci: unit-tests"
+      - "status-success=ci/circleci: end-to-end-transfer-test"
+      - "status-success=ci/circleci: end-to-end-sync-test"
+      - "status-success=ci/circleci: end-to-end-slashing-test"
+      - "status-success=ci/circleci: end-to-end-governance-test"
       - "status-success=ci/circleci: end-to-end-validator-order-test"
-      - "status-success=ci/circleci: end-to-end-geth-blockchain-parameters-test"
+      - "status-success=ci/circleci: end-to-end-blockchain-parameters-test"
     actions:
       merge:
         method: squash 
+        commit_message: title+body

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,18 +9,9 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       # Only enable this when the pull request is being merged into master
       - "base=master"
-      # List of all the tests that should pass.
-      # Keep this in sync with the github branch protection settings
-      - "status-success=Build (253914576835)"
-      - "status-success=ci/circleci: lint"
-      - "status-success=ci/circleci: unit-tests"
-      - "status-success=ci/circleci: end-to-end-transfer-test"
-      - "status-success=ci/circleci: end-to-end-sync-test"
-      - "status-success=ci/circleci: end-to-end-slashing-test"
-      - "status-success=ci/circleci: end-to-end-governance-test"
-      - "status-success=ci/circleci: end-to-end-validator-order-test"
-      - "status-success=ci/circleci: end-to-end-blockchain-parameters-test"
     actions:
       merge:
         method: squash 
         commit_message: title+body
+      delete_head_branch:
+        force: False


### PR DESCRIPTION
## Description

Change mergify config and PR template to use PR body and title in automerge commits and fix name mismatches in CI test names.
