### PR TITLE
Increase timeout for broadcastblock test

### DIFF
--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -600,7 +600,7 @@ func testBroadcastBlock(t *testing.T, totalPeers, broadcastExpected int) {
 			}
 		}(peer)
 	}
-	timeout := time.After(time.Second)
+	timeout := time.After(2 * time.Second)
 	var receivedCount int
 outer:
 	for {


### PR DESCRIPTION
### Description

The broadcastblock unit tests fails sometimes when --coverage is used.  This PR should reduce the frequency of failures.

### Other changes

None

### Tested

Ran unit tests and CI tests.

### Related issues

Relates to the fixing of flaky tests effort.

### Backwards compatibility

Yes
