### PR TITLE
Added plumo flag

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -214,7 +214,7 @@ func initGenesis(ctx *cli.Context) error {
 	stack := makeFullNode(ctx)
 	defer stack.Close()
 
-	for _, name := range []string{"chaindata", "lightchaindata", "lightestchaindata"} {
+	for _, name := range []string{"chaindata", "lightchaindata", "plumochaindata"} {
 		chaindb, err := stack.OpenDatabase(name, 0, 0, "")
 		if err != nil {
 			utils.Fatalf("Failed to open database: %v", err)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -216,7 +216,7 @@ var (
 	defaultSyncMode = eth.DefaultConfig.SyncMode
 	SyncModeFlag    = TextMarshalerFlag{
 		Name:  "syncmode",
-		Usage: `Blockchain sync mode ("fast", "full", "light", or "lightest")`,
+		Usage: `Blockchain sync mode ("fast", "full", "light", or "plumo" (alias "lightest"))`,
 		Value: &defaultSyncMode,
 	}
 	GCModeFlag = cli.StringFlag{
@@ -1837,8 +1837,8 @@ func MakeChainDatabase(ctx *cli.Context, stack *node.Node) ethdb.Database {
 	name := "chaindata"
 	if ctx.GlobalString(SyncModeFlag.Name) == "light" {
 		name = "lightchaindata"
-	} else if ctx.GlobalString(SyncModeFlag.Name) == "lightest" {
-		name = "lightestchaindata"
+	} else if ctx.GlobalString(SyncModeFlag.Name) == "lightest" || ctx.GlobalString(SyncModeFlag.Name) == "plumo" {
+		name = "plumochaindata"
 	}
 	chainDb, err := stack.OpenDatabaseWithFreezer(name, cache, handles, ctx.GlobalString(AncientFlag.Name), "")
 	if err != nil {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1876,7 +1876,10 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 	if err != nil {
 		Fatalf("%v", err)
 	}
-	config.FullHeaderChainAvailable = ctx.GlobalString(SyncModeFlag.Name) != "lightest"
+	config.FullHeaderChainAvailable = true
+	if ctx.GlobalString(SyncModeFlag.Name) == "lightest" || ctx.GlobalString(SyncModeFlag.Name) == "plumo" {
+		config.FullHeaderChainAvailable = false
+	}
 	if !ctx.GlobalBool(FakePoWFlag.Name) {
 		Fatalf("Only fake PoW engine is available")
 	}

--- a/eth/downloader/modes.go
+++ b/eth/downloader/modes.go
@@ -71,10 +71,12 @@ func (mode *SyncMode) UnmarshalText(text []byte) error {
 		*mode = FastSync
 	case "light":
 		*mode = LightSync
+	case "plumo":
+		*mode = LightestSync
 	case "lightest":
 		*mode = LightestSync
 	default:
-		return fmt.Errorf(`unknown sync mode %q, want "full", "fast", "light", or "lightest"`, text)
+		return fmt.Errorf(`unknown sync mode %q, want "full", "fast", "light", or "plumo" (alias "lightest")`, text)
 	}
 	return nil
 }

--- a/les/client.go
+++ b/les/client.go
@@ -79,7 +79,7 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 		chainName = "lightchaindata"
 		fullChainAvailable = true
 	} else if syncMode == downloader.LightestSync {
-		chainName = "lightestchaindata"
+		chainName = "plumochaindata"
 		fullChainAvailable = false
 	} else {
 		panic("Unexpected sync mode: " + syncMode.String())


### PR DESCRIPTION
### Description

Just added `plumo` as an alias for `lightest` in sync mode flag (didn't remove `lightest`).
Also changed the directory name.

### Other changes

### Tested

Tested with alfajores using command `./build/bin/geth --alfajores --syncmode plumo`

### Related issues

- Fixes #1014

### Backwards compatibility

No, changes the directory name.
