### PR TITLE
Add metrics for total validators, blocks proposed

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -120,7 +120,9 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 		blocksElectedMeter:                 metrics.NewRegisteredMeter("consensus/istanbul/blocks/elected", nil),
 		blocksElectedAndSignedMeter:        metrics.NewRegisteredMeter("consensus/istanbul/blocks/signedbyus", nil),
 		blocksElectedButNotSignedMeter:     metrics.NewRegisteredMeter("consensus/istanbul/blocks/missedbyus", nil),
+		blocksElectedAndProposedMeter:      metrics.NewRegisteredMeter("consensus/istanbul/blocks/proposedbyus", nil),
 		blocksTotalSigsGauge:               metrics.NewRegisteredGauge("consensus/istanbul/blocks/totalsigs", nil),
+		blocksValSetSizeGauge:              metrics.NewRegisteredGauge("consensus/istanbul/blocks/validators", nil),
 		blocksTotalMissedRoundsMeter:       metrics.NewRegisteredMeter("consensus/istanbul/blocks/missedrounds", nil),
 	}
 	backend.core = istanbulCore.New(backend, backend.config)
@@ -246,13 +248,17 @@ type Backend struct {
 	rewardDistributionTimer metrics.Timer
 
 	// Meters for number of blocks seen for which the current validator signer has been elected,
-	// for which it was elected and has signed, and elected but not signed.
+	// for which it was elected and has signed, elected but not signed, and both elected and proposed.
 	blocksElectedMeter             metrics.Meter
 	blocksElectedAndSignedMeter    metrics.Meter
 	blocksElectedButNotSignedMeter metrics.Meter
+	blocksElectedAndProposedMeter  metrics.Meter
 
 	// Gauge for total signatures in parentSeal of last received block (how much better than quorum are we doing)
 	blocksTotalSigsGauge metrics.Gauge
+
+	// Gauge for validator set size of grandparent of last received block (maximum value for blocksTotalSigsGauge)
+	blocksValSetSizeGauge metrics.Gauge
 
 	// Meter counting cumulative number of round changes that had to happen to get blocks agreed.
 	blocksTotalMissedRoundsMeter metrics.Meter

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -243,17 +243,16 @@ func (sb *Backend) NewWork() error {
 	return nil
 }
 
-// Determine if this validator signed the parent of the supplied block:
-// First check the grandparent's validator set. If not elected, it didn't.
-// Then, check the parent seal on the supplied block.
+// Maintain metrics around the *parent* of the supplied block.
+// To figure out if this validator signed the parent block:
+// * First check the grandparent's validator set. If not elected, it didn't.
+// * Then, check the parent seal on the supplied (child) block.
 // We cannot determine any specific info from the validators in the seal of
 // the parent block, because different nodes circulate different versions.
-// It only becomes canonical when the child block is proposed.
-func (sb *Backend) ValidatorElectedAndSignedParentBlock(child *types.Block) (elected bool, inParentSeal bool, countInParentSeal int, missedRounds int64) {
+// The bitmap of signed validators only becomes canonical when the child block is proposed.
+func (sb *Backend) UpdateMetricsForParentOfBlock(child *types.Block) {
 	sb.coreMu.RLock()
 	defer sb.coreMu.RUnlock()
-
-	countInParentSeal = -1
 
 	// Check the parent is not the genesis block.
 	number := child.Number().Uint64()
@@ -267,7 +266,6 @@ func (sb *Backend) ValidatorElectedAndSignedParentBlock(child *types.Block) (ele
 	// Check validator in grandparent valset.
 	gpValSet := sb.getValidators(number-2, parentHeader.ParentHash)
 	gpValSetIndex, _ := gpValSet.GetByAddress(sb.ValidatorAddress())
-	elected = gpValSetIndex >= 0
 
 	// Now check if in the "parent seal" (used for downtime calcs, on the child block)
 	childExtra, err := types.ExtractIstanbulExtra(child.Header())
@@ -275,16 +273,45 @@ func (sb *Backend) ValidatorElectedAndSignedParentBlock(child *types.Block) (ele
 		return
 	}
 
-	if elected {
-		inParentSeal = childExtra.ParentAggregatedSeal.Bitmap.Bit(gpValSetIndex) != 0
-	}
+	// total possible signatures
+	valSetSize := gpValSet.Size()
+	sb.blocksValSetSizeGauge.Update(int64(valSetSize))
 
-	missedRounds = childExtra.ParentAggregatedSeal.Round.Int64()
-	countInParentSeal = 0
+	// signatures present
+	countInParentSeal := 0
 	for i := 0; i < gpValSet.Size(); i++ {
 		countInParentSeal += int(childExtra.ParentAggregatedSeal.Bitmap.Bit(i))
 	}
-	return
+	sb.blocksTotalSigsGauge.Update(int64(countInParentSeal))
+
+	// cumulative count of rounds missed (i.e sequences not agreed on round=0)
+	missedRounds := childExtra.ParentAggregatedSeal.Round.Int64()
+	if missedRounds > 0 {
+		sb.blocksTotalMissedRoundsMeter.Mark(missedRounds)
+	}
+
+	// elected?
+	elected := gpValSetIndex >= 0
+	if !elected {
+		return
+	}
+	sb.blocksElectedMeter.Mark(1)
+
+	// The following metrics are only tracked if the validator is elected.
+
+	// proposed?
+	if parentHeader.Coinbase == sb.ValidatorAddress() {
+		sb.blocksElectedAndProposedMeter.Mark(1)
+	}
+
+	// signed, or missed?
+	inParentSeal := childExtra.ParentAggregatedSeal.Bitmap.Bit(gpValSetIndex) != 0
+	if inParentSeal {
+		sb.blocksElectedAndSignedMeter.Mark(1)
+	} else {
+		sb.blocksElectedButNotSignedMeter.Mark(1)
+		sb.logger.Warn("Elected but didn't sign block", "number", number-1, "address", sb.ValidatorAddress())
+	}
 }
 
 // Actions triggered by a new block being added to the chain.
@@ -293,21 +320,7 @@ func (sb *Backend) NewChainHead(newBlock *types.Block) {
 	sb.logger.Trace("Start NewChainHead", "number", newBlock.Number().Uint64())
 
 	// Update metrics for whether we were elected and signed the parent of this block.
-	elected, inChildsParentSeal, countInParentSeal, missedRounds := sb.ValidatorElectedAndSignedParentBlock(newBlock)
-	if countInParentSeal >= 0 {
-		if elected {
-			sb.blocksElectedMeter.Mark(1)
-			if inChildsParentSeal {
-				sb.blocksElectedAndSignedMeter.Mark(1)
-			} else {
-				sb.blocksElectedButNotSignedMeter.Mark(1)
-			}
-		}
-		sb.blocksTotalSigsGauge.Update(int64(countInParentSeal))
-		if missedRounds > 0 {
-			sb.blocksTotalMissedRoundsMeter.Mark(missedRounds)
-		}
-	}
+	sb.UpdateMetricsForParentOfBlock(newBlock)
 
 	// If this is the last block of the epoch:
 	// * Print an easy to find log message giving our address and whether we're elected in next epoch.


### PR DESCRIPTION
# Description

Add metric for number of blocks observed that are proposed by us:

```
# TYPE consensus_istanbul_blocks_proposedbyus gauge
consensus_istanbul_blocks_proposedbyus 5
```

And a metric for the validator set size:

```
# TYPE consensus_istanbul_blocks_validators gauge
consensus_istanbul_blocks_validators 4
```

### Other changes

Added a log message specifically when we've missed signing a block, to provide options for log-based monitoring.

### Tested

Ran e2e tests.
### Backwards compatibility

Yes