### PR TITLE
Remove start time dependency for announce protocol and proxy

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -440,6 +440,12 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 		if err := ethereum.StartMining(threads); err != nil {
 			utils.Fatalf("Failed to start mining: %v", err)
 		}
+		// Start the proxy handler if this is a node is proxied and "mining"
+		if ctx.GlobalBool(utils.ProxiedFlag.Name) {
+			if err := ethereum.StartProxyHandler(); err != nil {
+				utils.Fatalf("Failed to start the proxy handler: %v", err)
+			}
+		}
 	}
 	if !ctx.GlobalBool(utils.VersionCheckFlag.Name) {
 		blockchain_parameters.SpawnCheck()

--- a/cmd/geth/misccmd.go
+++ b/cmd/geth/misccmd.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/cmd/utils"
-	"github.com/ethereum/go-ethereum/eth"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/params"
 	"gopkg.in/urfave/cli.v1"
 )
@@ -58,7 +58,7 @@ func version(ctx *cli.Context) error {
 		fmt.Println("Git Commit Date:", gitDate)
 	}
 	fmt.Println("Architecture:", runtime.GOARCH)
-	fmt.Println("Protocol Versions:", eth.ProtocolVersions)
+	fmt.Println("Protocol Versions:", istanbul.ProtocolVersions)
 	fmt.Println("Go Version:", runtime.Version())
 	fmt.Println("Operating System:", runtime.GOOS)
 	fmt.Printf("GOPATH=%s\n", os.Getenv("GOPATH"))

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1387,6 +1387,7 @@ func setIstanbul(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	cfg.Istanbul.ValidatorEnodeDBPath = stack.ResolvePath(cfg.Istanbul.ValidatorEnodeDBPath)
 	cfg.Istanbul.VersionCertificateDBPath = stack.ResolvePath(cfg.Istanbul.VersionCertificateDBPath)
 	cfg.Istanbul.RoundStateDBPath = stack.ResolvePath(cfg.Istanbul.RoundStateDBPath)
+	cfg.Istanbul.Validator = ctx.GlobalIsSet(MiningEnabledFlag.Name)
 }
 
 func setProxyP2PConfig(ctx *cli.Context, proxyCfg *p2p.Config) {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -183,6 +183,12 @@ type Istanbul interface {
 	// StopAnnouncing stops the announcing
 	StopAnnouncing() error
 
+	// StartProxyHandler starts the proxy handler
+	StartProxyHandler() error
+
+	// StopProxyHandler stops the proxy handler
+	StopProxyHandler() error
+
 	// This is only implemented for Istanbul.
 	// It will update the validator set diff in the header, if the mined header is the last block of the epoch.
 	// The changes are executed inline.

--- a/consensus/istanbul/backend.go
+++ b/consensus/istanbul/backend.go
@@ -57,13 +57,13 @@ type Backend interface {
 	// EventMux returns the event mux in backend
 	EventMux() *event.TypeMux
 
-	// BroadcastConsensusMsg sends a message to all validators (include self)
-	BroadcastConsensusMsg(validators []common.Address, payload []byte) error
+	// Gossip will send a message to all connnected peers
+	Gossip(payload []byte, ethMsgCode uint64) error
 
 	// Multicast sends a message to it's connected nodes filtered on the 'addresses' parameter (where each address
 	// is associated with those node's signing key)
-	// If that parameter is nil, then it will send the message to all it's connected peers.
-	Multicast(addresses []common.Address, payload []byte, ethMsgCode uint64) error
+	// If sendToSelf is set to true, then the function will send an event to self via a message event
+	Multicast(addresses []common.Address, payload []byte, ethMsgCode uint64, sendToSelf bool) error
 
 	// Commit delivers an approved proposal to backend.
 	// The delivered proposal will be put into blockchain.

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -260,7 +260,7 @@ func (sb *Backend) shouldSaveAndPublishValEnodeURLs() (bool, error) {
 		return false, err
 	}
 
-	return sb.coreStarted && validatorConnSet[sb.Address()], nil
+	return validatorConnSet[sb.Address()], nil
 }
 
 // pruneAnnounceDataStructures will remove entries that are not in the validator connection set from all announce related data structures.

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -554,6 +554,7 @@ func (sb *Backend) handleQueryEnodeMsg(addr common.Address, peer consensus.Peer,
 	if sb.checkSelfGossipCache(payload) {
 		return nil
 	}
+	defer sb.markSelfGossipCache(payload)
 
 	// Decode message
 	err := msg.FromPayload(payload, istanbul.GetSignatureAddress)
@@ -900,6 +901,7 @@ func (sb *Backend) handleVersionCertificatesMsg(addr common.Address, peer consen
 	if sb.checkSelfGossipCache(payload) {
 		return nil
 	}
+	defer sb.markSelfGossipCache(payload)
 
 	var msg istanbul.Message
 	if err := msg.FromPayload(payload, nil); err != nil {

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -549,12 +549,12 @@ func (sb *Backend) handleQueryEnodeMsg(addr common.Address, peer consensus.Peer,
 
 	msg := new(istanbul.Message)
 
-	// Since this is a gossiped messaged, mark that the peer gossiped it and check to see if this node already gossiped it
-	sb.markPeerGossipCache(addr, payload)
-	if sb.checkSelfGossipCache(payload) {
+	// Since this is a gossiped messaged, mark that the peer gossiped it (and presumably processed it) and check to see if this node already processed it
+	sb.markMessageProcessedByPeer(addr, payload)
+	if sb.checkIfMessageProcessedBySelf(payload) {
 		return nil
 	}
-	defer sb.markSelfGossipCache(payload)
+	defer sb.markMessageProcessedBySelf(payload)
 
 	// Decode message
 	err := msg.FromPayload(payload, istanbul.GetSignatureAddress)
@@ -896,12 +896,12 @@ func (sb *Backend) handleVersionCertificatesMsg(addr common.Address, peer consen
 	logger := sb.logger.New("func", "handleVersionCertificatesMsg")
 	logger.Trace("Handling version certificates msg")
 
-	// Since this is a gossiped messaged, mark that the peer gossiped it and check to see if this node already gossiped it
-	sb.markPeerGossipCache(addr, payload)
-	if sb.checkSelfGossipCache(payload) {
+	// Since this is a gossiped messaged, mark that the peer gossiped it (and presumably processed it) and check to see if this node already processed it
+	sb.markMessageProcessedByPeer(addr, payload)
+	if sb.checkIfMessageProcessedBySelf(payload) {
 		return nil
 	}
-	defer sb.markSelfGossipCache(payload)
+	defer sb.markMessageProcessedBySelf(payload)
 
 	var msg istanbul.Message
 	if err := msg.FromPayload(payload, nil); err != nil {

--- a/consensus/istanbul/backend/announce_test.go
+++ b/consensus/istanbul/backend/announce_test.go
@@ -48,7 +48,7 @@ func TestHandleIstAnnounce(t *testing.T) {
 	b.address = val2Address
 
 	// Handle val1's announce message
-	if err = b.handleQueryEnodeMsg(nil, payload); err != nil {
+	if err = b.handleQueryEnodeMsg(common.Address{}, nil, payload); err != nil {
 		t.Errorf("error %v", err)
 	}
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -282,7 +282,12 @@ func (sb *Backend) IsProxy() bool {
 
 // IsProxiedValidator returns if instance has proxied validator flag
 func (sb *Backend) IsProxiedValidator() bool {
-	return sb.config.Proxied
+	return sb.config.Proxied && sb.config.Validator
+}
+
+// IsValidator return if instance is a validator (either proxied or standalone)
+func (sb *Backend) IsValidator() bool {
+	return sb.config.Validator
 }
 
 // SendDelegateSignMsgToProxy sends an istanbulDelegateSign message to a proxy

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -271,6 +271,9 @@ type Backend struct {
 	updatingCachedValidatorConnSetCond *sync.Cond
 
 	vph *validatorPeerHandler
+
+	proxyHandlerRunning bool
+	proxyHandlerMu      sync.RWMutex
 }
 
 // IsProxy returns if instance has proxy flag

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -149,10 +148,10 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 
 	// Set the handler functions for each istanbul message type
 	backend.istanbulAnnounceMsgHandlers = make(map[uint64]announceMsgHandler)
-	backend.istanbulAnnounceMsgHandlers[istanbulQueryEnodeMsg] = backend.handleQueryEnodeMsg
-	backend.istanbulAnnounceMsgHandlers[istanbulValEnodesShareMsg] = backend.handleValEnodesShareMsg
-	backend.istanbulAnnounceMsgHandlers[istanbulVersionCertificatesMsg] = backend.handleVersionCertificatesMsg
-	backend.istanbulAnnounceMsgHandlers[istanbulEnodeCertificateMsg] = backend.handleEnodeCertificateMsg
+	backend.istanbulAnnounceMsgHandlers[istanbul.QueryEnodeMsg] = backend.handleQueryEnodeMsg
+	backend.istanbulAnnounceMsgHandlers[istanbul.ValEnodesShareMsg] = backend.handleValEnodesShareMsg
+	backend.istanbulAnnounceMsgHandlers[istanbul.VersionCertificatesMsg] = backend.handleVersionCertificatesMsg
+	backend.istanbulAnnounceMsgHandlers[istanbul.EnodeCertificateMsg] = backend.handleEnodeCertificateMsg
 
 	return backend
 }
@@ -294,7 +293,7 @@ func (sb *Backend) SendDelegateSignMsgToProxy(msg []byte) error {
 		sb.logger.Error("SendDelegateSignMsgToProxy failed", "err", err)
 		return err
 	}
-	return sb.proxyNode.peer.Send(istanbulDelegateSign, msg)
+	return sb.proxyNode.peer.Send(istanbul.DelegateSignMsg, msg)
 }
 
 // SendDelegateSignMsgToProxiedValidator sends an istanbulDelegateSign message to a
@@ -305,7 +304,7 @@ func (sb *Backend) SendDelegateSignMsgToProxiedValidator(msg []byte) error {
 		sb.logger.Error("SendDelegateSignMsgToProxiedValidator failed", "err", err)
 		return err
 	}
-	return sb.proxiedPeer.Send(istanbulDelegateSign, msg)
+	return sb.proxiedPeer.Send(istanbul.DelegateSignMsg, msg)
 }
 
 // Authorize implements istanbul.Backend.Authorize
@@ -393,132 +392,6 @@ func (sb *Backend) NextBlockValidators(proposal istanbul.Proposal) (istanbul.Val
 func (sb *Backend) GetValidators(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator {
 	validatorSet := sb.getValidators(blockNumber.Uint64(), headerHash)
 	return validatorSet.List()
-}
-
-// This function will return the peers with the addresses in the "destAddresses" parameter.
-// If this is a proxied validator, then it will return the proxy.
-func (sb *Backend) getPeersForMessage(destAddresses []common.Address) map[enode.ID]consensus.Peer {
-	if sb.config.Proxied {
-		if sb.proxyNode != nil && sb.proxyNode.peer != nil {
-			returnMap := make(map[enode.ID]consensus.Peer)
-			returnMap[sb.proxyNode.peer.Node().ID()] = sb.proxyNode.peer
-
-			return returnMap
-		}
-		return nil
-	}
-
-	var targets map[enode.ID]bool
-	if destAddresses != nil {
-		targets = make(map[enode.ID]bool)
-		for _, addr := range destAddresses {
-			if valNode, err := sb.valEnodeTable.GetNodeFromAddress(addr); valNode != nil && err == nil {
-				targets[valNode.ID()] = true
-			}
-		}
-	}
-	return sb.broadcaster.FindPeers(targets, p2p.AnyPurpose)
-}
-
-// BroadcastConsensusMsg implements istanbul.Backend.BroadcastConsensusMsg
-// This function will wrap the consensus message in a fwdMessage if it's a proxied validator.  It will then
-// multicast the msg (the wrapped or original version) to the other validators and send it to itself.
-func (sb *Backend) BroadcastConsensusMsg(destAddresses []common.Address, payload []byte) error {
-	sb.logger.Trace("Broadcasting an istanbul message", "destAddresses", common.ConvertToStringSlice(destAddresses))
-
-	// Send to others
-	if err := sb.Multicast(destAddresses, payload, istanbulConsensusMsg); err != nil {
-		return err
-	}
-
-	// Send to self.  Note that it will never be a wrapped version of the consensus message.
-	msg := istanbul.MessageEvent{
-		Payload: payload,
-	}
-	go sb.istanbulEventMux.Post(msg)
-	return nil
-}
-
-// Multicast implements istanbul.Backend.Multicast
-// Multicast will send the eth message (with the message's payload and msgCode field set to the params
-// payload and ethMsgCode respectively) to the nodes with the signing address in the destAddresses param.
-// If this node is proxied and destAddresses is not nil, the message will be wrapped
-// in an istanbul.ForwardMessage to ensure the proxy sends it to the correct
-// destAddresses.
-// If the destAddresses param is set to nil, then this function will send the message to all connected
-// peers.
-func (sb *Backend) Multicast(destAddresses []common.Address, payload []byte, ethMsgCode uint64) error {
-	logger := sb.logger.New("func", "Multicast")
-
-	if sb.config.Proxied && destAddresses != nil {
-		// Convert the message to a fwdMessage
-		fwdMessage := &istanbul.ForwardMessage{
-			Code:          ethMsgCode,
-			DestAddresses: destAddresses,
-			Msg:           payload,
-		}
-		fwdMsgBytes, err := rlp.EncodeToBytes(fwdMessage)
-		if err != nil {
-			logger.Error("Failed to encode", "fwdMessage", fwdMessage)
-			return err
-		}
-
-		// Note that we are not signing message.  The message that is being wrapped is already signed.
-		msg := istanbul.Message{Code: istanbulFwdMsg, Msg: fwdMsgBytes, Address: sb.Address()}
-		fwdMsgPayload, err := msg.Payload()
-		if err != nil {
-			return err
-		}
-
-		return sb.multicast(destAddresses, fwdMsgPayload, istanbulFwdMsg)
-	}
-	return sb.multicast(destAddresses, payload, ethMsgCode)
-}
-
-// multicast will send the eth message (with the message's payload and msgCode field set to the params
-// payload and ethMsgCode respectively) to the nodes with the signing address in the destAddresses param.
-// If the destAddresses param is set to nil, then this function will send the message to all connected peers.
-func (sb *Backend) multicast(destAddresses []common.Address, payload []byte, ethMsgCode uint64) error {
-	logger := sb.logger.New("func", "multicast")
-	// Get peers to send.
-	peers := sb.getPeersForMessage(destAddresses)
-
-	logger.Trace("Going to multicast a message", "peers", peers, "ethMsgCode", ethMsgCode)
-
-	// Only cache for the announceMsg, as that is the only message that is gossiped.
-	var hash common.Hash
-	if sb.isGossipedMsgCode(ethMsgCode) {
-		hash = istanbul.RLPHash(payload)
-		sb.selfRecentMessages.Add(hash, true)
-	}
-
-	if len(peers) > 0 {
-		for _, p := range peers {
-			if sb.isGossipedMsgCode(ethMsgCode) {
-				nodePubKey := p.Node().Pubkey()
-				nodeAddr := crypto.PubkeyToAddress(*nodePubKey)
-				ms, ok := sb.peerRecentMessages.Get(nodeAddr)
-				var m *lru.ARCCache
-				if ok {
-					m, _ = ms.(*lru.ARCCache)
-					if _, k := m.Get(hash); k {
-						// This peer had this event, skip it
-						logger.Trace("Message already cached for peer.  Not sending it to peer", "peer", p)
-						continue
-					}
-				} else {
-					m, _ = lru.NewARC(inmemoryMessages)
-				}
-
-				m.Add(hash, true)
-				sb.peerRecentMessages.Add(nodeAddr, m)
-			}
-			logger.Trace("Sending istanbul message to peer", "peer", p)
-
-			go p.Send(ethMsgCode, payload)
-		}
-	}
-	return nil
 }
 
 // Commit implements istanbul.Backend.Commit
@@ -1002,4 +875,35 @@ func (sb *Backend) retrieveUncachedValidatorConnSet() (map[common.Address]bool, 
 
 	logger.Trace("Returning validator conn set", "validatorsSet", validatorsSet)
 	return validatorsSet, nil
+}
+
+func (sb *Backend) sendForwardMsgToProxy(finalDestAddresses []common.Address, ethMsgCode uint64, payload []byte) error {
+	logger := sb.logger.New("func", "SendForwardMsg")
+	if sb.proxyNode.peer == nil {
+		logger.Warn("No connected proxy for sending a fwd message", "ethMsgCode", ethMsgCode, "finalDestAddreses", common.ConvertToStringSlice(finalDestAddresses))
+		return errNoProxyConnection
+	}
+
+	// Convert the message to a fwdMessage
+	fwdMessage := &istanbul.ForwardMessage{
+		Code:          ethMsgCode,
+		DestAddresses: finalDestAddresses,
+		Msg:           payload,
+	}
+	fwdMsgBytes, err := rlp.EncodeToBytes(fwdMessage)
+	if err != nil {
+		logger.Error("Failed to encode", "fwdMessage", fwdMessage)
+		return err
+	}
+
+	// Note that we are not signing message.  The message that is being wrapped is already signed.
+	msg := istanbul.Message{Code: istanbul.FwdMsg, Msg: fwdMsgBytes, Address: sb.Address()}
+	fwdMsgPayload, err := msg.Payload()
+	if err != nil {
+		return err
+	}
+
+	go sb.proxyNode.peer.Send(istanbul.FwdMsg, fwdMsgPayload)
+
+	return nil
 }

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -670,7 +670,7 @@ func (sb *Backend) StartProxyHandler() error {
 				sb.logger.Error("Issue in adding proxy on istanbul start", "err", err)
 			}
 		}
-		go sb.sendValEnodesShareMsgs()
+		go sb.valEnodesShareThread()
 	}
 
 	sb.proxyHandlerRunning = true
@@ -688,8 +688,8 @@ func (sb *Backend) StopProxyHandler() error {
 	}
 
 	if sb.IsProxiedValidator() {
-		sb.valEnodesShareQuit <- struct{}{}
-		sb.valEnodesShareWg.Wait()
+		sb.valEnodesShareThreadQuit <- struct{}{}
+		sb.valEnodesShareThreadWg.Wait()
 
 		if sb.proxyNode != nil {
 			sb.removeProxy(sb.proxyNode.node)

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -664,14 +664,16 @@ func (sb *Backend) StartProxyHandler() error {
 
 	if !sb.IsProxiedValidator() {
 		return istanbul.ErrValidatorNotProxied
-	} else {
-		if sb.config.ProxyInternalFacingNode != nil && sb.config.ProxyExternalFacingNode != nil {
-			if err := sb.addProxy(sb.config.ProxyInternalFacingNode, sb.config.ProxyExternalFacingNode); err != nil {
-				sb.logger.Error("Issue in adding proxy on istanbul start", "err", err)
-			}
-		}
-		go sb.valEnodesShareThread()
 	}
+
+	// At this point, we can be sure that this node is a proxied validator.
+	if sb.config.ProxyInternalFacingNode != nil && sb.config.ProxyExternalFacingNode != nil {
+		if err := sb.addProxy(sb.config.ProxyInternalFacingNode, sb.config.ProxyExternalFacingNode); err != nil {
+			sb.logger.Error("Issue in adding proxy on istanbul start", "err", err)
+		}
+	}
+
+	go sb.valEnodesShareThread()
 
 	sb.proxyHandlerRunning = true
 

--- a/consensus/istanbul/backend/gossip_cache.go
+++ b/consensus/istanbul/backend/gossip_cache.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 )
 
-func (sb *Backend) markPeerGossipCache(peerNodeAddr common.Address, payload []byte) {
+func (sb *Backend) markMessageProcessedByPeer(peerNodeAddr common.Address, payload []byte) {
 	ms, ok := sb.peerRecentMessages.Get(peerNodeAddr)
 	var m *lru.ARCCache
 	if ok {
@@ -36,7 +36,7 @@ func (sb *Backend) markPeerGossipCache(peerNodeAddr common.Address, payload []by
 	m.Add(payloadHash, true)
 }
 
-func (sb *Backend) checkPeerGossipCache(peerNodeAddr common.Address, payload []byte) bool {
+func (sb *Backend) checkIfMessageProcessedByPeer(peerNodeAddr common.Address, payload []byte) bool {
 	ms, ok := sb.peerRecentMessages.Get(peerNodeAddr)
 	var m *lru.ARCCache
 	if ok {
@@ -49,12 +49,12 @@ func (sb *Backend) checkPeerGossipCache(peerNodeAddr common.Address, payload []b
 	return false
 }
 
-func (sb *Backend) markSelfGossipCache(payload []byte) {
+func (sb *Backend) markMessageProcessedBySelf(payload []byte) {
 	payloadHash := istanbul.RLPHash(payload)
 	sb.selfRecentMessages.Add(payloadHash, true)
 }
 
-func (sb *Backend) checkSelfGossipCache(payload []byte) bool {
+func (sb *Backend) checkIfMessageProcessedBySelf(payload []byte) bool {
 	payloadHash := istanbul.RLPHash(payload)
 	_, ok := sb.selfRecentMessages.Get(payloadHash)
 	return ok

--- a/consensus/istanbul/backend/gossip_cache.go
+++ b/consensus/istanbul/backend/gossip_cache.go
@@ -1,0 +1,61 @@
+// Copyright 2017 The celo Authors
+// This file is part of the celo library.
+//
+// The celo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The celo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the celo library. If not, see <http://www.gnu.org/licenses/>.
+
+package backend
+
+import (
+	lru "github.com/hashicorp/golang-lru"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
+)
+
+func (sb *Backend) markPeerGossipCache(peerNodeAddr common.Address, payload []byte) {
+	ms, ok := sb.peerRecentMessages.Get(peerNodeAddr)
+	var m *lru.ARCCache
+	if ok {
+		m, _ = ms.(*lru.ARCCache)
+	} else {
+		m, _ = lru.NewARC(inmemoryMessages)
+		sb.peerRecentMessages.Add(peerNodeAddr, m)
+	}
+	payloadHash := istanbul.RLPHash(payload)
+	m.Add(payloadHash, true)
+}
+
+func (sb *Backend) checkPeerGossipCache(peerNodeAddr common.Address, payload []byte) bool {
+	ms, ok := sb.peerRecentMessages.Get(peerNodeAddr)
+	var m *lru.ARCCache
+	if ok {
+		m, _ = ms.(*lru.ARCCache)
+		payloadHash := istanbul.RLPHash(payload)
+		_, ok := m.Get(payloadHash)
+		return ok
+	}
+
+	return false
+}
+
+func (sb *Backend) markSelfGossipCache(payload []byte) {
+	payloadHash := istanbul.RLPHash(payload)
+	sb.selfRecentMessages.Add(payloadHash, true)
+}
+
+func (sb *Backend) checkSelfGossipCache(payload []byte) bool {
+	payloadHash := istanbul.RLPHash(payload)
+	_, ok := sb.selfRecentMessages.Get(payloadHash)
+	return ok
+}

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -54,7 +54,7 @@ func (sb *Backend) HandleMsg(addr common.Address, msg p2p.Msg, peer consensus.Pe
 	defer sb.coreMu.Unlock()
 
 	if istanbul.IsIstanbulMsg(msg) {
-		if (!sb.coreStarted && !sb.config.Proxy) && (msg.Code == istanbul.ConsensusMsg) {
+		if (!sb.coreStarted && !sb.IsProxy()) && (msg.Code == istanbul.ConsensusMsg) {
 			return true, istanbul.ErrStoppedEngine
 		}
 

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rlp"
-	lru "github.com/hashicorp/golang-lru"
 )
 
 var (
@@ -43,28 +42,10 @@ var (
 
 // If you want to add a code, you need to increment the Lengths Array size!
 const (
-	istanbulConsensusMsg = 0x11
-	// TODO:  Support sending multiple announce messages withone one message
-	istanbulQueryEnodeMsg          = 0x12
-	istanbulValEnodesShareMsg      = 0x13
-	istanbulFwdMsg                 = 0x14
-	istanbulDelegateSign           = 0x15
-	istanbulVersionCertificatesMsg = 0x16
-	istanbulEnodeCertificateMsg    = 0x17
-	istanbulValidatorHandshakeMsg  = 0x18
-
 	handshakeTimeout = 5 * time.Second
 )
 
-func (sb *Backend) isIstanbulMsg(msg p2p.Msg) bool {
-	return msg.Code >= istanbulConsensusMsg && msg.Code <= istanbulValidatorHandshakeMsg
-}
-
-func (sb *Backend) isGossipedMsgCode(msgCode uint64) bool {
-	return msgCode == istanbulQueryEnodeMsg || msgCode == istanbulVersionCertificatesMsg
-}
-
-type announceMsgHandler func(consensus.Peer, []byte) error
+type announceMsgHandler func(common.Address, consensus.Peer, []byte) error
 
 // HandleMsg implements consensus.Handler.HandleMsg
 func (sb *Backend) HandleMsg(addr common.Address, msg p2p.Msg, peer consensus.Peer) (bool, error) {
@@ -72,8 +53,8 @@ func (sb *Backend) HandleMsg(addr common.Address, msg p2p.Msg, peer consensus.Pe
 	sb.coreMu.Lock()
 	defer sb.coreMu.Unlock()
 
-	if sb.isIstanbulMsg(msg) {
-		if (!sb.coreStarted && !sb.config.Proxy) && (msg.Code == istanbulConsensusMsg) {
+	if istanbul.IsIstanbulMsg(msg) {
+		if (!sb.coreStarted && !sb.config.Proxy) && (msg.Code == istanbul.ConsensusMsg) {
 			return true, istanbul.ErrStoppedEngine
 		}
 
@@ -83,7 +64,7 @@ func (sb *Backend) HandleMsg(addr common.Address, msg p2p.Msg, peer consensus.Pe
 			return true, errDecodeFailed
 		}
 
-		if msg.Code == istanbulDelegateSign {
+		if msg.Code == istanbul.DelegateSignMsg {
 			if sb.shouldHandleDelegateSign() {
 				go sb.delegateSignFeed.Send(istanbul.MessageEvent{Payload: data})
 				return true, nil
@@ -92,39 +73,16 @@ func (sb *Backend) HandleMsg(addr common.Address, msg p2p.Msg, peer consensus.Pe
 			return true, errors.New("No proxy or proxied validator found")
 		}
 
-		// Only use the recent messages and known messages cache for messages
-		// that are gossiped
-		if sb.isGossipedMsgCode(msg.Code) {
-			hash := istanbul.RLPHash(data)
-
-			// Mark peer's message
-			ms, ok := sb.peerRecentMessages.Get(addr)
-			var m *lru.ARCCache
-			if ok {
-				m, _ = ms.(*lru.ARCCache)
-			} else {
-				m, _ = lru.NewARC(inmemoryMessages)
-				sb.peerRecentMessages.Add(addr, m)
-			}
-			m.Add(hash, true)
-
-			// Mark self known message
-			if _, ok := sb.selfRecentMessages.Get(hash); ok {
-				return true, nil
-			}
-			sb.selfRecentMessages.Add(hash, true)
-		}
-
-		if msg.Code == istanbulConsensusMsg {
+		if msg.Code == istanbul.ConsensusMsg {
 			err := sb.handleConsensusMsg(peer, data)
 			return true, err
-		} else if msg.Code == istanbulFwdMsg {
+		} else if msg.Code == istanbul.FwdMsg {
 			err := sb.handleFwdMsg(peer, data)
 			return true, err
 		} else if announceHandlerFunc, ok := sb.istanbulAnnounceMsgHandlers[msg.Code]; ok { // Note that the valEnodeShare message is handled here as well
-			go announceHandlerFunc(peer, data)
+			go announceHandlerFunc(addr, peer, data)
 			return true, nil
-		} else if msg.Code == istanbulValidatorHandshakeMsg {
+		} else if msg.Code == istanbul.ValidatorHandshakeMsg {
 			logger.Warn("Received unexpected Istanbul validator handshake message")
 			return true, nil
 		}
@@ -162,7 +120,7 @@ func (sb *Backend) handleConsensusMsg(peer consensus.Peer, payload []byte) error
 		// Need to forward the message to the proxied validator
 		sb.logger.Trace("Forwarding consensus message to proxied validator", "from", peer.Node().ID())
 		if sb.proxiedPeer != nil {
-			go sb.proxiedPeer.Send(istanbulConsensusMsg, payload)
+			go sb.proxiedPeer.Send(istanbul.ConsensusMsg, payload)
 		}
 	} else { // The case when this node is a validator
 		go sb.istanbulEventMux.Post(istanbul.MessageEvent{
@@ -204,7 +162,7 @@ func (sb *Backend) handleFwdMsg(peer consensus.Peer, payload []byte) error {
 	}
 
 	sb.logger.Trace("Forwarding a message", "msg code", fwdMsg.Code)
-	go sb.Multicast(fwdMsg.DestAddresses, fwdMsg.Msg, fwdMsg.Code)
+	go sb.Multicast(fwdMsg.DestAddresses, fwdMsg.Msg, fwdMsg.Code, false)
 	return nil
 }
 
@@ -408,7 +366,7 @@ func (sb *Backend) Handshake(peer consensus.Peer) (bool, error) {
 			errCh <- err
 			return
 		}
-		err = peer.Send(istanbulValidatorHandshakeMsg, msgBytes)
+		err = peer.Send(istanbul.ValidatorHandshakeMsg, msgBytes)
 		if err != nil {
 			errCh <- err
 		}
@@ -450,7 +408,7 @@ func (sb *Backend) readValidatorHandshakeMessage(peer consensus.Peer) (bool, err
 	if err != nil {
 		return false, err
 	}
-	if peerMsg.Code != istanbulValidatorHandshakeMsg {
+	if peerMsg.Code != istanbul.ValidatorHandshakeMsg {
 		logger.Warn("Read incorrect message code", "code", peerMsg.Code)
 		return false, errors.New("Incorrect message code")
 	}

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -70,7 +70,7 @@ func TestIstanbulMessage(t *testing.T) {
 
 	// generate one msg
 	data := []byte("data1")
-	msg := makeMsg(istanbulQueryEnodeMsg, data)
+	msg := makeMsg(istanbul.QueryEnodeMsg, data)
 	addr := common.BytesToAddress([]byte("address"))
 
 	_, err := backend.HandleMsg(addr, msg, &MockPeer{})
@@ -86,31 +86,31 @@ func TestRecentMessageCaches(t *testing.T) {
 		shouldCache bool
 	}{
 		{
-			ethMsgCode:  istanbulConsensusMsg,
+			ethMsgCode:  istanbul.ConsensusMsg,
 			shouldCache: false,
 		},
 		{
-			ethMsgCode:  istanbulQueryEnodeMsg,
+			ethMsgCode:  istanbul.QueryEnodeMsg,
 			shouldCache: true,
 		},
 		{
-			ethMsgCode:  istanbulValEnodesShareMsg,
+			ethMsgCode:  istanbul.ValEnodesShareMsg,
 			shouldCache: false,
 		},
 		{
-			ethMsgCode:  istanbulFwdMsg,
+			ethMsgCode:  istanbul.FwdMsg,
 			shouldCache: false,
 		},
 		{
-			ethMsgCode:  istanbulVersionCertificatesMsg,
+			ethMsgCode:  istanbul.VersionCertificatesMsg,
 			shouldCache: true,
 		},
 		{
-			ethMsgCode:  istanbulEnodeCertificateMsg,
+			ethMsgCode:  istanbul.EnodeCertificateMsg,
 			shouldCache: false,
 		},
 		{
-			ethMsgCode:  istanbulValidatorHandshakeMsg,
+			ethMsgCode:  istanbul.ValidatorHandshakeMsg,
 			shouldCache: false,
 		},
 	}
@@ -170,7 +170,7 @@ func TestProxyConsensusForwarding(t *testing.T) {
 	}
 
 	msg := &istanbul.Message{
-		Code:      istanbulConsensusMsg,
+		Code:      istanbul.ConsensusMsg,
 		Msg:       bytes,
 		Address:   backend.Address(),
 		Signature: []byte{},
@@ -209,7 +209,7 @@ func TestReadValidatorHandshakeMessage(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error getting payload of empty msg %v", err)
 	}
-	peer.Messages <- makeMsg(istanbulValidatorHandshakeMsg, emptyMsgPayload)
+	peer.Messages <- makeMsg(istanbul.ValidatorHandshakeMsg, emptyMsgPayload)
 	isValidator, err := backend.readValidatorHandshakeMessage(peer)
 	if err != nil {
 		t.Errorf("Error from readValidatorHandshakeMessage %v", err)
@@ -239,7 +239,7 @@ func TestReadValidatorHandshakeMessage(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error getting payload of valid msg %v", err)
 	}
-	peer.Messages <- makeMsg(istanbulValidatorHandshakeMsg, validMsgPayload)
+	peer.Messages <- makeMsg(istanbul.ValidatorHandshakeMsg, validMsgPayload)
 
 	block := backend.currentBlock()
 	valSet := backend.getValidators(block.Number().Uint64(), block.Hash())

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -141,6 +141,9 @@ func TestRecentMessageCaches(t *testing.T) {
 			t.Fatalf("handle message failed: %v", err)
 		}
 
+		// Sleep for a bit, since some of the messages are handled in a different thread
+		time.Sleep(10 * time.Second)
+
 		// for peers
 		if ms, ok := backend.peerRecentMessages.Get(addr); tt.shouldCache != ok {
 			t.Fatalf("the cache of messages for this peer should be nil")

--- a/consensus/istanbul/backend/message_senders.go
+++ b/consensus/istanbul/backend/message_senders.go
@@ -1,0 +1,116 @@
+// Copyright 2017 The celo Authors
+// This file is part of the celo library.
+//
+// The celo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The celo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the celo library. If not, see <http://www.gnu.org/licenses/>.
+
+package backend
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// This function will return the peers with the addresses in the "destAddresses" parameter.
+func (sb *Backend) getPeersFromDestAddresses(destAddresses []common.Address) map[enode.ID]consensus.Peer {
+	var targets map[enode.ID]bool
+	if destAddresses != nil {
+		targets = make(map[enode.ID]bool)
+		for _, addr := range destAddresses {
+			if valNode, err := sb.valEnodeTable.GetNodeFromAddress(addr); valNode != nil && err == nil {
+				targets[valNode.ID()] = true
+			}
+		}
+	}
+	return sb.broadcaster.FindPeers(targets, p2p.AnyPurpose)
+}
+
+// Multicast implements istanbul.Backend.Multicast
+// Multicast will send the eth message (with the message's payload and msgCode field set to the params
+// payload and ethMsgCode respectively) to the nodes with the signing address in the destAddresses param.
+// If this node is proxied and destAddresses is not nil, the message will be wrapped
+// in an istanbul.ForwardMessage to ensure the proxy sends it to the correct
+// destAddresses.
+func (sb *Backend) Multicast(destAddresses []common.Address, payload []byte, ethMsgCode uint64, sendToSelf bool) error {
+	var err error
+
+	if sb.IsProxiedValidator() {
+		if err := sb.sendForwardMsgToProxy(destAddresses, ethMsgCode, payload); err != nil {
+			return err
+		}
+	} else {
+		destPeers := sb.getPeersFromDestAddresses(destAddresses)
+		if len(destPeers) > 0 {
+			err = sb.sendMsg(destPeers, payload, ethMsgCode)
+		}
+	}
+
+	if sendToSelf {
+		// Send to self.  Note that it will never be a wrapped version of the consensus message.
+		msg := istanbul.MessageEvent{
+			Payload: payload,
+		}
+
+		go sb.istanbulEventMux.Post(msg)
+	}
+
+	return err
+}
+
+// Gossip implements istanbul.Backend.Gossip
+// Gossip will gossip the eth message to all connected peers
+func (sb *Backend) Gossip(payload []byte, ethMsgCode uint64) error {
+	logger := sb.logger.New("func", "Gossip")
+
+	// Get all connected peers
+	peersToSendMsg := sb.broadcaster.FindPeers(nil, p2p.AnyPurpose)
+
+	// Mark that this node gossiped this message, so that it will ignore it if
+	// one of it's peers sends the message to it.
+	sb.markSelfGossipCache(payload)
+
+	// Filter out peers that already sent us this gossip message
+	for nodeID, peer := range peersToSendMsg {
+		nodePubKey := peer.Node().Pubkey()
+		nodeAddr := crypto.PubkeyToAddress(*nodePubKey)
+		if sb.checkPeerGossipCache(nodeAddr, payload) {
+			delete(peersToSendMsg, nodeID)
+			logger.Trace("Peer already gossiped this message.  Not sending message to it", "peer", peer)
+			continue
+		} else {
+			sb.markPeerGossipCache(nodeAddr, payload)
+		}
+	}
+
+	return sb.sendMsg(peersToSendMsg, payload, ethMsgCode)
+}
+
+// sendMsg will send the eth message (with the message's payload and msgCode field set to the params
+// payload and ethMsgCode respectively) to either the nodes with the signing address in the destAddresses param,
+// or to all the connected peers with this node (if gossip parameter set to true).
+func (sb *Backend) sendMsg(destPeers map[enode.ID]consensus.Peer, payload []byte, ethMsgCode uint64) error {
+	logger := sb.logger.New("func", "multicast")
+
+	logger.Trace("Going to send a message", "peers", destPeers, "ethMsgCode", ethMsgCode)
+
+	for _, peer := range destPeers {
+		logger.Trace("Sending istanbul message to peer", "peer", peer)
+		go peer.Send(ethMsgCode, payload)
+	}
+
+	return nil
+}

--- a/consensus/istanbul/backend/message_senders.go
+++ b/consensus/istanbul/backend/message_senders.go
@@ -100,7 +100,7 @@ func (sb *Backend) Gossip(payload []byte, ethMsgCode uint64) error {
 // sendMsg will send the eth message (with the message's payload and msgCode field set to the params
 // payload and ethMsgCode respectively) to all the nodes destPeers param.
 func (sb *Backend) sendMsg(destPeers map[enode.ID]consensus.Peer, payload []byte, ethMsgCode uint64) error {
-	logger := sb.logger.New("func", "multicast")
+	logger := sb.logger.New("func", "sendMsg")
 
 	logger.Trace("Going to send a message", "peers", destPeers, "ethMsgCode", ethMsgCode)
 

--- a/consensus/istanbul/backend/peer_handler.go
+++ b/consensus/istanbul/backend/peer_handler.go
@@ -101,7 +101,7 @@ func (vph *validatorPeerHandler) thread() {
 // Returns whether this node should maintain validator connections
 // Only proxies and non proxied validators need to connect maintain validator connections
 func (vph *validatorPeerHandler) MaintainValConnections() bool {
-	return vph.sb.config.Proxy || (vph.sb.coreStarted && !vph.sb.config.Proxied)
+	return vph.sb.IsProxy() || (vph.sb.IsValidator() && !vph.sb.IsProxiedValidator())
 }
 
 func (vph *validatorPeerHandler) AddValidatorPeer(node *enode.Node, address common.Address) {

--- a/consensus/istanbul/backend/val_enodes_share.go
+++ b/consensus/istanbul/backend/val_enodes_share.go
@@ -81,9 +81,9 @@ func (sd *valEnodesShareData) DecodeRLP(s *rlp.Stream) error {
 
 // This function is meant to be run as a goroutine.  It will periodically send validator enode share messages
 // to this node's proxies so that proxies know the enodes of validators
-func (sb *Backend) sendValEnodesShareMsgs() {
-	sb.valEnodesShareWg.Add(1)
-	defer sb.valEnodesShareWg.Done()
+func (sb *Backend) valEnodesShareThread() {
+	sb.valEnodesShareThreadWg.Add(1)
+	defer sb.valEnodesShareThreadWg.Done()
 
 	ticker := time.NewTicker(time.Minute)
 
@@ -94,7 +94,7 @@ func (sb *Backend) sendValEnodesShareMsgs() {
 			log.Trace("ValidatorEnodeTable dump", "ValidatorEnodeTable", sb.valEnodeTable.String())
 			go sb.sendValEnodesShareMsg()
 
-		case <-sb.valEnodesShareQuit:
+		case <-sb.valEnodesShareThreadQuit:
 			ticker.Stop()
 			return
 		}

--- a/consensus/istanbul/backend/val_enodes_share.go
+++ b/consensus/istanbul/backend/val_enodes_share.go
@@ -132,7 +132,7 @@ func (sb *Backend) generateValEnodesShareMsg() (*istanbul.Message, error) {
 	}
 
 	msg := &istanbul.Message{
-		Code:      istanbulValEnodesShareMsg,
+		Code:      istanbul.ValEnodesShareMsg,
 		Msg:       valEnodesShareBytes,
 		Address:   sb.Address(),
 		Signature: []byte{},
@@ -170,7 +170,7 @@ func (sb *Backend) sendValEnodesShareMsg() error {
 	}
 
 	logger.Trace("Sending Istanbul Validator Enodes Share payload to proxy peer")
-	if err := sb.proxyNode.peer.Send(istanbulValEnodesShareMsg, payload); err != nil {
+	if err := sb.proxyNode.peer.Send(istanbul.ValEnodesShareMsg, payload); err != nil {
 		logger.Error("Error sending Istanbul ValEnodesShare Message to proxy", "err", err)
 		return err
 	}
@@ -178,7 +178,7 @@ func (sb *Backend) sendValEnodesShareMsg() error {
 	return nil
 }
 
-func (sb *Backend) handleValEnodesShareMsg(_ consensus.Peer, payload []byte) error {
+func (sb *Backend) handleValEnodesShareMsg(_ common.Address, _ consensus.Peer, payload []byte) error {
 	sb.logger.Debug("Handling an Istanbul Validator Enodes Share message")
 
 	msg := new(istanbul.Message)

--- a/consensus/istanbul/backend/val_enodes_share_test.go
+++ b/consensus/istanbul/backend/val_enodes_share_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	vet "github.com/ethereum/go-ethereum/consensus/istanbul/backend/internal/enodes"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
@@ -35,7 +36,7 @@ func TestHandleValEnodeShareMsg(t *testing.T) {
 	// Set the backend's proxied validator address to itself
 	b.config.ProxiedValidatorAddress = senderAddress
 
-	if err = b.handleValEnodesShareMsg(nil, payload); err != nil {
+	if err = b.handleValEnodesShareMsg(common.Address{}, nil, payload); err != nil {
 		t.Errorf("error %v", err)
 	}
 
@@ -76,7 +77,7 @@ func TestHandleValEnodeShareMsg(t *testing.T) {
 	b.valEnodeTable.RemoveEntry(testAddress)
 
 	b.config.ProxiedValidatorAddress = senderAddress
-	if err = b.handleValEnodesShareMsg(nil, newPayload); err != nil {
+	if err = b.handleValEnodesShareMsg(common.Address{}, nil, newPayload); err != nil {
 		t.Errorf("error %v", err)
 	}
 

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	ValidatorEnodeDBPath        string         `toml:",omitempty"` // The location for the validator enodes DB
 	VersionCertificateDBPath    string         `toml:",omitempty"` // The location for the signed announce version DB
 	RoundStateDBPath            string         `toml:",omitempty"` // The location for the round states DB
+	Validator                   bool           `toml:",omitempty"` // Specified if this node is configured to validate (specifically if --mine command line is set)
 
 	// Proxy Configs
 	Proxy                   bool           `toml:",omitempty"` // Specifies if this node is a proxy
@@ -69,6 +70,7 @@ var DefaultConfig = &Config{
 	ValidatorEnodeDBPath:           "validatorenodes",
 	VersionCertificateDBPath:       "versioncertificates",
 	RoundStateDBPath:               "roundstates",
+	Validator:                      false,
 	Proxy:                          false,
 	Proxied:                        false,
 	AnnounceQueryEnodeGossipPeriod: 300, // 5 minutes

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -278,7 +278,7 @@ func (c *core) sendMsgTo(msg *istanbul.Message, addresses []common.Address) {
 	}
 
 	// Send payload to the specified addresses
-	if err := c.backend.BroadcastConsensusMsg(addresses, payload); err != nil {
+	if err := c.backend.Multicast(addresses, payload, istanbul.ConsensusMsg, true); err != nil {
 		logger.Error("Failed to send message", "m", msg, "err", err)
 		return
 	}

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -105,7 +105,7 @@ func (self *testSystemBackend) Send(message []byte, target common.Address) error
 	return nil
 }
 
-func (self *testSystemBackend) BroadcastConsensusMsg(validators []common.Address, message []byte) error {
+func (self *testSystemBackend) Multicast(validators []common.Address, message []byte, msgCode uint64, sendToSelf bool) error {
 	testLogger.Info("enqueuing a message...", "address", self.Address())
 	self.sentMsgs = append(self.sentMsgs, message)
 	send := func() {
@@ -114,10 +114,6 @@ func (self *testSystemBackend) BroadcastConsensusMsg(validators []common.Address
 		}
 	}
 	go send()
-	return nil
-}
-
-func (self *testSystemBackend) Multicast(validators []common.Address, message []byte, msgCode uint64, sendToSelf bool) error {
 	return nil
 }
 

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -117,9 +117,11 @@ func (self *testSystemBackend) BroadcastConsensusMsg(validators []common.Address
 	return nil
 }
 
-func (self *testSystemBackend) Multicast(validators []common.Address, message []byte, msgCode uint64) error {
+func (self *testSystemBackend) Multicast(validators []common.Address, message []byte, msgCode uint64, sendToSelf bool) error {
 	return nil
 }
+
+func (self *testSystemBackend) Gossip(payload []byte, ethMsgCode uint64) error
 
 func (self *testSystemBackend) SignBlockHeader(data []byte) (blscrypto.SerializedSignature, error) {
 	privateKey, _ := bls.DeserializePrivateKey(self.blsKey)

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -121,7 +121,9 @@ func (self *testSystemBackend) Multicast(validators []common.Address, message []
 	return nil
 }
 
-func (self *testSystemBackend) Gossip(payload []byte, ethMsgCode uint64) error
+func (self *testSystemBackend) Gossip(payload []byte, ethMsgCode uint64) error {
+	return nil
+}
 
 func (self *testSystemBackend) SignBlockHeader(data []byte) (blscrypto.SerializedSignature, error) {
 	privateKey, _ := bls.DeserializePrivateKey(self.blsKey)

--- a/consensus/istanbul/errors.go
+++ b/consensus/istanbul/errors.go
@@ -32,8 +32,14 @@ var (
 	ErrStoppedAnnounce = errors.New("stopped announce")
 	// ErrStartedAnnounce is returned if announce is already started
 	ErrStartedAnnounce = errors.New("started announce")
+	// ErrStoppedAnnounce is returned if proxy handler is stopped
+	ErrStoppedProxyHandler = errors.New("stopped proxy handler")
+	// ErrStartedProxyHandler is returned if proxy handler is already started
+	ErrStartedProxyHandler = errors.New("started proxy handler")
 	// ErrStoppedVPHThread is returned if validator peer handler thread is stopped
 	ErrStoppedVPHThread = errors.New("stopped validator peer handler thread")
 	// ErrStartedVPHThread is returned if validator peer handler thread is already started
 	ErrStartedVPHThread = errors.New("started validator peer handler thread")
+	// ErrValidatorNotProxied is returned if the validator is not configured to be proxied
+	ErrValidatorNotProxied = errors.New("validator not proxied")
 )

--- a/consensus/istanbul/protocol.go
+++ b/consensus/istanbul/protocol.go
@@ -1,0 +1,59 @@
+// Copyright 2017 The celo Authors
+// This file is part of the celo library.
+//
+// The celo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The celo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the celo library. If not, see <http://www.gnu.org/licenses/>.
+
+package istanbul
+
+import (
+	"github.com/ethereum/go-ethereum/p2p"
+)
+
+// Constants to match up protocol versions and messages
+const (
+	Celo64 = 64
+	Celo65 = 65
+)
+
+// protocolName is the official short name of the protocol used during capability negotiation.
+const ProtocolName = "istanbul"
+
+// ProtocolVersions are the supported versions of the eth protocol (first is primary).
+var ProtocolVersions = []uint{Celo65, Celo64}
+
+// protocolLengths are the number of implemented message corresponding to different protocol versions.
+var ProtocolLengths = map[uint]uint64{Celo64: 22, Celo65: 27}
+
+// Message codes for istanbul related messages
+// If you want to add a code, you need to increment the protocolLengths Array size
+// and update the IsIstanbulMsg function below!
+const (
+	ConsensusMsg           = 0x11
+	QueryEnodeMsg          = 0x12
+	ValEnodesShareMsg      = 0x13
+	FwdMsg                 = 0x14
+	DelegateSignMsg        = 0x15
+	VersionCertificatesMsg = 0x16
+	EnodeCertificateMsg    = 0x17
+	ValidatorHandshakeMsg  = 0x18
+)
+
+func IsIstanbulMsg(msg p2p.Msg) bool {
+	return msg.Code >= ConsensusMsg && msg.Code <= ValidatorHandshakeMsg
+}
+
+// IsGossipedMsg specifies which messages should be gossiped throughout the network (as opposed to directly sent to a peer).
+func IsGossipedMsg(msgCode uint64) bool {
+	return msgCode == QueryEnodeMsg || msgCode == VersionCertificatesMsg
+}

--- a/consensus/istanbul/protocol.go
+++ b/consensus/istanbul/protocol.go
@@ -52,8 +52,3 @@ const (
 func IsIstanbulMsg(msg p2p.Msg) bool {
 	return msg.Code >= ConsensusMsg && msg.Code <= ValidatorHandshakeMsg
 }
-
-// IsGossipedMsg specifies which messages should be gossiped throughout the network (as opposed to directly sent to a peer).
-func IsGossipedMsg(msgCode uint64) bool {
-	return msgCode == QueryEnodeMsg || msgCode == VersionCertificatesMsg
-}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -545,6 +545,22 @@ func (s *Ethereum) stopAnnounce() error {
 	return nil
 }
 
+func (s *Ethereum) StartProxyHandler() error {
+	if istanbul, ok := s.engine.(consensus.Istanbul); ok {
+		return istanbul.StartProxyHandler()
+	}
+
+	return nil
+}
+
+func (s *Ethereum) StopProxyHandler() error {
+	if istanbul, ok := s.engine.(consensus.Istanbul); ok {
+		return istanbul.StopProxyHandler()
+	}
+
+	return nil
+}
+
 func (s *Ethereum) IsMining() bool      { return s.miner.Mining() }
 func (s *Ethereum) Miner() *miner.Miner { return s.miner }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -171,7 +171,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if bcVersion != nil {
 		dbVer = fmt.Sprintf("%d", *bcVersion)
 	}
-	log.Info("Initialising Ethereum protocol", "versions", ProtocolVersions, "network", config.NetworkId, "dbversion", dbVer)
+	log.Info("Initialising Ethereum protocol", "versions", istanbul.ProtocolVersions, "network", config.NetworkId, "dbversion", dbVer)
 
 	if !config.SkipBcVersionCheck {
 		if bcVersion != nil && *bcVersion > core.BlockChainVersion {
@@ -572,7 +572,7 @@ func (s *Ethereum) EventMux() *event.TypeMux            { return s.eventMux }
 func (s *Ethereum) Engine() consensus.Engine            { return s.engine }
 func (s *Ethereum) ChainDb() ethdb.Database             { return s.chainDb }
 func (s *Ethereum) IsListening() bool                   { return true } // Always listening
-func (s *Ethereum) EthVersion() int                     { return int(ProtocolVersions[0]) }
+func (s *Ethereum) EthVersion() int                     { return int(istanbul.ProtocolVersions[0]) }
 func (s *Ethereum) NetVersion() uint64                  { return s.networkID }
 func (s *Ethereum) Downloader() *downloader.Downloader  { return s.protocolManager.downloader }
 func (s *Ethereum) GatewayFeeRecipient() common.Address { return common.Address{} } // Full-nodes do not make use of gateway fee.
@@ -583,8 +583,8 @@ func (s *Ethereum) ArchiveMode() bool                   { return s.config.NoPrun
 // Protocols implements node.Service, returning all the currently configured
 // network protocols to start.
 func (s *Ethereum) Protocols() []p2p.Protocol {
-	protos := make([]p2p.Protocol, len(ProtocolVersions))
-	for i, vsn := range ProtocolVersions {
+	protos := make([]p2p.Protocol, len(istanbul.ProtocolVersions))
+	for i, vsn := range istanbul.ProtocolVersions {
 		protos[i] = s.protocolManager.makeProtocol(vsn, i == 0)
 		protos[i].Attributes = []enr.Entry{s.currentEthEntry()}
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -209,13 +210,13 @@ func NewProtocolManager(config *params.ChainConfig, checkpoint *params.TrustedCh
 }
 
 func (pm *ProtocolManager) makeProtocol(version uint, primary bool) p2p.Protocol {
-	length, ok := protocolLengths[version]
+	length, ok := istanbul.ProtocolLengths[version]
 	if !ok {
 		panic("makeProtocol for unknown version")
 	}
 
 	return p2p.Protocol{
-		Name:    ProtocolName,
+		Name:    istanbul.ProtocolName,
 		Version: version,
 		Length:  length,
 		Primary: primary,

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	mockEngine "github.com/ethereum/go-ethereum/consensus/consensustest"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
@@ -495,7 +496,7 @@ func testCheckpointChallenge(t *testing.T, syncmode downloader.SyncMode, checkpo
 	defer pm.Stop()
 
 	// Connect a new peer and check that we receive the checkpoint challenge
-	peer, _ := newTestPeer("peer", celo64, pm, true)
+	peer, _ := newTestPeer("peer", istanbul.Celo64, pm, true)
 	defer peer.close()
 
 	if checkpoint {
@@ -582,7 +583,7 @@ func testBroadcastBlock(t *testing.T, totalPeers, broadcastExpected int) {
 	defer pm.Stop()
 	var peers []*testPeer
 	for i := 0; i < totalPeers; i++ {
-		peer, _ := newTestPeer(fmt.Sprintf("peer %d", i), celo64, pm, true)
+		peer, _ := newTestPeer(fmt.Sprintf("peer %d", i), istanbul.Celo64, pm, true)
 		defer peer.close()
 		peers = append(peers, peer)
 	}

--- a/eth/helper_test.go
+++ b/eth/helper_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	mockEngine "github.com/ethereum/go-ethereum/consensus/consensustest"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -183,7 +184,7 @@ func newTestPeer(name string, version int, pm *ProtocolManager, shake bool) (*te
 func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, genesis common.Hash, forkID forkid.ID, forkFilter forkid.Filter) {
 	var msg interface{}
 	switch {
-	case p.version == celo64:
+	case p.version == istanbul.Celo64:
 		msg = &statusData63{
 			ProtocolVersion: uint32(p.version),
 			NetworkId:       DefaultConfig.NetworkId,
@@ -191,7 +192,7 @@ func (p *testPeer) handshake(t *testing.T, td *big.Int, head common.Hash, genesi
 			CurrentBlock:    head,
 			GenesisBlock:    genesis,
 		}
-	case p.version == celo65:
+	case p.version == istanbul.Celo65:
 		msg = &statusData{
 			ProtocolVersion: uint32(p.version),
 			NetworkID:       DefaultConfig.NetworkId,

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -25,6 +25,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -365,7 +366,7 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 	)
 	go func() {
 		switch {
-		case p.version == celo64:
+		case p.version == istanbul.Celo64:
 			errc <- p2p.Send(p.rw, StatusMsg, &statusData63{
 				ProtocolVersion: uint32(p.version),
 				NetworkId:       network,
@@ -373,7 +374,7 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 				CurrentBlock:    head,
 				GenesisBlock:    genesis,
 			})
-		case p.version == celo65:
+		case p.version == istanbul.Celo65:
 			errc <- p2p.Send(p.rw, StatusMsg, &statusData{
 				ProtocolVersion: uint32(p.version),
 				NetworkID:       network,
@@ -388,9 +389,9 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 	}()
 	go func() {
 		switch {
-		case p.version == celo64:
+		case p.version == istanbul.Celo64:
 			errc <- p.readStatusLegacy(network, &status63, genesis)
-		case p.version == celo65:
+		case p.version == istanbul.Celo65:
 			errc <- p.readStatus(network, &status, genesis, forkFilter)
 		default:
 			panic(fmt.Sprintf("unsupported eth protocol version: %d", p.version))
@@ -409,9 +410,9 @@ func (p *peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 		}
 	}
 	switch {
-	case p.version == celo64:
+	case p.version == istanbul.Celo64:
 		p.td, p.head = status63.TD, status63.CurrentBlock
-	case p.version == celo65:
+	case p.version == istanbul.Celo65:
 		p.td, p.head = status.TD, status.Head
 	default:
 		panic(fmt.Sprintf("unsupported eth protocol version: %d", p.version))

--- a/eth/protocol.go
+++ b/eth/protocol.go
@@ -29,21 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
-// Constants to match up protocol versions and messages
-const (
-	celo64 = 64
-	celo65 = 65
-)
-
-// protocolName is the official short name of the protocol used during capability negotiation.
-const ProtocolName = "istanbul"
-
-// ProtocolVersions are the supported versions of the eth protocol (first is primary).
-var ProtocolVersions = []uint{celo65, celo64}
-
-// protocolLengths are the number of implemented message corresponding to different protocol versions.
-var protocolLengths = map[uint]uint64{celo64: 22, celo65: 27}
-
 const protocolMaxMsgSize = 10 * 1024 * 1024 // Maximum cap on the size of a protocol message
 
 // eth protocol message codes

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -369,13 +369,13 @@ func (s *Service) login(conn *websocket.Conn, sendCh chan *StatsPayload) error {
 		protocol  string
 		err       error
 	)
-	if info := infos.Protocols[eth.ProtocolName]; info != nil {
+	if info := infos.Protocols[istanbul.ProtocolName]; info != nil {
 		ethInfo, ok := info.(*eth.NodeInfo)
 		if !ok {
 			return errors.New("Could not resolve NodeInfo")
 		}
 		network = fmt.Sprintf("%d", ethInfo.Network)
-		protocol = fmt.Sprintf("%s/%d", eth.ProtocolName, eth.ProtocolVersions[0])
+		protocol = fmt.Sprintf("%s/%d", istanbul.ProtocolName, istanbul.ProtocolVersions[0])
 	} else {
 		lesProtocol, ok := infos.Protocols["les"]
 		if !ok {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -762,13 +762,7 @@ web3._extend({
 			getter: 'istanbul_getCurrentRoundState',
 		}),
 	],
-	properties:
-	[
-		new web3._extend.Property({
-			name: 'candidates',
-			getter: 'istanbul_candidates'
-		}),
-	]
+	properties: []
 });
 `
 


### PR DESCRIPTION
### Description

This PR removes the announce protocol's and establishment of proxy connection's dependency that the machines local time is greater than or equal to the network start time set in the genesis file.

### Other changes

Started effort in splitting up some of the `istanbul.backend`'s bulky files.  Specifically, does the following:

1. moved all of the new eth message codes into `istanbul/protocol.go` and any related utility functions
1. created new file for the gossip caches
1. created new file for the message sender functions
1. Removed the `candidates` property from the istanbul rpc api

### Tested

1. Deployed a testnet with a start timestamp about half an hour in the future.  Then ensured that the validator connections were established beforehand and that the testnet started validating at the start timestamp.
2. Unit tests

### Related issues

- Fixes #947

### Backwards compatibility

Yes
