### PR TITLE
Disables fast sync

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -200,7 +200,7 @@ var (
 	defaultSyncMode = eth.DefaultConfig.SyncMode
 	SyncModeFlag    = TextMarshalerFlag{
 		Name:  "syncmode",
-		Usage: `Blockchain sync mode ("fast", "full", "light", or "lightest")`,
+		Usage: `Blockchain sync mode ("full", "light", or "lightest")`,
 		Value: &defaultSyncMode,
 	}
 	GCModeFlag = cli.StringFlag{
@@ -1563,6 +1563,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 
 	if ctx.GlobalIsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)
+		if cfg.SyncMode == downloader.FastSync {
+			Fatalf("fast sync is not supported")
+		}
 	}
 	if ctx.GlobalIsSet(NetworkIdFlag.Name) {
 		cfg.NetworkId = ctx.GlobalUint64(NetworkIdFlag.Name)

--- a/eth/config.go
+++ b/eth/config.go
@@ -30,7 +30,7 @@ import (
 
 // DefaultConfig contains default settings for use on the Ethereum main net.
 var DefaultConfig = Config{
-	SyncMode:           downloader.FastSync,
+	SyncMode:           downloader.FullSync,
 	NetworkId:          1,
 	LightPeers:         99,
 	LightServ:          50,


### PR DESCRIPTION
### Description

It seems a few people have stumbled upon BAD BLOCK situations when using fast sync. I've verified that running a fast synced node starts failing on an epoch block on RC1. I think it's best we disable it until we investigate it further.