### PR TITLE
feat: only build monorepo packages needed to run e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b ${CELO_MONOREPO_BRANCH_TO_TEST}
             cd celo-monorepo
             yarn install || yarn install
-            PACKAGES=$(cat dependency-graph.json | python -c 'import json,sys;obj=json.load(sys.stdin);print "\n".join(str(x) for x in obj["celotool"][::-1])')
+            PACKAGES=$(cat dependency-graph.json | python -c 'import json,sys;obj=json.load(sys.stdin);print "\n".join(str(obj[x]["location"]) for x in obj["@celo/celotool"]["dependencies"][::-1])')
             for i in `echo $PACKAGES`; do yarn --cwd packages/$i build; done
             yarn --cwd packages/celotool build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,10 +135,10 @@ jobs:
       - run:
           name: Setup celo-monorepo
           command: |
-            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b alexbharley/celotool-missing-dependency
+            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b ${CELO_MONOREPO_BRANCH_TO_TEST}
             cd celo-monorepo
             yarn install || yarn install
-            PACKAGES=$(cat dependency-graph.json | python -c 'import json,sys;obj=json.load(sys.stdin);print "\n".join(str(x) for x in obj["celotool"][::-1])')            
+            PACKAGES=$(cat dependency-graph.json | python -c 'import json,sys;obj=json.load(sys.stdin);print "\n".join(str(x) for x in obj["celotool"][::-1])')
             for i in `echo $PACKAGES`; do yarn --cwd packages/$i build; done
             yarn --cwd packages/celotool build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,13 +135,12 @@ jobs:
       - run:
           name: Setup celo-monorepo
           command: |
-            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b ${CELO_MONOREPO_BRANCH_TO_TEST}
+            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b alexbharley/celotool-missing-dependency
             cd celo-monorepo
             yarn install || yarn install
-            # separate build to avoid ENOMEM in CI :(
-            yarn build --scope @celo/utils
-            yarn build --scope @celo/protocol
-            yarn build --ignore @celo/protocol --ignore docs --ignore @celo/web --ignore @celo/mobile --ignore @celo/react-components
+            PACKAGES=$(cat dependency-graph.json | python -c 'import json,sys;obj=json.load(sys.stdin);print "\n".join(str(x) for x in obj["celotool"][::-1])')            
+            for i in `echo $PACKAGES`; do yarn --cwd packages/$i build; done
+            yarn --cwd packages/celotool build
       - run:
           name: Setup Go language
           command: |


### PR DESCRIPTION
### Description

Use the generated `dependency-graph.json` file from the monorepo to only build packages needed to run the e2e tests. Depends on [this](https://github.com/celo-org/celo-monorepo/pull/3876) PR because we had a missing dependency.

### Tested

Ran a few builds in CI.

### Backwards compatibility

N/A
