### PR TITLE
vm, consensus move EpochSize, GetValidators

### DIFF
--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -189,6 +189,7 @@ type SRItem struct {
 
 type NoRewardEngine struct {
 	inner     consensus.Engine
+	istanbul  consensus.Istanbul
 	rewardsOn bool
 }
 
@@ -248,11 +249,11 @@ func (e *NoRewardEngine) SealHash(header *types.Header) common.Hash {
 }
 
 func (e *NoRewardEngine) GetValidators(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator {
-	return e.inner.GetValidators(blockNumber, headerHash)
+	return e.istanbul.GetValidators(blockNumber, headerHash)
 }
 
 func (e *NoRewardEngine) EpochSize() uint64 {
-	return e.inner.EpochSize()
+	return e.istanbul.EpochSize()
 }
 
 func (e *NoRewardEngine) APIs(chain consensus.ChainReader) []rpc.API {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -102,11 +102,6 @@ type Engine interface {
 	// SealHash returns the hash of a block prior to it being sealed.
 	SealHash(header *types.Header) common.Hash
 
-	// GetValidators returns the list of current validators.
-	GetValidators(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator
-
-	EpochSize() uint64
-
 	// APIs returns the RPC APIs this consensus engine provides.
 	APIs(chain ChainReader) []rpc.API
 
@@ -165,6 +160,11 @@ type PoW interface {
 // Istanbul is a consensus engine to avoid byzantine failure
 type Istanbul interface {
 	Engine
+
+	EpochSize() uint64
+
+	// GetValidators returns the list of current validators.
+	GetValidators(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator
 
 	// SetChain injects the blockchain and related functions to the istanbul consensus engine
 	SetChain(chain ChainReader, currentBlock func() *types.Block, stateAt func(common.Hash) (*state.StateDB, error))

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -862,7 +862,7 @@ func (c *getValidator) Run(input []byte, caller common.Address, evm *EVM, gas ui
 	}
 
 	// Note: Passing empty hash as here as it is an extra expense and the hash is not actually used.
-	validators := evm.Context.Engine.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
+	validators := evm.Context.Istanbul.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
 
 	// Ensure index, which is guaranteed to be non-negative, is valid.
 	if index.Cmp(big.NewInt(int64(len(validators)))) >= 0 {
@@ -908,7 +908,7 @@ func (c *numberValidators) Run(input []byte, caller common.Address, evm *EVM, ga
 	}
 
 	// Note: Passing empty hash as here as it is an extra expense and the hash is not actually used.
-	validators := evm.Context.Engine.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
+	validators := evm.Context.Istanbul.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
 
 	numberValidators := big.NewInt(int64(len(validators))).Bytes()
 	numberValidatorsBytes := common.LeftPadBytes(numberValidators[:], 32)
@@ -926,7 +926,7 @@ func (c *epochSize) Run(input []byte, caller common.Address, evm *EVM, gas uint6
 	if err != nil || len(input) != 0 {
 		return nil, gas, err
 	}
-	epochSize := new(big.Int).SetUint64(evm.Context.Engine.EpochSize()).Bytes()
+	epochSize := new(big.Int).SetUint64(evm.Context.Istanbul.EpochSize()).Bytes()
 	epochSizeBytes := common.LeftPadBytes(epochSize[:], 32)
 
 	return epochSizeBytes, gas, nil
@@ -1007,7 +1007,7 @@ func (c *getParentSealBitmap) Run(input []byte, caller common.Address, evm *EVM,
 	}
 
 	// Ensure the request is for a sufficiently recent block to limit state expansion.
-	historyLimit := new(big.Int).SetUint64(evm.Context.Engine.EpochSize() * 4)
+	historyLimit := new(big.Int).SetUint64(evm.Context.Istanbul.EpochSize() * 4)
 	if blockNumber.Cmp(new(big.Int).Sub(evm.Context.BlockNumber, historyLimit)) <= 0 {
 		return nil, gas, ErrBlockNumberOutOfBounds
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -111,7 +111,8 @@ type Context struct {
 
 	Header *types.Header
 
-	Engine consensus.Engine
+	Engine   consensus.Engine
+	Istanbul consensus.Istanbul
 }
 
 // EVM is the Ethereum Virtual Machine base object and provides


### PR DESCRIPTION
### Description

Moving `EpochSize()` and `GetValidators` to `Istanbul` interface. for #820 

@kevjue am I on the right track here?

### Tested

Ran `make lint`
Ran `make test`

Got `panic: runtime error: invalid memory address or nil pointer dereference [recovered]`
but unsure how this relates to my specific changes.

Unsure how to perform `End to end sync and transfer tests` locally. Is there documentation regarding this?
