### PR TITLE
Remove broken blocks

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -777,6 +777,10 @@ func (sb *Backend) snapshot(chain consensus.ChainReader, number uint64, hash com
 		}
 
 		genesis := chain.GetHeaderByNumber(0)
+		if genesis == nil {
+			log.Error("Cannot load genesis")
+			return nil, errors.New("Cannot load genesis")
+		}
 
 		istanbulExtra, err := types.ExtractIstanbulExtra(genesis)
 		if err != nil {


### PR DESCRIPTION
### Description

When DB is corrupted, removes all blocks that have no associated states.

### Other changes

Added a check to avoid segfault when quitting with interrupt.

### Tested

Only manual testing.

### Related issues

- Fixes #1051

### Backwards compatibility

