### PR TITLE
Extend existing eth_gasPrice with feeCurrency

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -519,6 +519,16 @@ func (ec *Client) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
 	return (*big.Int)(&hex), nil
 }
 
+// SuggestGasPrice retrieves the currently suggested gas price to allow a timely
+// execution of a transaction.
+func (ec *Client) SuggestGasPriceInCurrency(ctx context.Context, feeCurrency *common.Address) (*big.Int, error) {
+	var hex hexutil.Big
+	if err := ec.c.CallContext(ctx, &hex, "eth_gasPrice", feeCurrency); err != nil {
+		return nil, err
+	}
+	return (*big.Int)(&hex), nil
+}
+
 // EstimateGas tries to estimate the gas needed to execute a specific transaction based on
 // the current pending state of the backend blockchain. There is no guarantee that this is
 // the true gas limit requirement as other transactions may be added or removed by miners,

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -58,8 +58,17 @@ func NewPublicEthereumAPI(b Backend) *PublicEthereumAPI {
 }
 
 // GasPrice returns a suggestion for a gas price.
-func (s *PublicEthereumAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
-	price, err := s.b.SuggestPrice(ctx)
+func (s *PublicEthereumAPI) GasPrice(ctx context.Context, feeCurrency *common.Address) (*hexutil.Big, error) {
+	if feeCurrency == nil {
+		price, err := s.b.SuggestPrice(ctx)
+		return (*hexutil.Big)(price), err
+	}
+
+	state, header, err := s.b.StateAndHeaderByNumber(ctx, rpc.LatestBlockNumber)
+	if err != nil {
+		return nil, err
+	}
+	price, err := s.b.SuggestPriceInCurrency(ctx, feeCurrency, header, state)
 	return (*hexutil.Big)(price), err
 }
 


### PR DESCRIPTION
### Description

Extends the `eth_gasPrice` rpc to optionally accept a `feeCurrency` address. 

NOTE: an empty string `feeCurrency` parameter will cause an error

### Other changes

None

### Tested

Tested with Postman.

### Related issues

- Fixes #926

### Backwards compatibility

Should be backwards compatible with all existing javascript clients. 