### PR TITLE
Point CI back to celo-monorepo master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
       GO_VERSION: "1.13.7"
-      CELO_MONOREPO_BRANCH_TO_TEST: victor/tx-relay-tweak
+      CELO_MONOREPO_BRANCH_TO_TEST: master
 jobs:
   build-geth:
     executor: golang


### PR DESCRIPTION
### Description

Point CI back to master after merging #1045 and https://github.com/celo-org/celo-monorepo/pull/3870
