### PR TITLE
Update gosigar usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v0.0.0-20180603214616-504e848d77ea
 	github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf
-	github.com/elastic/gosigar v0.8.1-0.20180330100440-37f05ff46ffa
+	github.com/elastic/gosigar v0.10.5
 	github.com/fatih/color v1.3.0
 	github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc
 	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff
@@ -64,6 +64,3 @@ require (
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )
-
-// Use our fork which contains the fix to build on iOS
-replace github.com/elastic/gosigar => github.com/celo-org/gosigar v0.10.5-celo1

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf h1:sh8rkQZavChcmakYiSlqu2425CHyFXLZZnvm7PDpU8M=
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/elastic/gosigar v0.10.5 h1:GzPQ+78RaAb4J63unidA/JavQRKrB6s8IOzN6Ib59jo=
+github.com/elastic/gosigar v0.10.5/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/fatih/color v1.3.0 h1:YehCCcyeQ6Km0D6+IapqPinWBK6y+0eB5umvZXK9WPs=
 github.com/fatih/color v1.3.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc h1:jtW8jbpkO4YirRSyepBOH8E+2HEw6/hKkBvFPwhUN8c=

--- a/metrics/cpu_disabled.go
+++ b/metrics/cpu_disabled.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The go-ethereum Authors
+// Copyright 2020 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -14,11 +14,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+// +build ios
+
 package metrics
 
-// CPUStats is the system and process CPU stats.
-type CPUStats struct {
-	GlobalTime int64 // Time spent by the CPU working on all processes
-	GlobalWait int64 // Time spent by waiting on disk for all processes
-	LocalTime  int64 // Time spent by the CPU working on this process
-}
+// ReadCPUStats retrieves the current CPU stats. Internally this uses `gosigar`,
+// which is not supported on the platforms in this file.
+func ReadCPUStats(stats *CPUStats) {}

--- a/metrics/cpu_enabled.go
+++ b/metrics/cpu_enabled.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The go-ethereum Authors
+// Copyright 2020 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
 // The go-ethereum library is free software: you can redistribute it and/or modify
@@ -14,11 +14,18 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
+// +build !ios
+
 package metrics
 
-// CPUStats is the system and process CPU stats.
-type CPUStats struct {
-	GlobalTime int64 // Time spent by the CPU working on all processes
-	GlobalWait int64 // Time spent by waiting on disk for all processes
-	LocalTime  int64 // Time spent by the CPU working on this process
+import "github.com/elastic/gosigar"
+
+// ReadCPUStats retrieves the current CPU stats.
+func ReadCPUStats(stats *CPUStats) {
+	global := gosigar.Cpu{}
+	global.Get()
+
+	stats.GlobalTime = int64(global.User + global.Nice + global.Sys)
+	stats.GlobalWait = int64(global.Wait)
+	stats.LocalTime = getProcessCPUTime()
 }


### PR DESCRIPTION
### Description

We're currently using a fork of `gosigar` due to an issue with building it for iOS. In the meantime there has been a change in upstream geth that fixes the issue with the dependency and allows us to stop using our fork.

The problem with the current workaround is that it affects all `darwin` builds.

The patch in question: https://github.com/ethereum/go-ethereum/commit/42e02ac03bfc4e01496d15314e94f46260d98f86

This PR just cherry-picks the patch from `geth` and removes the go.mod override.

### Tested

We need to be 100% sure that this patch doesn't affect the iOS build. 

### Related issues

- Blocks #1073

