### PR TITLE
Setup binary release CI pipeline

### DIFF
--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -1,0 +1,37 @@
+# How to test changes to this file
+# docker build -f Dockerfile -t gcr.io/celo-testnet/geth:$USER .
+# To locally run that image
+# docker rm geth_container ; docker run --name geth_container gcr.io/celo-testnet/geth:$USER
+# and connect to it with
+# docker exec -t -i geth_container /bin/sh
+#
+# Once you are satisfied, build the image using
+# export COMMIT_SHA=$(git rev-parse HEAD)
+# docker build -f Dockerfile --build-arg COMMIT_SHA=$COMMIT_SHA -t gcr.io/celo-testnet/geth:$COMMIT_SHA .
+#
+# push the image to the cloud
+# docker push gcr.io/celo-testnet/geth:$COMMIT_SHA
+#
+# To use this image for testing, modify GETH_NODE_DOCKER_IMAGE_TAG in celo-monorepo/.env file
+
+# Build Geth binaries in the xgo builder container
+FROM techknowlogick/xgo as xgobuilder
+
+# We need a newer version of mingw, backported to Bionic
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && apt install -y  --no-install-recommends software-properties-common apt-utils
+RUN add-apt-repository -y ppa:mati865/mingw-w64
+RUN apt update && apt -y upgrade
+
+ADD . /go/src/github.com/ethereum/go-ethereum
+WORKDIR /go/src/github.com/ethereum/go-ethereum
+
+ENV GO=1.13
+ARG BUILD_TARGETS
+ARG COMMIT_SHA
+ARG ALLTOOLS
+ENV ALLTOOLS_COMMAND_SEGMENT=""
+RUN if [ "$ALLTOOLS" = "true" ]; then export ALLTOOLS_COMMAND_SEGMENT="--alltools"; fi
+
+RUN echo $COMMIT_SHA > /version.txt
+RUN go run build/ci.go xgo $ALLTOOLS_COMMAND_SEGMENT -- --go=$GO --targets=$BUILD_TARGETS -v ./cmd/geth

--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -1,21 +1,50 @@
-# How to test changes to this file
-# docker build -f Dockerfile -t gcr.io/celo-testnet/geth:$USER .
-# To locally run that image
-# docker rm geth_container ; docker run --name geth_container gcr.io/celo-testnet/geth:$USER
-# and connect to it with
-# docker exec -t -i geth_container /bin/sh
+# Purpose:
+# -------
+# This docker image is used by the ./cloudbuild-binaries.yaml CI flow to
+# cross-compile geth for different platforms.
+# At the time of writing this is only linux-{386/amd64} but there are two
+# pending update that will add darwin-{386,amd64} and windows-amd64 support.
 #
-# Once you are satisfied, build the image using
-# export COMMIT_SHA=$(git rev-parse HEAD)
-# docker build -f Dockerfile --build-arg COMMIT_SHA=$COMMIT_SHA -t gcr.io/celo-testnet/geth:$COMMIT_SHA .
+# How to test changes to this image locally:
+# -----------------------------------------
+# First build the image:
+# docker build -f Dockerfile.binaries -t gcr.io/celo-testnet/geth-xgo-builder:$USER .
 #
-# push the image to the cloud
-# docker push gcr.io/celo-testnet/geth:$COMMIT_SHA
+# Running this image depends on a series of environment variables:
+#   BUILD_TARGETS       Comma separated list of platforms to build for,
+#                       passed as an arg to xgo. eg: "linux/386,linux/amd64"
+#   TAG_NAME            Name of the tag associated with the current commit
+#   BRANCH_NAME         Name of the branch
+#   REPO_NAME           Name of the repo
+#   COMMIT_SHA          Full SHA of the commit
+#   COMMIT_TIMESTAMP    Commit timestamp
+#                       TODO: currently this is not accurately passed see
+#                             discussion in PR celo-blockchain#<number>
+#   CLOUDBUILD          True/False
+#   CI                  True/False
+#                       These two are used to comply with how geth handles build
+#                       environments internal/build/env.go where we have added a
+#                       branch for Cloudbuild
+# You also need to mount:
+#    $(pwd)/build/bin:/build - where binaries will be written
+#    $(pwd)/build/archives:/archives - where the archives (final release artfeact) will be written
+#    $(pwd):/go/src/github.com/ethereum/go-ethereum - the source code
 #
-# To use this image for testing, modify GETH_NODE_DOCKER_IMAGE_TAG in celo-monorepo/.env file
+# With all of the above in place the container needs to execute two commands:
+# (see ./cloudbuild-binaries.yaml for example of the full command)
+# 1. Create the binaries:
+#    go run build/ci.go xgo --alltools -- -targets=$BUILD_TARGETS -v -dest /build
+# 2. Create release archives:
+#    go run build/ci.go xgo-archive -targets=$_BUILD_TARGETS -in /build -out /archives
+#
+# This will result in build archives stored in ./build/archives
+# In the CI flow these are then uploaded to cloud storage as artefacts.
 
 # Build Geth binaries in the xgo builder container
-FROM techknowlogick/xgo as xgobuilder
+FROM techknowlogick/xgo:go-1.13.x
+# techknowlogic/xgo is a fork of karalabe/xgo updated to ubunut-18, it is more maintained
+# by the community and allows us to backport mingw in order to build for windows
+# See discussion in PR celo-blockchain#<number> about downsides of this image
 
 # We need a newer version of mingw, backported to Bionic
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -23,11 +23,7 @@ RUN apt update && apt install -y  --no-install-recommends software-properties-co
 RUN add-apt-repository -y ppa:mati865/mingw-w64
 RUN apt update && apt -y upgrade
 
-ADD . /go/src/github.com/ethereum/go-ethereum
-WORKDIR /go/src/github.com/ethereum/go-ethereum
-
 ENV GO=1.13
-
 ARG __BUILD_TARGETS
 ENV BUILD_TARGETS=$__BUILD_TARGETS
 ARG __TAG_NAME
@@ -48,6 +44,9 @@ ARG __CLOUDBUILD
 ENV CLOUDBUILD=$__CLOUDBUILD
 ARG __CI
 ENV CI=$__CI
+
+ADD . /go/src/github.com/ethereum/go-ethereum
+WORKDIR /go/src/github.com/ethereum/go-ethereum
 
 RUN go run build/ci.go xgo --alltools -- --go=$GO -targets=$BUILD_TARGETS -v -dest /build
 RUN mkdir /archives

--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -27,11 +27,28 @@ ADD . /go/src/github.com/ethereum/go-ethereum
 WORKDIR /go/src/github.com/ethereum/go-ethereum
 
 ENV GO=1.13
-ARG BUILD_TARGETS
-ARG COMMIT_SHA
-ARG ALLTOOLS
-ENV ALLTOOLS_COMMAND_SEGMENT=""
-RUN if [ "$ALLTOOLS" = "true" ]; then export ALLTOOLS_COMMAND_SEGMENT="--alltools"; fi
 
-RUN echo $COMMIT_SHA > /version.txt
-RUN go run build/ci.go xgo $ALLTOOLS_COMMAND_SEGMENT -- --go=$GO --targets=$BUILD_TARGETS -v ./cmd/geth
+ARG __BUILD_TARGETS
+ENV BUILD_TARGETS=$__BUILD_TARGETS
+ARG __TAG_NAME
+ENV TAG_NAME=$__TAG_NAME
+ARG __REPO_NAME
+ENV REPO_NAME=$__REPO_NAME
+ARG __BRANCH_NAME
+ENV BRANCH_NAME=$__BRANCH_NAME
+ARG __TAG_NAME
+ENV TAG_NAME=$__TAG_NAME
+ARG __COMMIT_SHA
+ENV COMMIT_SHA=$__COMMIT_SHA
+ARG __PR_NUMBER
+ENV _PR_NUMBER=$__PR_NUMBER
+ARG __COMMIT_TIMESTAMP
+ENV COMMIT_TIMESTAMP=$__COMMIT_TIMESTAMP
+ARG __CLOUDBUILD
+ENV CLOUDBUILD=$__CLOUDBUILD
+ARG __CI
+ENV CI=$__CI
+
+RUN go run build/ci.go xgo --alltools -- --go=$GO -targets=$BUILD_TARGETS -v -dest /build
+RUN mkdir /archives
+RUN go run build/ci.go xgo-archive -targets=$BUILD_TARGETS -in /build -out /archives

--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -23,31 +23,5 @@ RUN apt update && apt install -y  --no-install-recommends software-properties-co
 RUN add-apt-repository -y ppa:mati865/mingw-w64
 RUN apt update && apt -y upgrade
 
-ENV GO=1.13
-ARG __BUILD_TARGETS
-ENV BUILD_TARGETS=$__BUILD_TARGETS
-ARG __TAG_NAME
-ENV TAG_NAME=$__TAG_NAME
-ARG __REPO_NAME
-ENV REPO_NAME=$__REPO_NAME
-ARG __BRANCH_NAME
-ENV BRANCH_NAME=$__BRANCH_NAME
-ARG __TAG_NAME
-ENV TAG_NAME=$__TAG_NAME
-ARG __COMMIT_SHA
-ENV COMMIT_SHA=$__COMMIT_SHA
-ARG __PR_NUMBER
-ENV _PR_NUMBER=$__PR_NUMBER
-ARG __COMMIT_TIMESTAMP
-ENV COMMIT_TIMESTAMP=$__COMMIT_TIMESTAMP
-ARG __CLOUDBUILD
-ENV CLOUDBUILD=$__CLOUDBUILD
-ARG __CI
-ENV CI=$__CI
-
-ADD . /go/src/github.com/ethereum/go-ethereum
+RUN mkdir -p /go/src/github.com/ethereum/go-ethereum
 WORKDIR /go/src/github.com/ethereum/go-ethereum
-
-RUN go run build/ci.go xgo --alltools -- --go=$GO -targets=$BUILD_TARGETS -v -dest /build
-RUN mkdir /archives
-RUN go run build/ci.go xgo-archive -targets=$BUILD_TARGETS -in /build -out /archives

--- a/build/ci.go
+++ b/build/ci.go
@@ -1161,14 +1161,14 @@ func doXgoArchive(cmdline []string) {
 	}
 }
 
-func xgoAllToolsArchiveFiles(target string, dir string) []string {
+func xgoGethArchiveFiles(target string, dir string) []string {
 	return []string{
 		"COPYING",
 		executableXgoPath("geth", target, dir),
 	}
 }
 
-func xgoGethArchiveFiles(target string, dir string) []string {
+func xgoAllToolsArchiveFiles(target string, dir string) []string {
 	return []string{
 		"COPYING",
 		executableXgoPath("abigen", target, dir),

--- a/build/ci.go
+++ b/build/ci.go
@@ -501,8 +501,8 @@ func maybeSkipArchive(env build.Environment) {
 		log.Printf("skipping because this is a cron job")
 		os.Exit(0)
 	}
-	if env.Branch != "master" && !strings.HasPrefix(env.Tag, "v1.") {
-		log.Printf("skipping because branch %q, tag %q is not on the whitelist", env.Branch, env.Tag)
+	if env.Branch != "master" && !strings.HasPrefix(env.Branch, "release/") {
+		log.Printf("skipping because branch %q is not on the whitelist", env.Branch)
 		os.Exit(0)
 	}
 }

--- a/cloudbuild-binaries.yaml
+++ b/cloudbuild-binaries.yaml
@@ -51,15 +51,6 @@ steps:
         --env CI=True
         us.gcr.io/$PROJECT_ID/geth-xgo-builder:$COMMIT_SHA
         -c "go run build/ci.go xgo-archive -targets=$_BUILD_TARGETS -in /build -out /archives"'
-- name: 'gcr.io/cloud-builders/docker'
-  entrypoint: 'sh'
-  args:
-    - '-c'
-    - 'docker run --rm
-        -v $(pwd)/build/archives:/out
-        --entrypoint /bin/sh
-        us.gcr.io/$PROJECT_ID/geth-xgo-builder:$COMMIT_SHA
-        -c "cp /archives/* /out"'
 artifacts:
   objects:
     location: 'gs://$_BUCKET/$BRANCH_NAME/'

--- a/cloudbuild-binaries.yaml
+++ b/cloudbuild-binaries.yaml
@@ -3,25 +3,54 @@ steps:
   entrypoint: 'sh'
   args:
     - '-c'
-    - 'docker pull us.gcr.io/$PROJECT_ID/geth-binaries:latest || exit 0'
+    - 'docker pull us.gcr.io/$PROJECT_ID/geth-xgo-builder:latest || exit 0'
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'sh'
   args:
     - '-c'
     - 'docker build .
-        --build-arg __BUILD_TARGETS=linux/amd64,linux/386
-        --build-arg __COMMIT_SHA=$COMMIT_SHA
-        --build-arg __TAG_NAME=$TAG_NAME
-        --build-arg __REPO_NAME=$REPO_NAME
-        --build-arg __BRANCH_NAME=$BRANCH_NAME
-        --build-arg __COMMIT_TIMESTAMP=$(date +%s)
-        --build-arg __CLOUDBUILD=True
-        --build-arg __CI=True
-        --cache-from us.gcr.io/$PROJECT_ID/geth-binaries:latest
-        -t us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA
-        -t us.gcr.io/$PROJECT_ID/geth-binaries:latest
+        --cache-from us.gcr.io/$PROJECT_ID/geth-xgo-builder:latest
+        -t us.gcr.io/$PROJECT_ID/geth-xgo-builder:$COMMIT_SHA
+        -t us.gcr.io/$PROJECT_ID/geth-xgo-builder:latest
         -f Dockerfile.binaries'
-
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'sh'
+  args:
+    - '-c'
+    - 'docker run --rm
+        -v $(pwd)/build/bin:/build
+        -v $(pwd)/build/archives:/archives
+        -v $(pwd):/go/src/github.com/ethereum/go-ethereum
+        --entrypoint /bin/sh
+        --env BUILD_TARGETS=$_BUILD_TARGETS
+        --env TAG_NAME=$TAG_NAME
+        --env BRANCH_NAME=$BRANCH_NAME
+        --env REPO_NAME=$REPO_NAME
+        --env COMMIT_SHA=$COMMIT_SHA
+        --env COMMIT_TIMESTAMP=$(date +%s)
+        --env CLOUDBUILD=True
+        --env CI=True
+        us.gcr.io/$PROJECT_ID/geth-xgo-builder:$COMMIT_SHA
+        -c "go run build/ci.go xgo --alltools -- -targets=$_BUILD_TARGETS -v -dest /build"'
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'sh'
+  args:
+    - '-c'
+    - 'docker run --rm
+        -v $(pwd)/build/bin:/build
+        -v $(pwd)/build/archives:/archives
+        -v $(pwd):/go/src/github.com/ethereum/go-ethereum
+        --entrypoint /bin/sh
+        --env BUILD_TARGETS=$_BUILD_TARGETS
+        --env TAG_NAME=$TAG_NAME
+        --env BRANCH_NAME=$BRANCH_NAME
+        --env REPO_NAME=$REPO_NAME
+        --env COMMIT_SHA=$COMMIT_SHA
+        --env COMMIT_TIMESTAMP=$(date +%s)
+        --env CLOUDBUILD=True
+        --env CI=True
+        us.gcr.io/$PROJECT_ID/geth-xgo-builder:$COMMIT_SHA
+        -c "go run build/ci.go xgo-archive -targets=$_BUILD_TARGETS -in /build -out /archives"'
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'sh'
   args:
@@ -29,13 +58,13 @@ steps:
     - 'docker run --rm
         -v $(pwd)/build/archives:/out
         --entrypoint /bin/sh
-        us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA
+        us.gcr.io/$PROJECT_ID/geth-xgo-builder:$COMMIT_SHA
         -c "cp /archives/* /out"'
 artifacts:
   objects:
     location: 'gs://$_BUCKET/$BRANCH_NAME/'
     paths: ['./build/archives/*']
 images:
-- 'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA'
-- 'us.gcr.io/$PROJECT_ID/geth-binaries:latest'
+- 'us.gcr.io/$PROJECT_ID/geth-xgo-builder:$COMMIT_SHA'
+- 'us.gcr.io/$PROJECT_ID/geth-xgo-builder:latest'
 timeout: 2700s

--- a/cloudbuild-binaries.yaml
+++ b/cloudbuild-binaries.yaml
@@ -2,26 +2,30 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: [
     'build',
-    '-t', 'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA',
-    '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
     '.',
+    '--build-arg', '__BUILD_TARGETS=linux/amd64,linux/386',
+    '--build-arg', '__COMMIT_SHA=$COMMIT_SHA',
+    '--build-arg', '__TAG_NAME=$TAG_NAME',
+    '--build-arg', '__REPO_NAME=$REPO_NAME',
+    '--build-arg', '__BRANCH_NAME=$BRANCH_NAME',
+    '--build-arg', '__COMMIT_TIMESTAMP=$(git show -s --format=%ct $COMMIT_SHA)',
+    '--build-arg', '__CLOUDBUILD=True',
+    '--build-arg', '__CI=True',
+    '-t', 'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA',
     '-f', 'Dockerfile.binaries'
   ]
-  waitFor: ["-"]
 - name: 'gcr.io/cloud-builders/docker'
   args: [
     'run', '--rm',
-    '-v', '$(pwd):/out',
+    '-v', '$(pwd)/build/archives:/out',
     '--entrypoint', '/bin/sh',
     'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA',
-    '-c', '"cp /build/* /out/build/bin"'
+    '-c', '"cp /archives/* /out"'
   ]
-  waitFor: ["-"]
-- name: 'ubuntu'
-  args: ['bash', './script/prepare-release-binaries.sh']
-  env:
-    - 'BRANCH_NAME=$BRANCH_NAME'
-    - 'TAG_NAME=$TAG_NAME'
+artifacts:
+  objects:
+    location: 'gs://$_BUCKET/$TAG_NAME/'
+    paths: ['./build/archives/*']
 images:
 - 'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA'
 timeout: 2700s

--- a/cloudbuild-binaries.yaml
+++ b/cloudbuild-binaries.yaml
@@ -1,27 +1,29 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [
-    'build',
-    '.',
-    '--build-arg', '__BUILD_TARGETS=linux/amd64,linux/386',
-    '--build-arg', '__COMMIT_SHA=$COMMIT_SHA',
-    '--build-arg', '__TAG_NAME=$TAG_NAME',
-    '--build-arg', '__REPO_NAME=$REPO_NAME',
-    '--build-arg', '__BRANCH_NAME=$BRANCH_NAME',
-    '--build-arg', '__COMMIT_TIMESTAMP=$(git show -s --format=%ct $COMMIT_SHA)',
-    '--build-arg', '__CLOUDBUILD=True',
-    '--build-arg', '__CI=True',
-    '-t', 'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA',
-    '-f', 'Dockerfile.binaries'
-  ]
+  entrypoint: 'sh'
+  args:
+    - '-c'
+    - 'docker build .
+        --build-arg __BUILD_TARGETS=linux/amd64,linux/386
+        --build-arg __COMMIT_SHA=$COMMIT_SHA
+        --build-arg __TAG_NAME=$TAG_NAME
+        --build-arg __REPO_NAME=$REPO_NAME
+        --build-arg __BRANCH_NAME=$BRANCH_NAME
+        --build-arg __COMMIT_TIMESTAMP=$(date +%s)
+        --build-arg __CLOUDBUILD=True
+        --build-arg __CI=True
+        -t us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA
+        -f Dockerfile.binaries'
+
 - name: 'gcr.io/cloud-builders/docker'
-  args: [
-    'run', '--rm',
-    '-v', '$(pwd)/build/archives:/out',
-    '--entrypoint', '/bin/sh',
-    'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA',
-    '-c', '"cp /archives/* /out"'
-  ]
+  entrypoint: 'sh'
+  args:
+    - '-c'
+    - 'docker run --rm
+        -v $(pwd)/build/archives:/out
+        --entrypoint /bin/sh
+        us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA
+        -c "cp /archives/* /out"'
 artifacts:
   objects:
     location: 'gs://$_BUCKET/$TAG_NAME/'

--- a/cloudbuild-binaries.yaml
+++ b/cloudbuild-binaries.yaml
@@ -28,7 +28,7 @@ steps:
         -c "cp /archives/* /out"'
 artifacts:
   objects:
-    location: 'gs://$_BUCKET/$TAG_NAME/'
+    location: 'gs://$_BUCKET/$BRANCH_NAME/'
     paths: ['./build/archives/*']
 images:
 - 'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA'

--- a/cloudbuild-binaries.yaml
+++ b/cloudbuild-binaries.yaml
@@ -1,0 +1,27 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [
+    'build',
+    '-t', 'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA',
+    '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
+    '.',
+    '-f', 'Dockerfile.binaries'
+  ]
+  waitFor: ["-"]
+- name: 'gcr.io/cloud-builders/docker'
+  args: [
+    'run', '--rm',
+    '-v', '$(pwd):/out',
+    '--entrypoint', '/bin/sh',
+    'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA',
+    '-c', '"cp /build/* /out/build/bin"'
+  ]
+  waitFor: ["-"]
+- name: 'ubuntu'
+  args: ['bash', './script/prepare-release-binaries.sh']
+  env:
+    - 'BRANCH_NAME=$BRANCH_NAME'
+    - 'TAG_NAME=$TAG_NAME'
+images:
+- 'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA'
+timeout: 2700s

--- a/cloudbuild-binaries.yaml
+++ b/cloudbuild-binaries.yaml
@@ -12,7 +12,9 @@ steps:
         --build-arg __COMMIT_TIMESTAMP=$(date +%s)
         --build-arg __CLOUDBUILD=True
         --build-arg __CI=True
+        --cache-from us.gcr.io/$PROJECT_ID/geth-binaries:latest
         -t us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA
+        -t us.gcr.io/$PROJECT_ID/geth-binaries:latest
         -f Dockerfile.binaries'
 
 - name: 'gcr.io/cloud-builders/docker'
@@ -30,4 +32,5 @@ artifacts:
     paths: ['./build/archives/*']
 images:
 - 'us.gcr.io/$PROJECT_ID/geth-binaries:$COMMIT_SHA'
+- 'us.gcr.io/$PROJECT_ID/geth-binaries:latest'
 timeout: 2700s

--- a/cloudbuild-binaries.yaml
+++ b/cloudbuild-binaries.yaml
@@ -3,6 +3,11 @@ steps:
   entrypoint: 'sh'
   args:
     - '-c'
+    - 'docker pull us.gcr.io/$PROJECT_ID/geth-binaries:latest || exit 0'
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'sh'
+  args:
+    - '-c'
     - 'docker build .
         --build-arg __BUILD_TARGETS=linux/amd64,linux/386
         --build-arg __COMMIT_SHA=$COMMIT_SHA

--- a/cloudbuild-binaries.yaml
+++ b/cloudbuild-binaries.yaml
@@ -1,3 +1,4 @@
+# See ./Dockerfile.binaries for more information w.r.t this CI flow
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'sh'

--- a/internal/build/env.go
+++ b/internal/build/env.go
@@ -91,6 +91,24 @@ func Env() Environment {
 			IsCronJob:     os.Getenv("APPVEYOR_SCHEDULED_BUILD") == "True",
 			IsMusl:        os.Getenv("MUSL") == "true",
 		}
+	case os.Getenv("CI") == "True" && os.Getenv("CLOUDBUILD") == "True":
+		commit := os.Getenv("COMMIT_SHA")
+		date, err := strconv.ParseInt(strings.TrimSpace(os.Getenv("COMMIT_TIMESTAMP")), 10, 64)
+		if err != nil {
+			panic(fmt.Sprintf("failed to parse git commit date: %v", err))
+		}
+		return Environment{
+			Name:          "cloudbuild",
+			Repo:          os.Getenv("REPO_NAME"),
+			Commit:        commit,
+			Date:          time.Unix(date, 0).Format("20060102"),
+			Branch:        os.Getenv("BRANCH_NAME"),
+			Tag:           os.Getenv("TAG_NAME"),
+			Buildnum:      os.Getenv("BUILD_ID"),
+			IsPullRequest: os.Getenv("_PR_NUMBER") != "",
+			IsCronJob:     false,
+			IsMusl:        os.Getenv("MUSL") == "true",
+		}
 	default:
 		return LocalEnv()
 	}


### PR DESCRIPTION
### Description

This PR includes the necessary bits to setup a CI pipeline that cross-compiles all geth tools into release binaries for the platforms we want/support. Currently these are:

- ✅Linux 32bit/64bit
- ✅Darwin 32bit/64bit (~pending on #1082~ merged!)
- ✅Windows 64bit (~pending on celo-bls-go v0.1.6 release~ ~pending on #1089~ merged!)

Elements of the PR:

- `Dockerfile.binaries` for the container where cross-compilation occurs. It's based on a [fork of xgo](https://github.com/techknowlogick/xgo), and includes some back-ported mingw packages for the windows build.


- Changes to the `geth` build scripts:
   - Introduce a new CI environment in `internal/build/env.go` which which can be used for Google Cloud Build.
   - Create a new ci task in `build/ci.go` that bundles the binaries into well named release archive


- `cloudbuild-binaries.yaml` which defines the CI pipeline. It should be used in conjunction with a trigger on `release/.*` and `master` branches and the trigger should have to variables:
  - `_BUCKET` with the name of the google cloud storage bucket where the artefacts will be stored
  - `_BUILD_TARGETS` comma-separated string of build targets. e.g. `linux/amd64,linux/386`

#### Shortcomings 

- 🔴 The geth `build.Environment` struct requires the commit timestamp, which is then passed to `main.gitDate` in the binaries that it builds. Usually this is extracted from the git but in Cloud Build in the CI steps the git data is stripped and all we have is what's passed through env vars. I have substituted the commit timestamp with the build timestamp instead.
- 🟡 The `xgo` image is really large (3gb) and adds about ~4minutes to the build time

#### Release artefacts

The pipeline outputs release artefacts into `<bucket>/<branch>/<file>`. For example here's the output of a test build:

<img width="553" alt="Screenshot 2020-06-29 at 11 41 00" src="https://user-images.githubusercontent.com/304771/85994959-1433eb00-b9fe-11ea-9180-22ea95cb774c.png">

A few things to notice here:

- The folder is `<bucket>/release/1.1` yet the version is `1.0.0-unstable` this is because there isn't any enforced relationship between the branch name and the version sourced from `params/version.go` which is the authoritative source. So in this case I just created the dummy `release/1.1` branch on my fork in order to play around. Because we're using the branch name in the path all "nightly" version will be stored in the `<bucket>/master` folder, if we setup the trigger on `master`.

- There are 2 archives per platform, one containing only `geth` and the other containing all binary tools located inside `cmd`, just like geth releases. ⚠️ The archives also contain the "COPYING" file, we need to decide if we want to make changes to that ⚠️
 

#### Post-merge TODOs:

- [x] Create a bucket and triggers in `celo-testnet` to start running the pipeline
- [x] Enable more build targets as they are unblocked 
 
### Tested

I have currently tested the CI pipeline in a personal google cloud project and tested the linux binaries in docker.

### Related issues

- Fixes #1073 

### Backwards compatibility

Changes are only related to tooling so no problem with compatibility.
