### PR TITLE
Use celohq/node10-gcloud:v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
     working_directory: ~/repos/geth
   e2e:
     docker:
-      - image: celohq/node10-gcloud:v2
+      - image: celohq/node10-gcloud:v3
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
       GO_VERSION: "1.13.7"


### PR DESCRIPTION
### Description

This is to make `yarn install` work with changes done in https://github.com/celo-org/celo-monorepo/pull/4282
which requires `rsync` tool to be installed.

### Other changes

None

### Tested

`yarn install` works on CircleCI

### Related issues

None

### Backwards compatibility

Yes
