### PR TITLE
Fix CI issue on celo-monorepo yarn install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ executors:
     environment:
       GO_VERSION: "1.13.7"
       CELO_MONOREPO_BRANCH_TO_TEST: master
+      GITHUB_RSA_FINGERPRINT: SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
 jobs:
   build-geth:
     executor: golang
@@ -135,6 +136,9 @@ jobs:
       - run:
           name: Setup celo-monorepo
           command: |
+            set -e
+            mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+            ssh-keygen -F github.com -l -f ~/.ssh/known_hosts | grep 'github.com RSA ${GITHUB_RSA_FINGERPRINT}' && echo "Github key verification successful"
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b ${CELO_MONOREPO_BRANCH_TO_TEST}
             cd celo-monorepo
             yarn install || yarn install


### PR DESCRIPTION
### Description

Some recent change to `celo-monorepo` introduced dependencies that need to be installed from github over ssh and thus we need to add and verify the github.com ssh keys in order to avoid the classic:

```bash
The authenticity of host 'github.com (140.82.113.3)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? 
``` 

> Props to @valer-cara for some help with the ssh-fu