### PR TITLE
Remove useless echo that was causing the script to never fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
       - run:
           name: Setup celo-monorepo
           command: |
-            set -e
+            set -ex
             mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
             ssh-keygen -F github.com -l -f ~/.ssh/known_hosts | grep 'github.com RSA ${GITHUB_RSA_FINGERPRINT}'
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b ${CELO_MONOREPO_BRANCH_TO_TEST}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
           command: |
             set -e
             mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-            ssh-keygen -F github.com -l -f ~/.ssh/known_hosts | grep 'github.com RSA ${GITHUB_RSA_FINGERPRINT}' && echo "Github key verification successful"
+            ssh-keygen -F github.com -l -f ~/.ssh/known_hosts | grep 'github.com RSA ${GITHUB_RSA_FINGERPRINT}'
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b ${CELO_MONOREPO_BRANCH_TO_TEST}
             cd celo-monorepo
             yarn install || yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,9 +136,9 @@ jobs:
       - run:
           name: Setup celo-monorepo
           command: |
-            set -ex
+            set -e
             mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-            ssh-keygen -F github.com -l -f ~/.ssh/known_hosts | grep 'github.com RSA ${GITHUB_RSA_FINGERPRINT}'
+            ssh-keygen -F github.com -l -f ~/.ssh/known_hosts | grep "github.com RSA ${GITHUB_RSA_FINGERPRINT}"
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b ${CELO_MONOREPO_BRANCH_TO_TEST}
             cd celo-monorepo
             yarn install || yarn install


### PR DESCRIPTION
### Description

In bash if you do: 

```bash
set -e

cmd1 | cmd2
some_other_cmd
```

The script will exit after the pipe if `cmd2` fails.

Hover if you do:
```bash
set -e

cmd1 | cmd2 && echo "Ok!"
some_other_cmd
```

The script will **not** exit anymore if `cmd2` fails but will continue running. For some reason the result of that expression doesn't trigger the `set -e`

... the more you know. 

More info on the topic [here](https://unix.stackexchange.com/questions/447519/has-anyone-tried-to-write-a-shell-that-fixes-errexit-set-e/447651#447651).

Also I had an env var in single quotes and was expecting it to be substituted 🤦 
