### PR TITLE
Adds epochSnarkData to getBlock API

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -178,6 +178,10 @@ func (r *EpochSnarkData) EncodeRLP(w io.Writer) error {
 	return rlp.Encode(w, []interface{}{r.Bitmap, r.Signature})
 }
 
+func (r *EpochSnarkData) IsEmpty() bool {
+	return len(r.Signature) == 0
+}
+
 // Body is a simple (mutable, non-safe) data container for storing and moving
 // a block's data contents (transactions and uncles) together.
 type Body struct {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1047,6 +1047,15 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool) (map[string]i
 		"revealed":  hexutil.Bytes(block.Randomness().Revealed.Bytes()),
 		"committed": hexutil.Bytes(block.Randomness().Committed.Bytes()),
 	}
+	epochSnarkData := block.EpochSnarkData()
+	if epochSnarkData != nil {
+		fields["epochSnarkData"] = map[string]interface{}{
+			"bitmap":    hexutil.Bytes(block.EpochSnarkData().Bitmap.Bytes()),
+			"signature": hexutil.Bytes(block.EpochSnarkData().Signature),
+		}
+	} else {
+		fields["epochSnarkData"] = nil
+	}
 
 	if inclTx {
 		formatTx := func(tx *types.Transaction) (interface{}, error) {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1048,7 +1048,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool) (map[string]i
 		"committed": hexutil.Bytes(block.Randomness().Committed.Bytes()),
 	}
 	epochSnarkData := block.EpochSnarkData()
-	if epochSnarkData != nil {
+	if !epochSnarkData.IsEmpty() {
 		fields["epochSnarkData"] = map[string]interface{}{
 			"bitmap":    hexutil.Bytes(block.EpochSnarkData().Bitmap.Bytes()),
 			"signature": hexutil.Bytes(block.EpochSnarkData().Signature),

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1048,7 +1048,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool) (map[string]i
 		"committed": hexutil.Bytes(block.Randomness().Committed.Bytes()),
 	}
 	epochSnarkData := block.EpochSnarkData()
-	if !epochSnarkData.IsEmpty() {
+	if epochSnarkData != nil && !epochSnarkData.IsEmpty() {
 		fields["epochSnarkData"] = map[string]interface{}{
 			"bitmap":    hexutil.Bytes(block.EpochSnarkData().Bitmap.Bytes()),
 			"signature": hexutil.Bytes(block.EpochSnarkData().Signature),


### PR DESCRIPTION
### Description

While the data exists in the block body, the API did not expose it.