### PR TITLE
Fix use of potentially invalid headers to verify new headers

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -176,8 +176,18 @@ func (sb *Backend) VerifyHeaders(chain consensus.ChainReader, headers []*types.H
 	abort := make(chan struct{})
 	results := make(chan error, len(headers))
 	go func() {
+		errored := false
 		for i, header := range headers {
-			err := sb.verifyHeader(chain, header, headers[:i])
+			var err error
+			if errored {
+				err = consensus.ErrUnknownAncestor
+			} else {
+				err = sb.verifyHeader(chain, header, headers[:i])
+			}
+
+			if err != nil {
+				errored = true
+			}
 
 			select {
 			case <-abort:


### PR DESCRIPTION
### Description

VerifyHeaders() is used to verify new headers in batch obtained from peers.
To do the verification it uses `1..n` headers in batch to verify header
`n+1` in the batch.

The problem is that if some of if `1..n` header are invalid, it will still use them
for the verification. This can be potentially be used to attack a node's
validatorSet cache for the next epoch.

This commit fix this, by failing fast. When the first invalid header is
encountered, all subsequent headers on the batch will fail with `ErrUnknownAncestor`

### Backwards compatibility

Yes

Kudos to @kevjue @gakonst @mrsmkl for their help on finding and fixing this problem