### PR TITLE
Cache block process

### DIFF
--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -239,7 +239,7 @@ func (e *NoRewardEngine) FinalizeAndAssemble(chain consensus.ChainReader, header
 	}
 }
 
-func (e *NoRewardEngine) Seal(chain consensus.ChainReader, block *types.Block, results chan<- *consensus.BlockProcessResult, stop <-chan struct{}) error {
+func (e *NoRewardEngine) Seal(chain consensus.ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
 	return e.inner.Seal(chain, block, results, stop)
 }
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -97,7 +97,7 @@ type Engine interface {
 	//
 	// Note, the method returns immediately and will send the result async. More
 	// than one result may also be returned depending on the consensus algorithm.
-	Seal(chain ChainReader, block *types.Block, results chan<- *BlockProcessResult, stop <-chan struct{}) error
+	Seal(chain ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error
 
 	// SealHash returns the hash of a block prior to it being sealed.
 	SealHash(header *types.Header) common.Hash
@@ -197,14 +197,4 @@ type Istanbul interface {
 	// This is only implemented for Istanbul.
 	// It will check to see if the header is from the last block of an epoch
 	IsLastBlockOfEpoch(header *types.Header) bool
-}
-
-// BlockProcessResult caches block process result.
-type BlockProcessResult struct {
-	Block    *types.Block
-	Receipts []*types.Receipt
-	Logs     []*types.Log
-	State    *state.StateDB
-
-	IsProposer bool
 }

--- a/consensus/consensustest/mockprotocol.go
+++ b/consensus/consensustest/mockprotocol.go
@@ -329,10 +329,10 @@ func (e *MockEngine) SealHash(header *types.Header) (hash common.Hash) {
 	return hash
 }
 
-func (e *MockEngine) Seal(chain consensus.ChainReader, block *types.Block, results chan<- *consensus.BlockProcessResult, stop <-chan struct{}) error {
+func (e *MockEngine) Seal(chain consensus.ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
 	header := block.Header()
 	select {
-	case results <- &consensus.BlockProcessResult{Block: block.WithSeal(header)}:
+	case results <- block.WithSeal(header):
 	default:
 		log.Warn("Sealing result is not read by miner", "mode", "fake", "sealhash", e.SealHash(header))
 	}

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -114,7 +113,7 @@ func TestCheckValidatorSignature(t *testing.T) {
 func TestCommit(t *testing.T) {
 	backend := newBackend()
 
-	commitCh := make(chan *consensus.BlockProcessResult)
+	commitCh := make(chan *types.Block)
 	// Case: it's a proposer, so the backend.commit will receive channel result from backend.Commit function
 	testCases := []struct {
 		expectedErr       error
@@ -152,10 +151,6 @@ func TestCommit(t *testing.T) {
 			commitCh <- result
 		}()
 
-		backend.pendingMu.Lock()
-		backend.pendingBlockProcessResults[backend.SealHash(expBlock.Header())] = &consensus.BlockProcessResult{Block: expBlock}
-		backend.pendingMu.Unlock()
-
 		backend.proposedBlockHash = expBlock.Hash()
 		if err := backend.Commit(expBlock, types.IstanbulAggregatedSeal{Round: big.NewInt(0), Bitmap: big.NewInt(0), Signature: test.expectedSignature}, types.IstanbulEpochValidatorSetSeal{Bitmap: big.NewInt(0), Signature: nil}); err != nil {
 			if err != test.expectedErr {
@@ -167,8 +162,8 @@ func TestCommit(t *testing.T) {
 			// to avoid race condition is occurred by goroutine
 			select {
 			case result := <-commitCh:
-				if result.Block.Hash() != expBlock.Hash() {
-					t.Errorf("hash mismatch: have %v, want %v", result.Block.Hash(), expBlock.Hash())
+				if result.Hash() != expBlock.Hash() {
+					t.Errorf("hash mismatch: have %v, want %v", result.Hash(), expBlock.Hash())
 				}
 			case <-time.After(10 * time.Second):
 				t.Fatal("timeout")

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -473,7 +473,7 @@ func (sb *Backend) FinalizeAndAssemble(chain consensus.ChainReader, header *type
 
 // Seal generates a new block for the given input block with the local miner's
 // seal place on top.
-func (sb *Backend) Seal(chain consensus.ChainReader, block *types.Block, resultCh chan<- *consensus.BlockProcessResult, stop <-chan struct{}) error {
+func (sb *Backend) Seal(chain consensus.ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
 	// update the block header timestamp and signature and propose the block to core engine
 	header := block.Header()
 	number := header.Number.Uint64()
@@ -517,8 +517,8 @@ func (sb *Backend) Seal(chain consensus.ChainReader, block *types.Block, resultC
 				// Somehow, the block `result` coming from commitCh can be null
 				// if the block hash and the hash from channel are the same,
 				// return the result. Otherwise, keep waiting the next hash.
-				if result != nil && result.Block != nil && block.Hash() == result.Block.Hash() {
-					resultCh <- result
+				if result != nil && block.Hash() == result.Hash() {
+					results <- result
 					return
 				}
 			case <-stop:
@@ -582,7 +582,7 @@ func (sb *Backend) StartValidating(hasBadBlock func(common.Hash) bool,
 	if sb.commitCh != nil {
 		close(sb.commitCh)
 	}
-	sb.commitCh = make(chan *consensus.BlockProcessResult, 1)
+	sb.commitCh = make(chan *types.Block, 1)
 
 	sb.hasBadBlock = hasBadBlock
 	sb.processBlock = processBlock

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -82,7 +82,7 @@ func TestSealStopChannel(t *testing.T) {
 		eventSub.Unsubscribe()
 	}
 	go eventLoop()
-	results := make(chan *consensus.BlockProcessResult)
+	results := make(chan *types.Block)
 
 	err := engine.Seal(chain, block, results, stop)
 	if err != nil {
@@ -115,7 +115,7 @@ func testSealCommittedOtherHash(t *testing.T, numValidators int) {
 		t.Fatalf("did not create different blocks")
 	}
 
-	results := make(chan *consensus.BlockProcessResult)
+	results := make(chan *types.Block)
 	engine.Seal(chain, block, results, nil)
 
 	// in the single validator case, the result will instantly be processed
@@ -138,7 +138,7 @@ func TestSealCommitted(t *testing.T) {
 	block := makeBlockWithoutSeal(chain, engine, chain.Genesis())
 	expectedBlock, _ := engine.updateBlock(engine.chain.GetHeader(block.ParentHash(), block.NumberU64()-1), block)
 
-	results := make(chan *consensus.BlockProcessResult)
+	results := make(chan *types.Block)
 	go func() {
 		err := engine.Seal(chain, block, results, nil)
 		if err != nil {
@@ -146,9 +146,9 @@ func TestSealCommitted(t *testing.T) {
 		}
 	}()
 
-	result := <-results
-	if result.Block.Hash() != expectedBlock.Hash() {
-		t.Errorf("hash mismatch: have %v, want %v", result.Block.Hash(), expectedBlock.Hash())
+	finalBlock := <-results
+	if finalBlock.Hash() != expectedBlock.Hash() {
+		t.Errorf("hash mismatch: have %v, want %v", finalBlock.Hash(), expectedBlock.Hash())
 	}
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -152,7 +152,7 @@ type worker struct {
 	// Channels
 	newWorkCh          chan *newWorkReq
 	taskCh             chan *task
-	resultCh           chan *consensus.BlockProcessResult
+	resultCh           chan *types.Block
 	startCh            chan struct{}
 	exitCh             chan struct{}
 	resubmitIntervalCh chan time.Duration
@@ -206,7 +206,7 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		chainSideCh:        make(chan core.ChainSideEvent, chainSideChanSize),
 		newWorkCh:          make(chan *newWorkReq),
 		taskCh:             make(chan *task),
-		resultCh:           make(chan *consensus.BlockProcessResult, resultQueueSize),
+		resultCh:           make(chan *types.Block, resultQueueSize),
 		exitCh:             make(chan struct{}),
 		startCh:            make(chan struct{}, 1),
 		resubmitIntervalCh: make(chan time.Duration),
@@ -551,75 +551,64 @@ func (w *worker) taskLoop() {
 func (w *worker) resultLoop() {
 	for {
 		select {
-		case result := <-w.resultCh:
-			// Short circuit when receiving empty result or receiving duplicate result caused by resubmitting.
-			if result == nil || result.Block == nil || w.chain.HasBlock(result.Block.Hash(), result.Block.NumberU64()) {
+		case block := <-w.resultCh:
+			// Short circuit when receiving empty result.
+			if block == nil {
 				continue
 			}
-
-			if result.IsProposer {
-				var (
-					block    = result.Block
-					sealHash = w.engine.SealHash(block.Header())
-					hash     = block.Hash()
-				)
-
-				w.pendingMu.RLock()
-				task, exist := w.pendingTasks[sealHash]
-				w.pendingMu.RUnlock()
-				if !exist {
-					log.Error("Block found but no relative pending task", "number", block.Number(), "sealHash", sealHash, "hash", hash)
-					continue
-				}
-
-				var (
-					receipts = make([]*types.Receipt, len(task.receipts))
-					logs     []*types.Log
-				)
-				// Different block could share same sealHash, deep copy here to prevent write-write conflict.
-				for i, receipt := range task.receipts {
-					// add block location fields
-					receipt.BlockHash = hash
-					receipt.BlockNumber = block.Number()
-					receipt.TransactionIndex = uint(i)
-
-					receipts[i] = new(types.Receipt)
-					*receipts[i] = *receipt
-					// Update the block hash in all logs since it is now available and not when the
-					// receipt/log of individual transactions were created.
-					for _, log := range receipt.Logs {
-						log.BlockHash = hash
-						// Handle block finalization receipt
-						if (log.TxHash == common.Hash{}) {
-							log.TxHash = hash
-						}
-					}
-					logs = append(logs, receipt.Logs...)
-				}
-
-				// Commit block and state to database.
-				_, err := w.chain.WriteBlockWithState(block, receipts, logs, task.state, true)
-				if err != nil {
-					log.Error("Failed writing block to chain", "err", err)
-					continue
-				}
-				log.Info("Successfully sealed new block", "number", block.Number(), "sealHash", sealHash, "hash", hash,
-					"elapsed", common.PrettyDuration(time.Since(task.createdAt)))
-			} else {
-				if result.State != nil {
-					_, err := w.chain.WriteBlockWithState(result.Block, result.Receipts, result.Logs, result.State, true)
-					if err != nil {
-						log.Error("Failed writing block to chain", "err", err)
-						continue
-					}
-				}
+			// Short circuit when receiving duplicate result caused by resubmitting.
+			if w.chain.HasBlock(block.Hash(), block.NumberU64()) {
+				continue
 			}
+			var (
+				sealhash = w.engine.SealHash(block.Header())
+				hash     = block.Hash()
+			)
+			w.pendingMu.RLock()
+			task, exist := w.pendingTasks[sealhash]
+			w.pendingMu.RUnlock()
+			if !exist {
+				log.Error("Block found but no relative pending task", "number", block.Number(), "sealhash", sealhash, "hash", hash)
+				continue
+			}
+			// Different block could share same sealhash, deep copy here to prevent write-write conflict.
+			var (
+				receipts = make([]*types.Receipt, len(task.receipts))
+				logs     []*types.Log
+			)
+			for i, receipt := range task.receipts {
+				// add block location fields
+				receipt.BlockHash = hash
+				receipt.BlockNumber = block.Number()
+				receipt.TransactionIndex = uint(i)
+
+				receipts[i] = new(types.Receipt)
+				*receipts[i] = *receipt
+				// Update the block hash in all logs since it is now available and not when the
+				// receipt/log of individual transactions were created.
+				for _, log := range receipt.Logs {
+					log.BlockHash = hash
+					// Handle block finalization receipt
+					if (log.TxHash == common.Hash{}) {
+						log.TxHash = hash
+					}
+				}
+				logs = append(logs, receipt.Logs...)
+			}
+			// Commit block and state to database.
+			_, err := w.chain.WriteBlockWithState(block, receipts, logs, task.state, true)
+			if err != nil {
+				log.Error("Failed writing block to chain", "err", err)
+				continue
+			}
+			log.Info("Successfully sealed new block", "number", block.Number(), "sealhash", sealhash, "hash", hash,
+				"elapsed", common.PrettyDuration(time.Since(task.createdAt)))
 
 			// Broadcast the block and announce chain insertion event
-			w.mux.Post(core.NewMinedBlockEvent{Block: result.Block})
+			w.mux.Post(core.NewMinedBlockEvent{Block: block})
 
 			// Insert the block into the set of pending ones to resultLoop for confirmations
-			w.unconfirmed.Insert(result.Block.NumberU64(), result.Block.Hash())
+			w.unconfirmed.Insert(block.NumberU64(), block.Hash())
 
 		case <-w.exitCh:
 			return


### PR DESCRIPTION
### Description

Currently, block processing is executed two times after the validator sent the proposer, one before broadcasting to peers during `preprepare`, one after finalizing it.
Instead, we can cache the block processing result, and use it afterwards.

- [x] Introduce BlockProcessResults

- [x] Add/modify unit tests

### Other changes

For now we maintain `pendingTasks` in `worker.go` to cache sealing tasks in validators. Since we are introducing an engine level cache, this can be removed.

### Tested

e2e & unit tests

### Related issues

#1105 

### Backwards compatibility

This branch is on upstream 1.9.10 merge.
