### PR TITLE
Clarify the message on the genesis mismatch error

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -433,7 +433,7 @@ func (p *peer) readStatusLegacy(network uint64, status *statusData63, genesis co
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
 	if status.GenesisBlock != genesis {
-		return errResp(ErrGenesisMismatch, "%x (!= %x)", status.GenesisBlock[:8], genesis[:8])
+		return errResp(ErrGenesisMismatch, "peer: %x (local: %x)", status.GenesisBlock[:8], genesis[:8])
 	}
 	if status.NetworkId != network {
 		return errResp(ErrNetworkIDMismatch, "%d (!= %d)", status.NetworkId, network)
@@ -463,7 +463,7 @@ func (p *peer) readStatus(network uint64, status *statusData, genesis common.Has
 		return errResp(ErrProtocolVersionMismatch, "%d (!= %d)", status.ProtocolVersion, p.version)
 	}
 	if status.Genesis != genesis {
-		return errResp(ErrGenesisMismatch, "%x (!= %x)", status.Genesis, genesis)
+		return errResp(ErrGenesisMismatch, "peer: %x (local: %x)", status.Genesis, genesis)
 	}
 	if err := forkFilter(status.ForkID); err != nil {
 		return errResp(ErrForkIDRejected, "%v", err)

--- a/eth/protocol_test.go
+++ b/eth/protocol_test.go
@@ -74,7 +74,7 @@ func TestStatusMsgErrors64(t *testing.T) {
 		},
 		{
 			code: StatusMsg, data: statusData63{64, DefaultConfig.NetworkId, td, head.Hash(), common.Hash{3}},
-			wantError: errResp(ErrGenesisMismatch, "0300000000000000 (!= %x)", genesis.Hash().Bytes()[:8]),
+			wantError: errResp(ErrGenesisMismatch, "peer: 0300000000000000 (local: %x)", genesis.Hash().Bytes()[:8]),
 		},
 	}
 	for i, test := range tests {
@@ -126,7 +126,7 @@ func TestStatusMsgErrors65(t *testing.T) {
 		},
 		{
 			code: StatusMsg, data: statusData{65, DefaultConfig.NetworkId, td, head.Hash(), common.Hash{3}, forkID},
-			wantError: errResp(ErrGenesisMismatch, "0300000000000000000000000000000000000000000000000000000000000000 (!= %x)", genesis.Hash()),
+			wantError: errResp(ErrGenesisMismatch, "peer: 0300000000000000000000000000000000000000000000000000000000000000 (local: %x)", genesis.Hash()),
 		},
 		{
 			code: StatusMsg, data: statusData{65, DefaultConfig.NetworkId, td, head.Hash(), genesis.Hash(), forkid.ID{Hash: [4]byte{0x00, 0x01, 0x02, 0x03}}},


### PR DESCRIPTION
### Description

Update the message on the genesis mismatch error reported when syncing to a node with a different genesis block hash to clarify which reported hash is the local, and which is the remote peer.

### Tested

Unit tests

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/issues/4603