### PR TITLE
Add peer connection metrics by peer purpose

### DIFF
--- a/eth/peer.go
+++ b/eth/peer.go
@@ -483,7 +483,7 @@ func (p *peer) ReadMsg() (p2p.Msg, error) {
 }
 
 func (p *peer) PurposeIsSet(purpose p2p.PurposeFlag) bool {
-	return purpose == p2p.AnyPurpose || p.StaticNodePurposes.IsSet(purpose) || p.TrustedNodePurposes.IsSet(purpose)
+	return purpose == p2p.AnyPurpose || p.HasPurpose(purpose)
 }
 
 // String implements fmt.Stringer.

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -39,11 +39,13 @@ const (
 )
 
 var (
-	ingressConnectMeter = metrics.NewRegisteredMeter(MetricsInboundConnects, nil)  // Meter counting the ingress connections
-	ingressTrafficMeter = metrics.NewRegisteredMeter(MetricsInboundTraffic, nil)   // Meter metering the cumulative ingress traffic
-	egressConnectMeter  = metrics.NewRegisteredMeter(MetricsOutboundConnects, nil) // Meter counting the egress connections
-	egressTrafficMeter  = metrics.NewRegisteredMeter(MetricsOutboundTraffic, nil)  // Meter metering the cumulative egress traffic
-	activePeerGauge     = metrics.NewRegisteredGauge("p2p/peers", nil)             // Gauge tracking the current peer count
+	ingressConnectMeter       = metrics.NewRegisteredMeter(MetricsInboundConnects, nil)  // Meter counting the ingress connections
+	ingressTrafficMeter       = metrics.NewRegisteredMeter(MetricsInboundTraffic, nil)   // Meter metering the cumulative ingress traffic
+	egressConnectMeter        = metrics.NewRegisteredMeter(MetricsOutboundConnects, nil) // Meter counting the egress connections
+	egressTrafficMeter        = metrics.NewRegisteredMeter(MetricsOutboundTraffic, nil)  // Meter metering the cumulative egress traffic
+	activePeerGauge           = metrics.NewRegisteredGauge("p2p/peers", nil)             // Gauge tracking the current peer count
+	activeValidatorsPeerGauge = metrics.NewRegisteredGauge("p2p/peers/validators", nil)  // Gauge tracking the current validators peer count
+	activeProxiesPeerGauge    = metrics.NewRegisteredGauge("p2p/peers/proxies", nil)     // Gauge tracking the current proxies peer count
 
 	PeerIngressRegistry = metrics.NewPrefixedChildRegistry(metrics.EphemeralRegistry, MetricsInboundTraffic+"/")  // Registry containing the peer ingress
 	PeerEgressRegistry  = metrics.NewPrefixedChildRegistry(metrics.EphemeralRegistry, MetricsOutboundTraffic+"/") // Registry containing the peer egress

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -163,6 +163,10 @@ func (p *Peer) RemovePurpose(purpose PurposeFlag) {
 	p.purpose = p.purpose.Remove(purpose)
 }
 
+func (p *Peer) HasPurpose(purpose PurposeFlag) bool {
+	return p.purpose.IsSet(purpose)
+}
+
 // ID returns the node's public key.
 func (p *Peer) ID() enode.ID {
 	return p.rw.node.ID()

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -117,8 +117,7 @@ type Peer struct {
 	// events receives message send / receive events if set
 	events *event.Feed
 
-	StaticNodePurposes  *PurposeFlag
-	TrustedNodePurposes *PurposeFlag
+	purpose PurposeFlag
 
 	Server *Server
 }
@@ -128,9 +127,19 @@ func NewPeer(id enode.ID, name string, caps []Cap) *Peer {
 	pipe, _ := net.Pipe()
 	node := enode.SignNull(new(enr.Record), id)
 	conn := &conn{fd: pipe, transport: nil, node: node, caps: caps, name: name}
-	peer := newPeer(log.Root(), conn, nil, nil, nil, nil)
+	peer := newPeer(log.Root(), conn, nil, NoPurpose, nil)
 	close(peer.closed) // ensures Disconnect doesn't block
 	return peer
+}
+
+func (p *Peer) AddPurpose(purpose PurposeFlag) {
+	// TODO: metric.increaseConnectionCounter by purpose
+	p.purpose = p.purpose.Add(purpose)
+}
+
+func (p *Peer) RemovePurpose(purpose PurposeFlag) {
+	// TODO: metric.decreaseConnectionCounter by purpose
+	p.purpose = p.purpose.Remove(purpose)
 }
 
 // ID returns the node's public key.
@@ -184,19 +193,18 @@ func (p *Peer) Inbound() bool {
 	return p.rw.is(inboundConn)
 }
 
-func newPeer(log log.Logger, conn *conn, protocols []Protocol, staticNodePurposes *PurposeFlag, trustedNodePurposes *PurposeFlag, server *Server) *Peer {
+func newPeer(log log.Logger, conn *conn, protocols []Protocol, purpose PurposeFlag, server *Server) *Peer {
 	protomap := matchProtocols(protocols, conn.caps, conn)
 	p := &Peer{
-		rw:                  conn,
-		running:             protomap,
-		created:             mclock.Now(),
-		disc:                make(chan DiscReason),
-		protoErr:            make(chan error, len(protomap)+1), // protocols + pingLoop
-		closed:              make(chan struct{}),
-		log:                 log.New("id", conn.node.ID(), "conn", conn.flags),
-		StaticNodePurposes:  staticNodePurposes,
-		TrustedNodePurposes: trustedNodePurposes,
-		Server:              server,
+		rw:       conn,
+		running:  protomap,
+		created:  mclock.Now(),
+		disc:     make(chan DiscReason),
+		protoErr: make(chan error, len(protomap)+1), // protocols + pingLoop
+		closed:   make(chan struct{}),
+		log:      log.New("id", conn.node.ID(), "conn", conn.flags),
+		purpose:  purpose,
+		Server:   server,
 	}
 	return p
 }
@@ -219,6 +227,8 @@ func (p *Peer) run() (remoteRequested bool, err error) {
 	// Start all protocol handlers.
 	writeStart <- struct{}{}
 	p.startProtocols(writeStart, writeErr)
+
+	// TODO: metric.increaseConnectionCounter by purpose
 
 	// Wait for an error or disconnect.
 loop:
@@ -249,11 +259,13 @@ loop:
 		}
 	}
 
-	if !(p.StaticNodePurposes.NoPurpose() && p.TrustedNodePurposes.NoPurpose()) {
+	// TODO: metric.decreaseConnectionCounter by purpose
+
+	if p.purpose.HasPurpose() {
 		if err != nil {
-			p.log.Info("Disconnecting from static or trusted peer", "static", p.StaticNodePurposes, "trusted", p.TrustedNodePurposes, "reason", reason, "remoteRequested", remoteRequested, "err", err)
+			p.log.Info("Disconnecting from static or trusted peer", "purpose", p.purpose, "reason", reason, "remoteRequested", remoteRequested, "err", err)
 		} else {
-			p.log.Info("Disconnecting from static or trusted peer", "static", p.StaticNodePurposes, "trusted", p.TrustedNodePurposes, "reason", reason, "remoteRequested", remoteRequested)
+			p.log.Info("Disconnecting from static or trusted peer", "purpose", p.purpose, "reason", reason, "remoteRequested", remoteRequested)
 		}
 	}
 
@@ -462,14 +474,14 @@ func (rw *protoRW) ReadMsg() (Msg, error) {
 // peer. Sub-protocol independent fields are contained and initialized here, with
 // protocol specifics delegated to all connected sub-protocols.
 type PeerInfo struct {
-	ENR                 string   `json:"enr,omitempty"`   // Ethereum Node Record
-	Enode               string   `json:"enode"`           // Node URL
-	ID                  string   `json:"id"`              // Unique node identifier
-	Name                string   `json:"name"`            // Name of the node, including client type, version, OS, custom data
-	Caps                []string `json:"caps"`            // Protocols advertised by this peer
-	StaticNodePurposes  string   `json:"staticNodeInfo"`  // Purposes for the static node
-	TrustedNodePurposes string   `json:"trustedNodeInfo"` // Purposes for the trusted node
-	Network             struct {
+	ENR      string   `json:"enr,omitempty"` // Ethereum Node Record
+	Enode    string   `json:"enode"`         // Node URL
+	ID       string   `json:"id"`            // Unique node identifier
+	Name     string   `json:"name"`          // Name of the node, including client type, version, OS, custom data
+	Caps     []string `json:"caps"`          // Protocols advertised by this peer
+	Purposes string   `json:"nodeInfo"`      // Purposes for the peer
+	// TrustedNodePurposes string   `json:"trustedNodeInfo"` // Purposes for the trusted node
+	Network struct {
 		LocalAddress  string `json:"localAddress"`  // Local endpoint of the TCP data connection
 		RemoteAddress string `json:"remoteAddress"` // Remote endpoint of the TCP data connection
 		Inbound       bool   `json:"inbound"`
@@ -516,8 +528,7 @@ func (p *Peer) Info() *PeerInfo {
 		info.Protocols[proto.Name] = protoInfo
 	}
 
-	info.StaticNodePurposes = p.StaticNodePurposes.String()
-	info.TrustedNodePurposes = p.TrustedNodePurposes.String()
+	info.Purposes = p.purpose.String()
 
 	return info
 }

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -54,7 +54,7 @@ func testPeer(protos []Protocol) (func(), *conn, *Peer, <-chan error) {
 		c2.caps = append(c2.caps, p.cap())
 	}
 
-	peer := newPeer(log.Root(), c1, protos, nil, nil, nil)
+	peer := newPeer(log.Root(), c1, protos, NoPurpose, nil)
 	errc := make(chan error, 1)
 	go func() {
 		_, err := peer.run()

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -222,41 +222,35 @@ type PurposeFlag uint32
 
 const (
 	NoPurpose              PurposeFlag = 0
-	ExplicitStaticPurpose              = 1 << 0
-	ExplicitTrustedPurpose             = 1 << 1
-	ValidatorPurpose                   = 1 << 2
-	ProxyPurpose                       = 1 << 3
+	ExplicitStaticPurpose  PurposeFlag = 1 << 0
+	ExplicitTrustedPurpose PurposeFlag = 1 << 1
+	ValidatorPurpose       PurposeFlag = 1 << 2
+	ProxyPurpose           PurposeFlag = 1 << 3
 
 	AnyPurpose = ExplicitStaticPurpose | ExplicitTrustedPurpose | ValidatorPurpose | ProxyPurpose // This value should be the bitwise OR of all possible PurposeFlag values
 )
 
-func NewPurposeFlag() *PurposeFlag {
-	purposeFlag := new(PurposeFlag)
-	*purposeFlag = NoPurpose
-
-	return purposeFlag
+func (pf PurposeFlag) Add(f PurposeFlag) PurposeFlag {
+	return pf | f
 }
 
-func (pf *PurposeFlag) Set(f PurposeFlag, val bool) {
-	if val {
-		*pf |= f
-	} else {
-		*pf &= ^f
-	}
+func (pf PurposeFlag) Remove(f PurposeFlag) PurposeFlag {
+	return pf & ^f
 }
 
-func (pf *PurposeFlag) IsSet(f PurposeFlag) bool {
-	if pf == nil {
-		return false
-	}
-	return (*pf & f) != 0
+func (pf PurposeFlag) IsSet(f PurposeFlag) bool {
+	return (pf & f) != 0
 }
 
-func (pf *PurposeFlag) NoPurpose() bool {
-	return pf == nil || *pf == NoPurpose
+func (pf PurposeFlag) HasNoPurpose() bool {
+	return pf == NoPurpose
 }
 
-func (pf *PurposeFlag) String() string {
+func (pf PurposeFlag) HasPurpose() bool {
+	return pf != NoPurpose
+}
+
+func (pf PurposeFlag) String() string {
 	s := ""
 	if pf.IsSet(ExplicitStaticPurpose) {
 		s += "-ExplicitStaticPurpose"
@@ -759,10 +753,10 @@ func (srv *Server) run(dialstate dialer) {
 	defer srv.discmix.Close()
 
 	var (
-		static       = make(map[enode.ID]*PurposeFlag, len(srv.StaticNodes))
+		static       = make(map[enode.ID]PurposeFlag, len(srv.StaticNodes))
 		peers        = make(map[enode.ID]*Peer)
 		inboundCount = 0
-		trusted      = make(map[enode.ID]*PurposeFlag, len(srv.TrustedNodes))
+		trusted      = make(map[enode.ID]PurposeFlag, len(srv.TrustedNodes))
 		taskdone     = make(chan task, maxActiveDialTasks)
 		tick         = time.NewTicker(30 * time.Second)
 		runningTasks []task
@@ -773,14 +767,12 @@ func (srv *Server) run(dialstate dialer) {
 	// Put trusted nodes into a map to speed up checks.
 	// Trusted peers are loaded on startup or added via AddTrustedPeer RPC.
 	for _, n := range srv.TrustedNodes {
-		trusted[n.ID()] = NewPurposeFlag()
-		trusted[n.ID()].Set(ExplicitTrustedPurpose, true)
+		trusted[n.ID()] = ExplicitTrustedPurpose
 	}
 
 	// Put static nodes specified in a file into a map.
 	for _, n := range srv.StaticNodes {
-		static[n.ID()] = NewPurposeFlag()
-		static[n.ID()].Set(ExplicitStaticPurpose, true)
+		static[n.ID()] = ExplicitStaticPurpose
 	}
 
 	// removes t from runningTasks
@@ -814,69 +806,60 @@ func (srv *Server) run(dialstate dialer) {
 	}
 
 	addStatic := func(n *enode.Node, purpose PurposeFlag) {
-		if _, ok := static[n.ID()]; !ok {
-			static[n.ID()] = NewPurposeFlag()
-		}
-		static[n.ID()].Set(purpose, true)
+		newPurpose := static[n.ID()].Add(purpose)
+		static[n.ID()] = newPurpose
 
 		// If already connected, set the peer's static node purpose set
 		if p, ok := peers[n.ID()]; ok {
-			if p.StaticNodePurposes == nil {
-				p.StaticNodePurposes = static[n.ID()]
-			}
+			p.AddPurpose(purpose)
 		}
 
 		dialstate.addStatic(n)
 	}
 
 	removeStatic := func(n *enode.Node, purpose PurposeFlag) {
-		if staticPurposes, ok := static[n.ID()]; ok && staticPurposes.IsSet(purpose) {
-			static[n.ID()].Set(purpose, false)
+		newPurpose := static[n.ID()].Remove(purpose)
 
-			if static[n.ID()].NoPurpose() {
-				dialstate.removeStatic(n)
-
-				if p, ok := peers[n.ID()]; ok {
-					p.StaticNodePurposes = nil
-					p.Disconnect(DiscRequested)
-				}
-
-				delete(static, n.ID())
+		if newPurpose.HasNoPurpose() {
+			dialstate.removeStatic(n)
+			delete(static, n.ID())
+			if p, ok := peers[n.ID()]; ok {
+				// Since we're disconnecting (destroying), no need to remove the purpose
+				p.Disconnect(DiscRequested)
+			}
+		} else {
+			static[n.ID()] = newPurpose
+			if p, ok := peers[n.ID()]; ok {
+				p.RemovePurpose(purpose)
 			}
 		}
 	}
 
 	addTrusted := func(n *enode.Node, purpose PurposeFlag) {
-		if _, ok := trusted[n.ID()]; !ok {
-			trusted[n.ID()] = NewPurposeFlag()
-
-		}
-		trusted[n.ID()].Set(purpose, true)
+		trusted[n.ID()] = trusted[n.ID()].Add(purpose)
 
 		// Mark any already-connected peer as trusted
 		if p, ok := peers[n.ID()]; ok {
-			p.rw.set(trustedConn, true)
-
 			// If already connected, updated val peer counters and set the validatorConn flag in the connection
-			if p.TrustedNodePurposes == nil {
-				p.TrustedNodePurposes = trusted[n.ID()]
-			}
+			p.rw.set(trustedConn, true)
+			p.AddPurpose(purpose)
 		}
 	}
 
 	removeTrusted := func(n *enode.Node, purpose PurposeFlag) {
-		if trustedPurposes, ok := trusted[n.ID()]; ok && trustedPurposes.IsSet(purpose) {
-			trusted[n.ID()].Set(purpose, false)
+		newPurpose := trusted[n.ID()].Remove(purpose)
 
-			if trusted[n.ID()].NoPurpose() {
-
-				// Unmark any already-connected peer as trusted
-				if p, ok := peers[n.ID()]; ok {
-					p.rw.set(trustedConn, false)
-					p.TrustedNodePurposes = nil
-				}
-
-				delete(trusted, n.ID())
+		if newPurpose.HasNoPurpose() {
+			delete(trusted, n.ID())
+			// Unmark any already-connected peer as trusted
+			if p, ok := peers[n.ID()]; ok {
+				p.rw.set(trustedConn, false)
+				p.RemovePurpose(purpose)
+			}
+		} else {
+			trusted[n.ID()] = newPurpose
+			if p, ok := peers[n.ID()]; ok {
+				p.RemovePurpose(purpose)
 			}
 		}
 	}
@@ -932,7 +915,7 @@ running:
 		case c := <-srv.checkpointPostHandshake:
 			// A connection has passed the encryption handshake so
 			// the remote identity is known (but hasn't been verified yet).
-			if trusted[c.node.ID()] != nil {
+			if trusted[c.node.ID()].HasPurpose() {
 				// Ensure that the trusted flag is set before checking against MaxPeers.
 				c.flags |= trustedConn
 			}
@@ -945,10 +928,10 @@ running:
 			if err == nil {
 				// The handshakes are done and it passed all checks.
 
-				staticNodePurposes := static[c.node.ID()]
-				trustedNodePurposes := trusted[c.node.ID()]
+				purpose := static[c.node.ID()].Add(trusted[c.node.ID()])
 
-				p := newPeer(srv.log, c, srv.Protocols, staticNodePurposes, trustedNodePurposes, srv)
+				// TODO add Peer potential "connected" point
+				p := newPeer(srv.log, c, srv.Protocols, purpose, srv)
 				// If message events are enabled, pass the peerFeed
 				// to the peer
 				if srv.EnableMsgEvents {


### PR DESCRIPTION
### Description

Add number of active (connected) peers metrics discriminated by purpose (validator & proxy).

With this, we should be able to monitor how many validator or proxy connection a node currently has.

### Other changes

Refactors PurposeFlag use:

* Make it immutable, thus easier to track
* Use `Add` , `Remove` vs `Set(bool)`
* Peer now has a single purpose which is the combination of
trustedPurposes & staticPurposes

### Tested

CI, manual

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
