### PR TITLE
Adds new metrics for discovery

### DIFF
--- a/les/metrics.go
+++ b/les/metrics.go
@@ -112,6 +112,8 @@ var (
 
 	requestRTT       = metrics.NewRegisteredTimer("les/client/req/rtt", nil)
 	requestSendDelay = metrics.NewRegisteredTimer("les/client/req/sendDelay", nil)
+
+	clientDiscoveredNodesCounter = metrics.NewRegisteredCounter("les/client/discovered", nil) // Counter for discovered nodes
 )
 
 // meteredMsgReadWriter is a wrapper around a p2p.MsgReadWriter, capable of

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -198,6 +198,7 @@ func (pool *serverPool) discoverNodes() {
 		if err != nil {
 			continue
 		}
+		clientDiscoveredNodesCounter.Inc(1)
 		pool.discNodes <- enode.NewV4(pubkey, n.IP, int(n.TCP), int(n.UDP))
 	}
 }

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -328,6 +328,7 @@ type discoverTask struct {
 
 func (t *discoverTask) Do(srv *Server) {
 	t.results = enode.ReadNodes(srv.discmix, t.want)
+	discoveredPeersCounter.Inc(int64(len(t.results)))
 }
 
 func (t *discoverTask) String() string {

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -1,0 +1,24 @@
+// Copyright 2018 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package discover
+
+import "github.com/ethereum/go-ethereum/metrics"
+
+var (
+	ingressTrafficMeter = metrics.NewRegisteredMeter("discover/InboundTraffic", nil)
+	egressTrafficMeter  = metrics.NewRegisteredMeter("discover/OutboundTraffic", nil)
+)

--- a/p2p/discover/metrics.go
+++ b/p2p/discover/metrics.go
@@ -19,6 +19,6 @@ package discover
 import "github.com/ethereum/go-ethereum/metrics"
 
 var (
-	ingressTrafficMeter = metrics.NewRegisteredMeter("discover/InboundTraffic", nil)
-	egressTrafficMeter  = metrics.NewRegisteredMeter("discover/OutboundTraffic", nil)
+	ingressTrafficMeter = metrics.NewRegisteredMeter("discover/ingress", nil)
+	egressTrafficMeter  = metrics.NewRegisteredMeter("discover/egress", nil)
 )

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -95,7 +95,7 @@ type meteredConn struct {
 	connected time.Time    // Connection time of the peer
 	addr      *net.TCPAddr // TCP address of the peer
 	peer      *Peer        // Peer instance
-	ingress   bool         // Indicates wether connection inbound or outbound
+	ingress   bool         // Indicates whether connection inbound or outbound
 
 	// trafficMetered denotes if the peer is registered in the traffic registries.
 	// Its value is true if the metered peer count doesn't reach the limit in the

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -30,26 +30,23 @@ import (
 )
 
 const (
-	MetricsInboundTraffic            = "p2p/ingress"           // Name for the registered inbound traffic meter
-	MetricsOutboundTraffic           = "p2p/egress"            // Name for the registered outbound traffic meter
-	MetricsOutboundConnects          = "p2p/dials"             // Name for the registered outbound connects meter
-	MetricsOutboundHandshakeConnects = "p2p/dials/handshakes"  // Name for the registered outbound connects with successful handshake meter
-	MetricsInboundConnects           = "p2p/serves"            // Name for the registered inbound connects meter
-	MetricsInboundHandshakeConnects  = "p2p/serves/handshakes" // Name for the registered inbound connects with successful handshake meter
+	MetricsInboundTraffic  = "p2p/ingress" // Name for the registered inbound traffic meter
+	MetricsOutboundTraffic = "p2p/egress"  // Name for the registered outbound traffic meter
 
 	MeteredPeerLimit = 1024 // This amount of peers are individually metered
 )
 
 var (
-	ingressConnectMeter              = metrics.NewRegisteredMeter(MetricsInboundConnects, nil)           // Meter counting the ingress connections
-	ingressConnectWithHandshakeMeter = metrics.NewRegisteredMeter(MetricsInboundHandshakeConnects, nil)  // Meter counting the ingress with successful handshake connections
-	ingressTrafficMeter              = metrics.NewRegisteredMeter(MetricsInboundTraffic, nil)            // Meter metering the cumulative ingress traffic
-	egressConnectMeter               = metrics.NewRegisteredMeter(MetricsOutboundConnects, nil)          // Meter counting the egress connections
-	egressConnectWithHandshakeMeter  = metrics.NewRegisteredMeter(MetricsOutboundHandshakeConnects, nil) // Meter counting the egress with successful handshake connections
-	egressTrafficMeter               = metrics.NewRegisteredMeter(MetricsOutboundTraffic, nil)           // Meter metering the cumulative egress traffic
-	activePeerGauge                  = metrics.NewRegisteredGauge("p2p/peers", nil)                      // Gauge tracking the current peer count
-	activeValidatorsPeerGauge        = metrics.NewRegisteredGauge("p2p/peers/validators", nil)           // Gauge tracking the current validators peer count
-	activeProxiesPeerGauge           = metrics.NewRegisteredGauge("p2p/peers/proxies", nil)              // Gauge tracking the current proxies peer count
+	ingressConnectMeter              = metrics.NewRegisteredMeter("p2p/serves", nil)             // Meter counting the ingress connections
+	ingressConnectWithHandshakeMeter = metrics.NewRegisteredMeter("p2p/serves/handshakes", nil)  // Meter counting the ingress with successful handshake connections
+	ingressTrafficMeter              = metrics.NewRegisteredMeter(MetricsInboundTraffic, nil)    // Meter metering the cumulative ingress traffic
+	egressConnectMeter               = metrics.NewRegisteredMeter("p2p/dials", nil)              // Meter counting the egress connections
+	egressConnectWithHandshakeMeter  = metrics.NewRegisteredMeter("p2p/dials/handshakes", nil)   // Meter counting the egress with successful handshake connections
+	egressTrafficMeter               = metrics.NewRegisteredMeter(MetricsOutboundTraffic, nil)   // Meter metering the cumulative egress traffic
+	activePeerGauge                  = metrics.NewRegisteredGauge("p2p/peers", nil)              // Gauge tracking the current peer count
+	activeValidatorsPeerGauge        = metrics.NewRegisteredGauge("p2p/peers/validators", nil)   // Gauge tracking the current validators peer count
+	activeProxiesPeerGauge           = metrics.NewRegisteredGauge("p2p/peers/proxies", nil)      // Gauge tracking the current proxies peer count
+	discoveredPeersCounter           = metrics.NewRegisteredCounter("p2p/peers/discovered", nil) // Counter of the total discovered peers
 
 	PeerIngressRegistry = metrics.NewPrefixedChildRegistry(metrics.EphemeralRegistry, MetricsInboundTraffic+"/")  // Registry containing the peer ingress
 	PeerEgressRegistry  = metrics.NewPrefixedChildRegistry(metrics.EphemeralRegistry, MetricsOutboundTraffic+"/") // Registry containing the peer egress


### PR DESCRIPTION
### Description

Adds new metrics to the existing ones; with the objective of better understanding discovery. 

```
# Total number of discovered nodes by the les client
les_client_discovered
# Total number of inbound bytes for discovery v4
discover_ingress
# Total number of outbound bytes for discovery v4
discover_egress
# Total number of successful connections with valid handshakes (inbound)
p2p_serves_handshakes
# Total number of successful connections with valid handshakes (outbound)
p2p_dials_handshakes
```

### Other changes

No

### Tested

CI

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Yes 
