### PR TITLE
Adds "get validator public keys" endpoint

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -27,9 +27,9 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul/core"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/core/types"
+	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
-	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 )
 
 // API is a user facing RPC API to dump Istanbul state

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -90,8 +90,8 @@ func (api *API) GetValidators(number *rpc.BlockNumber) ([]common.Address, error)
 	return istanbul.MapValidatorsToAddresses(validators), nil
 }
 
-// GetValidatorsPublicKeys retrieves the list of validators public keys that must sign a given block.
-func (api *API) GetValidatorsPublicKeys(number *rpc.BlockNumber) ([]blscrypto.SerializedPublicKey, error) {
+// GetValidatorsBLSPublicKeys retrieves the list of validators BLS public keys that must sign a given block.
+func (api *API) GetValidatorsBLSPublicKeys(number *rpc.BlockNumber) ([]blscrypto.SerializedPublicKey, error) {
 	header, err := api.getParentHeaderByNumber(number)
 	if err != nil {
 		return nil, err

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/rpc"
+	blscrypto "github.com/ethereum/go-ethereum/crypto/bls"
 )
 
 // API is a user facing RPC API to dump Istanbul state
@@ -87,6 +88,16 @@ func (api *API) GetValidators(number *rpc.BlockNumber) ([]common.Address, error)
 	}
 	validators := api.istanbul.GetValidators(header.Number, header.Hash())
 	return istanbul.MapValidatorsToAddresses(validators), nil
+}
+
+// GetValidatorsPublicKeys retrieves the list of validators public keys that must sign a given block.
+func (api *API) GetValidatorsPublicKeys(number *rpc.BlockNumber) ([]blscrypto.SerializedPublicKey, error) {
+	header, err := api.getParentHeaderByNumber(number)
+	if err != nil {
+		return nil, err
+	}
+	validators := api.istanbul.GetValidators(header.Number, header.Hash())
+	return istanbul.MapValidatorsToPublicKeys(validators), nil
 }
 
 // GetProposer retrieves the proposer for a given block number (i.e. sequence) and round.

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -63,6 +63,17 @@ func MapValidatorsToAddresses(validators []Validator) []common.Address {
 	return returnList
 }
 
+// MapValidatorsToPublicKeys maps a slice of validator to a slice of public keys
+func MapValidatorsToPublicKeys(validators []Validator) []blscrypto.SerializedPublicKey {
+	returnList := make([]blscrypto.SerializedPublicKey, len(validators))
+
+	for i, val := range validators {
+		returnList[i] = val.BLSPublicKey()
+	}
+
+	return returnList
+}
+
 // ----------------------------------------------------------------------------
 
 type ValidatorsDataByAddress []ValidatorData

--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"reflect"
 
 	//nolint:goimports
 	"github.com/celo-org/celo-bls-go/bls"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -18,8 +20,44 @@ const (
 	SIGNATUREBYTES = bls.SIGNATUREBYTES
 )
 
+var (
+	serializedPublicKeyT = reflect.TypeOf(SerializedPublicKey{})
+	serializedSignatureT = reflect.TypeOf(SerializedSignature{})
+)
+
 type SerializedPublicKey [PUBLICKEYBYTES]byte
+
+// MarshalText returns the hex representation of pk.
+func (pk SerializedPublicKey) MarshalText() ([]byte, error) {
+	return hexutil.Bytes(pk[:]).MarshalText()
+}
+
+// UnmarshalText parses a BLS public key in hex syntax.
+func (pk *SerializedPublicKey) UnmarshalText(input []byte) error {
+	return hexutil.UnmarshalFixedText("SerializedPublicKey", input, pk[:])
+}
+
+// UnmarshalJSON parses a BLS public key in hex syntax.
+func (pk *SerializedPublicKey) UnmarshalJSON(input []byte) error {
+	return hexutil.UnmarshalFixedJSON(serializedPublicKeyT, input, pk[:])
+}
+
 type SerializedSignature [SIGNATUREBYTES]byte
+
+// MarshalText returns the hex representation of sig.
+func (sig SerializedSignature) MarshalText() ([]byte, error) {
+	return hexutil.Bytes(sig[:]).MarshalText()
+}
+
+// UnmarshalText parses a BLS signature in hex syntax.
+func (sig *SerializedSignature) UnmarshalText(input []byte) error {
+	return hexutil.UnmarshalFixedText("SerializedSignature", input, sig[:])
+}
+
+// UnmarshalJSON parses a BLS signature in hex syntax.
+func (sig *SerializedSignature) UnmarshalJSON(input []byte) error {
+	return hexutil.UnmarshalFixedJSON(serializedSignatureT, input, sig[:])
+}
 
 func ECDSAToBLS(privateKeyECDSA *ecdsa.PrivateKey) ([]byte, error) {
 	for i := 0; i < 256; i++ {

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -734,8 +734,8 @@ web3._extend({
 			inputFormatter: [null]
 		}),
 		new web3._extend.Method({
-			name: 'getValidatorsPublicKeys',
-			call: 'istanbul_getValidatorsPublicKeys',
+			name: 'getValidatorsBLSPublicKeys',
+			call: 'istanbul_getValidatorsBLSPublicKeys',
 			params: 1,
 			inputFormatter: [null]
 		}),

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -734,6 +734,12 @@ web3._extend({
 			inputFormatter: [null]
 		}),
 		new web3._extend.Method({
+			name: 'getValidatorsPublicKeys',
+			call: 'istanbul_getValidatorsPublicKeys',
+			params: 1,
+			inputFormatter: [null]
+		}),
+		new web3._extend.Method({
 			name: 'getProposer',
 			call: 'istanbul_getProposer',
 			params: 2,


### PR DESCRIPTION
### Description

The Plumo prover needs a list of the BLS public keys for epochs in order to create the witness for the proof.
