### PR TITLE
Set NoUSB to true for mobile

### DIFF
--- a/mobile/geth.go
+++ b/mobile/geth.go
@@ -157,6 +157,7 @@ func NewNode(datadir string, config *NodeConfig) (stack *Node, _ error) {
 			NAT:              nat.Any(),
 			MaxPeers:         config.MaxPeers,
 		},
+		NoUSB: true,
 	}
 
 	rawStack, err := node.New(nodeConf)


### PR DESCRIPTION
### Description

Set NoUSB to true on mobile to remove unnecessary log lines
