### PR TITLE
Fix IstanbulOverride decoding error when trying to use config.toml

### DIFF
--- a/eth/config.go
+++ b/eth/config.go
@@ -127,5 +127,5 @@ type Config struct {
 	CheckpointOracle *params.CheckpointOracleConfig `toml:",omitempty"`
 
 	// Istanbul block override (TODO: remove after the fork)
-	OverrideIstanbul *big.Int
+	OverrideIstanbul *big.Int `toml:",omitempty"`
 }

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -128,20 +128,20 @@ web3._extend({
 	],
 	properties: [
 		new web3._extend.Property({
-			name: 'nodeInfo',
-			getter: 'admin_nodeInfo'
+			name: 'datadir',
+			getter: 'admin_datadir'
 		}),
 		new web3._extend.Property({
 			name: 'discoverTableInfo',
 			getter: 'admin_discoverTableInfo'
 		}),
 		new web3._extend.Property({
-			name: 'peers',
-			getter: 'admin_peers'
+			name: 'nodeInfo',
+			getter: 'admin_nodeInfo'
 		}),
 		new web3._extend.Property({
-			name: 'datadir',
-			getter: 'admin_datadir'
+			name: 'peers',
+			getter: 'admin_peers'
 		}),
 	]
 });


### PR DESCRIPTION
### Description

Yesterday I used the `dumpconfig` command to generate a `config.toml` file and tried to use it to run a Geth node with `geth --config config.tml`, but got a decoder error. This PR includes a fix for the error in that flow.

### Other changes

* Sorted some methods in `web3ext.go` alphabetically

### Tested

Ran a node locally with the generated `config.toml`