### PR TITLE
Adjust log levels on a few common messages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,8 +142,7 @@ jobs:
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b ${CELO_MONOREPO_BRANCH_TO_TEST}
             cd celo-monorepo
             yarn install || yarn install
-            PACKAGES=$(cat dependency-graph.json | python -c 'import json,sys;obj=json.load(sys.stdin);print "\n".join(str(obj[x]["location"]) for x in obj["@celo/celotool"]["dependencies"][::-1])')
-            for i in $PACKAGES; do yarn --cwd $i build; done
+            yarn build --scope @celo/celotool --include-filtered-depenencies
             yarn --cwd packages/celotool build
       - run:
           name: Setup Go language

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b ${CELO_MONOREPO_BRANCH_TO_TEST}
             cd celo-monorepo
             yarn install || yarn install
-            yarn build --scope @celo/celotool --include-filtered-depenencies
+            yarn build --scope @celo/celotool --include-filtered-dependencies
             yarn --cwd packages/celotool build
       - run:
           name: Setup Go language

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -114,7 +114,7 @@ func (sb *Backend) handleConsensusMsg(peer consensus.Peer, payload []byte) error
 			return istanbul.CheckValidatorSignature(valSet, data, sig)
 		}
 		if err := msg.FromPayload(payload, checkValidatorSignature); err != nil {
-			sb.logger.Warning("Got a consensus message signed by a non validator", "err", err)
+			sb.logger.Warn("Got a consensus message signed by a non validator", "err", err)
 			return errNonValidatorMessage
 		}
 

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -114,7 +114,7 @@ func (sb *Backend) handleConsensusMsg(peer consensus.Peer, payload []byte) error
 			return istanbul.CheckValidatorSignature(valSet, data, sig)
 		}
 		if err := msg.FromPayload(payload, checkValidatorSignature); err != nil {
-			sb.logger.Error("Got a consensus message signed by a non validator.", "err", err)
+			sb.logger.Warning("Got a consensus message signed by a non validator", "err", err)
 			return errNonValidatorMessage
 		}
 

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -118,14 +118,14 @@ func (c *core) handleEvents() {
 				}
 			case istanbul.MessageEvent:
 				if err := c.handleMsg(ev.Payload); err != nil && err != errFutureMessage && err != errOldMessage {
-					logger.Info("Error in handling istanbul message", "err", err)
+					logger.Warn("Error in handling istanbul message", "err", err)
 				}
 			case backlogEvent:
 				if payload, err := ev.msg.Payload(); err != nil {
 					logger.Error("Error in retrieving payload from istanbul message that was sent from a backlog event", "err", err)
 				} else {
 					if err := c.handleMsg(payload); err != nil && err != errFutureMessage && err != errOldMessage {
-						logger.Info("Error in handling istanbul message that was sent from a backlog event", "err", err)
+						logger.Warn("Error in handling istanbul message that was sent from a backlog event", "err", err)
 					}
 				}
 			}


### PR DESCRIPTION
### Description

A few messages I've seen reported frequently on Discord have misleading log levels. This PR makes some small log level adjsutments for messages that are `Info` or `Error` but should be `Warning`.