### PR TITLE
Improve build command for celotool in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,8 +142,7 @@ jobs:
             git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo -b ${CELO_MONOREPO_BRANCH_TO_TEST}
             cd celo-monorepo
             yarn install || yarn install
-            PACKAGES=$(cat dependency-graph.json | python -c 'import json,sys;obj=json.load(sys.stdin);print "\n".join(str(obj[x]["location"]) for x in obj["@celo/celotool"]["dependencies"][::-1])')
-            for i in $PACKAGES; do yarn --cwd $i build; done
+            yarn build --scope @celo/celotool --include-filtered-depenencies
             yarn --cwd packages/celotool build
       - run:
           name: Setup Go language

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -149,7 +149,9 @@ func (sb *Backend) verifyCascadingFields(chain consensus.ChainReader, header *ty
 	if len(parents) > 0 {
 		parent = parents[len(parents)-1]
 	} else {
-		parent = chain.GetHeader(header.ParentHash, number-1)
+		// Retreive header by number, even though we have the parent hash, because we only want
+		// to consider blocks which are direct children of the canonical chain.
+		parent = chain.GetHeaderByNumber(number - 1)
 	}
 	if chain.Config().FullHeaderChainAvailable {
 


### PR DESCRIPTION
### Description

Circle CI has a build step that requires `celotool` from the `celo-monorepo`. It is currently built using small script to parse out dependencies and build them, but there is actually a builtin `lerna` command to do this. This PR changes the build step to use this command.