### PR TITLE
Fix disconnecting unelected validators in ReplaceValidatorPeers()

### DIFF
--- a/consensus/istanbul/backend/peer_handler.go
+++ b/consensus/istanbul/backend/peer_handler.go
@@ -134,7 +134,7 @@ func (vph *validatorPeerHandler) ReplaceValidatorPeers(newNodes []*enode.Node) {
 	}
 
 	// Remove old Validator Peers
-	for existingPeerID, existingPeer := range vph.sb.broadcaster.FindPeers(nodeIDSet, p2p.ValidatorPurpose) {
+	for existingPeerID, existingPeer := range vph.sb.broadcaster.FindPeers(nil, p2p.ValidatorPurpose) {
 		if !nodeIDSet[existingPeerID] {
 			vph.RemoveValidatorPeer(existingPeer.Node())
 		}


### PR DESCRIPTION
### Description

This is a partial fix for #948.  That issue mentions that we aren't removing validators if we're not connected to them at that moment.  But there was another bug which caused `ReplaceValidatorPeers()` to not disconnect validators at all.  This PR fixes that bug.

Notes:
1. This bug only affected `ReplaceValidatorPeers()`, whereas the problem of not removing validators we're not connected to right then affects both `ReplaceValidatorPeers()` and `ClearValidatorPeers()`.
2. A full fix for #948 will require some new code in `p2p/server.go` an `p2p/dial.go`, which we probably don't have time to do before the upcoming release (and which would be best done after cherry-picking https://github.com/ethereum/go-ethereum/pull/20592 from upstream).  That's why I'm opening this PR to at least fix this much right now.
3. In the absence of a full fix, it can still happen that an unelected validator disconnects from us first and so we don't remove them from our static and trusted list. In such a case, we will try to reconnect to them.  If we succeed, then the next time `RefreshValPeers()` runs (which is every 5 minutes), we will remove them properly and all will be well.  On the other hand, if they don't let us connect (say they're at their max peers limit already), then we will keep trying to connect to them unsuccessfully.  To avoid this, we need a full fix for #948.

### Tested

Units tests pass, e2e sync test pases.  As far as I know, we don't have tests that specifically check dropping unelected validators.  That said, the code here is clear enough to have confidence in the change, I think.

### Related issues

This doesn't directly fix #948, but it does fix a bug with similar effects.

### Backwards compatibility

This will only cause validators to disconnect from unelected validators, and so poses no problems as far as backwards compatibility.  
