### PR TITLE
Update the path for libbls

### DIFF
--- a/scripts/publish-mobile-client.sh
+++ b/scripts/publish-mobile-client.sh
@@ -23,7 +23,7 @@ fi
 
 # TODO: Create an appropriate README for NPM
 rm README.md
-cp build/_workspace/pkg/mod/github.com/celo-org/celo-bls-go@v0.1.4/libs/universal/libbls_snark_sys.a .
+cp $GOPATH/pkg/mod/github.com/celo-org/celo-bls-go@v0.1.6/libs/universal/libbls_snark_sys.a .
 
 npm -f --no-git-tag-version version "$new_version"
 npm publish --tag "$commit_sha_short" --access public -timeout=9999999


### PR DESCRIPTION
### Description

Update the path of `libbls_snark` for publishing the mobile client. This is trying to fix the last CI step on master.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

Confirm that libbls is at the given path, but can't easily check that this works until it's merged into master.

### Related issues

- Fixes #1199

### Backwards compatibility

yes

### Backwards compatibility

yes