### PR TITLE
Make primary protocol concept apply to specific versions of istanbul

### DIFF
--- a/consensus/istanbul/protocol.go
+++ b/consensus/istanbul/protocol.go
@@ -29,7 +29,8 @@ const (
 // protocolName is the official short name of the protocol used during capability negotiation.
 const ProtocolName = "istanbul"
 
-// ProtocolVersions are the supported versions of the istanbul protocol.
+// ProtocolVersions are the supported versions of the istanbul protocol (first is primary).
+// (First is primary in the sense that it's the most current one supported, not in the sense of IsPrimary() below)
 var ProtocolVersions = []uint{Celo65, Celo64}
 
 // Returns whether this version of Istanbul should have Primary: true (a legacy property that was needed to work

--- a/consensus/istanbul/protocol.go
+++ b/consensus/istanbul/protocol.go
@@ -29,8 +29,16 @@ const (
 // protocolName is the official short name of the protocol used during capability negotiation.
 const ProtocolName = "istanbul"
 
-// ProtocolVersions are the supported versions of the eth protocol (first is primary).
+// ProtocolVersions are the supported versions of the istanbul protocol.
 var ProtocolVersions = []uint{Celo65, Celo64}
+
+// Returns whether this version of Istanbul should have Primary: true (a legacy property that was needed to work
+// around an upstream bug in the LES protocol which prevented two LES servers from connecting to each other).
+// Versions up to Celo65 need to have it, for backwards compatibility. Newer versions don't need it, since the
+// upstream LES bug has now been fixed.
+func IsPrimary(version uint) bool {
+	return version <= Celo65
+}
 
 // protocolLengths are the number of implemented message corresponding to different protocol versions.
 var ProtocolLengths = map[uint]uint64{Celo64: 22, Celo65: 27}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -586,7 +586,7 @@ func (s *Ethereum) ArchiveMode() bool                   { return s.config.NoPrun
 func (s *Ethereum) Protocols() []p2p.Protocol {
 	protos := make([]p2p.Protocol, len(istanbul.ProtocolVersions))
 	for i, vsn := range istanbul.ProtocolVersions {
-		protos[i] = s.protocolManager.makeProtocol(vsn, i == 0)
+		protos[i] = s.protocolManager.makeProtocol(vsn)
 		protos[i].Attributes = []enr.Entry{s.currentEthEntry()}
 	}
 	if s.lesServer != nil {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -211,7 +211,7 @@ func NewProtocolManager(config *params.ChainConfig, checkpoint *params.TrustedCh
 	return manager, nil
 }
 
-func (pm *ProtocolManager) makeProtocol(version uint, primary bool) p2p.Protocol {
+func (pm *ProtocolManager) makeProtocol(version uint) p2p.Protocol {
 	length, ok := istanbul.ProtocolLengths[version]
 	if !ok {
 		panic("makeProtocol for unknown version")
@@ -221,7 +221,7 @@ func (pm *ProtocolManager) makeProtocol(version uint, primary bool) p2p.Protocol
 		Name:    istanbul.ProtocolName,
 		Version: version,
 		Length:  length,
-		Primary: primary,
+		Primary: istanbul.IsPrimary(version),
 		Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 			peer := pm.newPeer(int(version), p, rw)
 			select {

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -420,7 +420,7 @@ outer:
 	// If a primary protocol matched, return only that protocol.
 	for _, proto := range protocols {
 		if proto.Primary {
-			if _, ok := result[proto.Name]; ok {
+			if match, ok := result[proto.Name]; ok && match.Version == proto.Version {
 				primary := make(map[string]*protoRW)
 				primary[proto.Name] = result[proto.Name]
 				return primary

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -604,6 +604,9 @@ func (srv *Server) setupLocalNode() error {
 		}
 	}
 	if len(primaries) > 1 {
+		// It's ok for multiple versions of Istanbul to be marked as primary, since for a given peer
+		// connection only the latest version they both support will be used. But it's not ok if another
+		// protocol besides Istanbul is marked a primary, since then it's unclear which should be run.
 		srv.log.Crit("Multiple primary protocols specified", "names", primaries)
 	}
 	switch srv.NAT.(type) {


### PR DESCRIPTION
### Description

https://github.com/celo-org/celo-blockchain/pull/333 introduced a concept of a protocol being primary, which means that it is not run alongside any other protocol on the connection between two nodes.  But, in its implementation, if any version of istanbul is marked as primary, all versions of istanbul are treated as primary.  This PR updates the way the primary protocol concept is implemented so that versions 64 and 65 primary (to maintain backwards compatibility), but newer versions will not be.  This will enable running future versions of istanbul alongside other protocols such as LES or a separate proxy-validator protocol if we were to break that away from istanbul.  And, at a later time when versions 64 and 65 need not be supported, we can remove the concept of primary protocol entirely as suggested in #1131 

### Tested

I generated 3 binaries, with some additional logging to show which protocols are being used and when a peer is disconnected:
(a) master
(b) this branch
(c) this branch, but with a new istanbul version (66) that's the same as 65 except it's not primary (I did not commit this on any branch, it was just for testing how the code for this PR will behave when we create a new istanbul version later on)

I then ran them locally in pairs (setting each one to use the other as its bootnode) to see what happens when they connect.  In all cases, they managed to connect and maintained the connection.  The protocols used were as expected:
1. when (c) and (c) connect to each other, they run istanbul 66 and les 3
2. in the other 5 cases, they run only istanbul 65

I also verified that both (b) and (c) can starting syncing to mainnet.

### Backwards compatibility

This is backwards compatible, since istanbul 64 and 65 are made primary, so when connecting to peers running older versions of celo-blockchain, istanbul will be run by itself as described in the testing section.