### PR TITLE
Make static dials subject to the maxActiveDials limit.

### DIFF
--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -405,10 +405,11 @@ func (d *dialScheduler) checkDial(n *enode.Node) error {
 	return nil
 }
 
-// startStaticDials starts static dials for all nodes in the static pool.
+// startStaticDials starts static dials nodes in the static pool, subject to the maxActiveDials limit
 func (d *dialScheduler) startStaticDials() (started int) {
-	for started = 0; len(d.staticPool) > 0; started++ {
-		idx := 0
+	limit := d.maxActiveDials - len(d.dialing)
+	for started = 0; started < limit && len(d.staticPool) > 0; started++ {
+		idx := d.rand.Intn(len(d.staticPool))
 		task := d.staticPool[idx]
 		d.startDial(task)
 		d.removeFromStaticPool(idx)


### PR DESCRIPTION
### Description

In #1192, we pulled in the the new dial scheduler from upstream, but modified it to exempt static dials from the limits it put on them (which were set as `maxDialPeers` and `maxActiveDials`), because we rely on static dials for the connections between validators/proxies and their validator/proxy peers.  This PR modifies that to make them respect the `maxActiveDials` limit.  So, while static dialed connections will still be exempt from `maxDialPeers` (and therefore from `maxPeers)`, the establishing of those connections will not be allowed to push the number of active dials being attempted past its limit (whose default value was set to 50 upstream).  

Note that, prior to the new dial scheduler (i.e. in celo-blockchain 1.1.0 and earlier and in the corresponding code upstream), the equivalent to `maxActiveDial` (called `maxActiveDialTasks`) was 16, and static dials were subject to it (though not to `maxDialPeers`), so even after this PR we will still have a considerably larger limit than before it.  See the value at https://github.com/celo-org/celo-blockchain/blob/990a7a2b42ac8edbfb7389687c350baa657f583e/p2p/server.go#L54

### Tested

Updated the unit tests involved, as well as re-added a test from upstream (though modified to account for the fact that we exempt static dials from `maxDialPeers`), which checks that `maxActiveDials` is respected and that the peers to dial are selected at random from `d.staticPool`.

### Backwards compatibility

Doesn't affect the protocol, so there are no backwards compatibility concerns.
