### PR TITLE
Ethstats.go memory leak fix

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -399,17 +399,11 @@ func (s *Service) login(conn *websocket.Conn, sendCh chan *StatsPayload) error {
 	// Retrieve the remote ack or connection termination
 	var ack map[string][]string
 
-	signalCh := make(chan error)
-
-	go func() {
-		signalCh <- conn.ReadJSON(&ack)
-	}()
-
 	select {
 	case <-time.After(loginTimeout * time.Second):
 		// Login timeout, abort
 		return errors.New("delegation of login timed out")
-	case err := <-signalCh:
+	case err := <-conn.ReadJSON(&ack):
 		if err != nil {
 			return errors.New("unauthorized, try registering your validator to get whitelisted")
 		}


### PR DESCRIPTION
### Description

Remove unneeded goroutine and an extra channel. Also should fix unintended goroutine leak when logins are failing.

### Tested

Testing with pull request 

