### PR TITLE
Fix: account proof-of-possession should fail with invalid address

### DIFF
--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -264,7 +264,11 @@ func accountProofOfPossession(ctx *cli.Context) error {
 	ks := am.Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
 
 	signer := common.HexToAddress(ctx.Args()[0])
-	message := common.HexToAddress(ctx.Args()[1])
+	messageString := ctx.Args()[1]
+	if !common.IsHexAddress(messageString) {
+		utils.Fatalf("Address to sign is an invalid address")
+	}
+	message := common.HexToAddress(messageString)
 
 	var err error
 	var wallet accounts.Wallet


### PR DESCRIPTION
### Description

currently, running "geth --nousb account proof-of-possession $SIGNER_ADDRESS $ADDRESS_TO_SIGN" doesn't do a validity check on $ADDRESS_TO_SIGN as specified in #1119

### Tested

I'm using IsHexAddress in the common/types package. Since theres no new functionality i didn't think its necessary to add a test. if I assumed wrongly ill be happy to add a couple of tests

### Related issues

- Fixes #1119 

### Backwards compatibility

really small change so definitely backwards compatible 
