### PR TITLE
Fix goroutine leak in celostats login.

### DIFF
--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -399,7 +399,7 @@ func (s *Service) login(conn *websocket.Conn, sendCh chan *StatsPayload) error {
 	// Retrieve the remote ack or connection termination
 	var ack map[string][]string
 
-	signalCh := make(chan error)
+	signalCh := make(chan error, 1)
 
 	go func() {
 		signalCh <- conn.ReadJSON(&ack)


### PR DESCRIPTION
The channel needs to be buffered, so that if a timeout occurs the goroutine would still be able to terminate.

### Description

Fixes a goroutine leak spotted by @zviadm.  Note that this leak is new, and was not present on v1.1.0.

### Tested

Not tested directly, but build and unit tests pass.

### Related issues

- Fixes the issue mentioned in #1204

### Backwards compatibility

No effect on protocols, so no backwards compatibility concerns.
