### PR TITLE
Fix intermittent failure of TestHandleEnodeCertificateMessage unit test

### DIFF
--- a/consensus/istanbul/proxy/proxy_engine_test.go
+++ b/consensus/istanbul/proxy/proxy_engine_test.go
@@ -152,8 +152,8 @@ func TestHandleEnodeCertificateMessage(t *testing.T) {
 	unelectedValBE := unelectedValBEi.(BackendForProxiedValidatorEngine)
 	unelectedValPeer := consensustest.NewMockPeer(unelectedValBE.SelfNode(), p2p.AnyPurpose)
 
-	// Sleep for 5 seconds so that val1BE will generate it's enode certificate.
-	time.Sleep(5 * time.Second)
+	// Sleep for 6 seconds so that val1BE will generate it's enode certificate.
+	time.Sleep(6 * time.Second)
 
 	// Test that the node will forward a message from val within val connection set
 	testEnodeCertFromRemoteVal(t, val1BE, val1Peer, proxyBEi)


### PR DESCRIPTION
### Description

The TestHandleEnodeCertificateMessage proxy package unit test was failing about 1/3 of the time since it was not waiting long enough for the proxy engine's startup process.

### Other changes

None

### Tested

Ran the failing unit tests 5 times sequentially, and it didn't fail:  `go test ./consensus/istanbul/proxy -count 5`

### Related issues

None

### Backwards compatibility

Yes