### PR TITLE
Fix duplicated code from bad cherry-pick conflict resolution.

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -938,9 +938,6 @@ running:
 				purpose := static[c.node.ID()].Add(trusted[c.node.ID()])
 				p := srv.launchPeer(c, purpose)
 				peers[c.node.ID()] = p
-				if p.Inbound() {
-					inboundCount++
-				}
 				srv.log.Debug("Adding p2p peer", "peercount", len(peers), "id", p.ID(), "conn", c.flags, "addr", p.RemoteAddr(), "name", truncateName(c.name))
 				srv.dialsched.peerAdded(c)
 				if conn, ok := c.fd.(*meteredConn); ok {


### PR DESCRIPTION
This increment was moved a few lines lower down in the function in the upstream commit, but during the conflict resolution for #1192, I missed removing it here, so it became duplicated.

### Description

This was a bad merge on my part in PR #1192, resulted in this if block being duplicated (it is present a few lines below this), which is rectified here.

### Tested

Not specially tested, very clear fix of a bug.