### PR TITLE
Fix --networkid option of 'devp2p discv4' command.

### DIFF
--- a/cmd/devp2p/discv4cmd.go
+++ b/cmd/devp2p/discv4cmd.go
@@ -36,6 +36,7 @@ var (
 	discv4Command = cli.Command{
 		Name:  "discv4",
 		Usage: "Node Discovery v4 tools",
+		Flags: []cli.Flag{networkIdFlag},
 		Subcommands: []cli.Command{
 			discv4PingCommand,
 			discv4RequestRecordCommand,


### PR DESCRIPTION
This flag was added in #511, but wasn't working. It is required for the `discv4` subcommands to work properly for Celo networks.

### Description

#436 added a `networkid` check to the discovery v4 protocol, making it so that nodes from different networks (e.g. mainnet vs baklava) won't discover each other.  The `devp2p discv4` command, with its various subcommands, needs to know the `networkid` it should use.  However, the CLI flag for it wasn't properly configured, so this PR fixes that.

I came across the problem when trying out the crawl subcommand as described at https://geth.ethereum.org/docs/developers/dns-discovery-setup

### Tested

The following are the results of running `discv4 ping` with the enode of our mainnet v4 bootnode.

1. `master`, when passing the mainnet networkid:
```
❯ ./build/bin/devp2p discv4 --networkid 42220 ping enode://5c9a3afb564b48cc2fa2e06b76d0c5d8f6910e1930ea7d0930213a0cbc20450434cd442f6483688eff436ad14dc29cb90c9592cc5c1d27ca62f28d4d8475d932@34.82.79.155:30301
Incorrect Usage. flag provided but not defined: -networkid

NAME:
   devp2p discv4 - Node Discovery v4 tools

USAGE:
   devp2p discv4 command [command options] [arguments...]

COMMANDS:
     ping                             Sends ping to a node
     requestenr                       Requests a node record using EIP-868 enrRequest
     resolve                          Finds a node in the DHT
     resolve-json                     Re-resolves nodes in a nodes.json file
     crawl                            Updates a nodes.json file with random nodes found in the DHT

OPTIONS:
   --help, -h                         show help

flag provided but not defined: -networkid
```

2. `master`, when not passing the networkid option (gives a timeout, because it uses the default networkid of 1, and so the bootnode rejects our ping):
```
❯ ./build/bin/devp2p discv4 ping enode://5c9a3afb564b48cc2fa2e06b76d0c5d8f6910e1930ea7d0930213a0cbc20450434cd442f6483688eff436ad14dc29cb90c9592cc5c1d27ca62f28d4d8475d932@34.82.79.155:30301
INFO [11-04|10:07:40.178] New local node record                    seq=1 id=99e3eb7026d8226e ip=127.0.0.1 udp=53466 tcp=0
node didn't respond: RPC timeout
```

3. With this PR, when passing the mainnet networkid:
```
❯ ./build/bin/devp2p discv4 --networkid 42220 ping enode://5c9a3afb564b48cc2fa2e06b76d0c5d8f6910e1930ea7d0930213a0cbc20450434cd442f6483688eff436ad14dc29cb90c9592cc5c1d27ca62f28d4d8475d932@34.82.79.155:30301
INFO [11-04|10:11:30.520] New local node record                    seq=1 id=62ac57a9c85351b4 ip=127.0.0.1 udp=52619 tcp=0
node responded to ping (RTT 128.728172ms).
```

### Backwards compatibility

No backwards compatibility concerns, as this is just a helper utility that uses the discovery protocol, and there are no changes to the protocol itself.
