### PR TITLE
Fix eth_getTransactionReceipt on light clients

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/contract_comm/blockchain_parameters"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -1326,9 +1325,9 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 
 // GetTransactionReceipt returns the transaction receipt for the given transaction hash.
 func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
-	tx, blockHash, blockNumber, index := rawdb.ReadTransaction(s.b.ChainDb(), hash)
-	if tx == nil {
-		return nil, nil
+	tx, blockHash, blockNumber, index, err := s.b.GetTransaction(ctx, hash)
+	if err != nil || tx == nil {
+		return nil, err
 	}
 	receipts, err := s.b.GetReceipts(ctx, blockHash)
 	if err != nil {


### PR DESCRIPTION
### Description

This PR includes a simple change to fix the `eth_getTransactionReceipt` API on light nodes. It turns out in the original implementation of LES transaction fetching a minor omission was made in updating the `GetTransactionReceipt` method.

https://github.com/celo-org/celo-blockchain/commit/40cdcf8c47ff094775aca08fd5d94051f9cf1dbb#diff-c426ecd2f7d247753b9ea8c1cc003f21fa412661c1f967d203d4edf8163da344R1195

This PR updates the method to use the ODR-based light client backend instead of `rawdb`.

### Other changes

None

### Tested

Ran on `alfajores` and confirmed that `eth_getTransactionReceipt` now works.

### Related issues

- Related upstream issue: https://github.com/ethereum/go-ethereum/issues/16347

### Backwards compatibility

No concerns