### PR TITLE
Fix behavior of eth_getTransactionHash for pending transactions

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/contract_comm/blockchain_parameters"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -1326,9 +1325,9 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 
 // GetTransactionReceipt returns the transaction receipt for the given transaction hash.
 func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
-	tx, blockHash, blockNumber, index := rawdb.ReadTransaction(s.b.ChainDb(), hash)
-	if tx == nil {
-		return nil, nil
+	tx, blockHash, blockNumber, index, err := s.b.GetTransaction(ctx, hash)
+	if err != nil || tx == nil {
+		return nil, err
 	}
 	receipts, err := s.b.GetReceipts(ctx, blockHash)
 	if err != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1326,7 +1326,7 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 // GetTransactionReceipt returns the transaction receipt for the given transaction hash.
 func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
 	tx, blockHash, blockNumber, index, err := s.b.GetTransaction(ctx, hash)
-	if err != nil || blockHash == (common.Hash{}) {
+	if err != nil {
 		return nil, nil
 	}
 	receipts, err := s.b.GetReceipts(ctx, blockHash)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1326,8 +1326,8 @@ func (s *PublicTransactionPoolAPI) GetRawTransactionByHash(ctx context.Context, 
 // GetTransactionReceipt returns the transaction receipt for the given transaction hash.
 func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
 	tx, blockHash, blockNumber, index, err := s.b.GetTransaction(ctx, hash)
-	if err != nil || tx == nil {
-		return nil, err
+	if err != nil || blockHash == (common.Hash{}) {
+		return nil, nil
 	}
 	receipts, err := s.b.GetReceipts(ctx, blockHash)
 	if err != nil {


### PR DESCRIPTION
### Description

Follow-up to https://github.com/celo-org/celo-blockchain/pull/1214, I found that returning the error when the transaction is not found is not the behavior expected by clients and leads to difficult to debug behavior. This fix aligns with upstream and client expectations.

Prior #1214 and this PR, `eth_getTransactionReceipt` did not work on light clients because the API implementation was checking for the given transaction in the local `rawdb` rather than using ODR, as it was doing for `eth_getTransaction`. As a result any query for a transaction that was not otherwise cached would always return `nil`. With these PRs, this is fixed so that the transaction is retrieved via ODR, as expected.