### PR TITLE
Update release/1.1.0 branch for Go 1.14.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: celohq/node10-gcloud:v3
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
-      GO_VERSION: "1.14.11"
+      GO_VERSION: "1.14.12"
       CELO_MONOREPO_BRANCH_TO_TEST: master
       GITHUB_RSA_FINGERPRINT: SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,8 @@ jobs:
           command: |
             HOMEBREW_NO_AUTO_UPDATE=1 brew install go
             # Check that homebrew installed the expected go version
-            if [[ "$(go version)" != "go version go1.14"* ]]; then
-              echo "go1.14 is required"
+            if [[ "$(go version)" != "go version go1.13"* ]]; then
+              echo "go1.13 is required"
               exit 1
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.14
     working_directory: ~/repos/geth
   e2e:
     docker:
       - image: celohq/node10-gcloud:v3
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
-      GO_VERSION: "1.13.7"
+      GO_VERSION: "1.14.11"
       CELO_MONOREPO_BRANCH_TO_TEST: master
       GITHUB_RSA_FINGERPRINT: SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
 jobs:
@@ -108,8 +108,8 @@ jobs:
           command: |
             HOMEBREW_NO_AUTO_UPDATE=1 brew install go
             # Check that homebrew installed the expected go version
-            if [[ "$(go version)" != "go version go1.13"* ]]; then 
-              echo "go1.13 is required"
+            if [[ "$(go version)" != "go version go1.14"* ]]; then
+              echo "go1.14 is required"
               exit 1
             fi
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
     - stage: lint
       os: linux
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
       env:
         - lint
       git:
@@ -35,12 +35,24 @@ jobs:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
 
+    - stage: build
+      os: linux
+      dist: xenial
+      go: 1.13.x
+      env:
+        - GO111MODULE=on
+      script:
+        - go run build/ci.go install
+        - go run build/ci.go test -coverage $TEST_PACKAGES
+
     # These are the latest Go versions.
     - stage: build
       os: linux
       arch: amd64
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
+      env:
+        - GO111MODULE=on
       script:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
@@ -50,7 +62,9 @@ jobs:
       os: linux
       arch: arm64
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
+      env:
+        - GO111MODULE=on
       script:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
@@ -58,7 +72,9 @@ jobs:
     - stage: build
       os: osx
       osx_image: xcode11.3
-      go: 1.13.x
+      go: 1.14.x
+      env:
+        - GO111MODULE=on
       script:
         - echo "Increase the maximum number of open file descriptors on macOS"
         - NOFILE=20480
@@ -77,9 +93,10 @@ jobs:
       if: type = push
       os: linux
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
       env:
         - ubuntu-ppa
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       addons:
@@ -93,7 +110,7 @@ jobs:
             - python-paramiko
       script:
         - echo '|1|7SiYPr9xl3uctzovOTj4gMwAC1M=|t6ReES75Bo/PxlOPJ6/GsGbTrM0= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA0aKz5UTUndYgIGG7dQBV+HaeuEZJ2xPHo2DS2iSKvUL4xNMSAY4UguNW+pX56nAQmZKIZZ8MaEvSj6zMEDiq6HFfn5JcTlM80UwlnyKe8B8p7Nk06PPQLrnmQt5fh0HmEcZx+JU9TZsfCHPnX7MNz4ELfZE6cFsclClrKim3BHUIGq//t93DllB+h4O9LHjEUsQ1Sr63irDLSutkLJD6RXchjROXkNirlcNVHH/jwLWR5RcYilNX7S5bIkK8NlWPjsn/8Ua5O7I9/YoE97PpO6i73DTGLh5H9JN/SITwCKBkgSDWUt61uPK3Y11Gty7o2lWsBjhBUm2Y38CBsoGmBw==' >> ~/.ssh/known_hosts
-        - go run build/ci.go debsrc -goversion 1.13.6 -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
+        - go run build/ci.go debsrc -goversion 1.14.2 -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
 
     # This builder does the Linux Azure uploads
     - stage: build
@@ -101,9 +118,10 @@ jobs:
       os: linux
       dist: xenial
       sudo: required
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-linux
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       addons:
@@ -137,9 +155,10 @@ jobs:
       dist: xenial
       services:
         - docker
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-linux-mips
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
@@ -180,10 +199,11 @@ jobs:
       env:
         - azure-android
         - maven-android
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       before_install:
-        - curl https://dl.google.com/go/go1.13.6.linux-amd64.tar.gz | tar -xz
+        - curl https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz | tar -xz
         - export PATH=`pwd`/go/bin:$PATH
         - export GOROOT=`pwd`/go
         - export GOPATH=$HOME/go
@@ -201,11 +221,12 @@ jobs:
     - stage: build
       if: type = push
       os: osx
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-osx
         - azure-ios
         - cocoapods-ios
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
@@ -232,9 +253,10 @@ jobs:
       if: type = cron
       os: linux
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-purge
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # To use this image for testing, modify GETH_NODE_DOCKER_IMAGE_TAG in celo-monorepo/.env file
 
 # Build Geth in a stock Go builder container
-FROM golang:1.13-alpine as builder
+FROM golang:1.14-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.13-alpine as builder
+FROM golang:1.14-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -29,7 +29,7 @@ RUN rustup target add x86_64-linux-android
 # go and node installations command expect to run as root
 USER root
 
-RUN curl https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz | tar -xz
+RUN curl https://dl.google.com/go/go1.14.11.linux-amd64.tar.gz | tar -xz
 ENV PATH=/go/bin:$PATH
 ENV GOROOT=/go
 ENV GOPATH=$HOME/go

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -29,7 +29,7 @@ RUN rustup target add x86_64-linux-android
 # go and node installations command expect to run as root
 USER root
 
-RUN curl https://dl.google.com/go/go1.14.11.linux-amd64.tar.gz | tar -xz
+RUN curl https://dl.google.com/go/go1.14.12.linux-amd64.tar.gz | tar -xz
 ENV PATH=/go/bin:$PATH
 ENV GOROOT=/go
 ENV GOPATH=$HOME/go

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,8 +9,8 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add aarch64-unknown-linux-gnu
-RUN wget https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz && \
-    tar xf go1.13.5.linux-amd64.tar.gz -C /usr/local
+RUN wget https://dl.google.com/go/go1.14.11.linux-amd64.tar.gz && \
+    tar xf go1.14.11.linux-amd64.tar.gz -C /usr/local
 
 COPY . /go-ethereum
 WORKDIR /go-ethereum

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,8 +9,8 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add aarch64-unknown-linux-gnu
-RUN wget https://dl.google.com/go/go1.14.11.linux-amd64.tar.gz && \
-    tar xf go1.14.11.linux-amd64.tar.gz -C /usr/local
+RUN wget https://dl.google.com/go/go1.14.12.linux-amd64.tar.gz && \
+    tar xf go1.14.12.linux-amd64.tar.gz -C /usr/local
 
 COPY . /go-ethereum
 WORKDIR /go-ethereum

--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -41,7 +41,7 @@
 # In the CI flow these are then uploaded to cloud storage as artefacts.
 
 # Build Geth binaries in the xgo builder container
-FROM techknowlogick/xgo:go-1.13.x
+FROM techknowlogick/xgo:go-1.14.x
 # techknowlogic/xgo is a fork of karalabe/xgo updated to ubunut-18, it is more maintained
 # by the community and allows us to backport mingw in order to build for windows
 # See discussion in PR celo-blockchain#<number> about downsides of this image

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Most functionality of this client is similar to `go-ethereum`, also known as `ge
 
 ## Building the source
 
-Building `geth` requires both a Go (version 1.13) and a C compiler.
+Building `geth` requires both a Go (version 1.14) and a C compiler.
 You can install them using your favourite package manager. Once the dependencies are installed, run
 
 ```shell

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ clone_depth: 5
 version: "{branch}.{build}"
 environment:
   global:
+    GO111MODULE: on
     GOPATH: C:\gopath
     CC: gcc.exe
   matrix:
@@ -23,8 +24,8 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://dl.google.com/go/go1.13.6.windows-%GETH_ARCH%.zip
-  - 7z x go1.13.6.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://dl.google.com/go/go1.14.2.windows-%GETH_ARCH%.zip
+  - 7z x go1.14.2.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 

--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -1,6 +1,6 @@
 # This file contains sha256 checksums of optional build dependencies.
 
-aae5be954bdc40bcf8006eb77e8d8a5dde412722bc8effcdaf9772620d06420c  go1.13.6.src.tar.gz
+98de84e69726a66da7b4e58eac41b99cbe274d7e8906eeb8a5b7eb0aadee7f7c  go1.14.2.src.tar.gz
 
 1fcbc9e36f4319eeed02beb8cfd1b3d425ffc2f90ddf09a80f18d5064c51e0cb  golangci-lint-1.21.0-linux-386.tar.gz
 267b4066e67139a38d29499331a002d6a29ad5be7aafc83db3b1e88f1b027f90  golangci-lint-1.21.0-linux-armv6.tar.gz

--- a/docs/docs/_developers/devguide.md
+++ b/docs/docs/_developers/devguide.md
@@ -36,7 +36,7 @@ These early PRs should indicate 'in progress' status.
 
 ## Building and Testing
 
-We assume that you have Go installed. Please use Go version 1.13 or later. We use the gc
+We assume that you have Go installed. Please use Go version 1.14 or later. We use the gc
 toolchain for development, which you can get from the [Go downloads page][go-install].
 
 go-ethereum is a Go module, and uses the [Go modules system][go-modules] to manage

--- a/go.mod
+++ b/go.mod
@@ -55,9 +55,9 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef
 	github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4
 	golang.org/x/mobile v0.0.0-20200801112145-973feb4309de // indirect
-	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299
 	golang.org/x/text v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4 h1:QmwruyY+bKbDDL0BaglrbZABEali68eoMFhTZpCjYVA=
+golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -213,9 +215,12 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/p2p/discv5/node_test.go
+++ b/p2p/discv5/node_test.go
@@ -142,7 +142,7 @@ var parseNodeTests = []struct {
 	{
 		// This test checks that errors from url.Parse are handled.
 		rawurl:    "://foo",
-		wantError: `parse ://foo: missing protocol scheme`,
+		wantError: `missing protocol scheme`,
 	},
 }
 


### PR DESCRIPTION
### Description

This cherry-picks some commits from upstream, and adds some additional changes in a separate commit, to:

1. Become compatible with Go 1.14.x
2. Use the latest 1.14.x version in the CI and the dockerfiles

The idea is to then switch to v1.14.12 when it is released.

The changes from upstream are very minor:

1. Upgrading a dependency version
2. Fixing a test to work with 1.14

For now, I am creating this as a draft PR with "do not merge".  I believe what we should eventually do, rather than merge it to `release/1.1.0`, is create a new branch from it (e.g. `release/1.1.1`) and merge this PR onto that.  cc @trianglesphere 

### Tested

Unit tests and e2e sync tests pass.

### Backwards compatibility

No significant