### PR TITLE
Churrito hard fork

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -279,7 +279,11 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		// if the operation clears the return data (e.g. it has returning data)
 		// set the last return to the result of the operation.
 		if operation.returns {
-			in.returnData = res
+			if in.evm.chainRules.IsChurrito {
+				in.returnData = common.CopyBytes(res)
+			} else {
+				in.returnData = res
+			}
 		}
 
 		switch {

--- a/params/config.go
+++ b/params/config.go
@@ -63,6 +63,7 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		ChurritoBlock:       nil,
+		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -85,6 +86,7 @@ var (
 		PetersburgBlock:     big.NewInt(4939394),
 		IstanbulBlock:       big.NewInt(6485846),
 		ChurritoBlock:       nil,
+		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 0,
@@ -105,6 +107,7 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		ChurritoBlock:       nil,
+		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -126,6 +129,7 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		ChurritoBlock:       nil,
+		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -135,21 +139,21 @@ var (
 		},
 	}
 
-	DeveloperChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &IstanbulConfig{
+	DeveloperChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &IstanbulConfig{
 		Epoch:          300,
 		ProposerPolicy: 0,
 		RequestTimeout: 1000,
 		BlockPeriod:    1,
 	}, true, false}
 
-	IstanbulTestChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &IstanbulConfig{
+	IstanbulTestChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &IstanbulConfig{
 		Epoch:          300,
 		ProposerPolicy: 0,
 		RequestTimeout: 1000,
 		BlockPeriod:    1,
 	}, true, false}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &IstanbulConfig{
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &IstanbulConfig{
 		Epoch:          30000,
 		ProposerPolicy: 0,
 	}, true, true}
@@ -226,6 +230,7 @@ type ChainConfig struct {
 	IstanbulBlock       *big.Int `json:"istanbulBlock,omitempty"`       // Istanbul switch block (nil = no fork, 0 = already on istanbul)
 	EWASMBlock          *big.Int `json:"ewasmBlock,omitempty"`          // EWASM switch block (nil = no fork, 0 = already activated)
 	ChurritoBlock       *big.Int `json:"churritoBlock,omitempty"`       // Churrito switch block (nil = no fork, 0 = already activated)
+	DonutBlock          *big.Int `json:"donutBlock,omitempty"`          // Donut switch block (nil = no fork, 0 = already activated)
 
 	Istanbul *IstanbulConfig `json:"istanbul,omitempty"`
 
@@ -263,7 +268,7 @@ func (c *ChainConfig) String() string {
 	} else {
 		engine = "MockEngine"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v Churrito: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v Churrito: %v, Donut: %v, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -276,6 +281,7 @@ func (c *ChainConfig) String() string {
 		c.PetersburgBlock,
 		c.IstanbulBlock,
 		c.ChurritoBlock,
+		c.DonutBlock,
 		engine,
 	)
 }
@@ -337,6 +343,11 @@ func (c *ChainConfig) IsChurrito(num *big.Int) bool {
 	return isForked(c.ChurritoBlock, num)
 }
 
+// IsDonut returns whether num represents a block number after the Donut fork
+func (c *ChainConfig) IsDonut(num *big.Int) bool {
+	return isForked(c.DonutBlock, num)
+}
+
 // CheckCompatible checks whether scheduled fork transitions have been imported
 // with a mismatching chain configuration.
 func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height uint64) *ConfigCompatError {
@@ -373,6 +384,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{"petersburgBlock", c.PetersburgBlock},
 		{"istanbulBlock", c.IstanbulBlock},
 		{"churritoBlock", c.ChurritoBlock},
+		{"donutBlock", c.DonutBlock},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -431,6 +443,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	}
 	if isForkIncompatible(c.ChurritoBlock, newcfg.ChurritoBlock, head) {
 		return newCompatError("Churrito fork block", c.ChurritoBlock, newcfg.ChurritoBlock)
+	}
+	if isForkIncompatible(c.DonutBlock, newcfg.DonutBlock, head) {
+		return newCompatError("Donut fork block", c.DonutBlock, newcfg.DonutBlock)
 	}
 	return nil
 }
@@ -499,7 +514,7 @@ type Rules struct {
 	ChainID                                                 *big.Int
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
-	IsChurrito                                              bool
+	IsChurrito, IsDonut                                     bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -519,5 +534,6 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsPetersburg:     c.IsPetersburg(num),
 		IsIstanbul:       c.IsIstanbul(num),
 		IsChurrito:       c.IsChurrito(num),
+		IsDonut:          c.IsDonut(num),
 	}
 }

--- a/params/config.go
+++ b/params/config.go
@@ -62,7 +62,7 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		ChurritoBlock:       big.NewInt(3976252),
+		ChurritoBlock:       nil,
 		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
@@ -106,7 +106,7 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		ChurritoBlock:       big.NewInt(2598139),
+		ChurritoBlock:       big.NewInt(2719099),
 		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
@@ -128,7 +128,7 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		ChurritoBlock:       big.NewInt(2320192),
+		ChurritoBlock:       nil,
 		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,

--- a/params/config.go
+++ b/params/config.go
@@ -62,7 +62,7 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		ChurritoBlock:       nil,
+		ChurritoBlock:       big.NewInt(3976252),
 		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
@@ -106,7 +106,7 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		ChurritoBlock:       nil,
+		ChurritoBlock:       big.NewInt(2598139),
 		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
@@ -128,7 +128,7 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		ChurritoBlock:       nil,
+		ChurritoBlock:       big.NewInt(2320192),
 		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
@@ -139,21 +139,21 @@ var (
 		},
 	}
 
-	DeveloperChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &IstanbulConfig{
+	DeveloperChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, &IstanbulConfig{
 		Epoch:          300,
 		ProposerPolicy: 0,
 		RequestTimeout: 1000,
 		BlockPeriod:    1,
 	}, true, false}
 
-	IstanbulTestChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &IstanbulConfig{
+	IstanbulTestChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, &IstanbulConfig{
 		Epoch:          300,
 		ProposerPolicy: 0,
 		RequestTimeout: 1000,
 		BlockPeriod:    1,
 	}, true, false}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &IstanbulConfig{
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, &IstanbulConfig{
 		Epoch:          30000,
 		ProposerPolicy: 0,
 	}, true, true}


### PR DESCRIPTION
### Description

1. Replace unused Celo1 fork info with `churrito` hard fork (https://forum.celo.org/t/pre-announcement-of-security-hotfix-releases-celo-blockchain-1-1-1-and-1-2-2-and-churrito-hardfork/677), and implement the EVM change.  When we cherry-pick this on top of v1.1.0, we should first cherry-pick #1173, to avoid gratuitous merge conflicts.
2. Add Donut fork info (without setting activation block numbers), for use in future PRs implementing functionality for the future Donut hard fork (until now they had been using `Celo1`, which was added before the name Donut was chosen).
3. Set Churrito activation block number for Baklava as specified in https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0024.md, and enable churrito for dev chain (`--dev`) and the test chains (used in the automated testing).

### Tested

Confirmed locally using logging:

1. With the activation block number set to `nil`, the original path (without the copy) is executed.
2. With the activation block number set to 1, the original path is executed for block 0 and then on block 1 it switches to the new path.
3. With activation block set to the future, client is able to establish connections with unupgraded peers.
4. With activation block set to the past, connections to unupgraded peers are rejected during the handshake due to the fork id check.

### Backwards Compatibility

Not backwards compatible, as this triggers a hard fork on Baklava at the specified block numbers.  Therefore, validators must and full nodes must upgrade before that time to ensure the network's health.

After the activation block number, upgraded and unupgraded peers will not be able to connect to each other, as there is a fork id check in the handshake (see https://eips.ethereum.org/EIPS/eip-2364 for details).  If the activation block number arrives and there isn't a quorum of upgraded validators, the network is likely to stall, though not necessarily immediately (because the fork id check is done during the handshake, peers who are already connected to each other won't disconnect each other because of the fork id).