### PR TITLE
Only create replicaState if configured as a validator

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -250,5 +250,8 @@ func (api *API) IsValidating() bool {
 
 // GetCurrentRoundState retrieves the current replica state
 func (api *API) GetCurrentReplicaState() (*replica.ReplicaStateSummary, error) {
-	return api.istanbul.replicaState.Summary(), nil
+	if api.istanbul.replicaState != nil {
+		return api.istanbul.replicaState.Summary(), nil
+	}
+	return &replica.ReplicaStateSummary{State: "Not a validator"}, nil
 }

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -122,11 +122,15 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 		},
 	)
 
-	rs, err := replica.NewState(config.Replica, config.ReplicaStateDBPath, backend.StartValidating, backend.StopValidating)
-	if err != nil {
-		logger.Crit("Can't open ReplicaStateDB", "err", err, "dbpath", config.ReplicaStateDBPath)
+	if config.Validator {
+		rs, err := replica.NewState(config.Replica, config.ReplicaStateDBPath, backend.StartValidating, backend.StopValidating)
+		if err != nil {
+			logger.Crit("Can't open ReplicaStateDB", "err", err, "dbpath", config.ReplicaStateDBPath)
+		}
+		backend.replicaState = rs
+	} else {
+		backend.replicaState = nil
 	}
-	backend.replicaState = rs
 
 	backend.vph = newVPH(backend)
 	valEnodeTable, err := enodes.OpenValidatorEnodeDB(config.ValidatorEnodeDBPath, backend.vph)
@@ -382,8 +386,10 @@ func (sb *Backend) Close() error {
 	if err := sb.versionCertificateTable.Close(); err != nil {
 		errs = append(errs, err)
 	}
-	if err := sb.replicaState.Close(); err != nil {
-		errs = append(errs, err)
+	if sb.replicaState != nil {
+		if err := sb.replicaState.Close(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	var concatenatedErrs error
 	for i, err := range errs {
@@ -968,14 +974,22 @@ func (sb *Backend) VerifyValidatorConnectionSetSignature(data []byte, sig []byte
 }
 
 func (sb *Backend) IsPrimaryForSeq(seq *big.Int) bool {
-	return sb.replicaState.IsPrimaryForSeq(seq)
+	if sb.replicaState != nil {
+		return sb.replicaState.IsPrimaryForSeq(seq)
+	}
+	return false
 }
 
 func (sb *Backend) IsPrimary() bool {
-	return sb.replicaState.IsPrimary()
+	if sb.replicaState != nil {
+		return sb.replicaState.IsPrimary()
+	}
+	return false
 }
 
 // UpdateReplicaState updates the replica state with the latest seq.
 func (sb *Backend) UpdateReplicaState(seq *big.Int) {
-	sb.replicaState.NewChainHead(seq)
+	if sb.replicaState != nil {
+		sb.replicaState.NewChainHead(seq)
+	}
 }

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -620,7 +620,7 @@ func (sb *Backend) updateReplicaStateLoop(bc *ethCore.BlockChain) {
 	for {
 		select {
 		case chainEvent := <-chainEventCh:
-			if !sb.coreStarted {
+			if !sb.coreStarted && sb.replicaState != nil {
 				consensusBlock := new(big.Int).Add(chainEvent.Block.Number(), common.Big1)
 				sb.replicaState.NewChainHead(consensusBlock)
 			}
@@ -781,12 +781,18 @@ func (sb *Backend) StopProxiedValidatorEngine() error {
 
 // MakeReplica clears the start/stop state & stops this node from participating in consensus
 func (sb *Backend) MakeReplica() error {
-	return sb.replicaState.MakeReplica()
+	if sb.replicaState != nil {
+		return sb.replicaState.MakeReplica()
+	}
+	return istanbul.ErrUnauthorizedAddress
 }
 
 // MakePrimary clears the start/stop state & makes this node participate in consensus
 func (sb *Backend) MakePrimary() error {
-	return sb.replicaState.MakePrimary()
+	if sb.replicaState != nil {
+		return sb.replicaState.MakePrimary()
+	}
+	return istanbul.ErrUnauthorizedAddress
 }
 
 // snapshot retrieves the validator set needed to sign off on the block immediately after 'number'.  E.g. if you need to find the validator set that needs to sign off on block 6,
@@ -1009,6 +1015,9 @@ func (sb *Backend) addParentSeal(chain consensus.ChainReader, header *types.Head
 
 // SetStartValidatingBlock sets block that the validator will start validating on (inclusive)
 func (sb *Backend) SetStartValidatingBlock(blockNumber *big.Int) error {
+	if sb.replicaState == nil {
+		return errors.New("Not configured as a validator")
+	}
 	if blockNumber.Cmp(sb.currentBlock().Number()) < 0 {
 		return errors.New("blockNumber should be greater than the current block number")
 	}
@@ -1017,6 +1026,9 @@ func (sb *Backend) SetStartValidatingBlock(blockNumber *big.Int) error {
 
 // SetStopValidatingBlock sets the block that the validator will stop just before (exclusive range)
 func (sb *Backend) SetStopValidatingBlock(blockNumber *big.Int) error {
+	if sb.replicaState == nil {
+		return errors.New("Not configured as a validator")
+	}
 	if blockNumber.Cmp(sb.currentBlock().Number()) < 0 {
 		return errors.New("blockNumber should be greater than the current block number")
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -81,6 +81,8 @@ var (
 	// errUnauthorizedAnnounceMessage is returned when the received announce message is from
 	// an unregistered validator
 	errUnauthorizedAnnounceMessage = errors.New("unauthorized announce message")
+	// errNotAValidator is returned when the node is not configured as a validator
+	errNotAValidator = errors.New("Not configured as a validator")
 )
 
 var (
@@ -1016,7 +1018,7 @@ func (sb *Backend) addParentSeal(chain consensus.ChainReader, header *types.Head
 // SetStartValidatingBlock sets block that the validator will start validating on (inclusive)
 func (sb *Backend) SetStartValidatingBlock(blockNumber *big.Int) error {
 	if sb.replicaState == nil {
-		return errors.New("Not configured as a validator")
+		return errNotAValidator
 	}
 	if blockNumber.Cmp(sb.currentBlock().Number()) < 0 {
 		return errors.New("blockNumber should be greater than the current block number")
@@ -1027,7 +1029,7 @@ func (sb *Backend) SetStartValidatingBlock(blockNumber *big.Int) error {
 // SetStopValidatingBlock sets the block that the validator will stop just before (exclusive range)
 func (sb *Backend) SetStopValidatingBlock(blockNumber *big.Int) error {
 	if sb.replicaState == nil {
-		return errors.New("Not configured as a validator")
+		return errNotAValidator
 	}
 	if blockNumber.Cmp(sb.currentBlock().Number()) < 0 {
 		return errors.New("blockNumber should be greater than the current block number")


### PR DESCRIPTION
### Description

This should reduce problems with using data-dirs from full nodes. This will not completely eliminate the problem if a data-dir is reused from a validator.

### Other changes



### Tested

Confirmed that full nodes don't create the replica state and that nodes configured with --mine do.

### Related issues

### Backwards compatibility

Backwards compatible
