### PR TITLE
Release 1.2.2-beta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2.1
 executors:
   golang:
     docker:
-      - image: circleci/golang:1.13
+      - image: circleci/golang:1.14
     working_directory: ~/repos/geth
   e2e:
     docker:
       - image: celohq/node10-gcloud:v3
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
-      GO_VERSION: "1.13.7"
+      GO_VERSION: "1.14.12"
       CELO_MONOREPO_BRANCH_TO_TEST: master
       GITHUB_RSA_FINGERPRINT: SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
 jobs:
@@ -108,7 +108,7 @@ jobs:
           command: |
             HOMEBREW_NO_AUTO_UPDATE=1 brew install go
             # Check that homebrew installed the expected go version
-            if [[ "$(go version)" != "go version go1.13"* ]]; then 
+            if [[ "$(go version)" != "go version go1.13"* ]]; then
               echo "go1.13 is required"
               exit 1
             fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
     - stage: lint
       os: linux
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
       env:
         - lint
       git:
@@ -25,12 +25,24 @@ jobs:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
 
+    - stage: build
+      os: linux
+      dist: xenial
+      go: 1.13.x
+      env:
+        - GO111MODULE=on
+      script:
+        - go run build/ci.go install
+        - go run build/ci.go test -coverage $TEST_PACKAGES
+
     # These are the latest Go versions.
     - stage: build
       os: linux
       arch: amd64
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
+      env:
+        - GO111MODULE=on
       script:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
@@ -40,7 +52,9 @@ jobs:
       os: linux
       arch: arm64
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
+      env:
+        - GO111MODULE=on
       script:
         - go run build/ci.go install
         - go run build/ci.go test -coverage $TEST_PACKAGES
@@ -48,7 +62,9 @@ jobs:
     - stage: build
       os: osx
       osx_image: xcode11.3
-      go: 1.13.x
+      go: 1.14.x
+      env:
+        - GO111MODULE=on
       script:
         - echo "Increase the maximum number of open file descriptors on macOS"
         - NOFILE=20480
@@ -67,9 +83,10 @@ jobs:
       if: type = push
       os: linux
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
       env:
         - ubuntu-ppa
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       addons:
@@ -83,7 +100,7 @@ jobs:
             - python-paramiko
       script:
         - echo '|1|7SiYPr9xl3uctzovOTj4gMwAC1M=|t6ReES75Bo/PxlOPJ6/GsGbTrM0= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA0aKz5UTUndYgIGG7dQBV+HaeuEZJ2xPHo2DS2iSKvUL4xNMSAY4UguNW+pX56nAQmZKIZZ8MaEvSj6zMEDiq6HFfn5JcTlM80UwlnyKe8B8p7Nk06PPQLrnmQt5fh0HmEcZx+JU9TZsfCHPnX7MNz4ELfZE6cFsclClrKim3BHUIGq//t93DllB+h4O9LHjEUsQ1Sr63irDLSutkLJD6RXchjROXkNirlcNVHH/jwLWR5RcYilNX7S5bIkK8NlWPjsn/8Ua5O7I9/YoE97PpO6i73DTGLh5H9JN/SITwCKBkgSDWUt61uPK3Y11Gty7o2lWsBjhBUm2Y38CBsoGmBw==' >> ~/.ssh/known_hosts
-        - go run build/ci.go debsrc -goversion 1.13.6 -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
+        - go run build/ci.go debsrc -goversion 1.14.2 -upload ethereum/ethereum -sftp-user geth-ci -signer "Go Ethereum Linux Builder <geth-ci@ethereum.org>"
 
     # This builder does the Linux Azure uploads
     - stage: build
@@ -91,9 +108,10 @@ jobs:
       os: linux
       dist: xenial
       sudo: required
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-linux
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       addons:
@@ -127,9 +145,10 @@ jobs:
       dist: xenial
       services:
         - docker
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-linux-mips
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
@@ -170,10 +189,11 @@ jobs:
       env:
         - azure-android
         - maven-android
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       before_install:
-        - curl https://dl.google.com/go/go1.13.6.linux-amd64.tar.gz | tar -xz
+        - curl https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz | tar -xz
         - export PATH=`pwd`/go/bin:$PATH
         - export GOROOT=`pwd`/go
         - export GOPATH=$HOME/go
@@ -191,11 +211,12 @@ jobs:
     - stage: build
       if: type = push
       os: osx
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-osx
         - azure-ios
         - cocoapods-ios
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       script:
@@ -222,9 +243,10 @@ jobs:
       if: type = cron
       os: linux
       dist: xenial
-      go: 1.13.x
+      go: 1.14.x
       env:
         - azure-purge
+        - GO111MODULE=on
       git:
         submodules: false # avoid cloning ethereum/tests
       script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # To use this image for testing, modify GETH_NODE_DOCKER_IMAGE_TAG in celo-monorepo/.env file
 
 # Build Geth in a stock Go builder container
-FROM golang:1.13-alpine as builder
+FROM golang:1.14-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -1,5 +1,5 @@
 # Build Geth in a stock Go builder container
-FROM golang:1.13-alpine as builder
+FROM golang:1.14-alpine as builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -29,7 +29,7 @@ RUN rustup target add x86_64-linux-android
 # go and node installations command expect to run as root
 USER root
 
-RUN curl https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz | tar -xz
+RUN curl https://dl.google.com/go/go1.14.12.linux-amd64.tar.gz | tar -xz
 ENV PATH=/go/bin:$PATH
 ENV GOROOT=/go
 ENV GOPATH=$HOME/go

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,8 +9,8 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add aarch64-unknown-linux-gnu
-RUN wget https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz && \
-    tar xf go1.13.5.linux-amd64.tar.gz -C /usr/local
+RUN wget https://dl.google.com/go/go1.14.12.linux-amd64.tar.gz && \
+    tar xf go1.14.12.linux-amd64.tar.gz -C /usr/local
 
 COPY . /go-ethereum
 WORKDIR /go-ethereum

--- a/Dockerfile.binaries
+++ b/Dockerfile.binaries
@@ -41,7 +41,7 @@
 # In the CI flow these are then uploaded to cloud storage as artefacts.
 
 # Build Geth binaries in the xgo builder container
-FROM techknowlogick/xgo:go-1.13.x
+FROM techknowlogick/xgo:go-1.14.x
 # techknowlogic/xgo is a fork of karalabe/xgo updated to ubunut-18, it is more maintained
 # by the community and allows us to backport mingw in order to build for windows
 # See discussion in PR celo-blockchain#<number> about downsides of this image

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Most functionality of this client is similar to `go-ethereum`, also known as `ge
 
 ## Building the source
 
-Building `geth` requires both a Go (version 1.13) and a C compiler.
+Building `geth` requires both a Go (version 1.14) and a C compiler.
 You can install them using your favourite package manager. Once the dependencies are installed, run
 
 ```shell

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ clone_depth: 5
 version: "{branch}.{build}"
 environment:
   global:
+    GO111MODULE: on
     GOPATH: C:\gopath
     CC: gcc.exe
   matrix:
@@ -23,8 +24,8 @@ environment:
 install:
   - git submodule update --init
   - rmdir C:\go /s /q
-  - appveyor DownloadFile https://dl.google.com/go/go1.13.6.windows-%GETH_ARCH%.zip
-  - 7z x go1.13.6.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://dl.google.com/go/go1.14.2.windows-%GETH_ARCH%.zip
+  - 7z x go1.14.2.windows-%GETH_ARCH%.zip -y -oC:\ > NUL
   - go version
   - gcc --version
 

--- a/build/checksums.txt
+++ b/build/checksums.txt
@@ -1,6 +1,6 @@
 # This file contains sha256 checksums of optional build dependencies.
 
-aae5be954bdc40bcf8006eb77e8d8a5dde412722bc8effcdaf9772620d06420c  go1.13.6.src.tar.gz
+98de84e69726a66da7b4e58eac41b99cbe274d7e8906eeb8a5b7eb0aadee7f7c  go1.14.2.src.tar.gz
 
 1fcbc9e36f4319eeed02beb8cfd1b3d425ffc2f90ddf09a80f18d5064c51e0cb  golangci-lint-1.21.0-linux-386.tar.gz
 267b4066e67139a38d29499331a002d6a29ad5be7aafc83db3b1e88f1b027f90  golangci-lint-1.21.0-linux-armv6.tar.gz

--- a/consensus/istanbul/proxy/proxied_validator_engine.go
+++ b/consensus/istanbul/proxy/proxied_validator_engine.go
@@ -356,6 +356,22 @@ func (pv *proxiedValidatorEngine) SendForwardMsgToAllProxies(finalDestAddresses 
 	return nil
 }
 
+// NewEpoch will notify the proxied validator's thread that a new epoch started
+func (pv *proxiedValidatorEngine) NewEpoch() error {
+	if !pv.Running() {
+		return istanbul.ErrStoppedProxiedValidatorEngine
+	}
+
+	select {
+	case pv.newBlockchainEpoch <- struct{}{}:
+
+	case <-pv.quit:
+		return istanbul.ErrStoppedProxiedValidatorEngine
+	}
+
+	return nil
+}
+
 // run handles changes to proxies and validator assignments
 func (pv *proxiedValidatorEngine) threadRun() {
 	var (

--- a/consensus/istanbul/proxy/types.go
+++ b/consensus/istanbul/proxy/types.go
@@ -123,6 +123,9 @@ type ProxiedValidatorEngine interface {
 
 	// IsProxyPeer will check if the peerID is a proxy.
 	IsProxyPeer(peerID enode.ID) (bool, error)
+
+	// NewEpoch will notify the proxied validator's thread that a new epoch started
+	NewEpoch() error
 }
 
 // ==============================================

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -279,7 +279,11 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		// if the operation clears the return data (e.g. it has returning data)
 		// set the last return to the result of the operation.
 		if operation.returns {
-			in.returnData = res
+			if in.evm.chainRules.IsChurrito {
+				in.returnData = common.CopyBytes(res)
+			} else {
+				in.returnData = res
+			}
 		}
 
 		switch {

--- a/docs/docs/_developers/devguide.md
+++ b/docs/docs/_developers/devguide.md
@@ -36,7 +36,7 @@ These early PRs should indicate 'in progress' status.
 
 ## Building and Testing
 
-We assume that you have Go installed. Please use Go version 1.13 or later. We use the gc
+We assume that you have Go installed. Please use Go version 1.14 or later. We use the gc
 toolchain for development, which you can get from the [Go downloads page][go-install].
 
 go-ethereum is a Go module, and uses the [Go modules system][go-modules] to manage

--- a/go.mod
+++ b/go.mod
@@ -57,9 +57,9 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef
 	github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
+	golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4
 	golang.org/x/mobile v0.0.0-20200801112145-973feb4309de // indirect
-	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
+	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299
 	golang.org/x/text v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4 h1:QmwruyY+bKbDDL0BaglrbZABEali68eoMFhTZpCjYVA=
+golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
@@ -215,9 +217,12 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7 h1:rTIdg5QFRR7XCaK4LCjBiPbx8j4DQRpdYMnGn/bJUEU=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f h1:Bl/8QSvNqXvPGPGXa2z5xUTmV7VDcZyvRZ+QQXkXTZQ=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/p2p/discv5/node_test.go
+++ b/p2p/discv5/node_test.go
@@ -142,7 +142,7 @@ var parseNodeTests = []struct {
 	{
 		// This test checks that errors from url.Parse are handled.
 		rawurl:    "://foo",
-		wantError: `parse ://foo: missing protocol scheme`,
+		wantError: `missing protocol scheme`,
 	},
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -62,7 +62,8 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		Celo1Block:          nil,
+		ChurritoBlock:       nil,
+		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -84,7 +85,8 @@ var (
 		ConstantinopleBlock: big.NewInt(4230000),
 		PetersburgBlock:     big.NewInt(4939394),
 		IstanbulBlock:       big.NewInt(6485846),
-		Celo1Block:          nil,
+		ChurritoBlock:       nil,
+		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 0,
@@ -104,7 +106,8 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		Celo1Block:          nil,
+		ChurritoBlock:       big.NewInt(2719099),
+		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -125,7 +128,8 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		Celo1Block:          nil,
+		ChurritoBlock:       nil,
+		DonutBlock:          nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -135,21 +139,21 @@ var (
 		},
 	}
 
-	DeveloperChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &IstanbulConfig{
+	DeveloperChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, &IstanbulConfig{
 		Epoch:          300,
 		ProposerPolicy: 0,
 		RequestTimeout: 1000,
 		BlockPeriod:    1,
 	}, true, false}
 
-	IstanbulTestChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &IstanbulConfig{
+	IstanbulTestChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, &IstanbulConfig{
 		Epoch:          300,
 		ProposerPolicy: 0,
 		RequestTimeout: 1000,
 		BlockPeriod:    1,
 	}, true, false}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &IstanbulConfig{
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, &IstanbulConfig{
 		Epoch:          30000,
 		ProposerPolicy: 0,
 	}, true, true}
@@ -225,7 +229,8 @@ type ChainConfig struct {
 	PetersburgBlock     *big.Int `json:"petersburgBlock,omitempty"`     // Petersburg switch block (nil = same as Constantinople)
 	IstanbulBlock       *big.Int `json:"istanbulBlock,omitempty"`       // Istanbul switch block (nil = no fork, 0 = already on istanbul)
 	EWASMBlock          *big.Int `json:"ewasmBlock,omitempty"`          // EWASM switch block (nil = no fork, 0 = already activated)
-	Celo1Block          *big.Int `json:"celo1Block,omitempty"`          // Celo1 switch block (nil = no fork, 0 = already activated)
+	ChurritoBlock       *big.Int `json:"churritoBlock,omitempty"`       // Churrito switch block (nil = no fork, 0 = already activated)
+	DonutBlock          *big.Int `json:"donutBlock,omitempty"`          // Donut switch block (nil = no fork, 0 = already activated)
 
 	Istanbul *IstanbulConfig `json:"istanbul,omitempty"`
 
@@ -263,7 +268,7 @@ func (c *ChainConfig) String() string {
 	} else {
 		engine = "MockEngine"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v Celo1: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v Churrito: %v, Donut: %v, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -275,7 +280,8 @@ func (c *ChainConfig) String() string {
 		c.ConstantinopleBlock,
 		c.PetersburgBlock,
 		c.IstanbulBlock,
-		c.Celo1Block,
+		c.ChurritoBlock,
+		c.DonutBlock,
 		engine,
 	)
 }
@@ -332,9 +338,14 @@ func (c *ChainConfig) IsEWASM(num *big.Int) bool {
 	return isForked(c.EWASMBlock, num)
 }
 
-// IsCelo1 returns whether num represents a block number after the Celo1 fork
-func (c *ChainConfig) IsCelo1(num *big.Int) bool {
-	return isForked(c.Celo1Block, num)
+// IsChurrito returns whether num represents a block number after the Churrito fork
+func (c *ChainConfig) IsChurrito(num *big.Int) bool {
+	return isForked(c.ChurritoBlock, num)
+}
+
+// IsDonut returns whether num represents a block number after the Donut fork
+func (c *ChainConfig) IsDonut(num *big.Int) bool {
+	return isForked(c.DonutBlock, num)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
@@ -372,7 +383,8 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{"constantinopleBlock", c.ConstantinopleBlock},
 		{"petersburgBlock", c.PetersburgBlock},
 		{"istanbulBlock", c.IstanbulBlock},
-		{"celo1Block", c.Celo1Block},
+		{"churritoBlock", c.ChurritoBlock},
+		{"donutBlock", c.DonutBlock},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -429,8 +441,11 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.EWASMBlock, newcfg.EWASMBlock, head) {
 		return newCompatError("ewasm fork block", c.EWASMBlock, newcfg.EWASMBlock)
 	}
-	if isForkIncompatible(c.Celo1Block, newcfg.Celo1Block, head) {
-		return newCompatError("celo1 fork block", c.Celo1Block, newcfg.Celo1Block)
+	if isForkIncompatible(c.ChurritoBlock, newcfg.ChurritoBlock, head) {
+		return newCompatError("Churrito fork block", c.ChurritoBlock, newcfg.ChurritoBlock)
+	}
+	if isForkIncompatible(c.DonutBlock, newcfg.DonutBlock, head) {
+		return newCompatError("Donut fork block", c.DonutBlock, newcfg.DonutBlock)
 	}
 	return nil
 }
@@ -496,9 +511,10 @@ func (err *ConfigCompatError) Error() string {
 // Rules is a one time interface meaning that it shouldn't be used in between transition
 // phases.
 type Rules struct {
-	ChainID                                                          *big.Int
-	IsHomestead, IsEIP150, IsEIP155, IsEIP158                        bool
-	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul, IsCelo1 bool
+	ChainID                                                 *big.Int
+	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
+	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
+	IsChurrito, IsDonut                                     bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -517,6 +533,7 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsConstantinople: c.IsConstantinople(num),
 		IsPetersburg:     c.IsPetersburg(num),
 		IsIstanbul:       c.IsIstanbul(num),
-		IsCelo1:          c.IsCelo1(num),
+		IsChurrito:       c.IsChurrito(num),
+		IsDonut:          c.IsDonut(num),
 	}
 }

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 2          // Minor version component of the current release
-	VersionPatch = 1          // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1      // Major version component of the current release
+	VersionMinor = 2      // Minor version component of the current release
+	VersionPatch = 2      // Patch version component of the current release
+	VersionMeta  = "beta" // Version metadata to append to the version string
 )
 
 type VersionInfo struct {


### PR DESCRIPTION
### Description

Changes since 1.2.1:
* Churrito
* Fixes a bug in the proxied validator engine around epoch transitions
* Upgrades to Golang 1.14.12

This is 1.2.2-beta which sets the churrito block number for baklava, but not for the other testnets

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
