### PR TITLE
Notify proxied validator engine of new epoch

### DIFF
--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -320,7 +320,7 @@ func (sb *Backend) newChainHead(newBlock *types.Block) {
 
 	// If this is the last block of the epoch:
 	// * Print an easy to find log message giving our address and whether we're elected in next epoch.
-	// * If this is a proxy or a non proxied validator, refresh the validator enode table.
+	// * If this is a node maintaining validator connections (e.g. a proxy or a standalone validator), refresh the validator enode table.
 	// * If this is a proxied validator, notify the proxied validator engine of a new epoch.
 	if istanbul.IsLastBlockOfEpoch(newBlock.Number().Uint64(), sb.config.Epoch) {
 

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -337,6 +337,12 @@ func (sb *Backend) newChainHead(newBlock *types.Block) {
 				sb.logger.Warn("Error refreshing validator peers", "err", err)
 			}
 		}
+
+		if sb.IsProxiedValidator() {
+			if err := sb.proxiedValidatorEngine.NewEpoch(); err != nil {
+				sb.logger.Warn("Error while notifying proxied validator engine of new epoch", "err", err)
+			}
+		}
 	}
 
 	sb.blocksFinalizedTransactionsGauge.Update(int64(len(newBlock.Transactions())))

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -320,7 +320,8 @@ func (sb *Backend) newChainHead(newBlock *types.Block) {
 
 	// If this is the last block of the epoch:
 	// * Print an easy to find log message giving our address and whether we're elected in next epoch.
-	// * if this is a proxy or a non proxied validator, refresh the validator enode table.
+	// * If this is a proxy or a non proxied validator, refresh the validator enode table.
+	// * If this is a proxied validator, notify the proxied validator engine of a new epoch.
 	if istanbul.IsLastBlockOfEpoch(newBlock.Number().Uint64(), sb.config.Epoch) {
 
 		sb.coreMu.RLock()

--- a/consensus/istanbul/proxy/proxied_validator_engine.go
+++ b/consensus/istanbul/proxy/proxied_validator_engine.go
@@ -356,6 +356,22 @@ func (pv *proxiedValidatorEngine) SendForwardMsgToAllProxies(finalDestAddresses 
 	return nil
 }
 
+// NewEpoch will notify the proxied validator's thread that a new epoch started
+func (pv *proxiedValidatorEngine) NewEpoch() error {
+	if !pv.Running() {
+		return istanbul.ErrStoppedProxiedValidatorEngine
+	}
+
+	select {
+	case pv.newBlockchainEpoch <- struct{}{}:
+
+	case <-pv.quit:
+		return istanbul.ErrStoppedProxiedValidatorEngine
+	}
+
+	return nil
+}
+
 // run handles changes to proxies and validator assignments
 func (pv *proxiedValidatorEngine) threadRun() {
 	var (

--- a/consensus/istanbul/proxy/types.go
+++ b/consensus/istanbul/proxy/types.go
@@ -123,6 +123,9 @@ type ProxiedValidatorEngine interface {
 
 	// IsProxyPeer will check if the peerID is a proxy.
 	IsProxyPeer(peerID enode.ID) (bool, error)
+
+	// NewEpoch will notify the proxied validator's thread that a new epoch started
+	NewEpoch() error
 }
 
 // ==============================================


### PR DESCRIPTION
### Description

The proxied validator engine was not being notified of a new epoch, causing that engine to not be aware of any new validator set diffs, and consequently not assigning new validators to it's proxies and never connecting to them.

### Other changes

None

### Tested

- Unit tests
- Deployed patch to a few clabs validators and verified that they started signing all of their blocks.

### Backwards compatibility

Yes.