### PR TITLE
Disable DNS discovery by default

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1667,13 +1667,14 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	if ctx.GlobalIsSet(RPCGlobalGasCap.Name) {
 		cfg.RPCGasCap = new(big.Int).SetUint64(ctx.GlobalUint64(RPCGlobalGasCap.Name))
 	}
-	if ctx.GlobalIsSet(DNSDiscoveryFlag.Name) {
-		urls := ctx.GlobalString(DNSDiscoveryFlag.Name)
-		if urls == "" {
-			cfg.DiscoveryURLs = []string{}
-		} else {
-			cfg.DiscoveryURLs = splitAndTrim(urls)
-		}
+	// Disable DNS discovery by default (by using the flag's value even if it hasn't been set and so
+	// has the default value ""), since we don't have DNS discovery set up for Celo.
+	// Note that passing --discovery.dns "" is the way the Geth docs specify for disabling DNS discovery,
+	// so here we just make that be the default.
+	if urls := ctx.GlobalString(DNSDiscoveryFlag.Name); urls == "" {
+		cfg.DiscoveryURLs = []string{}
+	} else {
+		cfg.DiscoveryURLs = splitAndTrim(urls)
 	}
 
 	// Override any default configs for hard coded networks.


### PR DESCRIPTION
### Description

The DNS discovery code from upstream includes the URLs to use.  Since we haven't set up the nodes tree on DNS for use by DNS discovery, we have no URLs we can use for that.  I believed that having the url set to `""` was enough to disable it, because the docs say to disable it using `--discovery.dns ""`.  However, those are not equivalent, and it was leading to a crash.  So this PR modified the initialization code to work so that if you don't specify `--discovery.dns` it will behave as if you specified `--discovery.dns ""`.

This highlights a serious gap in our integration tests, that we have no test of non-light sync using discovery:
1. The e2e tests in the monorepo all use `--nodiscover`
2. `scripts/sync_test.sh` uses only lightest mode sync, but discovery isn't the same for light/lightest mode as for the other modes

I will open up a separate issue about fixing this gap in our integration tests.

### Tested

Running `geth` before this would crash.  After this fix, it starts syncing as it should.

### Backwards compatibility

Backwards compatible.
