### PR TITLE
Update ios build on CI to use go 1.14.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,10 +109,11 @@ jobs:
       - run:
           name: Setup Go language
           command: |
-            HOMEBREW_NO_AUTO_UPDATE=1 brew install go
+            brew install go@1.14
+            brew link go@1.14
             # Check that homebrew installed the expected go version
-            if [[ "$(go version)" != "go version go1.13"* ]]; then
-              echo "go1.13 is required"
+            if [[ "$(go version)" != "go version go1.14"* ]]; then
+              echo "go1.14 is required"
               exit 1
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ jobs:
       - run:
           name: Build Geth
           command: go run build/ci.go install
-      - run:
-          name: Save lib bls
-          command: cp $GOPATH/pkg/mod/github.com/celo-org/celo-bls-go@$(go list -m all | grep celo-bls-go | awk '{print $2}')/libs/universal/libbls_snark_sys.a ~/repos/geth/libbls_snark_sys.a
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:
@@ -123,6 +120,7 @@ jobs:
           root: ~/repos
           paths:
             - geth/build/bin/Geth.framework.tgz
+            - geth/libbls_snark_sys.a
 
   publish-mobile-client:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,12 @@ android:
 	@echo "Import \"$(GOBIN)/geth.aar\" to use the library."
 
 ios:
-	$(GORUN) build/ci.go xcode --local
+	DISABLE_BITCODE=true $(GORUN) build/ci.go xcode --local
 	pushd "$(GOBIN)"; rm -rf Geth.framework.tgz; tar -czvf Geth.framework.tgz Geth.framework; popd
+	# Geth.framework is a static framework, so we have to also keep the other static libs it depends on
+	# in order to link it to the final app
+	# One day gomobile will probably support xcframework which would solve this ;-)
+	cp -f "$$(go list -m -f "{{ .Dir }}" github.com/celo-org/celo-bls-go)/libs/universal/libbls_snark_sys.a" .
 	@echo "Done building."
 	@echo "Import \"$(GOBIN)/Geth.framework\" to use the library."
 

--- a/go.mod
+++ b/go.mod
@@ -73,3 +73,6 @@ require (
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )
+
+// Use our fork which disables bitcode
+replace golang.org/x/mobile => github.com/celo-org/mobile v0.0.0-20201127114005-6a1221213dcf

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/celo-org/celo-bls-go v0.1.6 h1:S9hfmKp02Wbd6k3GkCwc/1uCeg68ZP6JZ7qFGH
 github.com/celo-org/celo-bls-go v0.1.6/go.mod h1:eXUCLXu5F1yfd3M+3VaUk5ZUXaA0sLK2rWdLC1Cfaqo=
 github.com/celo-org/gosigar v0.10.5-celo1 h1:LbhCsvNot586MAVvGFVF4cekBAo1pAYfUxktl8VuPas=
 github.com/celo-org/gosigar v0.10.5-celo1/go.mod h1:/kPo9MOBSowZbtkqUg0tJ048OJJVjG8dpaHKwAgBLz4=
+github.com/celo-org/mobile v0.0.0-20201127114005-6a1221213dcf h1:vjXHjR4gf41rdPgg3XafcYgpxrj28zIAZ89KDTStL6U=
+github.com/celo-org/mobile v0.0.0-20201127114005-6a1221213dcf/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/scripts/publish-mobile-client.sh
+++ b/scripts/publish-mobile-client.sh
@@ -23,9 +23,6 @@ fi
 
 # TODO: Create an appropriate README for NPM
 rm README.md
-if [ -n "$GOPATH" ]; then
-  cp $GOPATH/pkg/mod/github.com/celo-org/celo-bls-go@$(go list -m all | grep celo-bls-go | awk '{print $2}')/libs/universal/libbls_snark_sys.a .
-fi
 
 npm -f --no-git-tag-version version "$new_version"
 npm publish --tag "$commit_sha_short" --access public -timeout=9999999


### PR DESCRIPTION
### Description

When we updated celo-blockchain to use Go 1.14.x, we left the CI ios build as is, because it was failing with an error.  This PR resolves that by:

1. Updating the ios build to use Go 1.14.x
2. (c/o @jeanregisser) Disabling bitcode for the ios build, which required creating and using a fork of https://github.com/golang/mobile (https://github.com/celo-org/mobile/tree/jeanregisser/disable-bitcode)
3. (c/o @jeanregisser) Refactoring how we include `libbls_snark_sys.a` in the build.