### PR TITLE
Disable bitcode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ jobs:
       - run:
           name: Build Geth
           command: go run build/ci.go install
-      - run:
-          name: Save lib bls
-          command: cp $GOPATH/pkg/mod/github.com/celo-org/celo-bls-go@$(go list -m all | grep celo-bls-go | awk '{print $2}')/libs/universal/libbls_snark_sys.a ~/repos/geth/libbls_snark_sys.a
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:
@@ -123,6 +120,7 @@ jobs:
           root: ~/repos
           paths:
             - geth/build/bin/Geth.framework.tgz
+            - geth/libbls_snark_sys.a
 
   publish-mobile-client:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ android:
 ios:
 	DISABLE_BITCODE=true $(GORUN) build/ci.go xcode --local
 	pushd "$(GOBIN)"; rm -rf Geth.framework.tgz; tar -czvf Geth.framework.tgz Geth.framework; popd
+	cp "$(shell go list -m -f "{{ .Dir }}" github.com/celo-org/celo-bls-go)/libs/universal/libbls_snark_sys.a" .
 	@echo "Done building."
 	@echo "Import \"$(GOBIN)/Geth.framework\" to use the library."
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ android:
 	@echo "Import \"$(GOBIN)/geth.aar\" to use the library."
 
 ios:
-	$(GORUN) build/ci.go xcode --local
+	DISABLE_BITCODE=true $(GORUN) build/ci.go xcode --local
 	pushd "$(GOBIN)"; rm -rf Geth.framework.tgz; tar -czvf Geth.framework.tgz Geth.framework; popd
 	@echo "Done building."
 	@echo "Import \"$(GOBIN)/Geth.framework\" to use the library."

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ android:
 ios:
 	DISABLE_BITCODE=true $(GORUN) build/ci.go xcode --local
 	pushd "$(GOBIN)"; rm -rf Geth.framework.tgz; tar -czvf Geth.framework.tgz Geth.framework; popd
+	# Geth.framework is a static framework, so we have to also keep the other static libs it depends on
+	# in order to link it to the final app
+	# One day gomobile will probably support xcframework which would solve this ;-)
 	cp "$(shell go list -m -f "{{ .Dir }}" github.com/celo-org/celo-bls-go)/libs/universal/libbls_snark_sys.a" .
 	@echo "Done building."
 	@echo "Import \"$(GOBIN)/Geth.framework\" to use the library."

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ ios:
 	# Geth.framework is a static framework, so we have to also keep the other static libs it depends on
 	# in order to link it to the final app
 	# One day gomobile will probably support xcframework which would solve this ;-)
-	cp "$(shell go list -m -f "{{ .Dir }}" github.com/celo-org/celo-bls-go)/libs/universal/libbls_snark_sys.a" .
+	cp -f "$$(go list -m -f "{{ .Dir }}" github.com/celo-org/celo-bls-go)/libs/universal/libbls_snark_sys.a" .
 	@echo "Done building."
 	@echo "Import \"$(GOBIN)/Geth.framework\" to use the library."
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -984,17 +984,6 @@ func doXCodeFramework(cmdline []string) {
 
 	// Build the iOS XCode framework
 	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile", "golang.org/x/mobile/cmd/gobind"))
-
-	// Patch gomobile to disable bitcode for now (rust generated bls lib output is not compatible)
-	listOutput, err := goTool("list", "-m", "-f", "{{ .Dir }}", "golang.org/x/mobile").Output()
-	if err != nil {
-		log.Fatal(err)
-	}
-	gomobileDir := strings.TrimSpace(string(listOutput))
-	gomobileEnvFile := filepath.Join(gomobileDir, "cmd/gomobile/env.go")
-	build.MustRunCommand("chmod", "+w", filepath.Join(gomobileEnvFile, ".."))
-	build.MustRunCommand("sed", "-i", "", `/^[[:space:]]*cflags += \" -fembed-bitcode\"$/s/^/\/\//`, gomobileEnvFile)
-
 	bind := gomobileTool("bind", "-ldflags", "-s -w", "--target", "ios", "-v", "github.com/ethereum/go-ethereum/mobile")
 
 	if *local {

--- a/build/ci.go
+++ b/build/ci.go
@@ -984,6 +984,17 @@ func doXCodeFramework(cmdline []string) {
 
 	// Build the iOS XCode framework
 	build.MustRun(goTool("get", "golang.org/x/mobile/cmd/gomobile", "golang.org/x/mobile/cmd/gobind"))
+
+	// Patch gomobile to disable bitcode for now (rust generated bls lib output is not compatible)
+	listOutput, err := goTool("list", "-m", "-f", "{{ .Dir }}", "golang.org/x/mobile").Output()
+	if err != nil {
+		log.Fatal(err)
+	}
+	gomobileDir := strings.TrimSpace(string(listOutput))
+	gomobileEnvFile := filepath.Join(gomobileDir, "cmd/gomobile/env.go")
+	build.MustRunCommand("chmod", "+w", filepath.Join(gomobileEnvFile, ".."))
+	build.MustRunCommand("sed", "-i", "", `/^[[:space:]]*cflags += \" -fembed-bitcode\"$/s/^/\/\//`, gomobileEnvFile)
+
 	bind := gomobileTool("bind", "-ldflags", "-s -w", "--target", "ios", "-v", "github.com/ethereum/go-ethereum/mobile")
 
 	if *local {

--- a/go.mod
+++ b/go.mod
@@ -73,3 +73,6 @@ require (
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )
+
+// Use our fork which disables bitcode
+replace golang.org/x/mobile => github.com/celo-org/mobile v0.0.0-20201127114005-6a1221213dcf

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/celo-org/celo-bls-go v0.1.6 h1:S9hfmKp02Wbd6k3GkCwc/1uCeg68ZP6JZ7qFGH
 github.com/celo-org/celo-bls-go v0.1.6/go.mod h1:eXUCLXu5F1yfd3M+3VaUk5ZUXaA0sLK2rWdLC1Cfaqo=
 github.com/celo-org/gosigar v0.10.5-celo1 h1:LbhCsvNot586MAVvGFVF4cekBAo1pAYfUxktl8VuPas=
 github.com/celo-org/gosigar v0.10.5-celo1/go.mod h1:/kPo9MOBSowZbtkqUg0tJ048OJJVjG8dpaHKwAgBLz4=
+github.com/celo-org/mobile v0.0.0-20201127114005-6a1221213dcf h1:vjXHjR4gf41rdPgg3XafcYgpxrj28zIAZ89KDTStL6U=
+github.com/celo-org/mobile v0.0.0-20201127114005-6a1221213dcf/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/scripts/publish-mobile-client.sh
+++ b/scripts/publish-mobile-client.sh
@@ -23,9 +23,6 @@ fi
 
 # TODO: Create an appropriate README for NPM
 rm README.md
-if [ -n "$GOPATH" ]; then
-  cp $GOPATH/pkg/mod/github.com/celo-org/celo-bls-go@$(go list -m all | grep celo-bls-go | awk '{print $2}')/libs/universal/libbls_snark_sys.a .
-fi
 
 npm -f --no-git-tag-version version "$new_version"
 npm publish --tag "$commit_sha_short" --access public -timeout=9999999


### PR DESCRIPTION
### Description

The work here disables bitcode so that the build works again on iOS using go 1.14
- Had to fork gomobile to patch this, PR submitted upstream https://github.com/golang/mobile/pull/59
- Move `libbls_snark_sys` handling to the Makefile and iOS step and explain why we need it

### Tested

- iOS build compiles again locally and on CircleCI
- was able to sync, send money using a local build connected to alfajores on iOS

### Backwards compatibility

Yes
