### PR TITLE
Cherry-pick: accounts/keystore: fix flaky test (#21703)

### DIFF
--- a/accounts/keystore/keystore_test.go
+++ b/accounts/keystore/keystore_test.go
@@ -355,7 +355,9 @@ func TestWalletNotifications(t *testing.T) {
 
 	// Shut down the event collector and check events.
 	sub.Unsubscribe()
-	<-updates
+	for ev := range updates {
+		events = append(events, walletEvent{ev, ev.Wallet.Accounts()[0]})
+	}
 	checkAccounts(t, live, ks.Wallets())
 	checkEvents(t, wantEvents, events)
 }


### PR DESCRIPTION
Cherry-pick https://github.com/ethereum/go-ethereum/pull/21703 from upstream to fix the flaky test `TestWalletNotifications`.

### Tested

* Tests pass locally and in CI

### Related issues

- Fixes #782

### Backwards compatibility

No concerns, only modifies a test, unrelated to protocol.
