### PR TITLE
Make LES server not run by default, and tweak related flags

### DIFF
--- a/cmd/geth/consolecmd_test.go
+++ b/cmd/geth/consolecmd_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	ipcAPIs  = "admin:1.0 debug:1.0 eth:1.0 istanbul:1.0 les:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 shh:1.0 txpool:1.0 web3:1.0"
+	ipcAPIs  = "admin:1.0 debug:1.0 eth:1.0 istanbul:1.0 miner:1.0 net:1.0 personal:1.0 rpc:1.0 shh:1.0 txpool:1.0 web3:1.0"
 	httpAPIs = "eth:1.0 net:1.0 rpc:1.0 web3:1.0"
 )
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1169,10 +1169,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	lightClient := ctx.GlobalString(SyncModeFlag.Name) == "light"
 	lightServer := ctx.GlobalInt(LightServeFlag.Name) != 0
 
-	lightPeers := 0
-	if ctx.GlobalIsSet(LightMaxPeersFlag.Name) {
-		lightPeers = ctx.GlobalInt(LightMaxPeersFlag.Name)
-	}
+	// LightPeers is in the eth config, not the p2p config, so we don't have it here, so we
+	// get it here separately using GlobalInt()
+	lightPeers := ctx.GlobalInt(LightMaxPeersFlag.Name)
 	if lightClient && !ctx.GlobalIsSet(LightMaxPeersFlag.Name) {
 		// dynamic default - for clients we use 1/10th of the default for servers
 		lightPeers /= 10

--- a/eth/config.go
+++ b/eth/config.go
@@ -33,7 +33,7 @@ var DefaultConfig = Config{
 	SyncMode:           downloader.FastSync,
 	NetworkId:          1,
 	LightPeers:         100,
-	LightServ:          50,
+	LightServ:          0,
 	UltraLightFraction: 75,
 	DatabaseCache:      768,
 	TrieCleanCache:     256,

--- a/eth/config.go
+++ b/eth/config.go
@@ -32,7 +32,7 @@ import (
 var DefaultConfig = Config{
 	SyncMode:           downloader.FastSync,
 	NetworkId:          1,
-	LightPeers:         99,
+	LightPeers:         100,
 	LightServ:          50,
 	UltraLightFraction: 75,
 	DatabaseCache:      768,


### PR DESCRIPTION
### Description

This changes the `light.serve` default back to zero so that serving light clients becomes opt-in rather than opt-out.  The reason is that there are many use-cases for running a node that don't involve light clients, and only one use-case that is about serving light clients, so it makes more sense to have it opt-in to avoid people running the light server without realizing it.

### Other changes

* Change `light.maxpeers` default value from 99 back to 100 (the change to 99 was to work around an issue that no longer exists, see below under "Related issues")
* Fix a bug in the logic for the `lightPeers` variable in `SetP2PConfig()` (it was not respecting the default value of LightPeers, leading to incorrect values in the `Maximum peer count` log line and to `MaxPeers` not being increased when it should have been.

### Tested

* Automated tests pass
* Without specifying any flags, LES is off, max peers is 175
* Specifying `--light.serve 100`, LES is on, total max peers is 275, max eth peers is 175, max light peers is 100
* Specifying `--light.serve 100 --light.maxpeers 200`, LES is on, total max peers is 375, max eth peers is 175, max light peers is 200
* Specifying `--light.serve 100 --maxpeers 150`, LES is on, total max peers is 250, max eth peers is 150, max light peers is 100
* Specifying `--light.serve 100 --light.maxpeers 1000 --maxpeers 100`, LES is on, total max peers is 1100, max eth peers is 100, max light peers is 1000 (these are the flag values recommended in the docs for serving light clients, and are based on the fact that if (and only if) you specify both `light.maxpeers` and `maxpeers` then `maxpeers` is assumed to include `light.maxpeers`)

### Related issues

- Closes #1262
- Additional context: #395, #416, #864 

### Backwards compatibility

Breaking change to the defaults, most notably `--light.serve`, but with limited impact, because in the docs for running a full node we specify `--light.serve`, `--light.maxpeers` and `--maxpeers`, so it's not relying on the defaults anyway.  And for users who are not intending to serve light clients, the new defaults make more sense.
