### PR TITLE
Bump up the CI resource_class for unit tests and coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
             - geth
   unit-tests:
     executor: golang
+    resource_class: medium+
     steps:
       - attach_workspace:
           at: ~/repos
@@ -56,6 +57,7 @@ jobs:
 
   coverage:
     executor: golang
+    resource_class: medium+
     steps:
       - attach_workspace:
           at: ~/repos


### PR DESCRIPTION
This changes them to use medium+ instead of the default medium, which should help with flaky tests where the machine is overloaded and which don't happen on dev machines since they're more powerful (e.g. #629). If the failures keep happening, we can either (a) increase further to large, (b) increase the waits in the tests, (c) make those specific tests not run using `t.Parallel()`.