### PR TITLE
Cleanup validator uptime computation

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -111,6 +111,7 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 		blocksFinalizedTransactionsGauge:   metrics.NewRegisteredGauge("consensus/istanbul/blocks/transactions", nil),
 		blocksFinalizedGasUsedGauge:        metrics.NewRegisteredGauge("consensus/istanbul/blocks/gasused", nil),
 	}
+
 	backend.core = istanbulCore.New(backend, backend.config)
 
 	backend.logger = istanbul.NewIstLogger(

--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -136,7 +136,8 @@ func (sb *Backend) updateValidatorScores(header *types.Header, state *state.Stat
 	logger.Trace("Updating validator scores")
 
 	// The denominator is the (last block - first block + 1) of the val score tally window
-	denominator := istanbul.GetValScoreTallyLastBlockNumber(epoch, sb.EpochSize()) - istanbul.GetValScoreTallyFirstBlockNumber(epoch, sb.EpochSize(), sb.LookbackWindow()) + 1
+	monitorStart, monitorEnd := istanbul.GetUptimeMonitoringWindow(epoch, sb.EpochSize(), sb.LookbackWindow())
+	denominator := monitorEnd - monitorStart + 1
 
 	uptimes := make([]*big.Int, 0, len(valSet))
 	accumulated := rawdb.ReadAccumulatedEpochUptime(sb.db, epoch)

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -48,25 +48,6 @@ type BLSSignerFn func(accounts.Account, []byte, []byte, bool) (blscrypto.Seriali
 // backing account.
 type HashSignerFn func(accounts.Account, []byte) ([]byte, error)
 
-// UptimeEntry contains the uptime score of a validator during an epoch as well as the
-// last block they signed on
-type UptimeEntry struct {
-	ScoreTally      uint64
-	LastSignedBlock uint64
-}
-
-func (u *UptimeEntry) String() string {
-	return fmt.Sprintf("UptimeEntry { scoreTally: %v, lastBlock: %v}", u.ScoreTally, u.LastSignedBlock)
-}
-
-// Uptime contains the latest block for which uptime metrics were accounted for. It also contains
-// an array of Entries where the `i`th entry represents the uptime statistics of the `i`th validator
-// in the validator set for that epoch
-type Uptime struct {
-	LatestBlock uint64
-	Entries     []UptimeEntry
-}
-
 // Proposal supports retrieving height and serialized block to be used during Istanbul consensus.
 type Proposal interface {
 	// Number retrieves the sequence number of this proposal.

--- a/consensus/istanbul/uptime/store/store.go
+++ b/consensus/istanbul/uptime/store/store.go
@@ -1,0 +1,24 @@
+package store
+
+import (
+	"github.com/ethereum/go-ethereum/consensus/istanbul/uptime"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+)
+
+type uptimeStoreImpl struct {
+	db ethdb.Database
+}
+
+func New(db ethdb.Database) uptime.Store {
+	return &uptimeStoreImpl{
+		db: db,
+	}
+}
+
+func (us *uptimeStoreImpl) ReadAccumulatedEpochUptime(epoch uint64) *uptime.Uptime {
+	return rawdb.ReadAccumulatedEpochUptime(us.db, epoch)
+}
+func (us *uptimeStoreImpl) WriteAccumulatedEpochUptime(epoch uint64, uptime *uptime.Uptime) {
+	rawdb.WriteAccumulatedEpochUptime(us.db, epoch, uptime)
+}

--- a/consensus/istanbul/uptime/uptime.go
+++ b/consensus/istanbul/uptime/uptime.go
@@ -1,0 +1,242 @@
+package uptime
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// Store provides a persistent storage for uptime entries
+type Store interface {
+	ReadAccumulatedEpochUptime(epoch uint64) *Uptime
+	WriteAccumulatedEpochUptime(epoch uint64, uptime *Uptime)
+}
+
+// Uptime contains the latest block for which uptime metrics were accounted for. It also contains
+// an array of Entries where the `i`th entry represents the uptime statistics of the `i`th validator
+// in the validator set for that epoch
+type Uptime struct {
+	LatestBlock uint64
+	Entries     []UptimeEntry
+}
+
+// UptimeEntry contains the uptime score of a validator during an epoch as well as the
+// last block they signed on
+type UptimeEntry struct {
+	ScoreTally      uint64
+	LastSignedBlock uint64
+}
+
+func (u *UptimeEntry) String() string {
+	return fmt.Sprintf("UptimeEntry { scoreTally: %v, lastBlock: %v}", u.ScoreTally, u.LastSignedBlock)
+}
+
+// GetUptimeMonitoringWindow retrieves the range [first block, last block] where uptime is to be monitored
+// for a give epoch. The range is inclusive.
+// First blocks of an epoch need to be skipped since we can't assess the last `lookbackWindow` block for validators
+// as those are froma different epoch.
+// Similarly, last block of epoch is skipped since we can't obtaine the signer for it; as they are in the next block
+func GetUptimeMonitoringWindow(epochNumber uint64, epochSize uint64, lookbackWindowSize uint64) (uint64, uint64) {
+	if epochNumber == 0 {
+		panic("no monitoring window for epoch 0")
+	}
+
+	epochFirstBlock, _ := istanbul.GetEpochFirstBlockNumber(epochNumber, epochSize)
+	epochLastBlock := istanbul.GetEpochLastBlockNumber(epochNumber, epochSize)
+
+	// first block to monitor:
+	// We need to wait for the completion of the first window with the start window's block being the
+	// 2nd block of the epoch, before we start tallying the validator score for epoch "epochNumber".
+	// We can't include the epoch's first block since it's aggregated parent seals
+	// is for the previous epoch's valset.
+	firstBlockToMonitor := epochFirstBlock + 1 + (lookbackWindowSize - 1)
+
+	// last block to monitor:
+	// We stop tallying for epoch "epochNumber" at the second to last block of that epoch.
+	// We can't include that epoch's last block as part of the tally because the epoch val score is calculated
+	// using a tally that is updated AFTER a block is finalized.
+	// Note that it's possible to count up to the last block of the epoch, but it's much harder to implement
+	// than couting up to the second to last one.
+	lastBlockToMonitor := epochLastBlock - 1
+
+	return firstBlockToMonitor, lastBlockToMonitor
+}
+
+// Monitor is responsible for monitoring uptime
+// by processing blocks
+type Monitor struct {
+	epochSize      uint64
+	lookbackWindow uint64
+
+	logger log.Logger
+	store  Store
+}
+
+// NewMonitor creates a new uptime monitor
+func NewMonitor(store Store, epochSize, lookbackWindow uint64) *Monitor {
+	return &Monitor{
+		epochSize:      epochSize,
+		lookbackWindow: lookbackWindow,
+		store:          store,
+		logger:         log.New("module", "uptime-monitor"),
+	}
+}
+
+// MonitoringWindow returns the monitoring window for the given epoch in the format
+// [firstBlock, lastBlock] both inclusive
+func (um *Monitor) MonitoringWindow(epoch uint64) (uint64, uint64) {
+	return GetUptimeMonitoringWindow(epoch, um.epochSize, um.lookbackWindow)
+}
+
+// MonitoringWindowSize returns the size (in blocks) of the monitoring window
+func (um *Monitor) MonitoringWindowSize(epoch uint64) uint64 {
+	start, end := um.MonitoringWindow(epoch)
+	return end - start + 1
+}
+
+// ComputeValidatorsUptime retrieves the uptime score for each validator for a given epoch
+func (um *Monitor) ComputeValidatorsUptime(epoch uint64, valSetSize int) ([]*big.Int, error) {
+	logger := um.logger.New("func", "Backend.updateValidatorScores", "epoch", epoch)
+	logger.Trace("Updating validator scores")
+
+	// The denominator is the (last block - first block + 1) of the val score tally window
+	denominator := um.MonitoringWindowSize(epoch)
+
+	uptimes := make([]*big.Int, 0, valSetSize)
+	accumulated := um.store.ReadAccumulatedEpochUptime(epoch)
+
+	if accumulated == nil {
+		err := errors.New("Accumulated uptimes not found, cannot update validator scores")
+		logger.Error(err.Error())
+		return nil, err
+	}
+
+	for i, entry := range accumulated.Entries {
+		if i >= valSetSize {
+			break
+		}
+
+		if entry.ScoreTally > denominator {
+			logger.Error("ScoreTally exceeds max possible", "scoreTally", entry.ScoreTally, "denominator", denominator, "valIdx", i)
+			uptimes = append(uptimes, params.Fixidity1)
+			continue
+		}
+
+		numerator := big.NewInt(0).Mul(big.NewInt(int64(entry.ScoreTally)), params.Fixidity1)
+		uptimes = append(uptimes, big.NewInt(0).Div(numerator, big.NewInt(int64(denominator))))
+	}
+
+	if len(uptimes) < valSetSize {
+		err := fmt.Errorf("%d accumulated uptimes found, cannot update validator scores", len(uptimes))
+		logger.Error(err.Error())
+		return nil, err
+	}
+
+	return uptimes, nil
+}
+
+// ProcessBlock will monitor uptimeness information on the give block and add it to current epoch tally
+func (um *Monitor) ProcessBlock(block *types.Block) error {
+	// The epoch's first block's aggregated parent signatures is for the previous epoch's valset.
+	// We can ignore updating the tally for that block.
+	if istanbul.IsFirstBlockOfEpoch(block.NumberU64(), um.epochSize) {
+		return nil
+	}
+
+	// Get the bitmap from the previous block
+	extra, err := types.ExtractIstanbulExtra(block.Header())
+	if err != nil {
+		um.logger.Error("Unable to extract istanbul extra", "func", "ProcessBlock", "blocknum", block.NumberU64())
+		return errors.New("could not extract block header extra")
+	}
+	signedValidatorsBitmap := extra.ParentAggregatedSeal.Bitmap
+
+	// Get the uptime scores
+	epochNum := istanbul.GetEpochNumber(block.NumberU64(), um.epochSize)
+	uptime := um.store.ReadAccumulatedEpochUptime(epochNum)
+
+	// We only update the uptime for blocks which are greater than the last block we saw.
+	// This ensures that we do not count the same block twice for any reason.
+	if uptime == nil || uptime.LatestBlock < block.NumberU64() {
+		uptime = updateUptime(uptime, block.NumberU64(), signedValidatorsBitmap, um.lookbackWindow, epochNum, um.epochSize)
+		um.store.WriteAccumulatedEpochUptime(epochNum, uptime)
+	} else {
+		log.Trace("WritingBlockWithState with block number less than a block we previously wrote", "latestUptimeBlock", uptime.LatestBlock, "blockNumber", block.NumberU64())
+	}
+
+	return nil
+}
+
+// updateUptime receives the currently accumulated uptime for all validators in an epoch and proceeds to update it
+// based on which validators signed on the provided block by inspecting the block's parent bitmap
+//
+// It expects a blockNumber with the signatures bitmap from the previous block (parent seal)
+func updateUptime(uptime *Uptime, blockNumber uint64, bitmap *big.Int, window uint64, epochNum uint64, epochSize uint64) *Uptime {
+	if uptime == nil {
+		uptime = new(Uptime)
+		// The number of validators is upper bounded by 3/2 of the number of 1s in the bitmap
+		// We multiply by 2 just to be extra cautious of off-by-one errors.
+		validatorsSizeUpperBound := uint64(math.Ceil(float64(bitCount(bitmap)) * 2))
+		uptime.Entries = make([]UptimeEntry, validatorsSizeUpperBound)
+	}
+
+	firstBlockToMonitor, lastBlockToMonitor := GetUptimeMonitoringWindow(epochNum, epochSize, window)
+
+	// lookbackBlockNum := (blockNumber -1) - window
+
+	// signedBlockWindowLastBlockNum is just the previous block
+	signedBlockWindowLastBlockNum := blockNumber - 1
+	signedBlockWindowFirstBlockNum := signedBlockWindowLastBlockNum - (window - 1)
+
+	uptime.LatestBlock = blockNumber
+	for i := 0; i < len(uptime.Entries); i++ {
+		if bitmap.Bit(i) == 1 {
+			// update their latest signed block
+			uptime.Entries[i].LastSignedBlock = blockNumber - 1
+		}
+
+		// If we are within the validator uptime tally window, then update the validator's score
+		// if its last signed block is within the lookback window
+		if blockNumber >= firstBlockToMonitor && blockNumber <= lastBlockToMonitor {
+			lastSignedBlock := uptime.Entries[i].LastSignedBlock
+
+			// Note that the second condition in the if condition is not necessary.  But it does
+			// make the logic easier to understand.  (e.g. it's checking is lastSignedBlock is within
+			// the range [signedBlockWindowFirstBlockNum, signedBlockWindowLastBlockNum])
+			if lastSignedBlock >= signedBlockWindowFirstBlockNum && lastSignedBlock <= signedBlockWindowLastBlockNum {
+				uptime.Entries[i].ScoreTally++
+			}
+		}
+	}
+	return uptime
+}
+
+// https://stackoverflow.com/questions/19105791/is-there-a-big-bitcount/32702348#32702348
+func bitCount(n *big.Int) int {
+	count := 0
+	for _, v := range n.Bits() {
+		count += popcount(uint64(v))
+	}
+	return count
+}
+
+// Straight and simple C to Go translation from https://en.wikipedia.org/wiki/Hamming_weight
+func popcount(x uint64) int {
+	const (
+		m1  = 0x5555555555555555 //binary: 0101...
+		m2  = 0x3333333333333333 //binary: 00110011..
+		m4  = 0x0f0f0f0f0f0f0f0f //binary:  4 zeros,  4 ones ...
+		h01 = 0x0101010101010101 //the sum of 256 to the power of 0,1,2,3...
+	)
+	x -= (x >> 1) & m1             //put count of each 2 bits into those 2 bits
+	x = (x & m2) + ((x >> 2) & m2) //put count of each 4 bits into those 4 bits
+	x = (x + (x >> 4)) & m4        //put count of each 8 bits into those 8 bits
+	return int((x * h01) >> 56)    //returns left 8 bits of x + (x<<8) + (x<<16) + (x<<24) + ...
+}

--- a/consensus/istanbul/uptime/uptime.go
+++ b/consensus/istanbul/uptime/uptime.go
@@ -52,7 +52,7 @@ func MonitoringWindow(epochNumber uint64, epochSize uint64, lookbackWindowSize u
 	// first block to monitor:
 	// we can't monitor uptime when current lookbackWindow crosses the epoch boundary
 	// thus, first block to monitor is the final block of the lookbackwindow that starts at firstBlockOfEpoch
-	firstBlockToMonitor := newWindowStartingOn(epochFirstBlock, lookbackWindowSize).End
+	firstBlockToMonitor := newWindowStartingAt(epochFirstBlock, lookbackWindowSize).End
 
 	// last block to monitor:
 	// Last 2 blocks from the epoch are removed from the window
@@ -174,7 +174,7 @@ func updateUptime(uptime *Uptime, blockNumber uint64, bitmap *big.Int, lookbackW
 	}
 
 	// Obtain current lookback window
-	currentLookbackWindow := newWindowEndingOn(blockNumber, lookbackWindowSize)
+	currentLookbackWindow := newWindowEndingAt(blockNumber, lookbackWindowSize)
 
 	for i := 0; i < len(uptime.Entries); i++ {
 		if bitmap.Bit(i) == 1 {

--- a/consensus/istanbul/uptime/uptime.go
+++ b/consensus/istanbul/uptime/uptime.go
@@ -40,10 +40,7 @@ func (u *UptimeEntry) String() string {
 }
 
 // MonitoringWindow retrieves the block window where uptime is to be monitored
-// for a given epoch. The range is inclusive.
-// We do not monitor while the lookback window crosses the epoch boundary; since we can only analyze window when the window
-// (block range) belongs to a single block (thus initial epoch blocks are skipped)
-// Similarly, last block of epoch is skipped since we can't obtain the signer for it; as they are in the next block
+// for a given epoch.
 func MonitoringWindow(epochNumber uint64, epochSize uint64, lookbackWindowSize uint64) Window {
 	if epochNumber == 0 {
 		panic("no monitoring window for epoch 0")
@@ -59,7 +56,7 @@ func MonitoringWindow(epochNumber uint64, epochSize uint64, lookbackWindowSize u
 
 	// last block to monitor:
 	// Last 2 blocks from the epoch are removed from the window
-	// lastBlock     => it's parentSeal is on firstBlock of next epoch
+	// lastBlock     => its parentSeal is on firstBlock of next epoch
 	// lastBlock - 1 => parentSeal is on lastBlockOfEpoch, but validatorScore is computed with lastBlockOfEpoch and before updating scores
 	// (lastBlock-1 could be counted, but much harder to implement)
 	lastBlockToMonitor := epochLastBlock - 2
@@ -166,8 +163,8 @@ func (um *Monitor) ProcessBlock(block *types.Block) error {
 	return nil
 }
 
-// updateUptime update accumulated uptime given a block and its validator's signatures bitmap
-func updateUptime(uptime *Uptime, blockNumber uint64, bitmap *big.Int, lookbackWindowSize uint64, monitoredWindow Window) *Uptime {
+// updateUptime updates the accumulated uptime given a block and its validator's signatures bitmap
+func updateUptime(uptime *Uptime, blockNumber uint64, bitmap *big.Int, lookbackWindowSize uint64, monitoringWindow Window) *Uptime {
 	if uptime == nil {
 		uptime = new(Uptime)
 		// The number of validators is upper bounded by 3/2 of the number of 1s in the bitmap
@@ -186,7 +183,7 @@ func updateUptime(uptime *Uptime, blockNumber uint64, bitmap *big.Int, lookbackW
 		}
 
 		// If block number is to be monitored, then check if lastSignedBlock is within current lookback window
-		if monitoredWindow.Contains(blockNumber) && currentLookbackWindow.Contains(uptime.Entries[i].LastSignedBlock) {
+		if monitoringWindow.Contains(blockNumber) && currentLookbackWindow.Contains(uptime.Entries[i].LastSignedBlock) {
 			// since within currentLookbackWindow there's at least one signed block (lastSignedBlock) validator is considered UP
 			uptime.Entries[i].UpBlocks++
 		}

--- a/consensus/istanbul/uptime/uptime_test.go
+++ b/consensus/istanbul/uptime/uptime_test.go
@@ -1,0 +1,124 @@
+package uptime
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+)
+
+func TestGetUptimeMonitoringWindow(t *testing.T) {
+	type args struct {
+		epochNumber        uint64
+		epochSize          uint64
+		lookbackWindowSize uint64
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  uint64
+		want1 uint64
+	}{
+		{"tally on first epoch", args{1, 10, 2}, 1 + 2, 9},
+		{"tally on second epoch", args{2, 10, 2}, 11 + 2, 19},
+		{"lookback window too big", args{1, 10, 10}, 11, 9},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetUptimeMonitoringWindow(tt.args.epochNumber, tt.args.epochSize, tt.args.lookbackWindowSize)
+			if got != tt.want {
+				t.Errorf("GetUptimeMonitoringWindow() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetUptimeMonitoringWindow() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func TestUptime(t *testing.T) {
+	var uptimes *Uptime
+	// (there can't be less than 2/3rds of validators sigs in a valid bitmap)
+	bitmaps := []*big.Int{
+		big.NewInt(3), // 011     // Parent aggregated seal for block #1
+		big.NewInt(7), // 111
+		big.NewInt(5), // 101
+		big.NewInt(3), // 011
+		big.NewInt(5), // 101
+		big.NewInt(7), // 111
+		big.NewInt(5), // 101     // Parent aggregated seal for block #7
+	}
+	// assume the first block is the first epoch's block (ie not the genesis)
+	block := uint64(1)
+	for _, bitmap := range bitmaps {
+		// use a window of 2 blocks - ideally we want to expand
+		// these tests to increase our confidence
+		uptimes = updateUptime(uptimes, block, bitmap, 2, 1, 10)
+		block++
+	}
+
+	expected := &Uptime{
+		LatestBlock: 7,
+		Entries: []UptimeEntry{
+			{
+				ScoreTally:      5,
+				LastSignedBlock: 6,
+			},
+			{
+				ScoreTally:      5,
+				LastSignedBlock: 5,
+			},
+			{
+				ScoreTally:      5,
+				LastSignedBlock: 6,
+			},
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 0,
+			},
+		},
+	}
+	if !reflect.DeepEqual(uptimes, expected) {
+		t.Fatalf("uptimes were not updated correctly, got %v, expected %v", uptimes, expected)
+	}
+}
+
+func TestUptimeSingle(t *testing.T) {
+	var uptimes *Uptime
+	uptimes = updateUptime(uptimes, 212, big.NewInt(7), 3, 2, 211)
+	// the first 2 uptime updates do not get scored since they're within the
+	// first window after the epoch block
+	expected := &Uptime{
+		LatestBlock: 212,
+		Entries: []UptimeEntry{
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 211,
+			},
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 211,
+			},
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 211,
+			},
+			// plus 2 dummies due to the *2
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 0,
+			},
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 0,
+			},
+			{
+				ScoreTally:      0,
+				LastSignedBlock: 0,
+			},
+		},
+	}
+	if !reflect.DeepEqual(uptimes, expected) {
+		t.Fatalf("uptimes were not updated correctly, got %v, expected %v", uptimes, expected)
+	}
+}

--- a/consensus/istanbul/uptime/uptime_test.go
+++ b/consensus/istanbul/uptime/uptime_test.go
@@ -18,8 +18,8 @@ func TestGetUptimeMonitoringWindow(t *testing.T) {
 		want  uint64
 		want1 uint64
 	}{
-		{"tally on first epoch", args{1, 10, 2}, 1 + 2, 9},
-		{"tally on second epoch", args{2, 10, 2}, 11 + 2, 19},
+		{"monitoringWindow on first epoch", args{1, 10, 2}, 3, 9},
+		{"monitoringWindow on second epoch", args{2, 10, 2}, 13, 19},
 		{"lookback window too big", args{1, 10, 10}, 11, 9},
 		// TODO: Add test cases.
 	}

--- a/consensus/istanbul/uptime/window.go
+++ b/consensus/istanbul/uptime/window.go
@@ -1,0 +1,36 @@
+package uptime
+
+func newWindowEndingOn(end uint64, size uint64) Window {
+	// being incluse range math then size is:
+	// size = end - start + 1
+	// and thus start is:
+	// start = end - size + 1
+	return Window{
+		Start: end - size + 1,
+		End:   end,
+	}
+}
+
+func newWindowStartingOn(start uint64, size uint64) Window {
+	// being incluse range math then size is:
+	// size = end - start + 1
+	// and thus end is:
+	// end = start + size - 1
+	return Window{
+		Start: start,
+		End:   start + size - 1,
+	}
+}
+
+// Window tipyfies a block range related to uptime monitoring
+type Window struct {
+	Start uint64
+	End   uint64
+}
+
+// Size returns the size of the window.
+// Window block ranges are inclusive
+func (w Window) Size() uint64 { return w.End - w.Start + 1 }
+
+// Contains indidicates if a block number is contained within the window
+func (w Window) Contains(n uint64) bool { return n <= w.End && n >= w.Start }

--- a/consensus/istanbul/uptime/window.go
+++ b/consensus/istanbul/uptime/window.go
@@ -1,7 +1,7 @@
 package uptime
 
-func newWindowEndingOn(end uint64, size uint64) Window {
-	// being incluse range math then size is:
+func newWindowEndingAt(end uint64, size uint64) Window {
+	// being inclusive range math then size is:
 	// size = end - start + 1
 	// and thus start is:
 	// start = end - size + 1
@@ -11,8 +11,8 @@ func newWindowEndingOn(end uint64, size uint64) Window {
 	}
 }
 
-func newWindowStartingOn(start uint64, size uint64) Window {
-	// being incluse range math then size is:
+func newWindowStartingAt(start uint64, size uint64) Window {
+	// being inclusive range math then size is:
 	// size = end - start + 1
 	// and thus end is:
 	// end = start + size - 1
@@ -22,14 +22,14 @@ func newWindowStartingOn(start uint64, size uint64) Window {
 	}
 }
 
-// Window tipyfies a block range related to uptime monitoring
+// Window represents a block range related to uptime monitoring
+// Block range goes from `Start` to `End` and it's inclusive
 type Window struct {
 	Start uint64
 	End   uint64
 }
 
 // Size returns the size of the window.
-// Window block ranges are inclusive
 func (w Window) Size() uint64 { return w.End - w.Start + 1 }
 
 // Contains indidicates if a block number is contained within the window

--- a/consensus/istanbul/uptime/window.go
+++ b/consensus/istanbul/uptime/window.go
@@ -32,5 +32,5 @@ type Window struct {
 // Size returns the size of the window.
 func (w Window) Size() uint64 { return w.End - w.Start + 1 }
 
-// Contains indidicates if a block number is contained within the window
+// Contains indicates if a block number is contained within the window
 func (w Window) Contains(n uint64) bool { return n <= w.End && n >= w.Start }

--- a/consensus/istanbul/utils.go
+++ b/consensus/istanbul/utils.go
@@ -119,37 +119,6 @@ func GetEpochLastBlockNumber(epochNumber uint64, epochSize uint64) uint64 {
 	return epochNumber * epochSize
 }
 
-// GetUptimeMonitoringWindow retrieves the range [first block, last block] where uptime is to be monitored
-// for a give epoch. The range is inclusive.
-// First blocks of an epoch need to be skipped since we can't assess the last `lookbackWindow` block for validators
-// as those are froma different epoch.
-// Similarly, last block of epoch is skipped since we can't obtaine the signer for it; as they are in the next block
-func GetUptimeMonitoringWindow(epochNumber uint64, epochSize uint64, lookbackWindowSize uint64) (uint64, uint64) {
-	if epochNumber == 0 {
-		panic("no monitoring window for epoch 0")
-	}
-
-	epochFirstBlock, _ := GetEpochFirstBlockNumber(epochNumber, epochSize)
-	epochLastBlock := GetEpochLastBlockNumber(epochNumber, epochSize)
-
-	// first block to monitor:
-	// We need to wait for the completion of the first window with the start window's block being the
-	// 2nd block of the epoch, before we start tallying the validator score for epoch "epochNumber".
-	// We can't include the epoch's first block since it's aggregated parent seals
-	// is for the previous epoch's valset.
-	firstBlockToMonitor := epochFirstBlock + 1 + (lookbackWindowSize - 1)
-
-	// last block to monitor:
-	// We stop tallying for epoch "epochNumber" at the second to last block of that epoch.
-	// We can't include that epoch's last block as part of the tally because the epoch val score is calculated
-	// using a tally that is updated AFTER a block is finalized.
-	// Note that it's possible to count up to the last block of the epoch, but it's much harder to implement
-	// than couting up to the second to last one.
-	lastBlockToMonitor := epochLastBlock - 1
-
-	return firstBlockToMonitor, lastBlockToMonitor
-}
-
 func ValidatorSetDiff(oldValSet []ValidatorData, newValSet []ValidatorData) ([]ValidatorData, *big.Int) {
 	valSetMap := make(map[common.Address]bool)
 	oldValSetIndices := make(map[common.Address]int)

--- a/consensus/istanbul/utils.go
+++ b/consensus/istanbul/utils.go
@@ -92,11 +92,11 @@ func IsFirstBlockOfEpoch(number uint64, epochSize uint64) bool {
 // Epoch 0 is a special block that only contains the genesis block (block 0), epoch 1
 // starts at block 1
 func GetEpochNumber(number uint64, epochSize uint64) uint64 {
-	epochNumber := number / epochSize
 	if IsLastBlockOfEpoch(number, epochSize) {
-		return epochNumber
+		return number / epochSize
+	} else {
+		return number/epochSize + 1
 	}
-	return epochNumber + 1
 }
 
 // GetEpochFirstBlockNumber retrieves first block of epoch.

--- a/consensus/istanbul/utils_test.go
+++ b/consensus/istanbul/utils_test.go
@@ -283,33 +283,3 @@ func TestGetEpochNumber(t *testing.T) {
 		})
 	}
 }
-
-func TestGetUptimeMonitoringWindow(t *testing.T) {
-	type args struct {
-		epochNumber        uint64
-		epochSize          uint64
-		lookbackWindowSize uint64
-	}
-	tests := []struct {
-		name  string
-		args  args
-		want  uint64
-		want1 uint64
-	}{
-		{"tally on first epoch", args{1, 10, 2}, 1 + 2, 9},
-		{"tally on second epoch", args{2, 10, 2}, 11 + 2, 19},
-		{"lookback window too big", args{1, 10, 10}, 11, 9},
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := GetUptimeMonitoringWindow(tt.args.epochNumber, tt.args.epochSize, tt.args.lookbackWindowSize)
-			if got != tt.want {
-				t.Errorf("GetUptimeMonitoringWindow() got = %v, want %v", got, tt.want)
-			}
-			if got1 != tt.want1 {
-				t.Errorf("GetUptimeMonitoringWindow() got1 = %v, want %v", got1, tt.want1)
-			}
-		})
-	}
-}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	mockEngine "github.com/ethereum/go-ethereum/consensus/consensustest"
-	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -45,93 +44,6 @@ var (
 	canonicalSeed = 1
 	forkSeed      = 2
 )
-
-func TestUptimeSingle(t *testing.T) {
-	var uptimes *istanbul.Uptime
-	uptimes = updateUptime(uptimes, 212, big.NewInt(7), 3, 2, 211)
-	// the first 2 uptime updates do not get scored since they're within the
-	// first window after the epoch block
-	expected := &istanbul.Uptime{
-		LatestBlock: 212,
-		Entries: []istanbul.UptimeEntry{
-			{
-				ScoreTally:      0,
-				LastSignedBlock: 211,
-			},
-			{
-				ScoreTally:      0,
-				LastSignedBlock: 211,
-			},
-			{
-				ScoreTally:      0,
-				LastSignedBlock: 211,
-			},
-			// plus 2 dummies due to the *2
-			{
-				ScoreTally:      0,
-				LastSignedBlock: 0,
-			},
-			{
-				ScoreTally:      0,
-				LastSignedBlock: 0,
-			},
-			{
-				ScoreTally:      0,
-				LastSignedBlock: 0,
-			},
-		},
-	}
-	if !reflect.DeepEqual(uptimes, expected) {
-		t.Fatalf("uptimes were not updated correctly, got %v, expected %v", uptimes, expected)
-	}
-}
-
-func TestUptime(t *testing.T) {
-	var uptimes *istanbul.Uptime
-	// (there can't be less than 2/3rds of validators sigs in a valid bitmap)
-	bitmaps := []*big.Int{
-		big.NewInt(3), // 011     // Parent aggregated seal for block #1
-		big.NewInt(7), // 111
-		big.NewInt(5), // 101
-		big.NewInt(3), // 011
-		big.NewInt(5), // 101
-		big.NewInt(7), // 111
-		big.NewInt(5), // 101     // Parent aggregated seal for block #7
-	}
-	// assume the first block is the first epoch's block (ie not the genesis)
-	block := uint64(1)
-	for _, bitmap := range bitmaps {
-		// use a window of 2 blocks - ideally we want to expand
-		// these tests to increase our confidence
-		uptimes = updateUptime(uptimes, block, bitmap, 2, 1, 10)
-		block++
-	}
-
-	expected := &istanbul.Uptime{
-		LatestBlock: 7,
-		Entries: []istanbul.UptimeEntry{
-			{
-				ScoreTally:      5,
-				LastSignedBlock: 6,
-			},
-			{
-				ScoreTally:      5,
-				LastSignedBlock: 5,
-			},
-			{
-				ScoreTally:      5,
-				LastSignedBlock: 6,
-			},
-			{
-				ScoreTally:      0,
-				LastSignedBlock: 0,
-			},
-		},
-	}
-	if !reflect.DeepEqual(uptimes, expected) {
-		t.Fatalf("uptimes were not updated correctly, got %v, expected %v", uptimes, expected)
-	}
-}
 
 // newCanonical creates a chain database, and injects a deterministic canonical
 // chain. Depending on the full flag, if creates either a full block chain or a

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -22,7 +22,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus/istanbul"
+	"github.com/ethereum/go-ethereum/consensus/istanbul/uptime"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
@@ -423,13 +423,13 @@ func ReadTd(db ethdb.Reader, hash common.Hash, number uint64) *big.Int {
 }
 
 // ReadAccumulatedEpochUptime retrieves the so-far accumulated uptime array for the validators of the specified epoch
-func ReadAccumulatedEpochUptime(db ethdb.Reader, epoch uint64) *istanbul.Uptime {
+func ReadAccumulatedEpochUptime(db ethdb.Reader, epoch uint64) *uptime.Uptime {
 	data, _ := db.Get(uptimeKey(epoch))
 	if len(data) == 0 {
 		log.Trace("ReadAccumulatedEpochUptime EMPTY", "epoch", epoch)
 		return nil
 	}
-	uptime := new(istanbul.Uptime)
+	uptime := new(uptime.Uptime)
 	if err := rlp.Decode(bytes.NewReader(data), uptime); err != nil {
 		log.Error("Invalid uptime RLP", "err", err)
 		return nil
@@ -438,7 +438,7 @@ func ReadAccumulatedEpochUptime(db ethdb.Reader, epoch uint64) *istanbul.Uptime 
 }
 
 // WriteAccumulatedEpochUptime updates the accumulated uptime array for the validators of the specified epoch
-func WriteAccumulatedEpochUptime(db ethdb.KeyValueWriter, epoch uint64, uptime *istanbul.Uptime) {
+func WriteAccumulatedEpochUptime(db ethdb.KeyValueWriter, epoch uint64, uptime *uptime.Uptime) {
 	data, err := rlp.EncodeToBytes(uptime)
 	if err != nil {
 		log.Crit("Failed to RLP encode updated uptime", "err", err)

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/uptime"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus/istanbul"
+	"github.com/ethereum/go-ethereum/consensus/istanbul/uptime"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -197,20 +197,20 @@ func TestUptimeStorage(t *testing.T) {
 		t.Fatalf("Non existent uptime returned: %v", entry)
 	}
 	// Write and verify the uptime in the database
-	uptimeEntries := make([]istanbul.UptimeEntry, 3)
-	uptimeEntries[0] = istanbul.UptimeEntry{
+	uptimeEntries := make([]uptime.UptimeEntry, 3)
+	uptimeEntries[0] = uptime.UptimeEntry{
 		ScoreTally:      0,
 		LastSignedBlock: 1,
 	}
-	uptimeEntries[1] = istanbul.UptimeEntry{
+	uptimeEntries[1] = uptime.UptimeEntry{
 		ScoreTally:      2,
 		LastSignedBlock: 2,
 	}
-	uptimeEntries[2] = istanbul.UptimeEntry{
+	uptimeEntries[2] = uptime.UptimeEntry{
 		ScoreTally:      8,
 		LastSignedBlock: 8,
 	}
-	uptime := &istanbul.Uptime{
+	uptime := &uptime.Uptime{
 		Entries:     uptimeEntries,
 		LatestBlock: 5,
 	}

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -196,22 +196,13 @@ func TestUptimeStorage(t *testing.T) {
 	if entry := ReadAccumulatedEpochUptime(db, epoch); entry != nil {
 		t.Fatalf("Non existent uptime returned: %v", entry)
 	}
-	// Write and verify the uptime in the database
-	uptimeEntries := make([]uptime.UptimeEntry, 3)
-	uptimeEntries[0] = uptime.UptimeEntry{
-		ScoreTally:      0,
-		LastSignedBlock: 1,
-	}
-	uptimeEntries[1] = uptime.UptimeEntry{
-		ScoreTally:      2,
-		LastSignedBlock: 2,
-	}
-	uptimeEntries[2] = uptime.UptimeEntry{
-		ScoreTally:      8,
-		LastSignedBlock: 8,
-	}
+
 	uptime := &uptime.Uptime{
-		Entries:     uptimeEntries,
+		Entries: []uptime.UptimeEntry{
+			{UpBlocks: 0, LastSignedBlock: 1},
+			{UpBlocks: 2, LastSignedBlock: 2},
+			{UpBlocks: 8, LastSignedBlock: 8},
+		},
 		LatestBlock: 5,
 	}
 	WriteAccumulatedEpochUptime(db, epoch, uptime)


### PR DESCRIPTION
### Description

Several people had trouble following current uptime scoring logic. It looks like a pool for off by one errors. This PR attempts to do some cleanup to make it more maintainable.

* Extracts the code to its own package where before code was distributed in 3+ files.
* Add Tests 
* Add godocs to functions
* Rename functions/variables to make code easier to understand
* Introduce the type `Window` which simplifies reasoning about UP blocks
* Modify the monitoringWindow and updateUptime functions so they work with the block whose signatures they intend to monitor, vs the block whose parent block signatures we want to monitor.

We can now summarize uptime computation as:

  * `monitoringWindow(epoch):` Range of blocks from an epoch where UP status will be monitor. Represents also the maximum number of blocks within an epoch a validator can be considered UP
  * `currentLookbackWindow(blockNumber)` Current range of blocks we consider to label a validator a UP. A valiadator is considered UP when it has sign at least a block in the currentLookbackWindow
  * `validator.UpBlocks` total number of blocks within an epoch a validator has been labeled as UP
 
Then the score is:
```
uptimeScore = validator.UpBlocks / monitoringWindow(epoch).Size()
```

Finally, for each block we process, the `LastSignedBlock` for each validator is updated, and then `validator.UPBlocks` is increased if: `monitoringWindow.contains(blockNumber) && currentLookbackWindow.contains(lastSignedBlock)`


### Other changes

* Improve epoch related functions
* Add godocs to non related functions

### Tested

* Unit tests

### Related issues

### Backwards compatibility

Yes
