### PR TITLE
Only report missed blocks by the local address

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -776,13 +776,10 @@ func (sb *Backend) RefreshValPeers() error {
 }
 
 func (sb *Backend) ValidatorAddress() common.Address {
-	var localAddress common.Address
 	if sb.IsProxy() {
-		localAddress = sb.config.ProxiedValidatorAddress
-	} else {
-		localAddress = sb.Address()
+		return sb.config.ProxiedValidatorAddress
 	}
-	return localAddress
+	return sb.Address()
 }
 
 // RetrieveValidatorConnSet returns the cached validator conn set if the cache

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -235,7 +235,7 @@ func (sb *Backend) UpdateMetricsForParentOfBlock(child *types.Block) {
 
 	// Check validator in grandparent valset.
 	gpValSet := sb.getValidators(number-2, parentHeader.ParentHash)
-	gpValSetIndex, _ := gpValSet.GetByAddress(sb.ValidatorAddress())
+	gpValSetIndex, _ := gpValSet.GetByAddress(sb.Address())
 
 	// Now check if in the "parent seal" (used for downtime calcs, on the child block)
 	childExtra, err := types.ExtractIstanbulExtra(child.Header())
@@ -271,7 +271,7 @@ func (sb *Backend) UpdateMetricsForParentOfBlock(child *types.Block) {
 	// The following metrics are only tracked if the validator is elected.
 
 	// proposed the block that was finalized?
-	if parentHeader.Coinbase == sb.ValidatorAddress() {
+	if parentHeader.Coinbase == sb.Address() {
 		sb.blocksElectedAndProposedMeter.Mark(1)
 	} else {
 		// could have proposed a block that was not finalized?
@@ -280,7 +280,7 @@ func (sb *Backend) UpdateMetricsForParentOfBlock(child *types.Block) {
 		gpAuthor := sb.AuthorForBlock(number - 2)
 		for i := int64(0); i < missedRounds; i++ {
 			proposer := validator.GetProposerSelector(sb.config.ProposerPolicy)(gpValSet, gpAuthor, uint64(i))
-			if sb.ValidatorAddress() == proposer.Address() {
+			if sb.Address() == proposer.Address() {
 				sb.blocksMissedRoundsAsProposerMeter.Mark(1)
 				break
 			}
@@ -295,13 +295,13 @@ func (sb *Backend) UpdateMetricsForParentOfBlock(child *types.Block) {
 	} else {
 		sb.blocksElectedButNotSignedMeter.Mark(1)
 		sb.blocksElectedButNotSignedGauge.Update(sb.blocksElectedButNotSignedGauge.Value() + 1)
-		sb.logger.Warn("Elected but didn't sign block", "number", number-1, "address", sb.ValidatorAddress(), "missed in a row", sb.blocksElectedButNotSignedGauge.Value())
+		sb.logger.Warn("Elected but didn't sign block", "number", number-1, "address", sb.Address(), "missed in a row", sb.blocksElectedButNotSignedGauge.Value())
 	}
 
 	// Report downtime events
 	if sb.blocksElectedButNotSignedGauge.Value() >= int64(sb.config.LookbackWindow) {
 		sb.blocksDowntimeEventMeter.Mark(1)
-		sb.logger.Error("Elected but getting marked as down", "missed block count", sb.blocksElectedButNotSignedGauge.Value(), "number", number-1, "address", sb.ValidatorAddress())
+		sb.logger.Error("Elected but getting marked as down", "missed block count", sb.blocksElectedButNotSignedGauge.Value(), "number", number-1, "address", sb.Address())
 	}
 
 	// Clear downtime counter on end of epoch.


### PR DESCRIPTION
### Description

As described in #1248, the proxy currently reported about missed blocks for it's validator peer.
This is confusing and my mislead the node operator to believe that their proxy is misconfigured to
run as a validator.

In this PR, the metrics check is changed to only report the local address and not on the peer
validator address. As a result, these lines will not appear on the proxy (unless it actually _is_
misconfigured to run as a valdiator)

### Related issues

- Fixes #1248

### Backwards compatibility

Metrics about the validator will not longer be reported by the proxy. If a node operator was relying
on this in there monitoring setup, the metrics will be unavailable when they update.