### PR TITLE
Don't report missed in a row if metrics are disabled

### DIFF
--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -295,7 +295,12 @@ func (sb *Backend) UpdateMetricsForParentOfBlock(child *types.Block) {
 	} else {
 		sb.blocksElectedButNotSignedMeter.Mark(1)
 		sb.blocksElectedButNotSignedGauge.Update(sb.blocksElectedButNotSignedGauge.Value() + 1)
-		sb.logger.Warn("Elected but didn't sign block", "number", number-1, "address", sb.ValidatorAddress(), "missed in a row", sb.blocksElectedButNotSignedGauge.Value())
+		if sb.blocksElectedButNotSignedGauge.Value() != 0 {
+			sb.logger.Warn("Elected but didn't sign block", "number", number-1, "address", sb.ValidatorAddress(), "missed in a row", sb.blocksElectedButNotSignedGauge.Value())
+		} else {
+			sb.logger.Warn("Elected but didn't sign block", "number", number-1, "address", sb.ValidatorAddress())
+		}
+
 	}
 
 	// Report downtime events


### PR DESCRIPTION
### Description

This removes a confusing log message when metrics are disabled.

### Other changes

None

### Tested

### Related issues

- Fixes #1247 

### Backwards compatibility

Yes
