### PR TITLE
random beacon cache changes

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -212,5 +212,5 @@ type Istanbul interface {
 	ValidatorAddress() common.Address
 
 	// GenerateRandomness will generate the random beacon randomness
-	GenerateRandomness(parentHash common.Hash, header *types.Header, state *state.StateDB) (common.Hash, common.Hash, error)
+	GenerateRandomness(parentHash common.Hash) (common.Hash, common.Hash, error)
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -209,4 +209,9 @@ type Istanbul interface {
 	// This is only implemented for Istanbul.
 	// It will check to see if the header is from the last block of an epoch
 	IsLastBlockOfEpoch(header *types.Header) bool
+
+	// This function will return the istanbul engine's validator address
+	ValidatorAddress() common.Address
+
+	GenerateRandomness(parentHash common.Hash, header *types.Header, state *state.StateDB) (common.Hash, common.Hash, error)
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -201,17 +201,16 @@ type Istanbul interface {
 	// StopProxiedValidatorEngine stops the proxied validator engine
 	StopProxiedValidatorEngine() error
 
-	// This is only implemented for Istanbul.
-	// It will update the validator set diff in the header, if the mined header is the last block of the epoch.
+	// UpdateValSetDiff will update the validator set diff in the header, if the mined header is the last block of the epoch.
 	// The changes are executed inline.
 	UpdateValSetDiff(chain ChainReader, header *types.Header, state *state.StateDB) error
 
-	// This is only implemented for Istanbul.
-	// It will check to see if the header is from the last block of an epoch
+	// IsLastBlockOfEpoch will check to see if the header is from the last block of an epoch
 	IsLastBlockOfEpoch(header *types.Header) bool
 
-	// This function will return the istanbul engine's validator address
+	// ValidatorAddress will return the istanbul engine's validator address
 	ValidatorAddress() common.Address
 
+	// GenerateRandomness will generate the random beacon randomness
 	GenerateRandomness(parentHash common.Hash, header *types.Header, state *state.StateDB) (common.Hash, common.Hash, error)
 }

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -163,13 +163,14 @@ type Backend struct {
 	config           *istanbul.Config
 	istanbulEventMux *event.TypeMux
 
-	address    common.Address       // Ethereum address of the ECDSA signing key
-	blsAddress common.Address       // Ethereum address of the BLS signing key
-	publicKey  *ecdsa.PublicKey     // The signer public key
-	decryptFn  istanbul.DecryptFn   // Decrypt function to decrypt ECIES ciphertext
-	signFn     istanbul.SignerFn    // Signer function to authorize hashes with
-	signBLSFn  istanbul.BLSSignerFn // Signer function to authorize BLS messages
-	signFnMu   sync.RWMutex         // Protects the signer fields
+	address    common.Address        // Ethereum address of the ECDSA signing key
+	blsAddress common.Address        // Ethereum address of the BLS signing key
+	publicKey  *ecdsa.PublicKey      // The signer public key
+	decryptFn  istanbul.DecryptFn    // Decrypt function to decrypt ECIES ciphertext
+	signFn     istanbul.SignerFn     // Signer function to authorize hashes with
+	signBLSFn  istanbul.BLSSignerFn  // Signer function to authorize BLS messages
+	signHashFn istanbul.HashSignerFn // Signer function to create random seed
+	signFnMu   sync.RWMutex          // Protects the signer fields
 
 	core         istanbulCore.Engine
 	logger       log.Logger
@@ -291,6 +292,9 @@ type Backend struct {
 	proxiedValidatorEngine        proxy.ProxiedValidatorEngine
 	proxiedValidatorEngineRunning bool
 	proxiedValidatorEngineMu      sync.RWMutex
+
+	randomSeed   []byte
+	randomSeedMu sync.Mutex
 }
 
 // IsProxy returns true if instance has proxy flag
@@ -349,7 +353,7 @@ func (sb *Backend) SendDelegateSignMsgToProxiedValidator(msg []byte) error {
 }
 
 // Authorize implements istanbul.Backend.Authorize
-func (sb *Backend) Authorize(ecdsaAddress, blsAddress common.Address, publicKey *ecdsa.PublicKey, decryptFn istanbul.DecryptFn, signFn istanbul.SignerFn, signBLSFn istanbul.BLSSignerFn) {
+func (sb *Backend) Authorize(ecdsaAddress, blsAddress common.Address, publicKey *ecdsa.PublicKey, decryptFn istanbul.DecryptFn, signFn istanbul.SignerFn, signBLSFn istanbul.BLSSignerFn, signHashFn istanbul.HashSignerFn) {
 	sb.signFnMu.Lock()
 	defer sb.signFnMu.Unlock()
 
@@ -359,6 +363,7 @@ func (sb *Backend) Authorize(ecdsaAddress, blsAddress common.Address, publicKey 
 	sb.decryptFn = decryptFn
 	sb.signFn = signFn
 	sb.signBLSFn = signBLSFn
+	sb.signHashFn = signHashFn
 	sb.core.SetAddress(ecdsaAddress)
 }
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -293,6 +293,7 @@ type Backend struct {
 	proxiedValidatorEngineRunning bool
 	proxiedValidatorEngineMu      sync.RWMutex
 
+	// RandomSeed (and it's mutex) used to generate the random beacon randomness
 	randomSeed   []byte
 	randomSeedMu sync.Mutex
 }

--- a/consensus/istanbul/backend/random.go
+++ b/consensus/istanbul/backend/random.go
@@ -32,6 +32,10 @@ var randomSeedString = []byte("Randomness seed string")
 func (sb *Backend) GenerateRandomness(parentHash common.Hash, header *types.Header, state *state.StateDB) (common.Hash, common.Hash, error) {
 	logger := sb.logger.New("func", "GenerateRandomness")
 
+	if !random.IsRunning() {
+		return common.Hash{}, common.Hash{}, nil
+	}
+
 	sb.randomSeedMu.Lock()
 	if sb.randomSeed == nil {
 		var err error
@@ -46,7 +50,7 @@ func (sb *Backend) GenerateRandomness(parentHash common.Hash, header *types.Head
 
 	randomness := crypto.Keccak256Hash(append(sb.randomSeed, parentHash.Bytes()...))
 	commitment, err := random.ComputeCommitment(header, state, randomness)
-	if err == nil {
+	if err != nil {
 		logger.Error("Failed to compute commitment", "err", err)
 		return common.Hash{}, common.Hash{}, err
 	}

--- a/consensus/istanbul/backend/random.go
+++ b/consensus/istanbul/backend/random.go
@@ -1,0 +1,53 @@
+// Copyright 2017 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package backend
+
+import (
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/contract_comm/random"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var randomSeedString = []byte("Randomness seed string")
+
+func (sb *Backend) GenerateRandomness(parentHash common.Hash, header *types.Header, state *state.StateDB) (common.Hash, common.Hash, error) {
+	logger := sb.logger.New("func", "GenerateRandomness")
+
+	sb.randomSeedMu.Lock()
+	if sb.randomSeed == nil {
+		var err error
+		sb.randomSeed, err = sb.signHashFn(accounts.Account{Address: sb.address}, common.BytesToHash(randomSeedString).Bytes())
+		if err != nil {
+			logger.Error("Failed to create randomSeed", "err", err)
+			sb.randomSeedMu.Unlock()
+			return common.Hash{}, common.Hash{}, err
+		}
+	}
+	sb.randomSeedMu.Unlock()
+
+	randomness := crypto.Keccak256Hash(append(sb.randomSeed, parentHash.Bytes()...))
+	commitment, err := random.ComputeCommitment(header, state, randomness)
+	if err == nil {
+		logger.Error("Failed to compute commitment", "err", err)
+		return common.Hash{}, common.Hash{}, err
+	}
+
+	return randomness, commitment, nil
+}

--- a/consensus/istanbul/backend/random.go
+++ b/consensus/istanbul/backend/random.go
@@ -25,8 +25,10 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+// String for creating the random seed
 var randomSeedString = []byte("Randomness seed string")
 
+// GenerateRandomness will generate the random beacon randomness
 func (sb *Backend) GenerateRandomness(parentHash common.Hash, header *types.Header, state *state.StateDB) (common.Hash, common.Hash, error) {
 	logger := sb.logger.New("func", "GenerateRandomness")
 

--- a/consensus/istanbul/backend/snapshot_test.go
+++ b/consensus/istanbul/backend/snapshot_test.go
@@ -260,7 +260,7 @@ func TestValSetChange(t *testing.T) {
 		privateKey := accounts.accounts[tt.validators[0]]
 		address := crypto.PubkeyToAddress(privateKey.PublicKey)
 
-		engine.Authorize(address, address, &privateKey.PublicKey, DecryptFn(privateKey), SignFn(privateKey), SignBLSFn(privateKey))
+		engine.Authorize(address, address, &privateKey.PublicKey, DecryptFn(privateKey), SignFn(privateKey), SignBLSFn(privateKey), SignHashFn(privateKey))
 
 		chain.AddHeader(0, genesis.ToBlock(nil).Header())
 

--- a/consensus/istanbul/backend/test_utils.go
+++ b/consensus/istanbul/backend/test_utils.go
@@ -57,7 +57,8 @@ func newBlockChainWithKeys(isProxy bool, proxiedValAddress common.Address, isPro
 		decryptFn := DecryptFn(privateKey)
 		signerFn := SignFn(privateKey)
 		signerBLSFn := SignBLSFn(privateKey)
-		b.Authorize(address, address, &publicKey, decryptFn, signerFn, signerBLSFn)
+		signerHashFn := SignHashFn(privateKey)
+		b.Authorize(address, address, &publicKey, decryptFn, signerFn, signerBLSFn, signerHashFn)
 	} else {
 		proxyNodeKey, _ := crypto.GenerateKey()
 		publicKey = proxyNodeKey.PublicKey
@@ -301,6 +302,16 @@ func SignBLSFn(key *ecdsa.PrivateKey) istanbul.BLSSignerFn {
 	}
 }
 
+func SignHashFn(key *ecdsa.PrivateKey) istanbul.HashSignerFn {
+	if key == nil {
+		key, _ = generatePrivateKey()
+	}
+
+	return func(_ accounts.Account, data []byte) ([]byte, error) {
+		return crypto.Sign(data, key)
+	}
+}
+
 // this will return an aggregate sig by the BLS keys corresponding to the `keys` array over the
 // block's hash, on consensus round 0, without a composite hasher
 func signBlock(keys []*ecdsa.PrivateKey, block *types.Block) types.IstanbulAggregatedSeal {
@@ -346,7 +357,7 @@ func newBackend() (b *Backend) {
 
 	key, _ := generatePrivateKey()
 	address := crypto.PubkeyToAddress(key.PublicKey)
-	b.Authorize(address, address, &key.PublicKey, DecryptFn(key), SignFn(key), SignBLSFn(key))
+	b.Authorize(address, address, &key.PublicKey, DecryptFn(key), SignFn(key), SignBLSFn(key), SignHashFn(key))
 	return
 }
 

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -44,6 +44,8 @@ type SignerFn func(accounts.Account, string, []byte) ([]byte, error)
 // backing account using BLS with a direct or composite hasher
 type BLSSignerFn func(accounts.Account, []byte, []byte, bool) (blscrypto.SerializedSignature, error)
 
+// HashSignerFn is a signer callback function to request a hash to be signed by a
+// backing account.
 type HashSignerFn func(accounts.Account, []byte) ([]byte, error)
 
 // UptimeEntry contains the uptime score of a validator during an epoch as well as the

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -44,6 +44,8 @@ type SignerFn func(accounts.Account, string, []byte) ([]byte, error)
 // backing account using BLS with a direct or composite hasher
 type BLSSignerFn func(accounts.Account, []byte, []byte, bool) (blscrypto.SerializedSignature, error)
 
+type HashSignerFn func(accounts.Account, []byte) ([]byte, error)
+
 // UptimeEntry contains the uptime score of a validator during an epoch as well as the
 // last block they signed on
 type UptimeEntry struct {

--- a/consensus/istanbul/utils.go
+++ b/consensus/istanbul/utils.go
@@ -216,3 +216,8 @@ func GetNodeID(enodeURL string) (*enode.ID, error) {
 	id := node.ID()
 	return &id, nil
 }
+
+func RandomnessCommitmentDBLocation(commitment common.Hash) []byte {
+	dbRandomnessPrefix := []byte("db-randomness-prefix")
+	return append(dbRandomnessPrefix, commitment.Bytes()...)
+}

--- a/consensus/istanbul/utils.go
+++ b/consensus/istanbul/utils.go
@@ -217,6 +217,8 @@ func GetNodeID(enodeURL string) (*enode.ID, error) {
 	return &id, nil
 }
 
+// RandomnessCommitmentDBLocation will return the key for where the
+// given commitment's cached key-value entry
 func RandomnessCommitmentDBLocation(commitment common.Hash) []byte {
 	dbRandomnessPrefix := []byte("db-randomness-prefix")
 	return append(dbRandomnessPrefix, commitment.Bytes()...)

--- a/contract_comm/random/random.go
+++ b/contract_comm/random/random.go
@@ -7,13 +7,10 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/contract_comm"
 	"github.com/ethereum/go-ethereum/contract_comm/errors"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -133,12 +130,7 @@ var (
 	randomFuncABI, _            = abi.JSON(strings.NewReader(randomAbi))
 	historicRandomFuncABI, _    = abi.JSON(strings.NewReader(historicRandomAbi))
 	zeroValue                   = common.Big0
-	dbRandomnessPrefix          = []byte("db-randomness-prefix")
 )
-
-func commitmentDbLocation(commitment common.Hash) []byte {
-	return append(dbRandomnessPrefix, commitment.Bytes()...)
-}
 
 func address() *common.Address {
 	randomAddress, err := contract_comm.GetRegisteredAddress(params.RandomRegistryId, nil, nil)
@@ -155,11 +147,8 @@ func IsRunning() bool {
 	return randomAddress != nil && *randomAddress != common.ZeroAddress
 }
 
-// GetLastRandomness returns up the last randomness we committed to by first
-// looking up our last commitment in the smart contract, and then finding the
-// corresponding preimage in a (commitment => randomness) mapping we keep in the
-// database.
-func GetLastRandomness(coinbase common.Address, db *ethdb.Database, header *types.Header, state vm.StateDB, chain consensus.ChainReader, seed []byte) (common.Hash, error) {
+// GetLastCommitment returns up the last commitment in the smart contract
+func GetLastCommitment(coinbase common.Address, header *types.Header, state vm.StateDB) (common.Hash, error) {
 	lastCommitment := common.Hash{}
 	_, err := contract_comm.MakeStaticCall(params.RandomRegistryId, commitmentsFuncABI, "commitments", []interface{}{coinbase}, &lastCommitment, params.MaxGasForCommitments, header, state)
 	if err != nil {
@@ -169,30 +158,14 @@ func GetLastRandomness(coinbase common.Address, db *ethdb.Database, header *type
 
 	if (lastCommitment == common.Hash{}) {
 		log.Debug("Unable to find last randomness commitment in smart contract")
-		return common.Hash{}, nil
 	}
 
-	parentBlockHashBytes, err := (*db).Get(commitmentDbLocation(lastCommitment))
-	if err != nil {
-		log.Warn("Failed to get last block proposed from database", "commitment", lastCommitment.Hex(), "err", err)
-		parentBlockHash := header.ParentHash
-		for {
-			blockHeader := chain.GetHeaderByHash(parentBlockHash)
-			parentBlockHash = blockHeader.ParentHash
-			if blockHeader.Coinbase == coinbase {
-				break
-			}
-		}
-		parentBlockHashBytes = parentBlockHash.Bytes()
-	}
-	return crypto.Keccak256Hash(append(seed, parentBlockHashBytes...)), nil
+	return lastCommitment, nil
 }
 
-// GenerateNewRandomnessAndCommitment generates a new random number and a corresponding commitment.
-// The random number is stored in the database, keyed by the corresponding commitment.
-func GenerateNewRandomnessAndCommitment(header *types.Header, state vm.StateDB, db *ethdb.Database, seed []byte) (common.Hash, error) {
+// ComputeCommitment calulcates the commitment for a given randomness.
+func ComputeCommitment(header *types.Header, state vm.StateDB, randomness common.Hash) (common.Hash, error) {
 	commitment := common.Hash{}
-	randomness := crypto.Keccak256Hash(append(seed, header.ParentHash.Bytes()...))
 	// TODO(asa): Make an issue to not have to do this via StaticCall
 	_, err := contract_comm.MakeStaticCall(params.RandomRegistryId, computeCommitmentFuncABI, "computeCommitment", []interface{}{randomness}, &commitment, params.MaxGasForComputeCommitment, header, state)
 	if err != nil {
@@ -200,10 +173,6 @@ func GenerateNewRandomnessAndCommitment(header *types.Header, state vm.StateDB, 
 		return common.Hash{}, err
 	}
 
-	err = (*db).Put(commitmentDbLocation(commitment), header.ParentHash.Bytes())
-	if err != nil {
-		log.Error("Failed to save last block parentHash to the database", "err", err)
-	}
 	return commitment, err
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1393,6 +1393,8 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	rawdb.WriteReceipts(blockBatch, block.Hash(), block.NumberU64(), receipts)
 	rawdb.WritePreimages(blockBatch, state.Preimages())
 	if (randomCommitment != common.Hash{}) {
+		// Note that the random commitment cache entry is never transferred over to the freezer,
+		// unlike all of the other saved data within this batch write
 		rawdb.WriteRandomCommitmentCache(blockBatch, randomCommitment, block.ParentHash())
 	}
 	if err := blockBatch.Write(); err != nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1321,7 +1321,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 
 	// We are going to update the uptime tally.
 	// TODO find a better way of checking if it's istanbul
-	var randomCommitment common.Hash
+	randomCommitment := common.Hash{}
 	if istEngine, isIstanbul := bc.engine.(consensus.Istanbul); isIstanbul {
 
 		if hash := bc.GetCanonicalHash(block.NumberU64()); (hash != common.Hash{} && hash != block.Hash()) {
@@ -1363,7 +1363,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		}
 
 		if blockAuthor == istEngine.ValidatorAddress() {
-			// Calculate the randomness and commitment
+			// Calculate the randomness commitment
 			_, randomCommitment, err = istEngine.GenerateRandomness(block.ParentHash(), block.Header(), state)
 
 			if err != nil {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -659,12 +659,15 @@ func DeleteBlockWithoutNumber(db ethdb.KeyValueWriter, hash common.Hash, number 
 	DeleteTd(db, hash, number)
 }
 
+// WriteRandomCommitmentCache will write a random beacon commitment's associated block parent hash
+// (which is used to calculate the commitmented random number).
 func WriteRandomCommitmentCache(db ethdb.KeyValueWriter, commitment common.Hash, parentHash common.Hash) {
 	if err := db.Put(istanbul.RandomnessCommitmentDBLocation(commitment), parentHash.Bytes()); err != nil {
 		log.Crit("Failed to store randomness commitment cache entry", "err", err)
 	}
 }
 
+// ReadRandomCommitmentCache will retun the random beacon commit's associated block parent hash.
 func ReadRandomCommitmentCache(db ethdb.Reader, commitment common.Hash) common.Hash {
 	parentHash, err := db.Get(istanbul.RandomnessCommitmentDBLocation(commitment))
 	if err != nil {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -659,6 +659,22 @@ func DeleteBlockWithoutNumber(db ethdb.KeyValueWriter, hash common.Hash, number 
 	DeleteTd(db, hash, number)
 }
 
+func WriteRandomCommitmentCache(db ethdb.KeyValueWriter, commitment common.Hash, parentHash common.Hash) {
+	if err := db.Put(istanbul.RandomnessCommitmentDBLocation(commitment), parentHash.Bytes()); err != nil {
+		log.Crit("Failed to store randomness commitment cache entry", "err", err)
+	}
+}
+
+func ReadRandomCommitmentCache(db ethdb.Reader, commitment common.Hash) common.Hash {
+	parentHash, err := db.Get(istanbul.RandomnessCommitmentDBLocation(commitment))
+	if err != nil {
+		log.Warn("Error in trying to retrieve randomness commitment cache entry")
+		return common.Hash{}
+	}
+
+	return common.BytesToHash(parentHash)
+}
+
 // FindCommonAncestor returns the last common ancestor of two block headers
 func FindCommonAncestor(db ethdb.Reader, a, b *types.Header) *types.Header {
 	for bn := b.Number.Uint64(); a.Number.Uint64() > bn; {

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -671,7 +671,7 @@ func WriteRandomCommitmentCache(db ethdb.KeyValueWriter, commitment common.Hash,
 func ReadRandomCommitmentCache(db ethdb.Reader, commitment common.Hash) common.Hash {
 	parentHash, err := db.Get(istanbul.RandomnessCommitmentDBLocation(commitment))
 	if err != nil {
-		log.Warn("Error in trying to retrieve randomness commitment cache entry")
+		log.Warn("Error in trying to retrieve randomness commitment cache entry", "error", err)
 		return common.Hash{}
 	}
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -238,7 +238,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 			})
 	}
 
-	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock, &chainDb)
+	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock, chainDb)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
 	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth}
@@ -494,7 +494,8 @@ func (s *Ethereum) StartMining(threads int) error {
 				log.Error("BLSbase account unavailable locally", "err", err)
 				return fmt.Errorf("BLS signer missing: %v", err)
 			}
-			istanbul.Authorize(eb, blsbase, publicKey, wallet.Decrypt, wallet.SignData, blswallet.SignBLS)
+
+			istanbul.Authorize(eb, blsbase, publicKey, wallet.Decrypt, wallet.SignData, blswallet.SignBLS, wallet.SignHash)
 
 			if istanbul.IsProxiedValidator() {
 				if err := istanbul.StartProxiedValidatorEngine(); err != nil {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -214,9 +214,10 @@ func (miner *Miner) commitmentCacheSaved(istEngine consensus.Istanbul) bool {
 	newBlockSub := bc.SubscribeChainEvent(newBlockCh)
 	defer newBlockSub.Unsubscribe()
 
-	// getCurrentHeaderAndState
-	currentHeader := bc.CurrentHeader()
-	currentState, err := bc.StateAt(currentHeader.Hash())
+	// getCurrentBlockAndState
+	currentBlock := bc.CurrentBlock()
+	currentHeader := currentBlock.Header()
+	currentState, err := bc.StateAt(currentBlock.Root())
 	if err != nil {
 		log.Error("Error in retrieving state", "block hash", currentHeader.Hash(), "error", err)
 		return false

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -211,7 +211,8 @@ func (miner *Miner) commitmentCacheSaved(istEngine consensus.Istanbul) bool {
 	// Subscribe to new block notifications
 	newBlockCh := make(chan core.ChainEvent)
 	bc := miner.eth.BlockChain()
-	bc.SubscribeChainEvent(newBlockCh)
+	newBlockSub := bc.SubscribeChainEvent(newBlockCh)
+	defer newBlockSub.Unsubscribe()
 
 	// getCurrentHeaderAndState
 	currentHeader := bc.CurrentHeader()

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -229,6 +229,11 @@ func (miner *Miner) commitmentCacheSaved(istEngine consensus.Istanbul) bool {
 		return false
 	}
 
+	// If there was no previous commitment from this validator, then return true.
+	if (lastCommitment == common.Hash{}) {
+		return true
+	}
+
 	if (rawdb.ReadRandomCommitmentCache(miner.db, lastCommitment) != common.Hash{}) {
 		return true
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -70,7 +70,7 @@ type Miner struct {
 	shouldStart int32 // should start indicates whether we should start after sync
 }
 
-func New(eth Backend, config *Config, chainConfig *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, isLocalBlock func(block *types.Block) bool, db *ethdb.Database) *Miner {
+func New(eth Backend, config *Config, chainConfig *params.ChainConfig, mux *event.TypeMux, engine consensus.Engine, isLocalBlock func(block *types.Block) bool, db ethdb.Database) *Miner {
 	miner := &Miner{
 		eth:      eth,
 		mux:      mux,

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -875,7 +875,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 
 		lastRandomnessParentHash := rawdb.ReadRandomCommitmentCache(w.db, lastCommitment)
 		if (lastRandomnessParentHash == common.Hash{}) {
-			log.Error("Failed to get last randomness cache entry", "err", err)
+			log.Error("Failed to get last randomness cache entry")
 			return
 		}
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
-	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc"
@@ -32,6 +31,7 @@ import (
 	gpm "github.com/ethereum/go-ethereum/contract_comm/gasprice_minimum"
 	"github.com/ethereum/go-ethereum/contract_comm/random"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -78,11 +78,6 @@ const (
 
 	// staleThreshold is the maximum depth of the acceptable stale block.
 	staleThreshold = 7
-)
-
-var (
-	randomSeedString = []byte("Randomness seed string")
-	randomSeed       []byte
 )
 
 // environment is the worker's current environment and holds all of the current state information.
@@ -186,10 +181,10 @@ type worker struct {
 	resubmitHook func(time.Duration, time.Duration) // Method to call upon updating resubmitting interval.
 
 	// Needed for randomness
-	db *ethdb.Database
+	db ethdb.Database
 }
 
-func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, isLocalBlock func(*types.Block) bool, db *ethdb.Database, init bool) *worker {
+func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, isLocalBlock func(*types.Block) bool, db ethdb.Database, init bool) *worker {
 	worker := &worker{
 		config:             config,
 		chainConfig:        chainConfig,
@@ -867,40 +862,44 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 
 	// Play our part in generating the random beacon.
 	if w.isRunning() && random.IsRunning() {
-		if randomSeed == nil {
-			account := accounts.Account{Address: w.coinbase}
-			wallet, err := w.eth.AccountManager().Find(account)
-			if err == nil {
-				// TODO: Use SignData instead
-				randomSeed, err = wallet.SignHash(account, common.BytesToHash(randomSeedString).Bytes())
-			}
-			if err != nil {
-				log.Error("Unable to create random seed", "err", err)
-				return
-			}
+		istanbul, ok := w.engine.(consensus.Istanbul)
+		if !ok {
+			log.Crit("Istanbul consensus engine must be in use for the randomness beacon")
 		}
 
-		lastRandomness, err := random.GetLastRandomness(w.coinbase, w.db, w.current.header, w.current.state, w.chain, randomSeed)
+		lastCommitment, err := random.GetLastCommitment(w.coinbase, w.current.header, w.current.state)
 		if err != nil {
-			log.Error("Failed to get last randomness", "err", err)
+			log.Error("Failed to get last commitment", "err", err)
 			return
 		}
 
-		commitment, err := random.GenerateNewRandomnessAndCommitment(w.current.header, w.current.state, w.db, randomSeed)
-		if err != nil {
-			log.Error("Failed to generate randomness commitment", "err", err)
+		lastRandomnessParentHash := rawdb.ReadRandomCommitmentCache(w.db, lastCommitment)
+		if (lastRandomnessParentHash == common.Hash{}) {
+			log.Error("Failed to get last randomness cache entry", "err", err)
 			return
 		}
 
-		err = random.RevealAndCommit(lastRandomness, commitment, w.coinbase, w.current.header, w.current.state)
+		lastRandomness, _, err := istanbul.GenerateRandomness(lastRandomnessParentHash, w.current.header, w.current.state)
 		if err != nil {
-			log.Error("Failed to reveal and commit randomness", "randomness", lastRandomness.Hex(), "commitment", commitment.Hex(), "err", err)
+			log.Error("Failed to generate last randomness", "err", err)
+			return
+		}
+
+		_, newCommitment, err := istanbul.GenerateRandomness(w.current.header.ParentHash, w.current.header, w.current.state)
+		if err != nil {
+			log.Error("Failed to generate new randomness", "err", err)
+			return
+		}
+
+		err = random.RevealAndCommit(lastRandomness, newCommitment, w.coinbase, w.current.header, w.current.state)
+		if err != nil {
+			log.Error("Failed to reveal and commit randomness", "randomness", lastRandomness.Hex(), "commitment", newCommitment.Hex(), "err", err)
 			return
 		}
 		// always true (EIP158)
 		w.current.state.IntermediateRoot(true)
 
-		w.current.randomness = &types.Randomness{Revealed: lastRandomness, Committed: commitment}
+		w.current.randomness = &types.Randomness{Revealed: lastRandomness, Committed: newCommitment}
 	} else {
 		w.current.randomness = &types.EmptyRandomness
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -882,14 +882,14 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			}
 
 			var err error
-			lastRandomness, _, err = istanbul.GenerateRandomness(lastRandomnessParentHash, w.current.header, w.current.state)
+			lastRandomness, _, err = istanbul.GenerateRandomness(lastRandomnessParentHash)
 			if err != nil {
 				log.Error("Failed to generate last randomness", "err", err)
 				return
 			}
 		}
 
-		_, newCommitment, err := istanbul.GenerateRandomness(w.current.header.ParentHash, w.current.header, w.current.state)
+		_, newCommitment, err := istanbul.GenerateRandomness(w.current.header.ParentHash)
 		if err != nil {
 			log.Error("Failed to generate new randomness", "err", err)
 			return

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -873,16 +873,20 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			return
 		}
 
-		lastRandomnessParentHash := rawdb.ReadRandomCommitmentCache(w.db, lastCommitment)
-		if (lastRandomnessParentHash == common.Hash{}) {
-			log.Error("Failed to get last randomness cache entry")
-			return
-		}
+		lastRandomness := common.Hash{}
+		if (lastCommitment != common.Hash{}) {
+			lastRandomnessParentHash := rawdb.ReadRandomCommitmentCache(w.db, lastCommitment)
+			if (lastRandomnessParentHash == common.Hash{}) {
+				log.Error("Failed to get last randomness cache entry")
+				return
+			}
 
-		lastRandomness, _, err := istanbul.GenerateRandomness(lastRandomnessParentHash, w.current.header, w.current.state)
-		if err != nil {
-			log.Error("Failed to generate last randomness", "err", err)
-			return
+			var err error
+			lastRandomness, _, err = istanbul.GenerateRandomness(lastRandomnessParentHash, w.current.header, w.current.state)
+			if err != nil {
+				log.Error("Failed to generate last randomness", "err", err)
+				return
+			}
 		}
 
 		_, newCommitment, err := istanbul.GenerateRandomness(w.current.header.ParentHash, w.current.header, w.current.state)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -181,7 +181,7 @@ func newTestWorker(t *testing.T, chainConfig *params.ChainConfig, engine consens
 	if shouldAddPendingTxs {
 		backend.txPool.AddLocals(pendingTxs)
 	}
-	w := newWorker(testConfig, chainConfig, engine, backend, new(event.TypeMux), nil, &backend.db, false)
+	w := newWorker(testConfig, chainConfig, engine, backend, new(event.TypeMux), nil, backend.db, false)
 	w.setEtherbase(testBankAddress)
 	return w, backend
 }
@@ -247,6 +247,7 @@ func getAuthorizedIstanbulEngine() consensus.Istanbul {
 
 	signerFn := backend.SignFn(testBankKey)
 	signBLSFn := backend.SignBLSFn(testBankKey)
+	signHashFn := backend.SignHashFn(testBankKey)
 	address := crypto.PubkeyToAddress(testBankKey.PublicKey)
 
 	config := istanbul.DefaultConfig
@@ -258,7 +259,7 @@ func getAuthorizedIstanbulEngine() consensus.Istanbul {
 	engine := istanbulBackend.New(config, rawdb.NewMemoryDatabase())
 	engine.(*istanbulBackend.Backend).SetBroadcaster(&consensustest.MockBroadcaster{})
 	engine.(*istanbulBackend.Backend).SetP2PServer(consensustest.NewMockP2PServer(nil))
-	engine.(*istanbulBackend.Backend).Authorize(address, address, &testBankKey.PublicKey, decryptFn, signerFn, signBLSFn)
+	engine.(*istanbulBackend.Backend).Authorize(address, address, &testBankKey.PublicKey, decryptFn, signerFn, signBLSFn, signHashFn)
 	engine.(*istanbulBackend.Backend).StartAnnouncing()
 	return engine
 }


### PR DESCRIPTION
### Description

The changes in this PR will make all validators have they randomness cache set before starting mining.  It does this by two ways:

1) Whenever a block is synced or finalized via the consensus engine, the node will check to see if it authored that block, and will cache the block's parent hash (which is needed to recover the block's randomness in the future).
2) Before a node starts syncing, it will check to see if its last randomness commitment (saved on the random smart contract) has a cached entry.  If not, then it will do a reverse search of the blockchain to find the last randomness's block and then cache the block's parent hash.

### Other changes

Refactored some of randomness logic.  Specifically

1) Moved generation of randomness logic from package `contract_comm/random` to `consensus/istanbul`.
2) Moved specification of randomness cache leveldb location from package `contract_comm/random` to `consensus/istanbul`.
3) Moved saving and retrieving to/from randomness cache logic from `contract_comm/random` to `core/rawdb/accessors_chain.go`.
4) Moved the randomness seed logic from `miner/worker.go` to `consensus/istanbul` package.  

### Tested

1) e2e tests (note that the `when a validator's data directory is deleted` test case in the e2e sync test will verify that restoring the randomness cache works.)
2) unit tests

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Yes