### PR TITLE
Fix eth peer error handling

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1189,7 +1189,7 @@ func (d *Downloader) fetchHeaders(p *peerConnection, from uint64, pivot uint64, 
 				break
 			}
 			// Header retrieval timed out, consider the peer bad and drop
-			p.log.Debug("Header request timed out", "elapsed", ttl)
+			p.log.Warn("Header request timed out, dropping peer", "elapsed", ttl)
 			headerTimeoutMeter.Mark(1)
 			d.dropPeer(p.id)
 
@@ -1405,7 +1405,7 @@ func (d *Downloader) fetchParts(deliveryCh chan dataPack, deliver func(dataPack)
 						peer.log.Trace("Data delivery timed out", "type", kind)
 						setIdle(peer, 0)
 					} else {
-						peer.log.Debug("Stalling delivery, dropping", "type", kind)
+						peer.log.Warn("Stalling delivery, dropping", "type", kind)
 
 						if d.dropPeer == nil {
 							// The dropPeer method is nil when `--copydb` is used for a local copy.

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -473,7 +473,7 @@ func (f *BlockFetcher) loop() {
 				if announce := f.fetching[hash]; announce != nil && announce.origin == task.peer && f.fetched[hash] == nil && f.completing[hash] == nil && f.queued[hash] == nil {
 					// If the delivered header does not match the promised number, drop the announcer
 					if header.Number.Uint64() != announce.number {
-						log.Trace("Invalid block number fetched", "peer", announce.origin, "hash", header.Hash(), "announced", announce.number, "provided", header.Number)
+						log.Warn("Invalid block number fetched", "peer", announce.origin, "hash", header.Hash(), "announced", announce.number, "provided", header.Number)
 						f.dropPeer(announce.origin)
 						f.forgetHash(hash)
 						continue
@@ -673,7 +673,7 @@ func (f *BlockFetcher) insert(peer string, block *types.Block) {
 
 		default:
 			// Something went very wrong, drop the peer
-			log.Debug("Propagated block verification failed", "peer", peer, "number", block.Number(), "hash", hash, "err", err)
+			log.Warn("Propagated block verification failed", "peer", peer, "number", block.Number(), "hash", hash, "err", err)
 			f.dropPeer(peer)
 			return
 		}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -255,13 +255,16 @@ func (pm *ProtocolManager) makeProtocol(version uint) p2p.Protocol {
 	}
 }
 
-func (pm *ProtocolManager) removePeer(id string) {
-	// Short circuit if the peer was already removed
+// unregisterPeer unregisters the peer from the protocol manager and its various services,
+// but does not disconnect the peer at the p2p networking layer.
+// It returns the peer, or nil if the peer had already been cleaned up previously.
+func (pm *ProtocolManager) unregisterPeer(id string) *peer {
+	// Short circuit if the peer has already been unregistered
 	peer := pm.peers.Peer(id)
 	if peer == nil {
-		return
+		return nil
 	}
-	log.Debug("Removing Ethereum peer", "peer", id)
+	log.Debug("Unregistering peer from istanbul protocol manager", "peer", id)
 
 	// Unregister the peer from the downloader, tx fetcher, consensus engine, and Ethereum peer set
 	if err := pm.downloader.UnregisterPeer(id); err != nil {
@@ -274,11 +277,18 @@ func (pm *ProtocolManager) removePeer(id string) {
 		handler.UnregisterPeer(peer, peer.Peer.Server == pm.proxyServer)
 	}
 	if err := pm.peers.Unregister(id); err != nil {
-		log.Error("Peer removal failed", "peer", id, "err", err)
+		log.Error("Unregistering peer failed", "peer", id, "err", err)
 	}
-	// Hard disconnect at the networking layer
+	return peer
+}
+
+// removePeer unregisters the peer and then disconnects it at the p2p (networking) layer.
+// The caller of removePeer is responsible for logging any relevant error information.
+func (pm *ProtocolManager) removePeer(id string) {
+	peer := pm.unregisterPeer(id)
 	if peer != nil {
-		peer.Peer.Disconnect(p2p.DiscUselessPeer)
+		// Hard disconnect at the networking layer
+		peer.Peer.Disconnect(p2p.DiscSubprotocolError)
 	}
 }
 
@@ -380,7 +390,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 		p.Log().Error("Ethereum peer registration failed", "err", err)
 		return err
 	}
-	defer pm.removePeer(p.id)
+	defer pm.unregisterPeer(p.id)
 
 	// Register the peer in the downloader. If the downloader considers it banned, we disconnect
 	if err := pm.downloader.RegisterPeer(p.id, p.version, p); err != nil {


### PR DESCRIPTION
### Description

Validators have reported cases where they've encountered problems with the validator or proxy nodes disconnecting from each other or from other validator peers, and their logs don't show the errors that led to disconnecting from the peers, instead showing "useless peer".

Investigation into the code involved revealed that this is due to an upstream problem in the error handling, which this PR fixes.  Full details about the bug and the fix can be found in the commit message.

This PR further ensures that calls to `pm.removePeer()` (in some cases called as as `dropPeer()`) are preceded by a warning being logged (whereas, before, some of the log statements were warnings but others were debug or trace) and slightly rewords some of the log messages.

### Tested

- Automated tests pass.
- Verified that errors from `pm.handleMsg()` are now received in the `p2p/peer.go` run loop as they should.
- Verified that `removePeer()` still works for the cases where the peer should be disconnected as well.

### Related issues

The following issues ran into this problem in the error handling.  Though their root cause was ultimately something else, the error handling problem prevents us from determining what the root cause was:

- #1040
- #1230

### Backwards compatibility

No backwards compatibility concerns.  Both before and after these changes, the node will disconnect from the peer when an error occurs, the only difference is that the meaningful error will no longer be lost.