### PR TITLE
Donut precompile scaffolding.

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -59,11 +59,11 @@ var PrecompiledContractsHomestead = map[common.Address]PrecompiledContract{
 }
 
 func celoPrecompileAddress(index byte) common.Address {
-	return common.BytesToAddress(append([]byte{0}, (CeloPrecompiledContractsAddressOffset - index)))
+	return common.BytesToAddress(append([]byte{0}, (celoPrecompiledContractsAddressOffset - index)))
 }
 
 var (
-	CeloPrecompiledContractsAddressOffset = byte(0xff)
+	celoPrecompiledContractsAddressOffset = byte(0xff)
 
 	transferAddress              = celoPrecompileAddress(2)
 	fractionMulExpAddress        = celoPrecompileAddress(3)
@@ -75,6 +75,27 @@ var (
 	hashHeaderAddress            = celoPrecompileAddress(9)
 	getParentSealBitmapAddress   = celoPrecompileAddress(10)
 	getVerifiedSealBitmapAddress = celoPrecompileAddress(11)
+
+	// New in Donut
+	edd25519Address          = celoPrecompileAddress(12)
+	b12_381G1AddAddress      = celoPrecompileAddress(13)
+	b12_381G1MulAddress      = celoPrecompileAddress(14)
+	b12_381G1MultiExpAddress = celoPrecompileAddress(15)
+	b12_381G2AddAddress      = celoPrecompileAddress(16)
+	b12_381G2MulAddress      = celoPrecompileAddress(17)
+	b12_381G2MultiExpAddress = celoPrecompileAddress(18)
+	b12_381PairingAddress    = celoPrecompileAddress(19)
+	b12_381MapFpToG1Address  = celoPrecompileAddress(20)
+	b12_381MapFp2ToG2Address = celoPrecompileAddress(21)
+	b12_377G1AddAddress      = celoPrecompileAddress(22)
+	b12_377G1MulAddress      = celoPrecompileAddress(23)
+	b12_377G1MultiExpAddress = celoPrecompileAddress(24)
+	b12_377G2AddAddress      = celoPrecompileAddress(25)
+	b12_377G2MulAddress      = celoPrecompileAddress(26)
+	b12_377G2MultiExpAddress = celoPrecompileAddress(27)
+	b12_377PairingAddress    = celoPrecompileAddress(28)
+	cip20Address             = celoPrecompileAddress(29)
+	cip26Address             = celoPrecompileAddress(30)
 )
 
 // PrecompiledContractsByzantium contains the default set of pre-compiled Ethereum
@@ -126,6 +147,53 @@ var PrecompiledContractsIstanbul = map[common.Address]PrecompiledContract{
 	hashHeaderAddress:            &hashHeader{},
 	getParentSealBitmapAddress:   &getParentSealBitmap{},
 	getVerifiedSealBitmapAddress: &getVerifiedSealBitmap{},
+}
+
+// PrecompiledContractsDonut contains the default set of pre-compiled Ethereum
+// contracts used in the Donit release.
+var PrecompiledContractsDonut = map[common.Address]PrecompiledContract{
+	common.BytesToAddress([]byte{1}): &ecrecover{},
+	common.BytesToAddress([]byte{2}): &sha256hash{},
+	common.BytesToAddress([]byte{3}): &ripemd160hash{},
+	common.BytesToAddress([]byte{4}): &dataCopy{},
+	common.BytesToAddress([]byte{5}): &bigModExp{},
+	common.BytesToAddress([]byte{6}): &bn256AddIstanbul{},
+	common.BytesToAddress([]byte{7}): &bn256ScalarMulIstanbul{},
+	common.BytesToAddress([]byte{8}): &bn256PairingIstanbul{},
+	common.BytesToAddress([]byte{9}): &blake2F{},
+
+	// Celo Precompiled Contracts
+	transferAddress:              &transfer{},
+	fractionMulExpAddress:        &fractionMulExp{},
+	proofOfPossessionAddress:     &proofOfPossession{},
+	getValidatorAddress:          &getValidator{},
+	numberValidatorsAddress:      &numberValidators{},
+	epochSizeAddress:             &epochSize{},
+	blockNumberFromHeaderAddress: &blockNumberFromHeader{},
+	hashHeaderAddress:            &hashHeader{},
+	getParentSealBitmapAddress:   &getParentSealBitmap{},
+	getVerifiedSealBitmapAddress: &getVerifiedSealBitmap{},
+
+	// TODO(Donut): Add instances
+	edd25519Address:          nil,
+	b12_381G1AddAddress:      nil,
+	b12_381G1MulAddress:      nil,
+	b12_381G1MultiExpAddress: nil,
+	b12_381G2AddAddress:      nil,
+	b12_381G2MulAddress:      nil,
+	b12_381G2MultiExpAddress: nil,
+	b12_381PairingAddress:    nil,
+	b12_381MapFpToG1Address:  nil,
+	b12_381MapFp2ToG2Address: nil,
+	b12_377G1AddAddress:      nil,
+	b12_377G1MulAddress:      nil,
+	b12_377G1MultiExpAddress: nil,
+	b12_377G2AddAddress:      nil,
+	b12_377G2MulAddress:      nil,
+	b12_377G2MultiExpAddress: nil,
+	b12_377PairingAddress:    nil,
+	cip20Address:             nil,
+	cip26Address:             nil,
 }
 
 // RunPrecompiledContract runs and evaluates the output of a precompiled contract.


### PR DESCRIPTION
Supersedes #1276. Same code, but branch is in this repo.

### Description

Goal is to prepare for Donut integration by providing a logical integration point for the precompile PRs

- Add new Donut precompile block
- Specify addresses for new Donut precompiles

### Other changes

- change `celoPrecompiledContractsAddressOffset` to unexported. It appears there was no reason to export this

### Tested

No tests needed, as this change produces no practical effects yet

### Related issues

- n/a

### Backwards compatibility

Changes are ineffectual as the donut precompiles are not referenced anywhere.