### PR TITLE
tests: change precompile tests to use Donut block

### DIFF
--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -706,7 +706,7 @@ var getVerifiedSealBitmapTests = []precompiledTest{
 }
 
 func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
-	p := PrecompiledContractsIstanbul[common.HexToAddress(addr)]
+	p := PrecompiledContractsDonut[common.HexToAddress(addr)]
 	in := common.Hex2Bytes(test.input)
 	contract := NewContract(AccountRef(common.HexToAddress("1337")),
 		nil, new(big.Int), p.RequiredGas(in))


### PR DESCRIPTION
### Description

Update precompile tests to use the Donut precompile block. This is further scaffolding for Donut CIP integrations, and does not have any functional changes

### Backwards compatibility

No functional changes.