### PR TITLE
Remove istanbul flags that must not be reconfigured

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -724,22 +724,22 @@ var (
 	// Istanbul settings
 	IstanbulRequestTimeoutFlag = cli.Uint64Flag{
 		Name:  "istanbul.requesttimeout",
-		Usage: "Timeout for each Istanbul round in milliseconds",
+		Usage: "Timeout for each Istanbul round in milliseconds (deprecated, value obtained from genesis config)",
 		Value: eth.DefaultConfig.Istanbul.RequestTimeout,
 	}
 	IstanbulBlockPeriodFlag = cli.Uint64Flag{
 		Name:  "istanbul.blockperiod",
-		Usage: "Default minimum difference between two consecutive block's timestamps in seconds",
+		Usage: "Default minimum difference between two consecutive block's timestamps in seconds  (deprecated, value obtained from genesis config)",
 		Value: eth.DefaultConfig.Istanbul.BlockPeriod,
 	}
 	IstanbulProposerPolicyFlag = cli.Uint64Flag{
 		Name:  "istanbul.proposerpolicy",
-		Usage: "Default minimum difference between two consecutive block's timestamps in seconds",
+		Usage: "Default minimum difference between two consecutive block's timestamps in seconds (deprecated, value obtained from genesis config)",
 		Value: uint64(eth.DefaultConfig.Istanbul.ProposerPolicy),
 	}
 	IstanbulLookbackWindowFlag = cli.Uint64Flag{
 		Name:  "istanbul.lookbackwindow",
-		Usage: "A validator's signature must be absent for this many consecutive blocks to be considered down for the uptime score",
+		Usage: "A validator's signature must be absent for this many consecutive blocks to be considered down for the uptime score  (deprecated, value obtained from genesis config)",
 		Value: eth.DefaultConfig.Istanbul.LookbackWindow,
 	}
 	IstanbulReplicaFlag = cli.BoolFlag{
@@ -1404,16 +1404,16 @@ func setWhitelist(ctx *cli.Context, cfg *eth.Config) {
 
 func setIstanbul(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	if ctx.GlobalIsSet(IstanbulRequestTimeoutFlag.Name) {
-		cfg.Istanbul.RequestTimeout = ctx.GlobalUint64(IstanbulRequestTimeoutFlag.Name)
+		log.Warn("Flag value is ignored, and obtained from genesis config", "flag", IstanbulRequestTimeoutFlag.Name)
 	}
 	if ctx.GlobalIsSet(IstanbulBlockPeriodFlag.Name) {
-		cfg.Istanbul.BlockPeriod = ctx.GlobalUint64(IstanbulBlockPeriodFlag.Name)
+		log.Warn("Flag value is ignored, and obtained from genesis config", "flag", IstanbulBlockPeriodFlag.Name)
 	}
 	if ctx.GlobalIsSet(IstanbulLookbackWindowFlag.Name) {
-		cfg.Istanbul.LookbackWindow = ctx.GlobalUint64(IstanbulLookbackWindowFlag.Name)
+		log.Warn("Flag value is ignored, and obtained from genesis config", "flag", IstanbulLookbackWindowFlag.Name)
 	}
 	if ctx.GlobalIsSet(IstanbulProposerPolicyFlag.Name) {
-		cfg.Istanbul.ProposerPolicy = istanbul.ProposerPolicy(ctx.GlobalUint64(IstanbulProposerPolicyFlag.Name))
+		log.Warn("Flag value is ignored, and obtained from genesis config", "flag", IstanbulProposerPolicyFlag.Name)
 	}
 	cfg.Istanbul.ReplicaStateDBPath = stack.ResolvePath(cfg.Istanbul.ReplicaStateDBPath)
 	cfg.Istanbul.ValidatorEnodeDBPath = stack.ResolvePath(cfg.Istanbul.ValidatorEnodeDBPath)

--- a/params/config.go
+++ b/params/config.go
@@ -67,6 +67,8 @@ var (
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
+			BlockPeriod:    5,
+			RequestTimeout: 3000,
 			LookbackWindow: 12,
 		},
 	}
@@ -111,6 +113,8 @@ var (
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
+			BlockPeriod:    5,
+			RequestTimeout: 10000,
 			LookbackWindow: 12,
 		},
 	}


### PR DESCRIPTION
### Description

Parameters:
  * lookbackWindow
  * epochSize
  * blockTime
  * requestTimeout for istanbul request
  * proposerPolicy

are configured on the genesis block (chainConfig). 

They can also be configured by command line flags. This is problematic, since we can't change `epochSize`, `lookbackWindow` or `blockTime` on already existent blockchain. For `requestTimeout` and `proposerPolicy` almost the same applies, if validators have different values for these parameters, then unwanted behaviour might appear

With that in mind, this PR removes the command line flags to set those parameters. 

#### Note about current usage

Current code in master, doesn't actually uses the cmdline flags values. This is because flags are read and pass to `istanbul.Config` object in `setIstanbul`; but later on on `eth.New()`, the function [CreateConsensusEngine](https://github.com/celo-org/celo-blockchain/blob/8ec69a83aa480883b4b4d719e8c4d645b1173fed/eth/backend.go#L272) is called that will use `chainConfig` (configuration obtained from the genesis block) and override those values (given they are defined in chainConfig, where they should)

Currently, docs.celo.org specifies those variables in Running a Validator guide for mainnet and baklava. 

For mainnet, the [guide](https://docs.celo.org/getting-started/mainnet/running-a-validator-in-mainnet#deploy-a-validator-machine) established:
```
--istanbul.blockperiod=5 --istanbul.requesttimeout=3000
```
but instead of using these values, the [genesis block](https://storage.googleapis.com/genesis_blocks/rc1) is used; which has the same values :)

For **baklava**; the story is different, since the [guide](https://docs.celo.org/getting-started/baklava-testnet/running-a-validator-in-baklava#deploy-a-validator-machine) established a `requesttimeout` of 3000, but the [genesis](https://storage.googleapis.com/genesis_blocks/baklava) block states 10000 as the timeout

### Tested

Unit tests

### Backwards compatibility

* Changes cmdline flags (should deprecate them first)
* Implies modifying the doc
