### PR TITLE
Fix gas estimation error if lacking cUSD to pay for fees

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -232,7 +232,7 @@ func (st *StateTransition) canPayFee(accountOwner common.Address, fee *big.Int, 
 	if err != nil {
 		return false
 	}
-	return balanceOf.Cmp(fee) > 0
+	return balanceOf.Cmp(fee) >= 0
 }
 
 func (st *StateTransition) debitGas(address common.Address, amount *big.Int, feeCurrency *common.Address) error {


### PR DESCRIPTION
In order to be able to pay the fees for a transaction, you must have at least the amount of the fee, you shouldn't need to have strictly more than that amount.

This was leading to spurious errors during gas estimation.  For gas estimation, the gas price is set to zero, and so `canPayFee()` should always return true, even if the account has no funds.  However, it was returning false if using cUSD as the fee currency.  If using Celo as the fee currency, it was returning true, but that is due to the upstream hack which sets the account's balance to maxuint (and which has been changed in upstream v1.9.13 and we will merge in PR #1251).

### Description

If an account doesn't have enough funds to pay transaction fees, it should fail when sending the transaction, not during gas estimation.  This PR fixes a logic bug that was causing it to fail during gas estimation when the fee currency was cUSD and the account had no cUSD.  Note, too, that after the changes in #1251 (not merged to master as of this moment), which removes the upstream maxuint hack, the bug would also have appeared if the fee currency had been CELO.

### Tested

Here are the results before and after this fix.  This was done by attempting to make a transaction using celo-cli, with the fee currency set to cUSD and an account that has no cUSD.

Before the fix:
```
Sending Transaction: voteTx... !
    Error: Gas estimation failed: Could not decode transaction failure reason
```

After the fix:
```
Sending Transaction: voteTx... !
    Error: insufficient funds for gas * price + value + gatewayFee
```
