### PR TITLE
Fix bug in istanbul's backlog 'clearBacklogForSeq()'

### DIFF
--- a/consensus/istanbul/core/backlog.go
+++ b/consensus/istanbul/core/backlog.go
@@ -223,11 +223,11 @@ func (c *msgBacklogImpl) getSortedBacklogSeqs() []uint64 {
 // clearBacklogForSeq will remove all entries in the backlog
 // for the given seq
 func (c *msgBacklogImpl) clearBacklogForSeq(seq uint64) {
-	c.processBacklogForSeq(seq, func(_ *istanbul.Message) bool { return true })
+	c.processBacklogForSeq(seq, func(_ *istanbul.Message) bool { return false })
 }
 
 // processBacklogForSeq will call process() with each entry of the backlog
-// for the given seq, until process return "false".
+// for the given seq, until process returns "true".
 // The entry on which process() returned false will remain in the backlog
 func (c *msgBacklogImpl) processBacklogForSeq(seq uint64, process func(*istanbul.Message) bool) {
 	backlogForSeq := c.backlogBySeq[seq]

--- a/consensus/istanbul/core/backlog_test.go
+++ b/consensus/istanbul/core/backlog_test.go
@@ -318,6 +318,56 @@ func TestStoreBacklog(t *testing.T) {
 	}
 }
 
+func TestClearBacklogForSequence(t *testing.T) {
+	testLogger.SetHandler(elog.StdoutHandler)
+
+	processed := false
+	backlog := newMsgBacklog(
+		func(msg *istanbul.Message) { processed = true },
+		func(msgCode uint64, msgView *istanbul.View) error { return nil },
+	).(*msgBacklogImpl)
+
+	// The backlog's state is sequence number 1, round 0.  Store future messages with sequence number 2
+	v := &istanbul.View{
+		Round:    big.NewInt(0),
+		Sequence: big.NewInt(2),
+	}
+	p1 := validator.New(common.BytesToAddress([]byte("12345667890")), blscrypto.SerializedPublicKey{})
+	preprepare := &istanbul.Preprepare{
+		View:     v,
+		Proposal: makeBlock(2),
+	}
+	prepreparePayload, _ := Encode(preprepare)
+	mPreprepare := &istanbul.Message{
+		Code:    istanbul.MsgPreprepare,
+		Msg:     prepreparePayload,
+		Address: p1.Address(),
+	}
+	numMsgs := 20
+	for i := 0; i < numMsgs; i++ {
+		backlog.store(mPreprepare)
+	}
+
+	// Sanity check that storing the messages worked
+	if backlog.msgCount != numMsgs {
+		t.Errorf("initial message count mismatch: have %d, want %d", backlog.msgCount, numMsgs)
+	}
+	// Try clearing a different sequence number, there should be no effect
+	backlog.clearBacklogForSeq(3)
+	if backlog.msgCount != numMsgs {
+		t.Errorf("middle message count mismatch: have %d, want %d", backlog.msgCount, numMsgs)
+	}
+	// Clear the messages with the right sequence number, should empty the backlog
+	backlog.clearBacklogForSeq(2)
+	if backlog.msgCount > 0 {
+		t.Errorf("backlog was not empty: msgCount %d", backlog.msgCount)
+	}
+	// The processor should not be called with the messages when clearBacklogForSeq() is called
+	if processed {
+		t.Errorf("backlog messages were processed during clearing")
+	}
+}
+
 func TestProcessFutureBacklog(t *testing.T) {
 	testLogger.SetHandler(elog.StdoutHandler)
 


### PR DESCRIPTION
### Description

While investigating issues with Baklava we noticed some errors in validator logs that led us to find this logic bug which means that `.clearBacklogForSeq()` wasn't doing anything, leading `.store()` calls to eventually drop new messages: https://github.com/celo-org/celo-blockchain/blob/278176e05ac8646c1c3642d02134fd7000a5be64/consensus/istanbul/core/backlog.go#L168-L170

This PR fixes the logic bug and adds a unit test that would have detected the bug, as well as similar logic mistake in the comment for `processBacklogForSeq()`

### Tested

- Before the fix, the new test fails
- After the fix, the new test passes

### Backwards compatibility

No backwards compatibility issues.
