### PR TITLE
Making dev mode work again

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1419,7 +1419,7 @@ func setIstanbul(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	cfg.Istanbul.ValidatorEnodeDBPath = stack.ResolvePath(cfg.Istanbul.ValidatorEnodeDBPath)
 	cfg.Istanbul.VersionCertificateDBPath = stack.ResolvePath(cfg.Istanbul.VersionCertificateDBPath)
 	cfg.Istanbul.RoundStateDBPath = stack.ResolvePath(cfg.Istanbul.RoundStateDBPath)
-	cfg.Istanbul.Validator = ctx.GlobalIsSet(MiningEnabledFlag.Name)
+	cfg.Istanbul.Validator = ctx.GlobalIsSet(MiningEnabledFlag.Name) || ctx.GlobalIsSet(DeveloperFlag.Name)
 	cfg.Istanbul.Replica = ctx.GlobalIsSet(IstanbulReplicaFlag.Name)
 }
 


### PR DESCRIPTION
### Description

Dev mode had stopped working in master (unless also --mine flag was specified).

### Other changes

### Tested

Only manual testing

### Related issues


### Backwards compatibility

