### PR TITLE
Revert "CIP-26: Get validator BLS key precompile"

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -616,7 +616,6 @@ func (sb *Backend) verifyValSetDiff(proposal istanbul.Proposal, block *types.Blo
 			oldValSet = append(oldValSet, istanbul.ValidatorData{
 				Address:      val.Address(),
 				BLSPublicKey: val.BLSPublicKey(),
-				Uncompressed: val.BLSPublicKeyUncompressed(),
 			})
 		}
 

--- a/consensus/istanbul/utils.go
+++ b/consensus/istanbul/utils.go
@@ -141,7 +141,6 @@ func ValidatorSetDiff(oldValSet []ValidatorData, newValSet []ValidatorData) ([]V
 			addedValidators = append(addedValidators, ValidatorData{
 				newVal.Address,
 				newVal.BLSPublicKey,
-				newVal.Uncompressed,
 			})
 		}
 	}

--- a/consensus/istanbul/utils_test.go
+++ b/consensus/istanbul/utils_test.go
@@ -114,7 +114,6 @@ func TestValidatorSetDiff(t *testing.T) {
 			convertedInputOldValSet = append(convertedInputOldValSet, ValidatorData{
 				addr,
 				blscrypto.SerializedPublicKey{},
-				nil,
 			})
 		}
 		convertedInputNewValSet := []ValidatorData{}
@@ -122,7 +121,6 @@ func TestValidatorSetDiff(t *testing.T) {
 			convertedInputNewValSet = append(convertedInputNewValSet, ValidatorData{
 				addr,
 				blscrypto.SerializedPublicKey{},
-				nil,
 			})
 		}
 		addedVals, removedVals := ValidatorSetDiff(convertedInputOldValSet, convertedInputNewValSet)

--- a/consensus/istanbul/validator.go
+++ b/consensus/istanbul/validator.go
@@ -34,7 +34,6 @@ var (
 type ValidatorData struct {
 	Address      common.Address
 	BLSPublicKey blscrypto.SerializedPublicKey
-	Uncompressed []byte
 }
 
 type Validator interface {
@@ -44,8 +43,6 @@ type Validator interface {
 	Address() common.Address
 
 	BLSPublicKey() blscrypto.SerializedPublicKey
-
-	BLSPublicKeyUncompressed() []byte
 
 	// Serialize returns binary reprenstation of the Validator
 	// can be use used to instantiate a validator with DeserializeValidator()
@@ -149,7 +146,6 @@ func CombineIstanbulExtraToValidatorData(addrs []common.Address, blsPublicKeys [
 		validators = append(validators, ValidatorData{
 			Address:      addrs[i],
 			BLSPublicKey: blsPublicKeys[i],
-			Uncompressed: blscrypto.UncompressKey(blsPublicKeys[i]),
 		})
 	}
 

--- a/consensus/istanbul/validator/default.go
+++ b/consensus/istanbul/validator/default.go
@@ -34,18 +34,12 @@ import (
 type defaultValidator struct {
 	address      common.Address
 	blsPublicKey blscrypto.SerializedPublicKey
-	uncompressed []byte
 }
 
 func newValidatorFromData(data *istanbul.ValidatorData) *defaultValidator {
-	uncompressed := data.Uncompressed
-	if len(uncompressed) == 0 {
-		uncompressed = nil
-	}
 	return &defaultValidator{
 		address:      data.Address,
 		blsPublicKey: data.BLSPublicKey,
-		uncompressed: uncompressed,
 	}
 }
 
@@ -53,13 +47,11 @@ func (val *defaultValidator) AsData() *istanbul.ValidatorData {
 	return &istanbul.ValidatorData{
 		Address:      val.address,
 		BLSPublicKey: val.blsPublicKey,
-		Uncompressed: val.uncompressed,
 	}
 }
 
 func (val *defaultValidator) Address() common.Address                     { return val.address }
 func (val *defaultValidator) BLSPublicKey() blscrypto.SerializedPublicKey { return val.blsPublicKey }
-func (val *defaultValidator) BLSPublicKeyUncompressed() []byte            { return val.uncompressed }
 func (val *defaultValidator) String() string                              { return val.Address().String() }
 
 func (val *defaultValidator) Serialize() ([]byte, error) { return rlp.EncodeToBytes(val) }

--- a/consensus/istanbul/validator/validator.go
+++ b/consensus/istanbul/validator/validator.go
@@ -27,7 +27,6 @@ func New(addr common.Address, blsPublicKey blscrypto.SerializedPublicKey) istanb
 	return &defaultValidator{
 		address:      addr,
 		blsPublicKey: blsPublicKey,
-		uncompressed: blscrypto.UncompressKey(blsPublicKey),
 	}
 }
 

--- a/contract_comm/validators/validators.go
+++ b/contract_comm/validators/validators.go
@@ -246,7 +246,6 @@ func GetValidatorData(header *types.Header, state vm.StateDB, validatorAddresses
 		validator := istanbul.ValidatorData{
 			Address:      addr,
 			BLSPublicKey: blsKeyFixedSize,
-			Uncompressed: blscrypto.UncompressKey(blsKeyFixedSize),
 		}
 		validatorData = append(validatorData, validator)
 	}

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -193,7 +193,7 @@ var PrecompiledContractsDonut = map[common.Address]PrecompiledContract{
 	b12_377G2MultiExpAddress: nil,
 	b12_377PairingAddress:    nil,
 	cip20Address:             nil,
-	cip26Address:             &getValidatorBLS{},
+	cip26Address:             nil,
 }
 
 // RunPrecompiledContract runs and evaluates the output of a precompiled contract.
@@ -943,72 +943,6 @@ func (c *getValidator) Run(input []byte, caller common.Address, evm *EVM, gas ui
 	addressBytes := common.LeftPadBytes(validatorAddress[:], 32)
 
 	return addressBytes, gas, nil
-}
-
-type getValidatorBLS struct{}
-
-func (c *getValidatorBLS) RequiredGas(input []byte) uint64 {
-	return params.GetValidatorBLSGas
-}
-
-func copyBEtoLE(result []byte, offset int, uncompressedBytes []byte, offset2 int) {
-	for i := 0; i < 48; i++ {
-		result[63-i+offset] = uncompressedBytes[i+offset2]
-	}
-}
-
-// Return the validator BLS public key for the validator at given index. The public key is given in uncompressed format, 4*48 bytes.
-func (c *getValidatorBLS) Run(input []byte, caller common.Address, evm *EVM, gas uint64) ([]byte, uint64, error) {
-	gas, err := debitRequiredGas(c, input, gas)
-	if err != nil {
-		return nil, gas, err
-	}
-
-	// input is comprised of two arguments:
-	//   index: 32 byte integer representing the index of the validator to get
-	//   blockNumber: 32 byte integer representing the block number to access
-	if len(input) < 64 {
-		return nil, gas, ErrInputLength
-	}
-
-	index := new(big.Int).SetBytes(input[0:32])
-
-	blockNumber := new(big.Int).SetBytes(input[32:64])
-	if blockNumber.Cmp(common.Big0) == 0 {
-		// Validator set for the genesis block is empty, so any index is out of bounds.
-		return nil, gas, ErrValidatorsOutOfBounds
-	}
-	if blockNumber.Cmp(evm.Context.BlockNumber) > 0 {
-		return nil, gas, ErrBlockNumberOutOfBounds
-	}
-
-	// Note: Passing empty hash as here as it is an extra expense and the hash is not actually used.
-	validators := evm.Context.Engine.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
-
-	// Ensure index, which is guaranteed to be non-negative, is valid.
-	if index.Cmp(big.NewInt(int64(len(validators)))) >= 0 {
-		return nil, gas, ErrValidatorsOutOfBounds
-	}
-
-	uncompressedBytes := validators[index.Uint64()].BLSPublicKeyUncompressed()
-	if len(uncompressedBytes) == 0 {
-		uncompressedBytes = blscrypto.UncompressKey(validators[index.Uint64()].BLSPublicKey())
-	}
-	if len(uncompressedBytes) != 192 {
-		return nil, gas, ErrUnexpected
-	}
-
-	result := make([]byte, 256)
-	for i := 0; i < 256; i++ {
-		result[i] = 0
-	}
-
-	copyBEtoLE(result, 0, uncompressedBytes, 0)
-	copyBEtoLE(result, 64, uncompressedBytes, 48)
-	copyBEtoLE(result, 128, uncompressedBytes, 96)
-	copyBEtoLE(result, 192, uncompressedBytes, 144)
-
-	return result, gas, nil
 }
 
 type numberValidators struct{}

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"golang.org/x/crypto/sha3"
@@ -55,11 +54,7 @@ func (e mockEngine) GetValidators(number *big.Int, _ common.Hash) []istanbul.Val
 	hash := sha3.Sum256(preimage)
 	var validators []istanbul.Validator
 	for i := 0; i < 16; i, hash = i+1, sha3.Sum256(hash[:]) {
-		key, _ := crypto.ToECDSA(hash[:])
-		blsPrivateKey, _ := blscrypto.ECDSAToBLS(key)
-		blsPublicKey, _ := blscrypto.PrivateToPublic(blsPrivateKey)
-		addr := crypto.PubkeyToAddress(key.PublicKey)
-		validators = append(validators, validator.New(addr, blsPublicKey))
+		validators = append(validators, validator.New(common.BytesToAddress(hash[:]), blscrypto.SerializedPublicKey{}))
 	}
 	return validators
 }
@@ -584,12 +579,12 @@ var getValidatorTests = []precompiledTest{
 	},
 	{
 		input:    "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff",
-		expected: "000000000000000000000000fbb697cf00d3de24bc81225b4b2a9e7e763f8136",
+		expected: "000000000000000000000000fa55ba38ef5f98473db2771dd03c17c02bbe0fdc",
 		name:     "correct_block_0xff_index_0x0",
 	},
 	{
 		input:    "000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000ff",
-		expected: "0000000000000000000000003e70ba60978582c2770aa95579e542a521456668",
+		expected: "00000000000000000000000068e2962e75d952ffabb71170783df3c2c85f7939",
 		name:     "correct_block_0xff_index_0xa",
 	},
 	{
@@ -600,50 +595,7 @@ var getValidatorTests = []precompiledTest{
 	},
 	{
 		input:    "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002710",
-		expected: "000000000000000000000000a7fdb33d85f63259ff56133b5be795ef669a5756",
-		name:     "correct_chain_head",
-	},
-	{
-		input:         "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002711",
-		expected:      "block number out of bounds",
-		name:          "invalid_future_block",
-		errorExpected: true,
-	},
-}
-
-var getValidatorBLSPublicKeyTests = []precompiledTest{
-	// Input is { validator index | block number }. Output is validator BLS public key.
-	{
-		input:         "",
-		expected:      "invalid input length",
-		name:          "input_invalid_empty",
-		errorExpected: true,
-	},
-	{
-		input:         "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-		expected:      "validator index out of bounds",
-		name:          "invalid_genesis_block",
-		errorExpected: true,
-	},
-	{
-		input:    "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ff",
-		expected: "00000000000000000000000000000000001fd78b7dee6db285d05c16aedcc6f33652607220efb1ab99d512c77d3dd77dba78c81d4190b4a633720d92c1a577f9000000000000000000000000000000000021bd7f370c65fba1afbcf16e256a82b6cdfea0a27d8df313edd1a881f41780609ee055b78974b1c8d97dac3c9461c300000000000000000000000000000000016366c10606045d43fb18300560995394a24bd1358b9210540f4ec29fdaaf8506af7651a8504230734a62b6599f744c0000000000000000000000000000000000209e3562ca2dc97e0182cd354662ff20bc2f312866b4655c3eed0af045de4133ab8b5f5a4cde9b2f12113e47d1157e",
-		name:     "correct_block_0xff_index_0x0",
-	},
-	{
-		input:    "000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000ff",
-		expected: "00000000000000000000000000000000015398774c6805e5f7edc1cd2ce40c44bd5b430caa3dfefe740b12efa1708bb20aeadce71d5bfe288158b87f07dc82c700000000000000000000000000000000000d3dca6f108fa022d1e106db969e36622eaec7b2a4b3eefa94aee9982a0133ca09a86b142b71fab14c770e7e70763a0000000000000000000000000000000000ac437ff49e987559a9c9ec9a421d46f6b1044b2888e4c23653827e94b9c3729c897fc02db7364694f8bc5e783529c30000000000000000000000000000000000bc9531ebddea1c9ca9a08c0eafd7d0d734d17d54150d75c5d3d0ab3d416807693da02dababe8ef734a50083c2ef889",
-		name:     "correct_block_0xff_index_0xa",
-	},
-	{
-		input:         "000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000ff",
-		expected:      "validator index out of bounds",
-		name:          "invalid_index_out_of_bounds",
-		errorExpected: true,
-	},
-	{
-		input:    "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002710",
-		expected: "000000000000000000000000000000000173d1ea9889757e8f176737629c7b6c446a6832ddec53562ebe0cda09455792927597a3025dd613021de96ebc2ecc130000000000000000000000000000000000866721e8b88328b0df9e6c52bd9bdcce076d9febeba542cf7d48e7fae54bbe783c785131678fb3f15c665f5c1fd1c500000000000000000000000000000000008a6412232130f837d31ce5223e088e338997fad1de25908ae7e4b65bfe2fe4839dcd41f5ae613d146796d98d65255c000000000000000000000000000000000039d57467b392c8c30b81e961469ff750a3473ffa423c12f671264ea9967f5bfd21b0247d02e132cdfd2682cf207ff9",
+		expected: "00000000000000000000000024e11f684408ce3e35772daa281facf81d8be157",
 		name:     "correct_chain_head",
 	},
 	{
@@ -782,7 +734,7 @@ func testPrecompiled(addr string, test precompiledTest, t *testing.T) {
 }
 
 func testPrecompiledOOG(addr string, test precompiledTest, t *testing.T) {
-	p := PrecompiledContractsDonut[common.HexToAddress(addr)]
+	p := PrecompiledContractsIstanbul[common.HexToAddress(addr)]
 	in := common.Hex2Bytes(test.input)
 	contract := NewContract(AccountRef(common.HexToAddress("1337")),
 		nil, new(big.Int), p.RequiredGas(in)-1)
@@ -800,7 +752,7 @@ func testPrecompiledOOG(addr string, test precompiledTest, t *testing.T) {
 }
 
 func testPrecompiledFailure(addr string, test precompiledFailureTest, t *testing.T) {
-	p := PrecompiledContractsDonut[common.HexToAddress(addr)]
+	p := PrecompiledContractsIstanbul[common.HexToAddress(addr)]
 	in := common.Hex2Bytes(test.input)
 	contract := NewContract(AccountRef(common.HexToAddress("31337")),
 		nil, new(big.Int), p.RequiredGas(in))
@@ -822,7 +774,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 	if test.noBenchmark {
 		return
 	}
-	p := PrecompiledContractsDonut[common.HexToAddress(addr)]
+	p := PrecompiledContractsIstanbul[common.HexToAddress(addr)]
 	in := common.Hex2Bytes(test.input)
 	reqGas := p.RequiredGas(in)
 	contract := NewContract(AccountRef(common.HexToAddress("1337")),
@@ -994,12 +946,6 @@ func TestPrecompiledProofOfPossession(t *testing.T) {
 func TestGetValidator(t *testing.T) {
 	for _, test := range getValidatorTests {
 		testPrecompiled("fa", test, t)
-	}
-}
-
-func TestGetValidatorBLSPublicKey(t *testing.T) {
-	for _, test := range getValidatorBLSPublicKeyTests {
-		testPrecompiled("e1", test, t)
 	}
 }
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -66,9 +66,6 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 		if evm.chainRules.IsIstanbul {
 			precompiles = PrecompiledContractsIstanbul
 		}
-		if evm.chainRules.IsDonut {
-			precompiles = PrecompiledContractsDonut
-		}
 		if p := precompiles[*contract.CodeAddr]; p != nil {
 			return RunPrecompiledContract(p, input, contract, evm)
 		}
@@ -256,9 +253,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		}
 		if evm.chainRules.IsIstanbul {
 			precompiles = PrecompiledContractsIstanbul
-		}
-		if evm.chainRules.IsDonut {
-			precompiles = PrecompiledContractsDonut
 		}
 		if precompiles[addr] == nil && evm.chainRules.IsEIP158 && value.Sign() == 0 {
 			// Calling a non existing account, don't do anything, but ping the tracer

--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -252,15 +252,3 @@ func SerializedSignatureFromBytes(serializedSignature []byte) (SerializedSignatu
 	copy(signatureBytesFixed[:], serializedSignature)
 	return signatureBytesFixed, nil
 }
-
-func UncompressKey(serialized SerializedPublicKey) []byte {
-	publicKey, err := bls.DeserializePublicKeyCached(serialized[:])
-	if err != nil {
-		return nil
-	}
-	uncompressedBytes, err := publicKey.SerializeUncompressed()
-	if err != nil {
-		return nil
-	}
-	return uncompressedBytes
-}

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -399,7 +399,7 @@ func New(code string) (*Tracer, error) {
 		return 1
 	})
 	tracer.vm.PushGlobalGoFunction("isPrecompiled", func(ctx *duktape.Context) int {
-		_, ok := vm.PrecompiledContractsDonut[common.BytesToAddress(popSlice(ctx))]
+		_, ok := vm.PrecompiledContractsIstanbul[common.BytesToAddress(popSlice(ctx))]
 		ctx.PushBoolean(ok)
 		return 1
 	})

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef
 	github.com/wsddn/go-ecdh v0.0.0-20161211032359-48726bab9208
 	golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4
-	golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f // indirect
+	golang.org/x/mobile v0.0.0-20200801112145-973feb4309de // indirect
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299

--- a/params/config.go
+++ b/params/config.go
@@ -139,7 +139,7 @@ var (
 		},
 	}
 
-	DeveloperChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), big.NewInt(0), &IstanbulConfig{
+	DeveloperChainConfig = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, big.NewInt(0), nil, &IstanbulConfig{
 		Epoch:          300,
 		ProposerPolicy: 0,
 		RequestTimeout: 1000,

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -138,7 +138,6 @@ const (
 	FractionMulExpGas           uint64 = 50     // Cost of performing multiplication and exponentiation of fractions to an exponent of up to 10^3.
 	ProofOfPossessionGas        uint64 = 350000 // Cost of verifying a BLS proof of possession.
 	GetValidatorGas             uint64 = 1000   // Cost of reading a validator's address.
-	GetValidatorBLSGas          uint64 = 1000   // Cost of reading a validator's BLS public key.
 	GetEpochSizeGas             uint64 = 10     // Cost of querying the number of blocks in an epoch.
 	GetBlockNumberFromHeaderGas uint64 = 10     // Cost of decoding a block header.
 	HashHeaderGas               uint64 = 10     // Cost of hashing a block header.


### PR DESCRIPTION
Reverts celo-org/celo-blockchain#1250

The change on `ValidatorData` implies a break on previous `roundStateDB` storage. We revert it until it's fixed.