### PR TITLE
Benchmark round changes and pre-prepares

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,16 @@ if you don't have `GOPATH` set-up.
 Once a PR is approved, adding on the `automerge` label will keep it up to date
 and do a squash merge once all the required tests have passed.
 
+### Benchmarking
+
+Golang has built in support for running benchmarks with go tool
+`go test -run=ThisIsNotATestName -bench=. ./$PACKAGE_NAME` will run all benchmarks in a package.
+
+One note around running benchmarks is that `BenchmarkHandlePreprepare` is quite takes a while to run, particularly when testing with a larger number of validators.
+Substituting `-bench=REGEX` for `-bench=.` will specify which tests to run. Adding `-cpuprofile=cpu.out` which can be visualized with `go tool pprof -html:8080 cpu.out` if `graphviz` is installed.
+
+See the [go testing flags](https://golang.org/cmd/go/#hdr-Testing_flags) and [go docs](https://golang.org/pkg/testing/#hdr-Benchmarks) for more information on benchmarking.
+
 
 ## License
 

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -398,7 +398,6 @@ type testSystem struct {
 }
 
 func newTestSystem(n uint64, f uint64, keys [][]byte) *testSystem {
-	testLogger.SetHandler(elog.StdoutHandler)
 	return &testSystem{
 		backends:       make([]*testSystemBackend, n),
 		validatorsKeys: keys,
@@ -433,9 +432,7 @@ func newTestValidatorSet(n int) istanbul.ValidatorSet {
 	return validator.NewSet(validators)
 }
 
-// FIXME: int64 is needed for N and F
-func NewTestSystemWithBackend(n, f uint64) *testSystem {
-	testLogger.SetHandler(elog.StdoutHandler)
+func newTestSystemWithBackend(n, f uint64) *testSystem {
 
 	validators, blsKeys, keys := generateValidators(int(n))
 	sys := newTestSystem(n, f, blsKeys)
@@ -496,6 +493,19 @@ func NewTestSystemWithBackendDonut(n, f, epoch uint64, donutBlock int64) *testSy
 	}
 
 	return sys
+}
+
+// FIXME: int64 is needed for N and F
+func NewTestSystemWithBackend(n, f uint64) *testSystem {
+	testLogger.SetHandler(elog.StdoutHandler)
+	return newTestSystemWithBackend(n, f)
+}
+
+// FIXME: int64 is needed for N and F
+func NewMutedTestSystemWithBackend(n, f uint64) *testSystem {
+	testLogger.SetHandler(elog.DiscardHandler())
+	return newTestSystemWithBackend(n, f)
+
 }
 
 // listen will consume messages from queue and deliver a message to core

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/params"
@@ -43,6 +42,12 @@ import (
 	elog "github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 )
+
+// ErrorReporter is the intersection of the testing.B and testing.T interfaces.
+// This enables setup functions to be used by both benchmarks and tests.
+type ErrorReporter interface {
+	Errorf(format string, args ...interface{})
+}
 
 var testLogger = elog.New()
 
@@ -544,7 +549,7 @@ func (t *testSystem) MinQuorumSize() uint64 {
 	return uint64(math.Ceil(float64(2*t.n) / 3))
 }
 
-func (sys *testSystem) getPreparedCertificate(t *testing.T, views []istanbul.View, proposal istanbul.Proposal) istanbul.PreparedCertificate {
+func (sys *testSystem) getPreparedCertificate(t ErrorReporter, views []istanbul.View, proposal istanbul.Proposal) istanbul.PreparedCertificate {
 	preparedCertificate := istanbul.PreparedCertificate{
 		Proposal:                proposal,
 		PrepareOrCommitMessages: []istanbul.Message{},
@@ -568,7 +573,7 @@ func (sys *testSystem) getPreparedCertificate(t *testing.T, views []istanbul.Vie
 	return preparedCertificate
 }
 
-func (sys *testSystem) getRoundChangeCertificate(t *testing.T, views []istanbul.View, preparedCertificate istanbul.PreparedCertificate) istanbul.RoundChangeCertificate {
+func (sys *testSystem) getRoundChangeCertificate(t ErrorReporter, views []istanbul.View, preparedCertificate istanbul.PreparedCertificate) istanbul.RoundChangeCertificate {
 	var roundChangeCertificate istanbul.RoundChangeCertificate
 	for i, backend := range sys.backends {
 		if uint64(i) == sys.MinQuorumSize() {

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -274,6 +274,26 @@ func (self *testSystemBackend) finalizeAndReturnMessage(msg *istanbul.Message) (
 	return *message, err
 }
 
+func (self *testSystemBackend) getPreprepareMessage(view istanbul.View, roundChangeCertificate istanbul.RoundChangeCertificate, proposal istanbul.Proposal) (istanbul.Message, error) {
+	preprepare := &istanbul.Preprepare{
+		View:                   &view,
+		RoundChangeCertificate: roundChangeCertificate,
+		Proposal:               proposal,
+	}
+
+	payload, err := Encode(preprepare)
+	if err != nil {
+		return istanbul.Message{}, err
+	}
+
+	msg := &istanbul.Message{
+		Code: istanbul.MsgPreprepare,
+		Msg:  payload,
+	}
+
+	return self.finalizeAndReturnMessage(msg)
+}
+
 func (self *testSystemBackend) getPrepareMessage(view istanbul.View, digest common.Hash) (istanbul.Message, error) {
 	prepare := &istanbul.Subject{
 		View:   &view,


### PR DESCRIPTION
### Description

This adds a simple benchmark for round changes and pre-prepares. It is parameterized with the validator set size
to determine the effect of increasing the set size on the time to complete a round change. 

### Other changes

* Adds getPreprepareMessage to testbackend
* Adds a test system with no logging
* Enables testing.B to be passed to testbackend getters
* Adds benchmarking instructions to README

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
