### PR TITLE
Add Churrito and Donut override flags

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"reflect"
 	"unicode"
@@ -148,6 +149,12 @@ func enableWhisper(ctx *cli.Context) bool {
 
 func makeFullNode(ctx *cli.Context) *node.Node {
 	stack, cfg := makeConfigNode(ctx)
+	if ctx.GlobalIsSet(utils.OverrideChurritoFlag.Name) {
+		cfg.Eth.OverrideChurrito = new(big.Int).SetUint64(ctx.GlobalUint64(utils.OverrideChurritoFlag.Name))
+	}
+	if ctx.GlobalIsSet(utils.OverrideDonutFlag.Name) {
+		cfg.Eth.OverrideDonut = new(big.Int).SetUint64(ctx.GlobalUint64(utils.OverrideDonutFlag.Name))
+	}
 	utils.RegisterEthService(stack, &cfg.Eth)
 
 	// Whisper must be explicitly enabled by specifying at least 1 whisper flag or in dev mode

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -70,6 +70,8 @@ var (
 		utils.ExternalSignerFlag,
 		utils.NoUSBFlag,
 		utils.SmartCardDaemonPathFlag,
+		utils.OverrideChurritoFlag,
+		utils.OverrideDonutFlag,
 		utils.TxPoolLocalsFlag,
 		utils.TxPoolNoLocalsFlag,
 		utils.TxPoolJournalFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -248,6 +248,16 @@ var (
 		Value: "0",
 	}
 
+	// Hard fork activation overrides
+	OverrideChurritoFlag = cli.Uint64Flag{
+		Name:  "override.churrito",
+		Usage: "Manually specify Churrito fork-block, overriding the bundled setting",
+	}
+	OverrideDonutFlag = cli.Uint64Flag{
+		Name:  "override.donut",
+		Usage: "Manually specify Donut fork-block, overriding the bundled setting",
+	}
+
 	// Light server and client settings
 
 	LightServeFlag = cli.IntFlag{

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -145,6 +145,10 @@ func (e *GenesisMismatchError) Error() string {
 //
 // The returned chain configuration is never nil.
 func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig, common.Hash, error) {
+	return SetupGenesisBlockWithOverride(db, genesis, nil, nil)
+}
+
+func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, overrideChurrito, overrideDonut *big.Int) (*params.ChainConfig, common.Hash, error) {
 	if genesis != nil && (genesis.Config == nil || genesis.Config.Istanbul == nil) {
 		return params.MainnetChainConfig, common.Hash{}, errGenesisNoConfig
 	}
@@ -193,6 +197,12 @@ func SetupGenesisBlock(db ethdb.Database, genesis *Genesis) (*params.ChainConfig
 
 	// Get the existing chain configuration.
 	newcfg := genesis.configOrDefault(stored)
+	if overrideChurrito != nil {
+		newcfg.ChurritoBlock = overrideChurrito
+	}
+	if overrideDonut != nil {
+		newcfg.DonutBlock = overrideDonut
+	}
 	if err := newcfg.CheckConfigForkOrder(); err != nil {
 		return newcfg, common.Hash{}, err
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -148,7 +148,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	if err != nil {
 		return nil, err
 	}
-	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlock(chainDb, config.Genesis)
+	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis, config.OverrideChurrito, config.OverrideDonut)
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}

--- a/eth/config.go
+++ b/eth/config.go
@@ -132,4 +132,10 @@ type Config struct {
 
 	// CheckpointOracle is the configuration for checkpoint oracle.
 	CheckpointOracle *params.CheckpointOracleConfig `toml:",omitempty"`
+
+	// Churrito block override (TODO: remove after the fork)
+	OverrideChurrito *big.Int `toml:",omitempty"`
+
+	// Donut block override (TODO: remove after the fork)
+	OverrideDonut *big.Int `toml:",omitempty"`
 }

--- a/eth/gen_config.go
+++ b/eth/gen_config.go
@@ -52,8 +52,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		RPCGasCap               *big.Int                       `toml:",omitempty"`
 		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle        *params.CheckpointOracleConfig `toml:",omitempty"`
-		OverrideIstanbul        *big.Int                       `toml:",omitempty"`
-		OverrideMuirGlacier     *big.Int                       `toml:",omitempty"`
+		OverrideChurrito        *big.Int                       `toml:",omitempty"`
+		OverrideDonut           *big.Int                       `toml:",omitempty"`
 	}
 	var enc Config
 	enc.Genesis = c.Genesis
@@ -91,6 +91,8 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.RPCGasCap = c.RPCGasCap
 	enc.Checkpoint = c.Checkpoint
 	enc.CheckpointOracle = c.CheckpointOracle
+	enc.OverrideChurrito = c.OverrideChurrito
+	enc.OverrideDonut = c.OverrideDonut
 	return &enc, nil
 }
 
@@ -132,8 +134,8 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		RPCGasCap               *big.Int                       `toml:",omitempty"`
 		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
 		CheckpointOracle        *params.CheckpointOracleConfig `toml:",omitempty"`
-		OverrideIstanbul        *big.Int                       `toml:",omitempty"`
-		OverrideMuirGlacier     *big.Int                       `toml:",omitempty"`
+		OverrideChurrito        *big.Int                       `toml:",omitempty"`
+		OverrideDonut           *big.Int                       `toml:",omitempty"`
 	}
 	var dec Config
 	if err := unmarshal(&dec); err != nil {
@@ -243,6 +245,12 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.CheckpointOracle != nil {
 		c.CheckpointOracle = dec.CheckpointOracle
+	}
+	if dec.OverrideChurrito != nil {
+		c.OverrideChurrito = dec.OverrideChurrito
+	}
+	if dec.OverrideDonut != nil {
+		c.OverrideDonut = dec.OverrideDonut
 	}
 	return nil
 }

--- a/les/client.go
+++ b/les/client.go
@@ -98,7 +98,8 @@ func New(ctx *node.ServiceContext, config *eth.Config) (*LightEthereum, error) {
 	if err != nil {
 		return nil, err
 	}
-	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlock(chainDb, config.Genesis)
+	chainConfig, genesisHash, genesisErr := core.SetupGenesisBlockWithOverride(chainDb, config.Genesis,
+		config.OverrideChurrito, config.OverrideDonut)
 	if _, isCompat := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !isCompat {
 		return nil, genesisErr
 	}


### PR DESCRIPTION
### Description

Add CLI flags `--override.churrito` and `--override.donut` which can be used to override the activation block numbers for the Churrito and Donut hard forks.  This could be used to set the activation on pre-existing ephemeral testnets, or in an emergency scenario where the activation block numbers have already been set and we need to postpone the fork, in which case the overrides would allow doing that using a flag rather than having to downgrade celo-blockchain.

This follows the pattern used for overrides in go-ethereum, for example with Istanbul and Muir Glacier.  The override has effect except if (it's the first time `geth` is being run && `geth init` wasn't used).  The value specified in the override isn't persisted to the database, so if you later on run geth without the override flag, the activation block will go back to normal.

### Tested

- Confirmed both flags work (separately or together) and that their effect goes away when the flags are removed (that the override is not persisted).
- Confirmed that activation block numbers are not affected when overrides aren't specified.

### Backwards compatibility

No breaking changes.
