### PR TITLE
Fix indeterministic test TestSideLogRebirth

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1139,7 +1139,7 @@ func TestSideLogRebirth(t *testing.T) {
 	logsCh := make(chan []*types.Log)
 	blockchain.SubscribeLogsEvent(logsCh)
 
-	chain, _ := GenerateChain(params.IstanbulTestChainConfig, genesis, mockEngine.NewFaker(), db, 2, func(i int, gen *BlockGen) {
+	chain, _ := GenerateChain(params.IstanbulTestChainConfig, genesis, mockEngine.NewFaker(), db, 3, func(i int, gen *BlockGen) {
 		if i == 1 {
 			// Higher block difficulty
 			gen.OffsetTime(-9)
@@ -1163,8 +1163,8 @@ func TestSideLogRebirth(t *testing.T) {
 		t.Fatalf("failed to insert forked chain: %v", err)
 	}
 
-	// Generate a new block based on side chain
-	newBlocks, _ := GenerateChain(params.IstanbulTestChainConfig, sideChain[len(sideChain)-1], mockEngine.NewFaker(), db, 1, func(i int, gen *BlockGen) {})
+	// Generate two new blocks based on side chain, to trigger a reorg
+	newBlocks, _ := GenerateChain(params.IstanbulTestChainConfig, sideChain[len(sideChain)-1], mockEngine.NewFaker(), db, 2, func(i int, gen *BlockGen) {})
 	go listenNewLog(logsCh, 1)
 	if _, err := blockchain.InsertChain(newBlocks); err != nil {
 		t.Fatalf("failed to insert forked chain: %v", err)


### PR DESCRIPTION
This test from go-ethereum includes code to make the main and side-chain have difficulties as desired for the test to work.  Since for Celo the difficulty of each block is 1, that part wasn't working and the main and side-chain both had difficulty 3.  As a result, whether or not a reorg was done when the side-chain is inserted was indeterministic (see writeBlockWithState() in core/blockchain.go).  But Go's math/rand global rand object uses the seed value 1, and so you get the same sequence of values every time.  This was leading to some very confusing behavior: this test was passing as part of the overall test suite, but failing if run by itself.  This commit fixes that by making the main chain have 3 blocks, the side chain 2 blocks, and then it adds 2 more to side chain, making it 4.  This way, the result is always as desired: there is no reorg when the side-chain is constructed and there is a reorg at the last step when we add 2 more.a reorg at the last step when we add 2 more.

### Description

This was a real head-scratcher.  The test `TestSideLogRebirth` was failing when run by itself, since the 1.9.13 merge.  I found the exact commit where it started failing, but it didn't seem to have anything to do with it.  It turned out to have been incidental: the test was indeterministic the whole time, depending on the state of the random number generator when it starts.  But Go's global random object is seeded with the value 1, so you get the same result every time you run the same code, but if you run it in a different context (e.g. by itself vs as part of the whole suite, or when other random calls exist in code that didn't exist in a prior commit), you can get different results.

This PR fixes it by making the difficulties not equal so there is no indeterminism.

### Tested

Verified that the test passes even if you add `rand.Seed(s)` for different values of `s` at the start of the test.