### PR TITLE
Add a cache to StateProcessor

### DIFF
--- a/consensus/consensustest/mockprotocol.go
+++ b/consensus/consensustest/mockprotocol.go
@@ -373,7 +373,7 @@ func (e *MockEngine) SealHash(header *types.Header) (hash common.Hash) {
 func (e *MockEngine) Seal(chain consensus.ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
 	header := block.Header()
 	select {
-	case results <- block.WithSeal(header):
+	case results <- block.WithHeader(header):
 	default:
 		log.Warn("Sealing result is not read by miner", "mode", "fake", "sealhash", e.SealHash(header))
 	}

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -478,7 +478,7 @@ func (sb *Backend) Commit(proposal istanbul.Proposal, aggregatedSeal types.Istan
 		return err
 	}
 	// update block's header
-	block = block.WithSeal(h)
+	block = block.WithHeader(h)
 	block = block.WithEpochSnarkData(&types.EpochSnarkData{
 		Bitmap:    aggregatedEpochValidatorSetSeal.Bitmap,
 		Signature: aggregatedEpochValidatorSetSeal.Signature,

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -579,7 +579,7 @@ func (sb *Backend) updateBlock(parent *types.Header, block *types.Block) (*types
 		return nil, err
 	}
 
-	return block.WithSeal(header), nil
+	return block.WithHeader(header), nil
 }
 
 // APIs returns the RPC APIs this consensus engine provides.

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -221,7 +221,7 @@ func EmptyPreparedCertificate() PreparedCertificate {
 	block = block.WithEpochSnarkData(&types.EmptyEpochSnarkData)
 
 	return PreparedCertificate{
-		Proposal:                block.WithSeal(emptyHeader),
+		Proposal:                block.WithHeader(emptyHeader),
 		PrepareOrCommitMessages: []Message{},
 	}
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -236,7 +236,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	}
 	bc.validator = NewBlockValidator(chainConfig, bc, engine)
 	bc.prefetcher = newStatePrefetcher(chainConfig, bc, engine)
-	bc.processor = NewStateProcessor(chainConfig, bc, engine)
+	bc.processor = NewCachingStateProcessor(chainConfig, bc, engine)
 
 	var err error
 	bc.hc, err = NewHeaderChain(db, chainConfig, engine, bc.getProcInterrupt)

--- a/core/caching_state_processor_test.go
+++ b/core/caching_state_processor_test.go
@@ -1,0 +1,102 @@
+package core
+
+import (
+	"math/big"
+	"reflect"
+	"testing"
+
+	mockEngine "github.com/celo-org/celo-blockchain/consensus/consensustest"
+	"github.com/celo-org/celo-blockchain/core/rawdb"
+	"github.com/celo-org/celo-blockchain/core/state"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/core/vm"
+	"github.com/celo-org/celo-blockchain/params"
+)
+
+// TestCache tests
+// * cache hit
+// * cache miss
+func TestCache(t *testing.T) {
+	// Generate a canonical chain to act as the main dataset
+	engine := mockEngine.NewFaker()
+
+	// Generate and import the canonical chain
+	diskdb := rawdb.NewMemoryDatabase()
+	new(Genesis).MustCommit(diskdb)
+	chain, err := NewBlockChain(diskdb, nil, params.TestChainConfig, engine, vm.Config{}, nil)
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+	root := chain.GetBlockByNumber(0).Root()
+	state, _ := state.New(root, chain.stateCache, chain.snaps)
+	block1 := makeBlock(100)
+	cachingStateProcessor := chain.processor.(*CachingStateProcessor)
+	// Before processing first block, shouldn't have any cache entry
+	if cachingStateProcessor.cache.Len() != 0 {
+		t.Error("Wrong cache length", "expected", 0, "actual", cachingStateProcessor.cache.Len())
+	}
+
+	// After processing block1, cache should have length of 1
+	cachingStateProcessor.Process(block1, state, chain.vmConfig)
+	if cachingStateProcessor.cache.Len() != 1 {
+		t.Error("Wrong cache length", "expected", 1, "actual", cachingStateProcessor.cache.Len())
+	}
+
+	// After processing block1 again, cache should have length of 2
+	cachingStateProcessor.Process(block1, state, chain.vmConfig)
+	if cachingStateProcessor.cache.Len() != 2 {
+		t.Error("Wrong cache length", "expected", 2, "actual", cachingStateProcessor.cache.Len())
+	}
+}
+
+// testAlternativeProcessors tests if StateProcessor & CachingStateProcessor will produce expected results.
+func testAlternativeProcessors(t *testing.T, block1, block2 *types.Block, same bool) {
+	// Generate a canonical chain to act as the main dataset
+	engine := mockEngine.NewFaker()
+
+	// Generate and import the canonical chain
+	diskdb := rawdb.NewMemoryDatabase()
+	new(Genesis).MustCommit(diskdb)
+	chain, err := NewBlockChain(diskdb, nil, params.TestChainConfig, engine, vm.Config{}, nil)
+	if err != nil {
+		t.Fatalf("failed to create tester chain: %v", err)
+	}
+
+	cachingStateProcessor := chain.processor
+	stateProcessor := NewStateProcessor(chain.chainConfig, chain, engine)
+
+	root := chain.GetBlockByNumber(0).Root()
+	state1, _ := state.New(root, chain.stateCache, chain.snaps)
+	state2, _ := state.New(root, chain.stateCache, chain.snaps)
+
+	r1, l1, g1, e1 := cachingStateProcessor.Process(block1, state1, chain.vmConfig)
+	r2, l2, g2, e2 := stateProcessor.Process(block2, state2, chain.vmConfig)
+
+	if isEqual(r1, r2, l1, l2, g1, g2, e1, e2, state1, state2) != same {
+		t.Error("Not expected")
+	}
+}
+
+// TestAlternativeProcessors tests:
+// * Given same block, two processors will give same results
+// * Given different blocks, two processors will give different results
+func TestAlternativeProcessors(t *testing.T) {
+	block1 := makeBlock(1)
+	block2 := makeBlock(2)
+	testAlternativeProcessors(t, block1, block1, true)
+	testAlternativeProcessors(t, block1, block2, false)
+}
+
+func makeBlock(number int64) *types.Block {
+	header := &types.Header{
+		Number:  big.NewInt(number),
+		GasUsed: 0,
+		Time:    uint64(0),
+	}
+	return types.NewBlock(header, nil, nil, nil)
+}
+
+func isEqual(r1, r2 types.Receipts, l1, l2 []*types.Log, g1, g2 uint64, e1, e2 error, s1, s2 *state.StateDB) bool {
+	return reflect.DeepEqual(r1, r2) && reflect.DeepEqual(l1, l2) && reflect.DeepEqual(g1, g2) && reflect.DeepEqual(e1, e2) && reflect.DeepEqual(s1, s2)
+	//&& s1.IntermediateRoot(true) == s2.IntermediateRoot(true)
+}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -365,9 +365,8 @@ func (c *writeCounter) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-// WithSeal returns a new block with the data from b but the header replaced with
-// the sealed one.
-func (b *Block) WithSeal(header *Header) *Block {
+// WithHeader returns a new block with the data from b but the header replaced with the given one.
+func (b *Block) WithHeader(header *Header) *Block {
 	cpy := *header
 
 	return &Block{


### PR DESCRIPTION
### Description

Implement a CachingStateProcessor to avoid redundancy.
Document:
https://www.notion.so/Block-Processing-Optimization-9c997b2fe2e04b879df3cd261c3ed6d8

- [x] Add a cache to StateProcessor to avoid redundant processing.
- [x] Replace `miner/worker.go`'s local cache `pendingTasks`
- [ ] Add unit tests

### Other changes

Renaming & removing unused code

### Tested

Pending

### Related issues

- Fixes #1253 

### Backwards compatibility

Yes
