### PR TITLE
Adds script to build and publish a private docker image

### DIFF
--- a/scripts/publish_private_docker_image.sh
+++ b/scripts/publish_private_docker_image.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+COMMIT_SHA=$(git rev-list  HEAD | head -n 1)
+
+docker build --build-arg COMMIT_SHA="$COMMIT_SHA" -t gcr.io/celo-testnet/geth:"$COMMIT_SHA" .
+docker build --build-arg COMMIT_SHA="$COMMIT_SHA" -t gcr.io/celo-testnet/geth-all:"$COMMIT_SHA"  -f Dockerfile.alltools .
+docker push gcr.io/celo-testnet/geth:"$COMMIT_SHA"
+docker push gcr.io/celo-testnet/geth-all:"$COMMIT_SHA"


### PR DESCRIPTION
### Description

Adds script to build and publish a private docker image
The image is uploaded to gcr.io/celo-testnet which is only accessible to cLabs.

