### PR TITLE
Refactor Istanbul Engine access in the EVM

### DIFF
--- a/consensus/consensustest/mockprotocol.go
+++ b/consensus/consensustest/mockprotocol.go
@@ -190,6 +190,10 @@ func (e *MockEngine) accumulateRewards(config *params.ChainConfig, state *state.
 	state.AddBalance(header.Coinbase, reward)
 }
 
+func (e *MockEngine) EpochSize() uint64 {
+	return uint64(17280)
+}
+
 func (e *MockEngine) Finalize(chain consensus.ChainReader, header *types.Header, statedb *state.StateDB, txs []*types.Transaction) {
 	e.accumulateRewards(chain.Config(), statedb, header)
 	header.Root = statedb.IntermediateRoot(chain.Config().IsEIP158(header.Number))

--- a/core/vm/context.go
+++ b/core/vm/context.go
@@ -93,8 +93,10 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, txFeeR
 	if chain != nil {
 		engine = chain.Engine()
 		getHeaderByNumberFn = chain.GetHeaderByNumber
-		getValidatorsFn = engine.GetValidators
-		epochSize = engine.EpochSize()
+		if engine != nil {
+			getValidatorsFn = engine.GetValidators
+			epochSize = engine.EpochSize()
+		}
 	}
 
 	return Context{

--- a/core/vm/context.go
+++ b/core/vm/context.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -87,9 +88,13 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, txFeeR
 
 	var engine consensus.Engine
 	var getHeaderByNumberFn func(uint64) *types.Header
+	var getValidatorsFn func(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator
+	var epochSize uint64
 	if chain != nil {
 		engine = chain.Engine()
 		getHeaderByNumberFn = chain.GetHeaderByNumber
+		getValidatorsFn = engine.GetValidators
+		epochSize = engine.EpochSize()
 	}
 
 	return Context{
@@ -103,7 +108,8 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, txFeeR
 		BlockNumber:       new(big.Int).Set(header.Number),
 		Time:              new(big.Int).SetUint64(header.Time),
 		GasPrice:          new(big.Int).Set(msg.GasPrice()),
-		Engine:            engine,
+		EpochSize:         epochSize,
+		GetValidators:     getValidatorsFn,
 	}
 }
 

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -974,7 +974,7 @@ func (c *getValidator) Run(input []byte, caller common.Address, evm *EVM, gas ui
 	}
 
 	// Note: Passing empty hash as here as it is an extra expense and the hash is not actually used.
-	validators := evm.Context.Engine.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
+	validators := evm.Context.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
 
 	// Ensure index, which is guaranteed to be non-negative, is valid.
 	if index.Cmp(big.NewInt(int64(len(validators)))) >= 0 {
@@ -1025,7 +1025,7 @@ func (c *getValidatorBLS) Run(input []byte, caller common.Address, evm *EVM, gas
 	}
 
 	// Note: Passing empty hash as here as it is an extra expense and the hash is not actually used.
-	validators := evm.Context.Engine.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
+	validators := evm.Context.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
 
 	// Ensure index, which is guaranteed to be non-negative, is valid.
 	if index.Cmp(big.NewInt(int64(len(validators)))) >= 0 {
@@ -1084,7 +1084,7 @@ func (c *numberValidators) Run(input []byte, caller common.Address, evm *EVM, ga
 	}
 
 	// Note: Passing empty hash as here as it is an extra expense and the hash is not actually used.
-	validators := evm.Context.Engine.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
+	validators := evm.Context.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
 
 	numberValidators := big.NewInt(int64(len(validators))).Bytes()
 	numberValidatorsBytes := common.LeftPadBytes(numberValidators[:], 32)
@@ -1102,7 +1102,7 @@ func (c *epochSize) Run(input []byte, caller common.Address, evm *EVM, gas uint6
 	if err != nil || len(input) != 0 {
 		return nil, gas, err
 	}
-	epochSize := new(big.Int).SetUint64(evm.Context.Engine.EpochSize()).Bytes()
+	epochSize := new(big.Int).SetUint64(evm.Context.EpochSize).Bytes()
 	epochSizeBytes := common.LeftPadBytes(epochSize[:], 32)
 
 	return epochSizeBytes, gas, nil
@@ -1183,7 +1183,7 @@ func (c *getParentSealBitmap) Run(input []byte, caller common.Address, evm *EVM,
 	}
 
 	// Ensure the request is for a sufficiently recent block to limit state expansion.
-	historyLimit := new(big.Int).SetUint64(evm.Context.Engine.EpochSize() * 4)
+	historyLimit := new(big.Int).SetUint64(evm.Context.EpochSize * 4)
 	if blockNumber.Cmp(new(big.Int).Sub(evm.Context.BlockNumber, historyLimit)) <= 0 {
 		return nil, gas, ErrBlockNumberOutOfBounds
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -28,7 +28,7 @@ import (
 	abipkg "github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -50,11 +50,14 @@ type (
 	// GetHashFunc returns the n'th block hash in the blockchain
 	// and is used by the BLOCKHASH EVM op code.
 	GetHashFunc func(uint64) common.Hash
-	// GetHeaderByNumber returns the header of the nth block in the chain.
+	// GetHeaderByNumberFunc returns the header of the nth block in the chain.
 	GetHeaderByNumberFunc func(uint64) *types.Header
 	// VerifySealFunc returns true if the given header contains a valid seal
 	// according to the engine's consensus rules.
 	VerifySealFunc func(*types.Header) bool
+
+	// GetValidatorsFunc is the signature for the GetValidators function
+	GetValidatorsFunc func(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator
 )
 
 // run runs the given contract and takes care of running precompiles with a fallback to the byte code interpreter.
@@ -116,7 +119,8 @@ type Context struct {
 
 	Header *types.Header
 
-	Engine consensus.Engine
+	EpochSize     uint64
+	GetValidators GetValidatorsFunc
 }
 
 // EVM is the Ethereum Virtual Machine base object and provides

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -34,5 +34,10 @@ func NewEnv(cfg *Config) *vm.EVM {
 		GasPrice:    cfg.GasPrice,
 	}
 
+	// Missing getValidators here
+	if cfg.ChainConfig.Istanbul != nil {
+		context.EpochSize = cfg.ChainConfig.Istanbul.Epoch
+	}
+
 	return vm.NewEVM(context, cfg.State, cfg.ChainConfig, cfg.EVMConfig)
 }


### PR DESCRIPTION
### Description

This removes `consensus.Engine` from the evm `Context` and instead supplies the specific functions and fields that we are using. This enables calls against the EVM to be run without creating a full IBFT engine.

### Context

This is required for `mycelo`, but I'm pulling it out to it's own PR because it's affecting the wider celo codebase outside of the `mycelo` command.


### Tested

Unit tests pass.

### Backwards compatibility

Should be.