### PR TITLE
Refactor EVMContext to avoid depending from engine

### DIFF
--- a/consensus/consensustest/mockprotocol.go
+++ b/consensus/consensustest/mockprotocol.go
@@ -389,3 +389,8 @@ func (e *MockEngine) APIs(chain consensus.ChainReader) []rpc.API {
 func (e *MockEngine) Close() error {
 	return nil
 }
+
+// EpochSize size of the epoch
+func (e *MockEngine) EpochSize() uint64 {
+	return 100
+}

--- a/core/vm/context.go
+++ b/core/vm/context.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
@@ -85,26 +86,27 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, txFeeR
 		beneficiary = *txFeeRecipient
 	}
 
-	var engine consensus.Engine
-	var getHeaderByNumberFn func(uint64) *types.Header
-	if chain != nil {
-		engine = chain.Engine()
-		getHeaderByNumberFn = chain.GetHeaderByNumber
+	ctx := Context{
+		CanTransfer: CanTransfer,
+		Transfer:    Transfer,
+		GetHash:     GetHashFn(header, chain),
+		VerifySeal:  VerifySealFn(header, chain),
+		Origin:      msg.From(),
+		Coinbase:    beneficiary,
+		BlockNumber: new(big.Int).Set(header.Number),
+		Time:        new(big.Int).SetUint64(header.Time),
+		GasPrice:    new(big.Int).Set(msg.GasPrice()),
 	}
 
-	return Context{
-		CanTransfer:       CanTransfer,
-		Transfer:          Transfer,
-		GetHash:           GetHashFn(header, chain),
-		GetHeaderByNumber: getHeaderByNumberFn,
-		VerifySeal:        VerifySealFn(header, chain),
-		Origin:            msg.From(),
-		Coinbase:          beneficiary,
-		BlockNumber:       new(big.Int).Set(header.Number),
-		Time:              new(big.Int).SetUint64(header.Time),
-		GasPrice:          new(big.Int).Set(msg.GasPrice()),
-		Engine:            engine,
+	if chain != nil {
+		ctx.EpochSize = chain.Engine().EpochSize()
+		ctx.GetValidators = chain.Engine().GetValidators
+		ctx.GetHeaderByNumber = chain.GetHeaderByNumber
+	} else {
+		ctx.GetValidators = func(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator { return nil }
+		ctx.GetHeaderByNumber = func(uint64) *types.Header { panic("evm context without blockchain context") }
 	}
+	return ctx
 }
 
 // GetHashFn returns a GetHashFunc which retrieves header hashes by number

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -974,7 +974,7 @@ func (c *getValidator) Run(input []byte, caller common.Address, evm *EVM, gas ui
 	}
 
 	// Note: Passing empty hash as here as it is an extra expense and the hash is not actually used.
-	validators := evm.Context.Engine.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
+	validators := evm.Context.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
 
 	// Ensure index, which is guaranteed to be non-negative, is valid.
 	if index.Cmp(big.NewInt(int64(len(validators)))) >= 0 {
@@ -1025,7 +1025,7 @@ func (c *getValidatorBLS) Run(input []byte, caller common.Address, evm *EVM, gas
 	}
 
 	// Note: Passing empty hash as here as it is an extra expense and the hash is not actually used.
-	validators := evm.Context.Engine.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
+	validators := evm.Context.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
 
 	// Ensure index, which is guaranteed to be non-negative, is valid.
 	if index.Cmp(big.NewInt(int64(len(validators)))) >= 0 {
@@ -1084,7 +1084,7 @@ func (c *numberValidators) Run(input []byte, caller common.Address, evm *EVM, ga
 	}
 
 	// Note: Passing empty hash as here as it is an extra expense and the hash is not actually used.
-	validators := evm.Context.Engine.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
+	validators := evm.Context.GetValidators(new(big.Int).Sub(blockNumber, common.Big1), common.Hash{})
 
 	numberValidators := big.NewInt(int64(len(validators))).Bytes()
 	numberValidatorsBytes := common.LeftPadBytes(numberValidators[:], 32)
@@ -1102,7 +1102,7 @@ func (c *epochSize) Run(input []byte, caller common.Address, evm *EVM, gas uint6
 	if err != nil || len(input) != 0 {
 		return nil, gas, err
 	}
-	epochSize := new(big.Int).SetUint64(evm.Context.Engine.EpochSize()).Bytes()
+	epochSize := new(big.Int).SetUint64(evm.Context.EpochSize).Bytes()
 	epochSizeBytes := common.LeftPadBytes(epochSize[:], 32)
 
 	return epochSizeBytes, gas, nil
@@ -1183,7 +1183,7 @@ func (c *getParentSealBitmap) Run(input []byte, caller common.Address, evm *EVM,
 	}
 
 	// Ensure the request is for a sufficiently recent block to limit state expansion.
-	historyLimit := new(big.Int).SetUint64(evm.Context.Engine.EpochSize() * 4)
+	historyLimit := new(big.Int).SetUint64(evm.Context.EpochSize * 4)
 	if blockNumber.Cmp(new(big.Int).Sub(evm.Context.BlockNumber, historyLimit)) <= 0 {
 		return nil, gas, ErrBlockNumberOutOfBounds
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -28,7 +28,7 @@ import (
 	abipkg "github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -50,11 +50,14 @@ type (
 	// GetHashFunc returns the n'th block hash in the blockchain
 	// and is used by the BLOCKHASH EVM op code.
 	GetHashFunc func(uint64) common.Hash
-	// GetHeaderByNumber returns the header of the nth block in the chain.
+	// GetHeaderByNumberFunc returns the header of the nth block in the chain.
 	GetHeaderByNumberFunc func(uint64) *types.Header
 	// VerifySealFunc returns true if the given header contains a valid seal
 	// according to the engine's consensus rules.
 	VerifySealFunc func(*types.Header) bool
+
+	// GetValidatorsFunc is the signature for the GetValidators function
+	GetValidatorsFunc func(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator
 )
 
 // run runs the given contract and takes care of running precompiles with a fallback to the byte code interpreter.
@@ -116,7 +119,8 @@ type Context struct {
 
 	Header *types.Header
 
-	Engine consensus.Engine
+	EpochSize     uint64
+	GetValidators GetValidatorsFunc
 }
 
 // EVM is the Ethereum Virtual Machine base object and provides

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -21,6 +21,7 @@ import (
 )
 
 func NewEnv(cfg *Config) *vm.EVM {
+
 	context := vm.Context{
 		CanTransfer: vm.CanTransfer,
 		Transfer:    vm.Transfer,
@@ -32,6 +33,10 @@ func NewEnv(cfg *Config) *vm.EVM {
 		BlockNumber: cfg.BlockNumber,
 		Time:        cfg.Time,
 		GasPrice:    cfg.GasPrice,
+	}
+
+	if cfg.ChainConfig.Istanbul != nil {
+		context.EpochSize = cfg.ChainConfig.Istanbul.Epoch
 	}
 
 	return vm.NewEVM(context, cfg.State, cfg.ChainConfig, cfg.EVMConfig)


### PR DESCRIPTION
### Description

EVM Context exposes the `consensus.Engine` which couples the engine with everyone that uses the context. This PR changes that, by only exposing the necessary functions directly on the context.

Side benefit of this, is that you don't need a full engine to create a `Context`, which is useful to fix and use the `evm` command from cmdline.

### Tested

unit tests

### Related issues

- This is necessary work for `mycelo`

### Backwards compatibility

Yes
