### PR TITLE
Small fixes for mycelo validator-run command.

### DIFF
--- a/mycelo/cluster/node.go
+++ b/mycelo/cluster/node.go
@@ -156,6 +156,7 @@ func (n *Node) Run(ctx context.Context) error {
 		"--syncmode", "full",
 		"--mine",
 		"--allow-insecure-unlock",
+		"--nodiscover",
 		"--nat", "extip:127.0.0.1",
 		"--port", strconv.FormatInt(n.NodePort(), 10),
 		"--rpc",
@@ -192,8 +193,8 @@ func (n *Node) Run(ctx context.Context) error {
 
 	go func() {
 		<-ctx.Done()
-		if err := cmd.Process.Kill(); err != nil {
-			log.Fatal("Failed to kill geth cmd")
+		if err := cmd.Process.Signal(os.Interrupt); err != nil {
+			log.Fatal("Failed to send interrupt signal to geth cmd")
 		}
 	}()
 


### PR DESCRIPTION
- Add --nodiscover flag (we're using static nodes)
- Use interrupt signal to quit geth, to prevent db corruption leading to stall on restart

### Description

Fixes a couple of problems I ran into while using mycelo testnets:

1. Since we aren't specifying either bootnodes nor `--nodiscover`, it tries to use the mainnet bootnodes.  This commit adds `--nodiscover` to prevent that
2. When quitting from validator-run, it was using a kill signal which meant the validators didn't have time to shut down cleanly.  This led to database corruption.  When starting again it would then rewind (on all validators), leading the network to stall permanently since the validators don't have the necessary state in their db.  This PR makes it instead use the interrupt signal, which lets the node shut down cleanly.

### Tested

- Confirmed that it's no longer using the bootnode
- Confirmed that the network stall on restart no longer happens