### PR TITLE
mycelo: Fix load bot & add --init to validator-run

### DIFF
--- a/cmd/mycelo/main.go
+++ b/cmd/mycelo/main.go
@@ -149,7 +149,10 @@ var runValidatorsCommand = cli.Command{
 	Usage:     "Runs the testnet",
 	ArgsUsage: "[envdir]",
 	Action:    validatorRun,
-	Flags:     []cli.Flag{gethPathFlag},
+	Flags: []cli.Flag{
+		gethPathFlag,
+		cli.BoolFlag{Name: "init", Usage: "Init nodes before running them"},
+	},
 }
 
 // var initNodesCommand = cli.Command{
@@ -376,6 +379,12 @@ func validatorRun(ctx *cli.Context) error {
 	}
 
 	cluster := cluster.New(env, gethPath)
+
+	if ctx.IsSet("init") {
+		if err := cluster.Init(); err != nil {
+			return fmt.Errorf("error running init: %w", err)
+		}
+	}
 
 	group, runCtx := errgroup.WithContext(withExitSignals(context.Background()))
 

--- a/mycelo/contract/contracts.go
+++ b/mycelo/contract/contracts.go
@@ -28,7 +28,7 @@ func NewTruffleReader(buildPath string) TruffleReader {
 
 	librariesMapping := make(map[string]common.Address, len(env.Libraries()))
 	for _, name := range env.Libraries() {
-		librariesMapping[name] = env.MustAddressFor(name)
+		librariesMapping[name] = env.MustLibraryAddressFor(name)
 	}
 
 	return &truffleReader{

--- a/mycelo/env/core_contracts.go
+++ b/mycelo/env/core_contracts.go
@@ -8,7 +8,7 @@ import (
 
 var addr = common.HexToAddress
 
-var genesisAddresses = map[string]common.Address{
+var libraryAddresses = map[string]common.Address{
 	"FixidityLib":                       addr("0xa001"),
 	"Proposals":                         addr("0xa002"),
 	"LinkedList":                        addr("0xa003"),
@@ -19,7 +19,9 @@ var genesisAddresses = map[string]common.Address{
 	"IntegerSortedLinkedList":           addr("0xa008"),
 	"AddressSortedLinkedListWithMedian": addr("0xa009"),
 	"Signatures":                        addr("0xa010"),
+}
 
+var genesisAddresses = map[string]common.Address{
 	// Contract implementations
 	"Registry":                   addr("0xce11"),
 	"Freezer":                    addr("0xf001"),
@@ -89,8 +91,17 @@ var libraries = []string{
 // Libraries returns all celo-blockchain library names
 func Libraries() []string { return libraries }
 
-// AddressFor obtains the address for a core contract
-func AddressFor(name string) (common.Address, error) {
+// LibraryAddressFor obtains the address for a core contract
+func LibraryAddressFor(name string) (common.Address, error) {
+	address, ok := libraryAddresses[name]
+	if !ok {
+		return common.ZeroAddress, fmt.Errorf("can't find genesis address for %s", name)
+	}
+	return address, nil
+}
+
+// ImplAddressFor obtains the address for a core contract
+func ImplAddressFor(name string) (common.Address, error) {
 	address, ok := genesisAddresses[name]
 	if !ok {
 		return common.ZeroAddress, fmt.Errorf("can't find genesis address for %s", name)
@@ -107,10 +118,20 @@ func ProxyAddressFor(name string) (common.Address, error) {
 	return address, nil
 }
 
-// MustAddressFor obtains the address for a core contract
+// MustLibraryAddressFor obtains the address for a core contract
 // this variant panics on error
-func MustAddressFor(name string) common.Address {
-	address, err := AddressFor(name)
+func MustLibraryAddressFor(name string) common.Address {
+	address, err := LibraryAddressFor(name)
+	if err != nil {
+		panic(err)
+	}
+	return address
+}
+
+// MustImplAddressFor obtains the address for a core contract
+// this variant panics on error
+func MustImplAddressFor(name string) common.Address {
+	address, err := ImplAddressFor(name)
 	if err != nil {
 		panic(err)
 	}

--- a/mycelo/genesis/genesis_state.go
+++ b/mycelo/genesis/genesis_state.go
@@ -202,7 +202,7 @@ func (ctx *deployContext) fundAdminAccount() {
 func (ctx *deployContext) deployLibraries() error {
 	for _, name := range env.Libraries() {
 		bytecode := ctx.truffleReader.MustReadDeployedBytecodeFor(name)
-		ctx.statedb.SetCode(env.MustAddressFor(name), bytecode)
+		ctx.statedb.SetCode(env.MustLibraryAddressFor(name), bytecode)
 	}
 	return nil
 }
@@ -211,7 +211,7 @@ func (ctx *deployContext) deployLibraries() error {
 // It will deploy the proxy contract, the impl contract, and initialize both
 func (ctx *deployContext) deployProxiedContract(name string, initialize func(contract *contract.EVMBackend) error) error {
 	proxyAddress := env.MustProxyAddressFor(name)
-	implAddress := env.MustAddressFor(name)
+	implAddress := env.MustImplAddressFor(name)
 	bytecode := ctx.truffleReader.MustReadDeployedBytecodeFor(name)
 
 	logger := ctx.logger.New("contract", name)

--- a/mycelo/loadbot/bot.go
+++ b/mycelo/loadbot/bot.go
@@ -57,7 +57,7 @@ func Start(ctx context.Context, cfg *Config) error {
 
 func runBot(ctx context.Context, acc env.Account, sleepTime time.Duration, client bind.ContractBackend, nextTransfer func() (common.Address, *big.Int)) error {
 	abi := contract.AbiFor("StableToken")
-	stableToken := bind.NewBoundContract(env.MustAddressFor("StableToken"), *abi, client)
+	stableToken := bind.NewBoundContract(env.MustProxyAddressFor("StableToken"), *abi, client)
 
 	transactor := bind.NewKeyedTransactor(acc.PrivateKey)
 	transactor.Context = ctx


### PR DESCRIPTION
### Description

3 small changes:

 * Add `--init` to `mycelo validator-run`; to avoid a call to mycelo
 * Fix load-bot: It was using the impl address instead of the proxy address
 * Rename `env.XXAddressFor` functions so it's clear if you're asking for the impl or the proxy address. 

### Tested

Run mycelo & loadbot

