### PR TITLE
[mycelo] typos on env accounts cmd

### DIFF
--- a/cmd/mycelo/env_commands.go
+++ b/cmd/mycelo/env_commands.go
@@ -10,7 +10,7 @@ import (
 
 var envCommand = cli.Command{
 	Name:  "env",
-	Usage: "Family on environment commands",
+	Usage: "Environment utility commands",
 	Subcommands: []cli.Command{
 		getAccountCommand,
 	},
@@ -52,6 +52,6 @@ func getAccount(ctx *cli.Context) error {
 		return err
 	}
 
-	fmt.Printf("AccountType: %s\nIndex:%d\nAddress: %s\nPrivateKey: %s", accountType, idx, account.Address.Hex(), account.PrivateKeyHex())
+	fmt.Printf("AccountType: %s\nIndex:%d\nAddress: %s\nPrivateKey: %s\n", accountType, idx, account.Address.Hex(), account.PrivateKeyHex())
 	return nil
 }

--- a/mycelo/env/accounts.go
+++ b/mycelo/env/accounts.go
@@ -62,7 +62,7 @@ func (a *Account) BLSPublicKey() (blscrypto.SerializedPublicKey, error) {
 	return blscrypto.PrivateToPublic(privateKey)
 }
 
-// PrivateKeyHex hex represenation of the private key
+// PrivateKeyHex hex representation of the private key
 func (a *Account) PrivateKeyHex() string {
 	return common.Bytes2Hex(crypto.FromECDSA(a.PrivateKey))
 }
@@ -121,7 +121,7 @@ func (accountType AccountType) String() string {
 	case Admin:
 		return "admin"
 	default:
-		return "unkown"
+		return "unknown"
 	}
 }
 
@@ -153,7 +153,7 @@ func (accountType AccountType) MarshalText() ([]byte, error) {
 	case Admin:
 		return []byte("admin"), nil
 	default:
-		return nil, fmt.Errorf("unknown sync mode %d", accountType)
+		return nil, fmt.Errorf("unknown account type %d", accountType)
 	}
 }
 
@@ -185,7 +185,7 @@ func (accountType *AccountType) UnmarshalText(text []byte) error {
 	case "admin":
 		*accountType = Admin
 	default:
-		return fmt.Errorf(`unknown sync mode %q, want "validator", "developer", "txNode", "faucet", "attestation", "priceOracle", "proxy", "attestationBot", "votingBot", "txNodePrivate", "validatorGroup", "admin"`, text)
+		return fmt.Errorf(`unknown account type %q, want "validator", "developer", "txNode", "faucet", "attestation", "priceOracle", "proxy", "attestationBot", "votingBot", "txNodePrivate", "validatorGroup", "admin"`, text)
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

Address comments on https://github.com/celo-org/celo-blockchain/commit/fa61583f1b5779096672f2d9595e9e977f063627#

