### PR TITLE
Disable GPM updates during mycelo load tests

### DIFF
--- a/cmd/mycelo/templates.go
+++ b/cmd/mycelo/templates.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/common/fixed"
 	"github.com/celo-org/celo-blockchain/mycelo/env"
 	"github.com/celo-org/celo-blockchain/mycelo/genesis"
 	"github.com/celo-org/celo-blockchain/params"
@@ -157,6 +158,10 @@ func (e loadtestEnv) createGenesisConfig(env *env.Environment) (*genesis.Config,
 	genesisConfig.StableToken.InflationFactorUpdatePeriod = big.NewInt(1 * genesis.Year)
 	genesisConfig.StableToken.InitialBalances = cusdBalances
 	genesisConfig.GoldToken.InitialBalances = goldBalances
+
+	// Disable gas price min being updated
+	genesisConfig.GasPriceMinimum.TargetDensity = fixed.MustNew("0.9999")
+	genesisConfig.GasPriceMinimum.AdjustmentSpeed = fixed.MustNew("0")
 
 	// Ensure nothing is frozen
 	genesisConfig.GoldToken.Frozen = false

--- a/mycelo/loadbot/bot.go
+++ b/mycelo/loadbot/bot.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	"math/rand"
 	"time"
 
 	bind "github.com/celo-org/celo-blockchain/accounts/abi/bind_v2"
@@ -36,9 +35,10 @@ type Config struct {
 func Start(ctx context.Context, cfg *Config) error {
 	group, ctx := errgroup.WithContext(ctx)
 
+	idx := len(cfg.Accounts) / 2
 	nextTransfer := func() (common.Address, *big.Int) {
-		idx := rand.Intn(len(cfg.Accounts))
-		return cfg.Accounts[idx].Address, cfg.Amount
+		idx++
+		return cfg.Accounts[idx%len(cfg.Accounts)].Address, cfg.Amount
 	}
 
 	// developer accounts / TPS = duration in seconds.


### PR DESCRIPTION
### Description

Disables gas price updating in the load test. Prior to this change the gas price was going so high that transactions cannot go through after a couple hundred full blocks
This also sends transactions in a round robin fashion (Initial attempt to fix). This is probably not strictly needed to fix the issue.


### Tested

- [x] Manual ~10 min test
- [x] k8s 30 mins test

### Related issues

- Fixes #1400

