### PR TITLE
Adds flag to limit pending txs

### DIFF
--- a/cmd/mycelo/main.go
+++ b/cmd/mycelo/main.go
@@ -472,9 +472,9 @@ func loadBot(ctx *cli.Context) error {
 	return loadbot.Start(runCtx, &loadbot.Config{
 		Accounts:              env.DeveloperAccounts(),
 		Amount:                big.NewInt(10000000),
-		TransactionsPerSecond: ctx.Int("tps"),
+		TransactionsPerSecond: ctx.Int(loadTestTPSFlag.Name),
 		Clients:               clients,
 		Verbose:               verbose,
-		MaxPending:            ctx.Uint64("maxpending"),
+		MaxPending:            ctx.Uint64(loadTestMaxPendingFlag.Name),
 	})
 }

--- a/cmd/mycelo/main.go
+++ b/cmd/mycelo/main.go
@@ -120,6 +120,12 @@ var loadTestTPSFlag = cli.IntFlag{
 	Value: 20,
 }
 
+var loadTestMaxPendingFlag = cli.UintFlag{
+	Name:  "maxpending",
+	Usage: "Maximum number of in flight txs. Set to 0 to disable.",
+	Value: 200,
+}
+
 var createGenesisCommand = cli.Command{
 	Name:      "genesis",
 	Usage:     "Creates genesis.json from a template and overrides",
@@ -186,7 +192,7 @@ var loadBotCommand = cli.Command{
 	Usage:     "Runs the load bot on the environment",
 	ArgsUsage: "[envdir]",
 	Action:    loadBot,
-	Flags:     []cli.Flag{loadTestTPSFlag},
+	Flags:     []cli.Flag{loadTestTPSFlag, loadTestMaxPendingFlag},
 }
 
 func readWorkdir(ctx *cli.Context) (string, error) {
@@ -469,5 +475,6 @@ func loadBot(ctx *cli.Context) error {
 		TransactionsPerSecond: ctx.Int("tps"),
 		Clients:               clients,
 		Verbose:               verbose,
+		MaxPending:            ctx.Uint64("maxpending"),
 	})
 }

--- a/mycelo/loadbot/bot.go
+++ b/mycelo/loadbot/bot.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"sync"
 	"time"
 
 	bind "github.com/celo-org/celo-blockchain/accounts/abi/bind_v2"
@@ -15,6 +16,10 @@ import (
 	"github.com/celo-org/celo-blockchain/mycelo/env"
 	"golang.org/x/sync/errgroup"
 )
+
+var maxPending uint64
+var pending uint64
+var pendingLock sync.Mutex
 
 // Range represents an inclusive big.Int range
 type Range struct {
@@ -29,6 +34,7 @@ type Config struct {
 	TransactionsPerSecond int
 	Clients               []*ethclient.Client
 	Verbose               bool
+	MaxPending            uint64
 }
 
 // Start will start loads bots
@@ -45,6 +51,7 @@ func Start(ctx context.Context, cfg *Config) error {
 	// Need the fudger factor to get up a consistent TPS at the target.
 	delay := time.Duration(int(float64(len(cfg.Accounts)*1000/cfg.TransactionsPerSecond)*0.95)) * time.Millisecond
 	startDelay := delay / time.Duration(len(cfg.Accounts))
+	maxPending = cfg.MaxPending
 
 	for i, acc := range cfg.Accounts {
 		// Spread out client load across different diallers
@@ -63,7 +70,7 @@ func Start(ctx context.Context, cfg *Config) error {
 	return group.Wait()
 }
 
-func runBot(ctx context.Context, acc env.Account, verbose bool, sleepTime time.Duration, client bind.ContractBackend, nextTransfer func() (common.Address, *big.Int)) error {
+func runBot(ctx context.Context, acc env.Account, verbose bool, sleepTime time.Duration, client *ethclient.Client, nextTransfer func() (common.Address, *big.Int)) error {
 	abi := contract.AbiFor("StableToken")
 	stableToken := bind.NewBoundContract(env.MustProxyAddressFor("StableToken"), *abi, client)
 
@@ -74,6 +81,14 @@ func runBot(ctx context.Context, acc env.Account, verbose bool, sleepTime time.D
 	transactor.FeeCurrency = &stableTokenAddress
 
 	for {
+		pendingLock.Lock()
+		if maxPending != 0 && pending > maxPending {
+			pendingLock.Unlock()
+			continue
+		} else {
+			pending++
+			pendingLock.Unlock()
+		}
 		txSentTime := time.Now()
 		recipient, value := nextTransfer()
 		tx, err := stableToken.TxObj(transactor, "transferWithComment", recipient, value, "need to proivde some long comment to make it similar to an encrypted comment").Send()
@@ -89,6 +104,12 @@ func runBot(ctx context.Context, acc env.Account, verbose bool, sleepTime time.D
 		}
 
 		_, err = tx.WaitMined(ctx)
+		pendingLock.Lock()
+		if maxPending != 0 {
+			pending--
+		}
+		pendingLock.Unlock()
+
 		if err != nil {
 			if err != context.Canceled {
 				fmt.Printf("Error waiting for tx: %v\n", err)


### PR DESCRIPTION
### Description

Limits the number of pending txs sent to --maxpending
This does not completely prevent a slowdown on the testnet, but it stops it
from becoming a cascading failure.


### Tested

Yes

