### PR TITLE
Adds revert reason on eth_call and simulatedBackend

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -350,6 +350,18 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 		return nil, err
 	}
 	res, err := b.callContract(ctx, call, b.blockchain.CurrentBlock(), state)
+
+	if res != nil && res.Err != vm.ErrOutOfGas {
+		if len(res.Revert()) > 0 {
+			ret, err := abi.UnpackRevert(res.Revert())
+			if err != nil {
+				return nil, fmt.Errorf("execution reverted: %#x", res.Revert())
+			} else {
+				return nil, fmt.Errorf("execution reverted: %s", ret)
+			}
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -353,12 +353,10 @@ func (b *SimulatedBackend) CallContract(ctx context.Context, call ethereum.CallM
 
 	if res != nil && res.Err != vm.ErrOutOfGas {
 		if len(res.Revert()) > 0 {
-			ret, err := abi.UnpackRevert(res.Revert())
-			if err != nil {
-				return nil, fmt.Errorf("execution reverted: %#x", res.Revert())
-			} else {
+			if ret, err := abi.UnpackRevert(res.Revert()); err == nil {
 				return nil, fmt.Errorf("execution reverted: %s", ret)
 			}
+			return nil, fmt.Errorf("execution reverted: %#x", res.Revert())
 		}
 	}
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -878,6 +878,17 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNrOr
 	if err != nil {
 		return nil, err
 	}
+
+	if result != nil && result.Err != vm.ErrOutOfGas {
+		if len(result.Revert()) > 0 {
+			ret, err := abi.UnpackRevert(result.Revert())
+			if err != nil {
+				return nil, fmt.Errorf("execution reverted: %#x", result.Revert())
+			} else {
+				return nil, fmt.Errorf("execution reverted: %s", ret)
+			}
+		}
+	}
 	return result.Return(), nil
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -881,12 +881,10 @@ func (s *PublicBlockChainAPI) Call(ctx context.Context, args CallArgs, blockNrOr
 
 	if result != nil && result.Err != vm.ErrOutOfGas {
 		if len(result.Revert()) > 0 {
-			ret, err := abi.UnpackRevert(result.Revert())
-			if err != nil {
-				return nil, fmt.Errorf("execution reverted: %#x", result.Revert())
-			} else {
+			if ret, err := abi.UnpackRevert(result.Revert()); err == nil {
 				return nil, fmt.Errorf("execution reverted: %s", ret)
 			}
+			return nil, fmt.Errorf("execution reverted: %#x", result.Revert())
 		}
 	}
 	return result.Return(), nil


### PR DESCRIPTION
### Description

Adds smart contract revert reason to the error message when a call to a smart contract fails.

For the case:
 * `eth_call` RPC
 * `SimulatedBackend.CallContract()`

### Tested

Manual testing

