### PR TITLE
Remove Ethereum flags that don't apply to Celo

### DIFF
--- a/cmd/clef/README.md
+++ b/cmd/clef/README.md
@@ -32,7 +32,6 @@ GLOBAL OPTIONS:
    --chainid value         Chain id to use for signing (1=mainnet, 3=Ropsten, 4=Rinkeby, 5=Goerli) (default: 1)
    --lightkdf              Reduce key-derivation RAM & CPU usage at some expense of KDF strength
    --nousb                 Disables monitoring for and managing USB hardware wallets
-   --pcscdpath value       Path to the smartcard daemon (pcscd) socket file (default: "/run/pcscd/pcscd.comm")
    --rpcaddr value         HTTP-RPC server listening interface (default: "localhost")
    --rpcvhosts value       Comma separated list of virtual hostnames from which to accept requests (server enforced). Accepts '*' wildcard. (default: "localhost")
    --ipcdisable            Disable the IPC-RPC server

--- a/cmd/clef/main.go
+++ b/cmd/clef/main.go
@@ -222,7 +222,6 @@ func init() {
 		chainIdFlag,
 		utils.LightKDFFlag,
 		utils.NoUSBFlag,
-		utils.SmartCardDaemonPathFlag,
 		utils.RPCListenAddrFlag,
 		utils.RPCVirtualHostsFlag,
 		utils.IPCDisabledFlag,
@@ -416,7 +415,7 @@ func newAccount(c *cli.Context) error {
 		lightKdf                  = c.GlobalBool(utils.LightKDFFlag.Name)
 	)
 	log.Info("Starting clef", "keystore", ksLoc, "light-kdf", lightKdf)
-	am := core.StartClefAccountManager(ksLoc, true, lightKdf, "")
+	am := core.StartClefAccountManager(ksLoc, true, lightKdf)
 	// This gives is us access to the external API
 	apiImpl := core.NewSignerAPI(am, 0, true, ui, nil, false, pwStorage)
 	// This gives us access to the internal API
@@ -549,11 +548,10 @@ func signer(c *cli.Context) error {
 		lightKdf = c.GlobalBool(utils.LightKDFFlag.Name)
 		advanced = c.GlobalBool(advancedMode.Name)
 		nousb    = c.GlobalBool(utils.NoUSBFlag.Name)
-		scpath   = c.GlobalString(utils.SmartCardDaemonPathFlag.Name)
 	)
 	log.Info("Starting signer", "chainid", chainId, "keystore", ksLoc,
 		"light-kdf", lightKdf, "advanced", advanced)
-	am := core.StartClefAccountManager(ksLoc, nousb, lightKdf, scpath)
+	am := core.StartClefAccountManager(ksLoc, nousb, lightKdf)
 	apiImpl := core.NewSignerAPI(am, chainId, nousb, ui, db, advanced, pwStorage)
 
 	// Establish the bidirectional communication, by creating a new UI backend and registering

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -165,7 +165,6 @@ The export-preimages command export hash preimages to an RLP encoded stream`,
 			utils.BaklavaFlag,
 			utils.CacheFlag,
 			utils.SyncModeFlag,
-			utils.FakePoWFlag,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -158,7 +158,7 @@ The export-preimages command export hash preimages to an RLP encoded stream`,
 		Action:    utils.MigrateFlags(copyDb),
 		Name:      "copydb",
 		Usage:     "Create a local chain from a target chaindata folder",
-		ArgsUsage: "<sourceChaindataDir>",
+		ArgsUsage: "<sourceChainDataDir> <sourceAncientChainDataDir>",
 		Flags: []cli.Flag{
 			utils.DataDirFlag,
 			utils.AlfajoresFlag,
@@ -168,7 +168,8 @@ The export-preimages command export hash preimages to an RLP encoded stream`,
 		},
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
-The first argument must be the directory containing the blockchain to download from`,
+The first argument must be the directory containing the blockchain to download from,
+the second argument must be the directory containing the ancient blockchain to download from`,
 	}
 	removedbCommand = cli.Command{
 		Action:    utils.MigrateFlags(removeDB),
@@ -203,7 +204,7 @@ Remove blockchain and state databases`,
 		Category: "BLOCKCHAIN COMMANDS",
 		Description: `
 The arguments are interpreted as block numbers or hashes.
-Use "ethereum dump 0" to dump the genesis block.`,
+Use "geth dump 0" to dump the genesis block.`,
 	}
 	inspectCommand = cli.Command{
 		Action:    utils.MigrateFlags(inspect),
@@ -302,15 +303,9 @@ func importChain(ctx *cli.Context) error {
 	// Import the chain
 	start := time.Now()
 
-	if len(ctx.Args()) == 1 {
-		if err := utils.ImportChain(chain, ctx.Args().First()); err != nil {
-			log.Error("Import error", "err", err)
-		}
-	} else {
-		for _, arg := range ctx.Args() {
-			if err := utils.ImportChain(chain, arg); err != nil {
-				log.Error("Import error", "file", arg, "err", err)
-			}
+	for _, arg := range ctx.Args() {
+		if err := utils.ImportChain(chain, arg); err != nil {
+			log.Error("Import error", "file", arg, "err", err)
 		}
 	}
 	chain.Stop()

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -138,7 +138,6 @@ var (
 		utils.NetworkIdFlag,
 		utils.CeloStatsURLFlag,
 		utils.EthStatsLegacyURLFlag,
-		utils.FakePoWFlag,
 		utils.NoCompactionFlag,
 		utils.EWASMInterpreterFlag,
 		utils.EVMInterpreterFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -69,7 +69,6 @@ var (
 		utils.KeyStoreDirFlag,
 		utils.ExternalSignerFlag,
 		utils.NoUSBFlag,
-		utils.SmartCardDaemonPathFlag,
 		utils.OverrideChurritoFlag,
 		utils.OverrideDonutFlag,
 		utils.TxPoolLocalsFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -213,7 +213,6 @@ var AppHelpFlagGroups = []flagGroup{
 	{
 		Name: "LOGGING AND DEBUGGING",
 		Flags: append([]cli.Flag{
-			utils.FakePoWFlag,
 			utils.NoCompactionFlag,
 		}, debug.Flags...),
 	},

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -70,7 +70,6 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.AncientFlag,
 			utils.KeyStoreDirFlag,
 			utils.NoUSBFlag,
-			utils.SmartCardDaemonPathFlag,
 			utils.NetworkIdFlag,
 			utils.BaklavaFlag,
 			utils.AlfajoresFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -495,10 +495,6 @@ var (
 		Name:  "celostats",
 		Usage: "Reporting URL of a celostats service (nodename:secret@host:port)",
 	}
-	FakePoWFlag = cli.BoolFlag{
-		Name:  "fakepow",
-		Usage: "Disables proof-of-work verification",
-	}
 	NoCompactionFlag = cli.BoolFlag{
 		Name:  "nocompaction",
 		Usage: "Disables db compaction after import",
@@ -1935,9 +1931,6 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 		Fatalf("%v", err)
 	}
 	config.FullHeaderChainAvailable = ctx.GlobalString(SyncModeFlag.Name) != "lightest"
-	if !ctx.GlobalBool(FakePoWFlag.Name) {
-		Fatalf("Only fake PoW engine is available")
-	}
 	engine := mockEngine.NewFaker()
 
 	if gcmode := ctx.GlobalString(GCModeFlag.Name); gcmode != "full" && gcmode != "archive" {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -60,7 +60,6 @@ import (
 	"github.com/celo-org/celo-blockchain/params"
 	"github.com/celo-org/celo-blockchain/rpc"
 	whisper "github.com/celo-org/celo-blockchain/whisper/whisperv6"
-	pcsclite "github.com/gballet/go-libpcsclite"
 	cli "gopkg.in/urfave/cli.v1"
 )
 
@@ -153,11 +152,6 @@ var (
 	NoUSBFlag = cli.BoolFlag{
 		Name:  "nousb",
 		Usage: "Disables monitoring for and managing USB hardware wallets",
-	}
-	SmartCardDaemonPathFlag = cli.StringFlag{
-		Name:  "pcscdpath",
-		Usage: "Path to the smartcard daemon (pcscd) socket file",
-		Value: pcsclite.PCSCDSockName,
 	}
 	NetworkIdFlag = cli.Uint64Flag{
 		Name:  "networkid",
@@ -1322,7 +1316,6 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	setWS(ctx, cfg)
 	setNodeUserIdent(ctx, cfg)
 	setDataDir(ctx, cfg)
-	setSmartCard(ctx, cfg)
 
 	if ctx.GlobalIsSet(ExternalSignerFlag.Name) {
 		cfg.ExternalSigner = ctx.GlobalString(ExternalSignerFlag.Name)
@@ -1340,26 +1333,6 @@ func SetNodeConfig(ctx *cli.Context, cfg *node.Config) {
 	if ctx.GlobalIsSet(InsecureUnlockAllowedFlag.Name) {
 		cfg.InsecureUnlockAllowed = ctx.GlobalBool(InsecureUnlockAllowedFlag.Name)
 	}
-}
-
-func setSmartCard(ctx *cli.Context, cfg *node.Config) {
-	// Skip enabling smartcards if no path is set
-	path := ctx.GlobalString(SmartCardDaemonPathFlag.Name)
-	if path == "" {
-		return
-	}
-	// Sanity check that the smartcard path is valid
-	fi, err := os.Stat(path)
-	if err != nil {
-		log.Info("Smartcard socket not found, disabling", "err", err)
-		return
-	}
-	if fi.Mode()&os.ModeType != os.ModeSocket {
-		log.Error("Invalid smartcard daemon path", "path", path, "type", fi.Mode().String())
-		return
-	}
-	// Smartcard daemon path exists and is a socket, enable it
-	cfg.SmartCardDaemonPath = path
 }
 
 func setDataDir(ctx *cli.Context, cfg *node.Config) {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -169,8 +169,8 @@ func (b *BlockGen) OffsetTime(seconds int64) {
 // and their coinbase will be the zero address.
 //
 // Blocks created by GenerateChain do not contain valid proof of work
-// values. Inserting them into BlockChain requires use of FakePow or
-// a similar non-validating proof of work implementation.
+// values. Inserting them into BlockChain requires use of
+// a non-validating proof of work implementation.
 func GenerateChain(config *params.ChainConfig, parent *types.Block, engine consensus.Engine, db ethdb.Database, n int, gen func(int, *BlockGen)) ([]*types.Block, []types.Receipts) {
 	if config == nil {
 		config = params.TestChainConfig

--- a/docs/docs/_interface/Command-Line-Options.md
+++ b/docs/docs/_interface/Command-Line-Options.md
@@ -164,7 +164,6 @@ VIRTUAL MACHINE OPTIONS:
   --vm.ewasm value                    External ewasm configuration (default = built-in interpreter)
 
 LOGGING AND DEBUGGING OPTIONS:
-  --fakepow                           Disables proof-of-work verification
   --nocompaction                      Disables db compaction after import
   --verbosity value                   Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (default: 3)
   --vmodule value                     Per-module verbosity: comma-separated list of <pattern>=<level> (e.g. eth/*=5,p2p=4)

--- a/docs/docs/_interface/Command-Line-Options.md
+++ b/docs/docs/_interface/Command-Line-Options.md
@@ -45,7 +45,6 @@ ETHEREUM OPTIONS:
   --datadir.ancient value             Data directory for ancient chain segments (default = inside chaindata)
   --keystore value                    Directory for the keystore (default = inside the datadir)
   --nousb                             Disables monitoring for and managing USB hardware wallets
-  --pcscdpath value                   Path to the smartcard daemon (pcscd) socket file
   --networkid value                   Network identifier (integer, 1=Frontier, 2=Morden (disused), 3=Ropsten, 4=Rinkeby) (default: 1)
   --testnet                           Ropsten network: pre-configured proof-of-work test network
   --rinkeby                           Rinkeby network: pre-configured proof-of-authority test network

--- a/node/config.go
+++ b/node/config.go
@@ -99,9 +99,6 @@ type Config struct {
 	// NoUSB disables hardware wallet monitoring and connectivity.
 	NoUSB bool `toml:",omitempty"`
 
-	// SmartCardDaemonPath is the path to the smartcard daemon's socket
-	SmartCardDaemonPath string `toml:",omitempty"`
-
 	// IPCPath is the requested location to place the IPC endpoint. If the path is
 	// a simple file name, it is placed inside the data directory (or on the root
 	// pipe path on Windows), whereas if it's a resolvable path name (absolute or

--- a/signer/core/api.go
+++ b/signer/core/api.go
@@ -124,7 +124,7 @@ type Metadata struct {
 	Origin    string `json:"Origin"`
 }
 
-func StartClefAccountManager(ksLocation string, nousb, lightKDF bool, scpath string) *accounts.Manager {
+func StartClefAccountManager(ksLocation string, nousb, lightKDF bool) *accounts.Manager {
 	var (
 		backends []accounts.Backend
 		n, p     = keystore.StandardScryptN, keystore.StandardScryptP

--- a/signer/core/api_test.go
+++ b/signer/core/api_test.go
@@ -125,7 +125,7 @@ func setup(t *testing.T) (*core.SignerAPI, *headlessUi) {
 		t.Fatal(err.Error())
 	}
 	ui := &headlessUi{make(chan string, 20), make(chan string, 20)}
-	am := core.StartClefAccountManager(tmpDirName(t), true, true, "")
+	am := core.StartClefAccountManager(tmpDirName(t), true, true)
 	api := core.NewSignerAPI(am, 1337, true, ui, db, true, &storage.NoStorage{})
 	return api, ui
 


### PR DESCRIPTION
### Description

All celo-blockchain flags should either function as they do in upstream geth, or be removed.
This is to reduce confusion for external devs familiar with upstream geth.

Certain flags are removed in this PR.
--fakepow
--pcscdpath

### Other changes

Examed following commands:

`geth import`
`geth export`
`geth copydb`
`geth dump`
`geth inspect`

### Tested

Yes

### Related issues

- Fixes #1064

### Backwards compatibility

Yes