### PR TITLE
Change verbose info log

### DIFF
--- a/consensus/istanbul/proxy/proxied_validator_engine.go
+++ b/consensus/istanbul/proxy/proxied_validator_engine.go
@@ -529,7 +529,8 @@ func (pv *proxiedValidatorEngine) sendValEnodeShareMsgs(ps *proxySet) {
 			for valAddress := range assignedValidators {
 				valAddresses = append(valAddresses, valAddress)
 			}
-			logger.Info("Sending val enode share msg to proxy", "proxy peer", proxy.peer, "valAddresses", common.ConvertToStringSlice(valAddresses))
+			logger.Info("Sending val enode share msg to proxy", "proxy peer", proxy.peer, "valAddresses length", len(valAddresses))
+			logger.Trace("Val enode share msg validator addresses", "valAddresses", common.ConvertToStringSlice(valAddresses))
 			pv.sendValEnodesShareMsg(proxy.peer, valAddresses)
 		}
 	}

--- a/consensus/istanbul/proxy/proxied_validator_engine.go
+++ b/consensus/istanbul/proxy/proxied_validator_engine.go
@@ -530,7 +530,7 @@ func (pv *proxiedValidatorEngine) sendValEnodeShareMsgs(ps *proxySet) {
 				valAddresses = append(valAddresses, valAddress)
 			}
 			logger.Info("Sending val enode share msg to proxy", "proxy peer", proxy.peer, "valAddresses length", len(valAddresses))
-			logger.Trace("Val enode share msg validator addresses", "valAddresses", common.ConvertToStringSlice(valAddresses))
+			logger.Trace("Sending val enode share msg to proxy with validator addresses", "valAddresses", common.ConvertToStringSlice(valAddresses))
 			pv.sendValEnodesShareMsg(proxy.peer, valAddresses)
 		}
 	}


### PR DESCRIPTION
### Description

There's currently an info log that will frequently print the addresses of every validator in the validator set. This change prints the length of the validator address array in the info log, but only prints the entire array in a trace log.

See https://discord.com/channels/600834479145353243/697229909545713775/817039572968931420

### Other changes

n/a

### Tested

Just `make geth`

### Related issues

n/a

### Backwards compatibility

yes
