### PR TITLE
Split extra flags on whitespace

### DIFF
--- a/mycelo/cluster/node.go
+++ b/mycelo/cluster/node.go
@@ -170,7 +170,7 @@ func (n *Node) Run(ctx context.Context) error {
 		"--password", n.pwdFile(),
 	}
 	if n.ExtraFlags != "" {
-		args = append(args, n.ExtraFlags)
+		args = append(args, strings.Fields(n.ExtraFlags)...)
 	}
 	cmd := exec.Command(n.GethPath, args...) // #nosec G204
 


### PR DESCRIPTION
### Description

Split extra flags on whitespace and then pass the array.
This enables passing multiple extra flags through to geth.

