### PR TITLE
Short circuit in currency compare

### DIFF
--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -147,7 +147,8 @@ func Convert(val *big.Int, currencyFrom *common.Address, currencyTo *common.Addr
 }
 
 func Cmp(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
-	if currency1 == currency2 {
+	// Short circuit if the fee currency is the same. nil currency => native currency
+	if (currency1 == nil && currency2 == nil) || (currency1 != nil && currency2 != nil && *currency1 == *currency2) {
 		return val1.Cmp(val2)
 	}
 


### PR DESCRIPTION
### Description

Properly dereference the fee currency point such that currency.Cmp short circuits when comparing non-native fee currencies.


### Tested

https://colab.research.google.com/drive/1duSJnIAxUs-3U8YQeEzPGZy8xnpwgWGC#scrollTo=4MyDZZHg_eZh

Tested with all cUSD and a mix of cUSD and CELO fee currencies.

### Related issues

- Partial fix of https://github.com/celo-org/celo-labs/issues/837

### Backwards compatibility

Yes.