### PR TITLE
Implement CIP35 for Donut hard fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
       GO_VERSION: "1.14.14"
-      CELO_MONOREPO_BRANCH_TO_TEST: oneeman/cip35-e2e-tests
+      CELO_MONOREPO_BRANCH_TO_TEST: master
       GITHUB_RSA_FINGERPRINT: SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
 jobs:
   build-geth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
       GO_VERSION: "1.14.14"
-      CELO_MONOREPO_BRANCH_TO_TEST: master
+      CELO_MONOREPO_BRANCH_TO_TEST: oneeman/cip35-e2e-tests
       GITHUB_RSA_FINGERPRINT: SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
 jobs:
   build-geth:

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -652,6 +652,7 @@ func (m callmsg) GatewayFee() *big.Int                 { return m.CallMsg.Gatewa
 func (m callmsg) Gas() uint64                          { return m.CallMsg.Gas }
 func (m callmsg) Value() *big.Int                      { return m.CallMsg.Value }
 func (m callmsg) Data() []byte                         { return m.CallMsg.Data }
+func (m callmsg) EthCompatible() bool                  { return m.CallMsg.EthCompatible }
 
 // filterBackend implements filters.Backend to support filtering for logs without
 // taking bloom-bits acceleration structures into account.

--- a/cmd/geth/retesteth_copypaste.go
+++ b/cmd/geth/retesteth_copypaste.go
@@ -40,6 +40,7 @@ type RPCTransaction struct {
 	V                *hexutil.Big    `json:"v"`
 	R                *hexutil.Big    `json:"r"`
 	S                *hexutil.Big    `json:"s"`
+	EthCompatible    bool            `json:"ethCompatible"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
@@ -53,17 +54,18 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 	v, r, s := tx.RawSignatureValues()
 
 	result := &RPCTransaction{
-		From:     from,
-		Gas:      hexutil.Uint64(tx.Gas()),
-		GasPrice: (*hexutil.Big)(tx.GasPrice()),
-		Hash:     tx.Hash(),
-		Input:    hexutil.Bytes(tx.Data()),
-		Nonce:    hexutil.Uint64(tx.Nonce()),
-		To:       tx.To(),
-		Value:    (*hexutil.Big)(tx.Value()),
-		V:        (*hexutil.Big)(v),
-		R:        (*hexutil.Big)(r),
-		S:        (*hexutil.Big)(s),
+		From:          from,
+		Gas:           hexutil.Uint64(tx.Gas()),
+		GasPrice:      (*hexutil.Big)(tx.GasPrice()),
+		Hash:          tx.Hash(),
+		Input:         hexutil.Bytes(tx.Data()),
+		Nonce:         hexutil.Uint64(tx.Nonce()),
+		To:            tx.To(),
+		Value:         (*hexutil.Big)(tx.Value()),
+		V:             (*hexutil.Big)(v),
+		R:             (*hexutil.Big)(r),
+		S:             (*hexutil.Big)(s),
+		EthCompatible: tx.EthCompatible(),
 	}
 	if blockHash != (common.Hash{}) {
 		result.BlockHash = blockHash

--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	emptyMessage                = types.NewMessage(common.HexToAddress("0x0"), nil, 0, common.Big0, 0, common.Big0, nil, nil, common.Big0, []byte{}, false)
+	emptyMessage                = types.NewMessage(common.HexToAddress("0x0"), nil, 0, common.Big0, 0, common.Big0, nil, nil, common.Big0, []byte{}, false, false)
 	internalEvmHandlerSingleton *InternalEVMHandler
 )
 

--- a/core/error.go
+++ b/core/error.go
@@ -76,4 +76,12 @@ var (
 	// ErrIntrinsicGas is returned if the transaction is specified to use less gas
 	// than required to start the invocation.
 	ErrIntrinsicGas = errors.New("intrinsic gas too low")
+
+	// ErrEthCompatibleTransactionsNotSupported is returned if the transaction omits the 3 Celo-only
+	// fields (FeeCurrency & co.) but support for this kind of transaction is not enabled.
+	ErrEthCompatibleTransactionsNotSupported = errors.New("support for eth-compatible transactions is not enabled")
+
+	// ErrEthCompatibleTransactionIsntCompatible is returned if the transaction has EthCompatible: true
+	// but has non-nil-or-0 values for some of the Celo-only fields
+	ErrEthCompatibleTransactionIsntCompatible = errors.New("ethCompatible is true, but non-eth-compatible fields are present")
 )

--- a/core/error.go
+++ b/core/error.go
@@ -81,10 +81,6 @@ var (
 	// fields (FeeCurrency & co.) but support for this kind of transaction is not enabled.
 	ErrEthCompatibleTransactionsNotSupported = errors.New("support for eth-compatible transactions is not enabled")
 
-	// ErrEthCompatibleTransactionIsntCompatible is returned if the transaction has EthCompatible: true
-	// but has non-nil-or-0 values for some of the Celo-only fields
-	ErrEthCompatibleTransactionIsntCompatible = errors.New("ethCompatible is true, but non-eth-compatible fields are present")
-
 	// ErrUnprotectedTransaction is returned if replay protection is required (post-Donut) but the transaction doesn't
 	// use it.
 	ErrUnprotectedTransaction = errors.New("replay protection is required")

--- a/core/error.go
+++ b/core/error.go
@@ -84,4 +84,8 @@ var (
 	// ErrEthCompatibleTransactionIsntCompatible is returned if the transaction has EthCompatible: true
 	// but has non-nil-or-0 values for some of the Celo-only fields
 	ErrEthCompatibleTransactionIsntCompatible = errors.New("ethCompatible is true, but non-eth-compatible fields are present")
+
+	// ErrUnprotectedTransaction is returned if replay protection is required (post-Donut) but the transaction doesn't
+	// use it.
+	ErrUnprotectedTransaction = errors.New("replay protection is required")
 )

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -112,6 +112,9 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 // for the transaction, gas used and an error if the transaction failed,
 // indicating the block was invalid.
 func ApplyTransaction(config *params.ChainConfig, bc vm.ChainContext, txFeeRecipient *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
+	if config.IsDonut(header.Number) && !tx.Protected() {
+		return nil, ErrUnprotectedTransaction
+	}
 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number))
 	if err != nil {
 		return nil, err

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -363,8 +363,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if st.msg.EthCompatible() && !st.evm.ChainConfig().IsDonut(st.evm.BlockNumber) {
 		return nil, ErrEthCompatibleTransactionsNotSupported
 	}
-	if st.msg.EthCompatible() && !(st.msg.FeeCurrency() == nil && st.msg.GatewayFeeRecipient() == nil && st.msg.GatewayFee().Sign() == 0) {
-		return nil, ErrEthCompatibleTransactionIsntCompatible
+	if err := vm.CheckEthCompatibility(st.msg); err != nil {
+		return nil, err
 	}
 
 	// Check clauses 1-2

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -584,8 +584,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if tx.EthCompatible() && !pool.donut {
 		return ErrEthCompatibleTransactionsNotSupported
 	}
-	if tx.EthCompatible() && !(tx.FeeCurrency() == nil && tx.GatewayFeeRecipient() == nil && tx.GatewayFee().Sign() == 0) {
-		return ErrEthCompatibleTransactionIsntCompatible
+	if err := tx.CheckEthCompatibility(); err != nil {
+		return err
 	}
 	// Reject transactions over defined size to prevent DOS attacks
 	if uint64(tx.Size()) > txMaxSize {

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -38,9 +38,13 @@ import (
 	"github.com/celo-org/celo-blockchain/params"
 )
 
-// testTxPoolConfig is a transaction pool configuration without stateful disk
-// sideeffects used during testing.
-var testTxPoolConfig TxPoolConfig
+var (
+	// testTxPoolConfig is a transaction pool configuration without stateful disk
+	// sideeffects used during testing.
+	testTxPoolConfig TxPoolConfig
+	// eip155Signer to use for generating replay-protected transactions
+	eip155Signer = types.NewEIP155Signer(params.TestChainConfig.ChainID)
+)
 
 func init() {
 	testTxPoolConfig = DefaultTxPoolConfig
@@ -100,6 +104,11 @@ func pricedDataTransaction(nonce uint64, gaslimit uint64, gasprice *big.Int, key
 	rand.Read(data)
 
 	tx, _ := types.SignTx(types.NewTransaction(nonce, common.Address{}, big.NewInt(0), gaslimit, gasprice, nil, nil, nil, data), types.HomesteadSigner{}, key)
+	return tx
+}
+
+func protectedTransaction(nonce uint64, gaslimit uint64, key *ecdsa.PrivateKey) *types.Transaction {
+	tx, _ := types.SignTx(types.NewTransaction(nonce, common.Address{}, big.NewInt(100), gaslimit, big.NewInt(1), nil, nil, nil, nil), eip155Signer, key)
 	return tx
 }
 
@@ -754,6 +763,54 @@ func TestTransactionGapFilling(t *testing.T) {
 	if err := validateEvents(events, 2); err != nil {
 		t.Fatalf("gap-filling event firing failed: %v", err)
 	}
+	if err := validateTxPoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+}
+
+// Tests that pool.handleDonutActivation() removes transactions without replay protection
+// When we change TestChangeConfig to enable Donut this test will need:
+// (a) to set pool.donut = false at its start (so we can add unprotected transactions)
+// (b) different functions to generate protected vs unprotected transactions, since we will
+//     need to update transaction() and the others to use replay protection
+func TestHandleDonutActivation(t *testing.T) {
+	t.Parallel()
+
+	// Create a test account and fund it
+	pool, key := setupTxPool()
+	defer pool.Stop()
+
+	account := crypto.PubkeyToAddress(key.PublicKey)
+	pool.currentState.AddBalance(account, big.NewInt(1000000))
+
+	pool.AddRemotesSync([]*types.Transaction{
+		protectedTransaction(0, 100000, key),
+		transaction(1, 100000, key),
+		protectedTransaction(2, 100000, key),
+		transaction(7, 100000, key),
+		protectedTransaction(8, 100000, key),
+		transaction(9, 100000, key),
+		transaction(10, 100000, key),
+	})
+
+	pending, queued := pool.Stats()
+	if pending != 3 {
+		t.Fatalf("pending transactions mismatched: have %d, want %d", pending, 3)
+	}
+	if queued != 4 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 4)
+	}
+
+	pool.handleDonutActivation()
+
+	pending, queued = pool.Stats()
+	if pending != 1 {
+		t.Fatalf("pending transactions mismatched: have %d, want %d", pending, 1)
+	}
+	if queued != 2 {
+		t.Fatalf("queued transactions mismatched: have %d, want %d", queued, 2)
+	}
+
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}

--- a/core/types/gen_tx_json.go
+++ b/core/types/gen_tx_json.go
@@ -21,7 +21,7 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 		GasLimit            hexutil.Uint64  `json:"gas"      gencodec:"required"`
 		FeeCurrency         *common.Address `json:"feeCurrency" rlp:"nil"`
 		GatewayFeeRecipient *common.Address `json:"gatewayFeeRecipient" rlp:"nil"`
-		GatewayFee          *hexutil.Big    `json:"gatewayFee" rlp:"nil"`
+		GatewayFee          *hexutil.Big    `json:"gatewayFee"`
 		Recipient           *common.Address `json:"to"       rlp:"nil"`
 		Amount              *hexutil.Big    `json:"value"    gencodec:"required"`
 		Payload             hexutil.Bytes   `json:"input"    gencodec:"required"`
@@ -55,7 +55,7 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 		GasLimit            *hexutil.Uint64 `json:"gas"      gencodec:"required"`
 		FeeCurrency         *common.Address `json:"feeCurrency" rlp:"nil"`
 		GatewayFeeRecipient *common.Address `json:"gatewayFeeRecipient" rlp:"nil"`
-		GatewayFee          *hexutil.Big    `json:"gatewayFee" rlp:"nil"`
+		GatewayFee          *hexutil.Big    `json:"gatewayFee"`
 		Recipient           *common.Address `json:"to"       rlp:"nil"`
 		Amount              *hexutil.Big    `json:"value"    gencodec:"required"`
 		Payload             *hexutil.Bytes  `json:"input"    gencodec:"required"`

--- a/core/types/gen_tx_json.go
+++ b/core/types/gen_tx_json.go
@@ -29,6 +29,7 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 		R                   *hexutil.Big    `json:"r" gencodec:"required"`
 		S                   *hexutil.Big    `json:"s" gencodec:"required"`
 		Hash                *common.Hash    `json:"hash" rlp:"-"`
+		EthCompatible       bool            `json:"ethCompatible" rlp:"-"`
 	}
 	var enc txdata
 	enc.AccountNonce = hexutil.Uint64(t.AccountNonce)
@@ -44,6 +45,7 @@ func (t txdata) MarshalJSON() ([]byte, error) {
 	enc.R = (*hexutil.Big)(t.R)
 	enc.S = (*hexutil.Big)(t.S)
 	enc.Hash = t.Hash
+	enc.EthCompatible = t.EthCompatible
 	return json.Marshal(&enc)
 }
 
@@ -63,6 +65,7 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 		R                   *hexutil.Big    `json:"r" gencodec:"required"`
 		S                   *hexutil.Big    `json:"s" gencodec:"required"`
 		Hash                *common.Hash    `json:"hash" rlp:"-"`
+		EthCompatible       *bool           `json:"ethCompatible" rlp:"-"`
 	}
 	var dec txdata
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -114,6 +117,9 @@ func (t *txdata) UnmarshalJSON(input []byte) error {
 	t.S = (*big.Int)(dec.S)
 	if dec.Hash != nil {
 		t.Hash = dec.Hash
+	}
+	if dec.EthCompatible != nil {
+		t.EthCompatible = *dec.EthCompatible
 	}
 	return nil
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -49,8 +49,8 @@ type txdata struct {
 	GasLimit            uint64          `json:"gas"      gencodec:"required"`
 	FeeCurrency         *common.Address `json:"feeCurrency" rlp:"nil"`         // nil means native currency
 	GatewayFeeRecipient *common.Address `json:"gatewayFeeRecipient" rlp:"nil"` // nil means no gateway fee is paid
-	GatewayFee          *big.Int        `json:"gatewayFee" rlp:"nil"`          // nil means no gateway fee is paid
-	Recipient           *common.Address `json:"to"       rlp:"nil"`            // nil means contract creation
+	GatewayFee          *big.Int        `json:"gatewayFee"`
+	Recipient           *common.Address `json:"to"       rlp:"nil"` // nil means contract creation
 	Amount              *big.Int        `json:"value"    gencodec:"required"`
 	Payload             []byte          `json:"input"    gencodec:"required"`
 

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -32,7 +32,7 @@ import (
 //go:generate gencodec -type txdata -field-override txdataMarshaling -out gen_tx_json.go
 
 const (
-	ETH_COMPATIBLE_TX_NUM_FIELDS = 9
+	ethCompatibleTxNumFields = 9
 )
 
 var (
@@ -232,7 +232,7 @@ func (tx *Transaction) DecodeRLP(s *rlp.Stream) (err error) {
 	if err != nil {
 		return err
 	}
-	if numElems == ETH_COMPATIBLE_TX_NUM_FIELDS {
+	if numElems == ethCompatibleTxNumFields {
 		ethCompatibleData := ethcompatibletxdata{}
 		err = rlp.DecodeBytes(raw, &ethCompatibleData)
 		tx.data = fromEthCompatibleTxData(ethCompatibleData)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -73,6 +73,21 @@ type txdata struct {
 	EthCompatible bool `json:"ethCompatible" rlp:"-"`
 }
 
+type txdataMarshaling struct {
+	AccountNonce        hexutil.Uint64
+	Price               *hexutil.Big
+	GasLimit            hexutil.Uint64
+	FeeCurrency         *common.Address
+	GatewayFeeRecipient *common.Address
+	GatewayFee          *hexutil.Big
+	Amount              *hexutil.Big
+	Payload             hexutil.Bytes
+	V                   *hexutil.Big
+	R                   *hexutil.Big
+	S                   *hexutil.Big
+	EthCompatible       bool
+}
+
 // ethCompatibleTxRlpList is used for RLP encoding/decoding of eth-compatible transactions.
 // As such, it:
 // (a) excludes the Celo-only fields,
@@ -121,21 +136,6 @@ func fromEthCompatibleRlpList(data ethCompatibleTxRlpList) txdata {
 		Hash:                nil, // txdata.Hash is calculated and saved inside tx.Hash()
 		EthCompatible:       true,
 	}
-}
-
-type txdataMarshaling struct {
-	AccountNonce        hexutil.Uint64
-	Price               *hexutil.Big
-	GasLimit            hexutil.Uint64
-	FeeCurrency         *common.Address
-	GatewayFeeRecipient *common.Address
-	GatewayFee          *hexutil.Big
-	Amount              *hexutil.Big
-	Payload             hexutil.Bytes
-	V                   *hexutil.Big
-	R                   *hexutil.Big
-	S                   *hexutil.Big
-	EthCompatible       bool
 }
 
 func NewTransaction(nonce uint64, to common.Address, amount *big.Int, gasLimit uint64, gasPrice *big.Int, feeCurrency, gatewayFeeRecipient *common.Address, gatewayFee *big.Int, data []byte) *Transaction {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -92,34 +92,34 @@ type ethCompatibleTxRlpList struct {
 
 func toEthCompatibleRlpList(data txdata) ethCompatibleTxRlpList {
 	return ethCompatibleTxRlpList{
-		data.AccountNonce,
-		data.Price,
-		data.GasLimit,
-		data.Recipient,
-		data.Amount,
-		data.Payload,
-		data.V,
-		data.R,
-		data.S,
+		AccountNonce: data.AccountNonce,
+		Price:        data.Price,
+		GasLimit:     data.GasLimit,
+		Recipient:    data.Recipient,
+		Amount:       data.Amount,
+		Payload:      data.Payload,
+		V:            data.V,
+		R:            data.R,
+		S:            data.S,
 	}
 }
 
 func fromEthCompatibleRlpList(data ethCompatibleTxRlpList) txdata {
 	return txdata{
-		data.AccountNonce,
-		data.Price,
-		data.GasLimit,
-		nil,
-		nil,
-		big.NewInt(0),
-		data.Recipient,
-		data.Amount,
-		data.Payload,
-		data.V,
-		data.R,
-		data.S,
-		nil, // txdata.Hash is calculated and saved inside tx.Hash()
-		true,
+		AccountNonce:        data.AccountNonce,
+		Price:               data.Price,
+		GasLimit:            data.GasLimit,
+		FeeCurrency:         nil,
+		GatewayFeeRecipient: nil,
+		GatewayFee:          big.NewInt(0),
+		Recipient:           data.Recipient,
+		Amount:              data.Amount,
+		Payload:             data.Payload,
+		V:                   data.V,
+		R:                   data.R,
+		S:                   data.S,
+		Hash:                nil, // txdata.Hash is calculated and saved inside tx.Hash()
+		EthCompatible:       true,
 	}
 }
 

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -154,18 +154,30 @@ func (s EIP155Signer) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 // Hash returns the hash to be signed by the sender.
 // It does not uniquely identify the transaction.
 func (s EIP155Signer) Hash(tx *Transaction) common.Hash {
-	return rlpHash([]interface{}{
-		tx.data.AccountNonce,
-		tx.data.Price,
-		tx.data.GasLimit,
-		tx.data.FeeCurrency,
-		tx.data.GatewayFeeRecipient,
-		tx.data.GatewayFee,
-		tx.data.Recipient,
-		tx.data.Amount,
-		tx.data.Payload,
-		s.chainId, uint(0), uint(0),
-	})
+	if tx.data.EthCompatible {
+		return rlpHash([]interface{}{
+			tx.data.AccountNonce,
+			tx.data.Price,
+			tx.data.GasLimit,
+			tx.data.Recipient,
+			tx.data.Amount,
+			tx.data.Payload,
+			s.chainId, uint(0), uint(0),
+		})
+	} else {
+		return rlpHash([]interface{}{
+			tx.data.AccountNonce,
+			tx.data.Price,
+			tx.data.GasLimit,
+			tx.data.FeeCurrency,
+			tx.data.GatewayFeeRecipient,
+			tx.data.GatewayFee,
+			tx.data.Recipient,
+			tx.data.Amount,
+			tx.data.Payload,
+			s.chainId, uint(0), uint(0),
+		})
+	}
 }
 
 // HomesteadTransaction implements TransactionInterface using the

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -231,17 +231,28 @@ func (fs FrontierSigner) SignatureValues(tx *Transaction, sig []byte) (r, s, v *
 // Hash returns the hash to be signed by the sender.
 // It does not uniquely identify the transaction.
 func (fs FrontierSigner) Hash(tx *Transaction) common.Hash {
-	return rlpHash([]interface{}{
-		tx.data.AccountNonce,
-		tx.data.Price,
-		tx.data.GasLimit,
-		tx.data.FeeCurrency,
-		tx.data.GatewayFeeRecipient,
-		tx.data.GatewayFee,
-		tx.data.Recipient,
-		tx.data.Amount,
-		tx.data.Payload,
-	})
+	if tx.data.EthCompatible {
+		return rlpHash([]interface{}{
+			tx.data.AccountNonce,
+			tx.data.Price,
+			tx.data.GasLimit,
+			tx.data.Recipient,
+			tx.data.Amount,
+			tx.data.Payload,
+		})
+	} else {
+		return rlpHash([]interface{}{
+			tx.data.AccountNonce,
+			tx.data.Price,
+			tx.data.GasLimit,
+			tx.data.FeeCurrency,
+			tx.data.GatewayFeeRecipient,
+			tx.data.GatewayFee,
+			tx.data.Recipient,
+			tx.data.Amount,
+			tx.data.Payload,
+		})
+	}
 }
 
 func (fs FrontierSigner) Sender(tx *Transaction) (common.Address, error) {

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -207,6 +207,55 @@ func TestTxGatewayFee(t *testing.T) {
 	}
 }
 
+func TestTxEthCompatible(t *testing.T) {
+	key, addr := defaultTestKey()
+	tx := NewTransactionEthCompatible(
+		3,
+		common.Address{19},
+		big.NewInt(9),
+		7,
+		big.NewInt(13),
+		common.FromHex("ff05ff"),
+	)
+
+	var encoded []byte
+	var parsed *Transaction
+
+	encoded, _ = rlp.EncodeToBytes(tx)
+	parsed = &Transaction{}
+	rlp.DecodeBytes(encoded, &parsed)
+	if tx.Hash() != parsed.Hash() {
+		t.Errorf("RLP parsed pre-signing tx differs from original, want %v, got %v", tx, parsed)
+	}
+	encoded, _ = tx.MarshalJSON()
+	parsed = &Transaction{}
+	parsed.UnmarshalJSON(encoded)
+	if tx.Hash() != parsed.Hash() {
+		t.Errorf("JSON parsed pre-signing tx differs from original, want %v, got %v", tx, parsed)
+	}
+
+	// Repeat the tests but now with a signed transaction
+	signer := NewEIP155Signer(common.Big1)
+	signed, _ := SignTx(tx, signer, key)
+	sender, _ := Sender(signer, signed)
+	if sender != addr {
+		t.Errorf("recovered sender differs from original, want %v, got %v", addr, sender)
+	}
+
+	encoded, _ = rlp.EncodeToBytes(signed)
+	parsed = &Transaction{}
+	rlp.DecodeBytes(encoded, &parsed)
+	if signed.Hash() != parsed.Hash() {
+		t.Errorf("RLP parsed post-signing tx differs from original, want %v, got %v", signed, parsed)
+	}
+	encoded, _ = signed.MarshalJSON()
+	parsed = &Transaction{}
+	parsed.UnmarshalJSON(encoded)
+	if signed.Hash() != parsed.Hash() {
+		t.Errorf("JSON parsed post-signing tx differs from original, want %v, got %v", signed, parsed)
+	}
+}
+
 // Tests that transactions can be correctly sorted according to their price in
 // decreasing order, but at the same time with increasing nonces when issued by
 // the same account.

--- a/core/vm/context.go
+++ b/core/vm/context.go
@@ -46,6 +46,9 @@ type Message interface {
 	Nonce() uint64
 	CheckNonce() bool
 	Data() []byte
+
+	// Whether this transaction omitted the 3 Celo-only fields (FeeCurrency & co.)
+	EthCompatible() bool
 }
 
 // ChainContext supports retrieving chain data and consensus parameters

--- a/core/vm/context.go
+++ b/core/vm/context.go
@@ -51,6 +51,13 @@ type Message interface {
 	EthCompatible() bool
 }
 
+func CheckEthCompatibility(msg Message) error {
+	if msg.EthCompatible() && !(msg.FeeCurrency() == nil && msg.GatewayFeeRecipient() == nil && msg.GatewayFee().Sign() == 0) {
+		return types.ErrEthCompatibleTransactionIsntCompatible
+	}
+	return nil
+}
+
 // ChainContext supports retrieving chain data and consensus parameters
 // from the blockchain to be used during transaction processing.
 type ChainContext interface {

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -123,7 +123,7 @@ func (c mockChainContext) Engine() consensus.Engine {
 // Create a global mock EVM for use in the following tests.
 var mockEVM = &EVM{
 	Context: NewEVMContext(
-		types.NewMessage(common.HexToAddress("a11ce"), nil, 0, common.Big0, 0, common.Big1, nil, nil, common.Big0, nil, false),
+		types.NewMessage(common.HexToAddress("a11ce"), nil, 0, common.Big0, 0, common.Big1, nil, nil, common.Big0, nil, false, false),
 		makeTestHeader(big.NewInt(10000)),
 		mockChainContext{},
 		&common.Address{},

--- a/interfaces.go
+++ b/interfaces.go
@@ -122,6 +122,7 @@ type CallMsg struct {
 	GasPrice            *big.Int        // wei <-> gas exchange ratio
 	Value               *big.Int        // amount of wei sent along with the call
 	Data                []byte          // input data, usually an ABI-encoded contract method invocation
+	EthCompatible       bool            // Whether the 3 Celo-only fields (FeeCurrent & co.) were omitted
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by

--- a/interfaces.go
+++ b/interfaces.go
@@ -122,7 +122,7 @@ type CallMsg struct {
 	GasPrice            *big.Int        // wei <-> gas exchange ratio
 	Value               *big.Int        // amount of wei sent along with the call
 	Data                []byte          // input data, usually an ABI-encoded contract method invocation
-	EthCompatible       bool            // Whether the 3 Celo-only fields (FeeCurrent & co.) were omitted
+	EthCompatible       bool            // Whether the 3 Celo-only fields (FeeCurrency & co.) were omitted
 }
 
 // A ContractCaller provides contract calls, essentially transactions that are executed by

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1396,9 +1396,8 @@ type SendTxArgs struct {
 
 // setDefaults is a helper function that fills in default values for unspecified tx fields.
 func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
-	// Reject if Celo-only fields set when EthCompatible is true
-	if args.EthCompatible && !(args.FeeCurrency == nil && args.GatewayFeeRecipient == nil && (args.GatewayFee == nil || args.GatewayFee.ToInt().Sign() == 0)) {
-		return core.ErrEthCompatibleTransactionIsntCompatible
+	if err := args.checkEthCompatibility(); err != nil {
+		return err
 	}
 	if args.Gas == nil {
 		args.Gas = new(hexutil.Uint64)
@@ -1489,6 +1488,14 @@ func (args *SendTxArgs) setDefaults(ctx context.Context, b Backend) error {
 	}
 	if args.GatewayFeeRecipient != nil && args.GatewayFee == nil {
 		args.GatewayFee = (*hexutil.Big)(b.GatewayFee())
+	}
+	return nil
+}
+
+func (args *SendTxArgs) checkEthCompatibility() error {
+	// Reject if Celo-only fields set when EthCompatible is true
+	if args.EthCompatible && !(args.FeeCurrency == nil && args.GatewayFeeRecipient == nil && (args.GatewayFee == nil || args.GatewayFee.ToInt().Sign() == 0)) {
+		return types.ErrEthCompatibleTransactionIsntCompatible
 	}
 	return nil
 }

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -130,7 +130,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 				from := statedb.GetOrNewStateObject(bankAddr)
 				from.SetBalance(math.MaxBig256)
 
-				msg := callmsg{types.NewMessage(from.Address(), &testContractAddr, 0, new(big.Int), 100000, new(big.Int), nil, nil, new(big.Int), data, false)}
+				msg := callmsg{types.NewMessage(from.Address(), &testContractAddr, 0, new(big.Int), 100000, new(big.Int), nil, nil, new(big.Int), data, false, false)}
 
 				context := vm.NewEVMContext(msg, header, bc, nil)
 				vmenv := vm.NewEVM(context, statedb, config, vm.Config{})
@@ -144,7 +144,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 			header := lc.GetHeaderByHash(bhash)
 			state := light.NewState(ctx, header, lc.Odr())
 			state.SetBalance(bankAddr, math.MaxBig256)
-			msg := callmsg{types.NewMessage(bankAddr, &testContractAddr, 0, new(big.Int), 100000, new(big.Int), nil, nil, new(big.Int), data, false)}
+			msg := callmsg{types.NewMessage(bankAddr, &testContractAddr, 0, new(big.Int), 100000, new(big.Int), nil, nil, new(big.Int), data, false, false)}
 			context := vm.NewEVMContext(msg, header, lc, nil)
 			vmenv := vm.NewEVM(context, state, config, vm.Config{})
 			gp := new(core.GasPool).AddGas(math.MaxUint64)

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -242,7 +242,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 
 		// Perform read-only call.
 		st.SetBalance(testBankAddress, math.MaxBig256)
-		msg := callmsg{types.NewMessage(testBankAddress, &testContractAddr, 0, new(big.Int), 1000000, new(big.Int), nil, nil, new(big.Int), data, false)}
+		msg := callmsg{types.NewMessage(testBankAddress, &testContractAddr, 0, new(big.Int), 1000000, new(big.Int), nil, nil, new(big.Int), data, false, false)}
 		context := vm.NewEVMContext(msg, header, chain, nil)
 		vmenv := vm.NewEVM(context, st, config, vm.Config{})
 		gp := new(core.GasPool).AddGas(math.MaxUint64)

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -362,6 +362,9 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 		err  error
 	)
 
+	if pool.donut && !tx.Protected() {
+		return core.ErrUnprotectedTransaction
+	}
 	if tx.EthCompatible() && !pool.donut {
 		return core.ErrEthCompatibleTransactionsNotSupported
 	}

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -72,6 +72,7 @@ type TxPool struct {
 	clearIdx     uint64                               // earliest block nr that can contain mined tx info
 
 	istanbul bool // Fork indicator whether we are in the istanbul stage.
+	donut    bool // Fork indicated whether Donut has been activated
 }
 
 // TxRelayBackend provides an interface to the mechanism that forwards transacions
@@ -325,6 +326,7 @@ func (pool *TxPool) setNewHead(head *types.Header) {
 	// Update fork indicator by next pending block number
 	next := new(big.Int).Add(head.Number, big.NewInt(1))
 	pool.istanbul = pool.config.IsIstanbul(next)
+	pool.donut = pool.config.IsDonut(next)
 }
 
 // Stop stops the light transaction pool
@@ -359,6 +361,13 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 		from common.Address
 		err  error
 	)
+
+	if tx.EthCompatible() && !pool.donut {
+		return core.ErrEthCompatibleTransactionsNotSupported
+	}
+	if tx.EthCompatible() && !(tx.FeeCurrency() == nil && tx.GatewayFeeRecipient() == nil && tx.GatewayFee().Sign() == 0) {
+		return core.ErrEthCompatibleTransactionIsntCompatible
+	}
 
 	// Validate the transaction sender and it's sig. Throw
 	// if the from fields is invalid.

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -368,8 +368,8 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 	if tx.EthCompatible() && !pool.donut {
 		return core.ErrEthCompatibleTransactionsNotSupported
 	}
-	if tx.EthCompatible() && !(tx.FeeCurrency() == nil && tx.GatewayFeeRecipient() == nil && tx.GatewayFee().Sign() == 0) {
-		return core.ErrEthCompatibleTransactionIsntCompatible
+	if err := tx.CheckEthCompatibility(); err != nil {
+		return err
 	}
 
 	// Validate the transaction sender and it's sig. Throw

--- a/rlp/decode.go
+++ b/rlp/decode.go
@@ -952,7 +952,13 @@ func (s *Stream) readFull(buf []byte) (err error) {
 		n += nn
 	}
 	if err == io.EOF {
-		err = io.ErrUnexpectedEOF
+		if n < len(buf) {
+			err = io.ErrUnexpectedEOF
+		} else {
+			// Readers are allowed to give EOF even though the read succeeded.
+			// In such cases, we discard the EOF, like io.ReadFull() does.
+			err = nil
+		}
 	}
 	return err
 }

--- a/rlp/decode_test.go
+++ b/rlp/decode_test.go
@@ -665,6 +665,26 @@ func TestDecodeWithByteReader(t *testing.T) {
 	})
 }
 
+func testDecodeWithEncReader(t *testing.T, n int) {
+	s := strings.Repeat("0", n)
+	_, r, _ := EncodeToReader(s)
+	var decoded string
+	err := Decode(r, &decoded)
+	if err != nil {
+		t.Errorf("Unexpected decode error with n=%v: %v", n, err)
+	}
+	if decoded != s {
+		t.Errorf("Decode mismatch with n=%v", n)
+	}
+}
+
+// This is a regression test checking that decoding from encReader
+// works for RLP values of size 8192 bytes or more.
+func TestDecodeWithEncReader(t *testing.T) {
+	testDecodeWithEncReader(t, 8188) // length with header is 8191
+	testDecodeWithEncReader(t, 8189) // length with header is 8192
+}
+
 // plainReader reads from a byte slice but does not
 // implement ReadByte. It is also not recognized by the
 // size validation. This is useful to test how the decoder

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -86,6 +86,7 @@ type RPCTransaction struct {
 	V                   *hexutil.Big    `json:"v"`
 	R                   *hexutil.Big    `json:"r"`
 	S                   *hexutil.Big    `json:"s"`
+	EthCompatible       bool            `json:"ethCompatible"`
 }
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:

--- a/signer/core/types.go
+++ b/signer/core/types.go
@@ -76,6 +76,7 @@ type SendTxArgs struct {
 	GatewayFee          hexutil.Big              `json:"gatewayFee"`
 	Value               hexutil.Big              `json:"value"`
 	Nonce               hexutil.Uint64           `json:"nonce"`
+	EthCompatible       bool                     `json:"ethCompatible"`
 	// We accept "data" and "input" for backwards-compatibility reasons.
 	Data  *hexutil.Bytes `json:"data"`
 	Input *hexutil.Bytes `json:"input,omitempty"`
@@ -107,7 +108,13 @@ func (args *SendTxArgs) toTransaction() *types.Transaction {
 		gatewayFeeRecipient = &tmp
 	}
 	if args.To == nil {
+		if args.EthCompatible {
+			return types.NewContractCreationEthCompatible(uint64(args.Nonce), (*big.Int)(&args.Value), uint64(args.Gas), (*big.Int)(&args.GasPrice), input)
+		}
 		return types.NewContractCreation(uint64(args.Nonce), (*big.Int)(&args.Value), uint64(args.Gas), (*big.Int)(&args.GasPrice), feeCurrency, gatewayFeeRecipient, (*big.Int)(&args.GatewayFee), input)
+	}
+	if args.EthCompatible {
+		return types.NewTransactionEthCompatible(uint64(args.Nonce), args.To.Address(), (*big.Int)(&args.Value), (uint64)(args.Gas), (*big.Int)(&args.GasPrice), input)
 	}
 	return types.NewTransaction(uint64(args.Nonce), args.To.Address(), (*big.Int)(&args.Value), (uint64)(args.Gas), (*big.Int)(&args.GasPrice), feeCurrency, gatewayFeeRecipient, (*big.Int)(&args.GatewayFee), input)
 }

--- a/signer/core/types.go
+++ b/signer/core/types.go
@@ -90,6 +90,10 @@ func (args SendTxArgs) String() string {
 	return err.Error()
 }
 
+func (args SendTxArgs) CheckEthCompatibility() error {
+	return args.toTransaction().CheckEthCompatibility()
+}
+
 func (args *SendTxArgs) toTransaction() *types.Transaction {
 	var input []byte
 	if args.Data != nil {

--- a/signer/fourbyte/validation.go
+++ b/signer/fourbyte/validation.go
@@ -23,7 +23,6 @@ import (
 	"math/big"
 
 	"github.com/celo-org/celo-blockchain/common"
-	celoCore "github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/signer/core"
 )
 
@@ -34,8 +33,8 @@ func (db *Database) ValidateTransaction(selector *string, tx *core.SendTxArgs) (
 	messages := new(core.ValidationMessages)
 
 	// Reject if EthCompatible is true but the transaction has non-nil-or-0 values for the non-eth-compatible fields
-	if tx.EthCompatible && !(tx.FeeCurrency == nil && tx.GatewayFeeRecipient == nil && tx.GatewayFee.ToInt().Sign() == 0) {
-		return nil, celoCore.ErrEthCompatibleTransactionIsntCompatible
+	if err := tx.CheckEthCompatibility(); err != nil {
+		return nil, err
 	}
 	// Prevent accidental erroneous usage of both 'input' and 'data' (show stopper)
 	if tx.Data != nil && tx.Input != nil && !bytes.Equal(*tx.Data, *tx.Input) {

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -282,7 +282,7 @@ func (tx *stTransaction) toMessage(ps stPostState) (vm.Message, error) {
 		return nil, fmt.Errorf("invalid tx data %q", dataHex)
 	}
 
-	msg := types.NewMessage(from, to, tx.Nonce, value, gasLimit, tx.GasPrice, nil, nil, common.Big0, data, true)
+	msg := types.NewMessage(from, to, tx.Nonce, value, gasLimit, tx.GasPrice, nil, nil, common.Big0, data, false, true)
 	return msg, nil
 }
 


### PR DESCRIPTION
### Description

This PR implements CIP35 as specified at https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0035.md.

Summary of changes:

* `Transaction` type has a new field `EthCompatible` to distinguish between normal transactions (with the Celo-only fields) and ethereum-compatible ones (without those fields)
* When decoding transactions of RLP, it identifies the type based on the number of fields the RLP list has
* When encoding transactions to RLP, it encodes them to have either 9 or 12 fields depending on the value of `EthCompatible`
* When generating or verifying transaction signatures, the signing data used is determined by the value of `EthCompatible`
* When serializing to or deserializing from JSON, the `EthCompatible` field is encoded as `ethCompatible`.
* When validating transactions (whether in the tx pool or in the state transition function), reject them if either
   (a) `EthCompatible` is true but Donut has not been activated,
   (b) `EthCompatible` is true but they have non-trivial values for any of the Celo-only fields (which can't happen if decoding from RLP, but can if decoding from JSON), or
   (c) Donut has been activated but the transaction doesn't use replay protection (EIP-155)

### Other changes

* Fix an upstream bug in RLP decoding (fixed upstream by https://github.com/ethereum/go-ethereum/pull/22336)
* Remove the `rlp:nil` tag from `txdata.GatewayFee`.  This tag is not respected for `*big.Int` values, and so its presence was misleading.
* Point the CI to use the celo-monorepo branch `oneeman/cip35-e2e-tests`.  This was not strictly speaking necessary, since I have a PR on celo-monorepo pointing at this branch, the tests will execute there.  Regardless, this change will be reverted to point it back to master

### Tested

* Unit tests for serialization an deserialization of transactions (for both RLP and JSON)
* e2e tests (see https://github.com/celo-org/celo-monorepo/pull/7418) which cover combinations of scenarios such as pre-Donut vs post-Donut, eth-compatible vs normal transactions, sending to a full node or a light client, including vs not including Celo-only fields, sending using `eth_sendTransaction` vs using `eth_sendRawTransaction`.

### Backwards compatibility

* `Transaction` and other types like it (e.g. `RPCTransaction`) have a new field.  However, as the zero value for boolean fields is `false` (which means normal Celo transactions), no changes should be required for software importing `celo-blockchain` packages as a library.
* When Donut is activated, a new transaction type will be valid which isn't currently
* When Donut is activated, transactions without EIP-155 replay protection (i.e. using the chain id) will be rejected.  However, all known Celo wallets and all up to date Ethereum wallets use replay protection, so this isn't likely to affect anyone.
* Before and after Donut, transactions serialized to JSON will have a new boolean field, `ethCompatible`.  This should not break existing software as additional fields are generally ignored during JSON parsing.  In particular, contractkit is not affected, as may be seen in the e2e tests.
