### PR TITLE
Refactor load bot to reduce CPU Usage

### DIFF
--- a/mycelo/loadbot/bot.go
+++ b/mycelo/loadbot/bot.go
@@ -21,12 +21,6 @@ var maxPending uint64
 var pending uint64
 var pendingLock sync.Mutex
 
-// Range represents an inclusive big.Int range
-type Range struct {
-	From *big.Int
-	To   *big.Int
-}
-
 // Config represent the load bot run configuration
 type Config struct {
 	Accounts              []env.Account
@@ -39,38 +33,57 @@ type Config struct {
 
 // Start will start loads bots
 func Start(ctx context.Context, cfg *Config) error {
+	// Set up round robin selectors that rollover
+	recvIdx := uint(len(cfg.Accounts) / 2)
+	nextRecipient := func() common.Address {
+		recvIdx++
+		return cfg.Accounts[recvIdx%uint(len(cfg.Accounts))].Address
+	}
+	sendIdx := uint(0)
+	nextSender := func() env.Account {
+		sendIdx++
+		return cfg.Accounts[sendIdx%uint(len(cfg.Accounts))]
+	}
+	clientIdx := uint(0)
+	nextClient := func() *ethclient.Client {
+		clientIdx++
+		return cfg.Clients[clientIdx%uint(len(cfg.Clients))]
+	}
+
+	// Fire off transactions
+	period := 1 * time.Second / time.Duration(cfg.TransactionsPerSecond)
+	ticker := time.NewTicker(period)
 	group, ctx := errgroup.WithContext(ctx)
 
-	idx := len(cfg.Accounts) / 2
-	nextTransfer := func() (common.Address, *big.Int) {
-		idx++
-		return cfg.Accounts[idx%len(cfg.Accounts)].Address, cfg.Amount
-	}
-
-	// developer accounts / TPS = duration in seconds.
-	// Need the fudger factor to get up a consistent TPS at the target.
-	delay := time.Duration(int(float64(len(cfg.Accounts)*1000/cfg.TransactionsPerSecond)*0.95)) * time.Millisecond
-	startDelay := delay / time.Duration(len(cfg.Accounts))
-	maxPending = cfg.MaxPending
-
-	for i, acc := range cfg.Accounts {
-		// Spread out client load across different diallers
-		client := cfg.Clients[i%len(cfg.Clients)]
-		acc := acc
-
-		err := waitFor(ctx, startDelay)
-		if err != nil {
-			return err
+	for {
+		select {
+		case <-ticker.C:
+			pendingLock.Lock()
+			if maxPending != 0 && pending > maxPending {
+				pendingLock.Unlock()
+				continue
+			} else {
+				pending++
+				pendingLock.Unlock()
+			}
+			group.Go(func() error {
+				return runTransaction(ctx, nextSender(), cfg.Verbose, nextClient(), nextRecipient(), cfg.Amount)
+			})
+		case <-ctx.Done():
+			return group.Wait()
 		}
-		group.Go(func() error {
-			return runBot(ctx, acc, cfg.Verbose, delay, client, nextTransfer)
-		})
 	}
-
-	return group.Wait()
 }
 
-func runBot(ctx context.Context, acc env.Account, verbose bool, sleepTime time.Duration, client *ethclient.Client, nextTransfer func() (common.Address, *big.Int)) error {
+func runTransaction(ctx context.Context, acc env.Account, verbose bool, client *ethclient.Client, recipient common.Address, value *big.Int) error {
+	defer func() {
+		pendingLock.Lock()
+		if maxPending != 0 {
+			pending--
+		}
+		pendingLock.Unlock()
+	}()
+
 	abi := contract.AbiFor("StableToken")
 	stableToken := bind.NewBoundContract(env.MustProxyAddressFor("StableToken"), *abi, client)
 
@@ -80,63 +93,27 @@ func runBot(ctx context.Context, acc env.Account, verbose bool, sleepTime time.D
 	stableTokenAddress := env.MustProxyAddressFor("StableToken")
 	transactor.FeeCurrency = &stableTokenAddress
 
-	for {
-		pendingLock.Lock()
-		if maxPending != 0 && pending > maxPending {
-			pendingLock.Unlock()
-			continue
-		} else {
-			pending++
-			pendingLock.Unlock()
+	tx, err := stableToken.TxObj(transactor, "transferWithComment", recipient, value, "need to proivde some long comment to make it similar to an encrypted comment").Send()
+	if err != nil {
+		if err != context.Canceled {
+			fmt.Printf("Error sending transaction: %v\n", err)
 		}
-		txSentTime := time.Now()
-		recipient, value := nextTransfer()
-		tx, err := stableToken.TxObj(transactor, "transferWithComment", recipient, value, "need to proivde some long comment to make it similar to an encrypted comment").Send()
-		if err != nil {
-			if err != context.Canceled {
-				fmt.Printf("Error sending transaction: %v\n", err)
-			}
-			return fmt.Errorf("Error sending transaction: %w", err)
-		}
-		if verbose {
-			fmt.Printf("cusd transfer generated: from: %s to: %s amount: %s\ttxhash: %s\n", acc.Address.Hex(), recipient.Hex(), value.String(), tx.Transaction.Hash().Hex())
-			printJSON(tx)
-		}
-
-		_, err = tx.WaitMined(ctx)
-		pendingLock.Lock()
-		if maxPending != 0 {
-			pending--
-		}
-		pendingLock.Unlock()
-
-		if err != nil {
-			if err != context.Canceled {
-				fmt.Printf("Error waiting for tx: %v\n", err)
-			}
-			return fmt.Errorf("Error waiting for tx: %w", err)
-		}
-
-		nextSendTime := txSentTime.Add(sleepTime)
-		if time.Now().After(nextSendTime) {
-			continue
-		}
-
-		err = waitFor(ctx, time.Until(nextSendTime))
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("Error sending transaction: %w", err)
+	}
+	if verbose {
+		fmt.Printf("cusd transfer generated: from: %s to: %s amount: %s\ttxhash: %s\n", acc.Address.Hex(), recipient.Hex(), value.String(), tx.Transaction.Hash().Hex())
+		printJSON(tx)
 	}
 
-}
+	_, err = tx.WaitMined(ctx)
 
-func waitFor(ctx context.Context, waitTime time.Duration) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(waitTime):
-		return nil
+	if err != nil {
+		if err != context.Canceled {
+			fmt.Printf("Error waiting for tx: %v\n", err)
+		}
+		return fmt.Errorf("Error waiting for tx: %w", err)
 	}
+	return err
 }
 
 func printJSON(obj interface{}) {


### PR DESCRIPTION
### Description

Refactors the load bot to reduce CPU Usage. This does it by having one thread that is on a ticker and firing off single run go-rountine transfers.

Previously there where `developer account` go routines being ran, and each was sleeping until it should send its transaction (through a couple of calculations to ensure that the TPS was correct). It appears to be a semi-known issue that ticker's (and fewer of them) seem to perform better than sleeping.

### Tested

Tested on a gcp vm instance. At 5s block times, order 50-100 TPS, cpu usage dropped from a couple hundred percent (out of 400% b/c 4 core machine), to 10-15% sustained. (The old version actually does ok at ~25 TPS, but gets much worse as the load increases)
