### PR TITLE
Fix typo in precompile address variable name

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -177,7 +177,7 @@ var PrecompiledContractsDonut = map[common.Address]PrecompiledContract{
 	getParentSealBitmapAddress:   &getParentSealBitmap{},
 	getVerifiedSealBitmapAddress: &getVerifiedSealBitmap{},
 
-	// TODO(Donut): Add instances
+	// New in Donut hard fork
 	ed25519Address:           &ed25519Verify{},
 	b12_381G1AddAddress:      &bls12381G1Add{},
 	b12_381G1MulAddress:      &bls12381G1Mul{},

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -80,7 +80,7 @@ var (
 	getVerifiedSealBitmapAddress = celoPrecompileAddress(11)
 
 	// New in Donut
-	edd25519Address          = celoPrecompileAddress(12)
+	ed25519Address           = celoPrecompileAddress(12)
 	b12_381G1AddAddress      = celoPrecompileAddress(13)
 	b12_381G1MulAddress      = celoPrecompileAddress(14)
 	b12_381G1MultiExpAddress = celoPrecompileAddress(15)
@@ -178,7 +178,7 @@ var PrecompiledContractsDonut = map[common.Address]PrecompiledContract{
 	getVerifiedSealBitmapAddress: &getVerifiedSealBitmap{},
 
 	// TODO(Donut): Add instances
-	edd25519Address:          &ed25519Verify{},
+	ed25519Address:           &ed25519Verify{},
 	b12_381G1AddAddress:      &bls12381G1Add{},
 	b12_381G1MulAddress:      &bls12381G1Mul{},
 	b12_381G1MultiExpAddress: &bls12381G1MultiExp{},


### PR DESCRIPTION
### Description

Just fixes a typo, and updates a stale comment in passing

### Tested

CI