### PR TITLE
Fixing dev mode and eth_call

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1767,6 +1767,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 		if !ctx.GlobalIsSet(MinerGasPriceFlag.Name) && !ctx.GlobalIsSet(MinerLegacyGasPriceFlag.Name) {
 			cfg.Miner.GasPrice = big.NewInt(1)
 		}
+		if !ctx.GlobalIsSet(MinerValidatorFlag.Name) {
+			cfg.Miner.Validator = developer.Address
+			cfg.TxFeeRecipient = developer.Address
+		}
 	default:
 		if cfg.NetworkId == params.MainnetNetworkId {
 			setDNSDiscoveryDefaults(cfg, params.KnownDNSNetworks[params.MainnetGenesisHash])

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -206,6 +206,16 @@ func (st *StateTransition) to() common.Address {
 
 // payFees deducts gas and gateway fees from sender balance and adds the purchased amount of gas to the state.
 func (st *StateTransition) payFees() error {
+	// Simulated call
+	if st.msg.From() == (common.Address{}) {
+		if err := st.gp.SubGas(st.msg.Gas()); err != nil {
+			return err
+		}
+		st.initialGas = st.msg.Gas()
+		st.gas += st.msg.Gas()
+		return nil
+	}
+
 	if st.msg.FeeCurrency() != nil && (!currency.IsWhitelisted(*st.msg.FeeCurrency(), st.evm.GetHeader(), st.evm.GetStateDB())) {
 		log.Trace("Fee currency not whitelisted", "fee currency address", st.msg.FeeCurrency())
 		return ErrNonWhitelistedFeeCurrency


### PR DESCRIPTION
### Description

Changed it so that validator and tx fee recipient do not have to be specified when running in dev mode.
Also looks like eth_call rpc call failed when there's no specified "from", added a special case for that.

### Other changes

### Tested

Only manual testing.

### Related issues


### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
