### PR TITLE
Verify commit message BLS signatures in aggregate

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -205,9 +205,6 @@ type Istanbul interface {
 	// The changes are executed inline.
 	UpdateValSetDiff(chain ChainReader, header *types.Header, state *state.StateDB) error
 
-	// IsLastBlockOfEpoch will check to see if the header is from the last block of an epoch
-	IsLastBlockOfEpoch(header *types.Header) bool
-
 	// LookbackWindow returns the size of the lookback window for calculating uptime (in blocks)
 	LookbackWindow(header *types.Header, state *state.StateDB) uint64
 

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -864,26 +864,10 @@ func (sb *Backend) generateVersionCertificate(version uint) (*versionCertificate
 	return vc, nil
 }
 
-func (sb *Backend) encodeVersionCertificatesMsg(versionCertificates []*versionCertificate) ([]byte, error) {
-	payload, err := rlp.EncodeToBytes(versionCertificates)
-	if err != nil {
-		return nil, err
-	}
-	msg := &istanbul.Message{
-		Code: istanbul.VersionCertificatesMsg,
-		Msg:  payload,
-	}
-	msgPayload, err := msg.Payload()
-	if err != nil {
-		return nil, err
-	}
-	return msgPayload, nil
-}
-
 func (sb *Backend) gossipVersionCertificatesMsg(versionCertificates []*versionCertificate) error {
 	logger := sb.logger.New("func", "gossipVersionCertificatesMsg")
 
-	payload, err := sb.encodeVersionCertificatesMsg(versionCertificates)
+	payload, err := istanbul.NewMessage(versionCertificates, sb.address).Payload()
 	if err != nil {
 		logger.Warn("Error encoding version certificate msg", "err", err)
 		return err
@@ -912,7 +896,7 @@ func (sb *Backend) sendVersionCertificateTable(peer consensus.Peer) error {
 		logger.Warn("Error getting all version certificates", "err", err)
 		return err
 	}
-	payload, err := sb.encodeVersionCertificatesMsg(allVersionCertificates)
+	payload, err := istanbul.NewMessage(allVersionCertificates, sb.address).Payload()
 	if err != nil {
 		logger.Warn("Error encoding version certificate msg", "err", err)
 		return err

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -29,7 +29,6 @@ import (
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
-	vet "github.com/celo-org/celo-blockchain/consensus/istanbul/backend/internal/enodes"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul/proxy"
 	"github.com/celo-org/celo-blockchain/crypto"
 	"github.com/celo-org/celo-blockchain/crypto/ecies"
@@ -767,9 +766,9 @@ var versionCertificateSalt = []byte("versionCertificate")
 
 // versionCertificate is a signed message from a validator indicating the most
 // recent version of its enode.
-type versionCertificate vet.VersionCertificateEntry
+type versionCertificate istanbul.VersionCertificateEntry
 
-func newVersionCertificateFromEntry(entry *vet.VersionCertificateEntry) *versionCertificate {
+func newVersionCertificateFromEntry(entry *istanbul.VersionCertificateEntry) *versionCertificate {
 	return &versionCertificate{
 		Address:   entry.Address,
 		PublicKey: entry.PublicKey,
@@ -834,8 +833,8 @@ func (vc *versionCertificate) DecodeRLP(s *rlp.Stream) error {
 	return nil
 }
 
-func (vc *versionCertificate) Entry() *vet.VersionCertificateEntry {
-	return &vet.VersionCertificateEntry{
+func (vc *versionCertificate) Entry() *istanbul.VersionCertificateEntry {
+	return &istanbul.VersionCertificateEntry{
 		Address:   vc.Address,
 		PublicKey: vc.PublicKey,
 		Version:   vc.Version,
@@ -953,7 +952,7 @@ func (sb *Backend) handleVersionCertificatesMsg(addr common.Address, peer consen
 		return err
 	}
 
-	var validEntries []*vet.VersionCertificateEntry
+	var validEntries []*istanbul.VersionCertificateEntry
 	validAddresses := make(map[common.Address]bool)
 	// Verify all entries are valid and remove duplicates
 	for _, versionCertificate := range versionCertificates {
@@ -981,7 +980,7 @@ func (sb *Backend) handleVersionCertificatesMsg(addr common.Address, peer consen
 	return nil
 }
 
-func (sb *Backend) upsertAndGossipVersionCertificateEntries(entries []*vet.VersionCertificateEntry) error {
+func (sb *Backend) upsertAndGossipVersionCertificateEntries(entries []*istanbul.VersionCertificateEntry) error {
 	logger := sb.logger.New("func", "upsertAndGossipVersionCertificateEntries")
 	shouldProcess, err := sb.shouldParticipateInAnnounce()
 	if err != nil {
@@ -1121,7 +1120,7 @@ func (sb *Backend) setAndShareUpdatedAnnounceVersion(version uint) error {
 	if err != nil {
 		return err
 	}
-	return sb.upsertAndGossipVersionCertificateEntries([]*vet.VersionCertificateEntry{
+	return sb.upsertAndGossipVersionCertificateEntries([]*istanbul.VersionCertificateEntry{
 		newVersionCertificate.Entry(),
 	})
 }

--- a/consensus/istanbul/backend/announce_test.go
+++ b/consensus/istanbul/backend/announce_test.go
@@ -34,12 +34,12 @@ func TestAnnounceGossipQueryMsg(t *testing.T) {
 	engine0Enode := engine0.SelfNode()
 
 	// Create version certificate messages for engine1 and engine2, so that engine0 will send a queryEnodeMessage to them
-	vCert1, err := engine1.generateVersionCertificate(engine1AnnounceVersion)
+	vCert1, err := istanbul.NewVersionCertificate(engine1AnnounceVersion, engine1.Sign)
 	if err != nil {
 		t.Errorf("Error in generating version certificate for engine1.  Error: %v", err)
 	}
 
-	vCert2, err := engine2.generateVersionCertificate(engine2AnnounceVersion)
+	vCert2, err := istanbul.NewVersionCertificate(engine1AnnounceVersion, engine2.Sign)
 	if err != nil {
 		t.Errorf("Error in generating version certificate for engine2.  Error: %v", err)
 	}

--- a/consensus/istanbul/backend/announce_test.go
+++ b/consensus/istanbul/backend/announce_test.go
@@ -45,7 +45,8 @@ func TestAnnounceGossipQueryMsg(t *testing.T) {
 	}
 
 	// Have engine0 handle vCert messages from engine1 and engine2
-	vCert1MsgPayload, err := engine1.encodeVersionCertificatesMsg([]*versionCertificate{vCert1})
+
+	vCert1MsgPayload, err := istanbul.NewMessage([]*versionCertificate{vCert1}, engine1Address).Payload()
 	if err != nil {
 		t.Errorf("Error in encoding vCert1.  Error: %v", err)
 	}
@@ -54,7 +55,7 @@ func TestAnnounceGossipQueryMsg(t *testing.T) {
 		t.Errorf("Error in handling vCert1.  Error: %v", err)
 	}
 
-	vCert2MsgPayload, err := engine2.encodeVersionCertificatesMsg([]*versionCertificate{vCert2})
+	vCert2MsgPayload, err := istanbul.NewMessage([]*versionCertificate{vCert2}, engine2Address).Payload()
 	if err != nil {
 		t.Errorf("Error in encoding vCert2.  Error: %v", err)
 	}

--- a/consensus/istanbul/backend/announce_test.go
+++ b/consensus/istanbul/backend/announce_test.go
@@ -46,7 +46,7 @@ func TestAnnounceGossipQueryMsg(t *testing.T) {
 
 	// Have engine0 handle vCert messages from engine1 and engine2
 
-	vCert1MsgPayload, err := istanbul.NewMessage([]*versionCertificate{vCert1}, engine1Address).Payload()
+	vCert1MsgPayload, err := istanbul.NewMessage([]*istanbul.VersionCertificate{vCert1}, engine1Address).Payload()
 	if err != nil {
 		t.Errorf("Error in encoding vCert1.  Error: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestAnnounceGossipQueryMsg(t *testing.T) {
 		t.Errorf("Error in handling vCert1.  Error: %v", err)
 	}
 
-	vCert2MsgPayload, err := istanbul.NewMessage([]*versionCertificate{vCert2}, engine2Address).Payload()
+	vCert2MsgPayload, err := istanbul.NewMessage([]*istanbul.VersionCertificate{vCert2}, engine2Address).Payload()
 	if err != nil {
 		t.Errorf("Error in encoding vCert2.  Error: %v", err)
 	}

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -651,13 +651,14 @@ func (sb *Backend) Sign(data []byte) ([]byte, error) {
 }
 
 // Sign implements istanbul.Backend.SignBLS
-func (sb *Backend) SignBLS(data []byte, extra []byte, useComposite, cip22 bool) (blscrypto.SerializedSignature, error) {
+func (sb *Backend) SignBLS(data []byte, extra []byte, useComposite, cip22 bool) ([]byte, error) {
 	if sb.signBLSFn == nil {
-		return blscrypto.SerializedSignature{}, errInvalidSigningFn
+		return nil, errInvalidSigningFn
 	}
 	sb.signFnMu.RLock()
 	defer sb.signFnMu.RUnlock()
-	return sb.signBLSFn(accounts.Account{Address: sb.blsAddress}, data, extra, useComposite, cip22)
+	sig, err := sb.signBLSFn(accounts.Account{Address: sb.blsAddress}, data, extra, useComposite, cip22)
+	return sig[:], err
 }
 
 // CheckSignature implements istanbul.Backend.CheckSignature

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -462,7 +462,8 @@ func (sb *Backend) GetValidators(blockNumber *big.Int, headerHash common.Hash) [
 	return validatorSet.List()
 }
 
-// Commit implements istanbul.Backend.Commit
+// Commit implements istanbul.Backend.Commit, unless this is committing the
+// last block of an epoch the aggregatedEpochValidatorSetSeal will be empty.
 func (sb *Backend) Commit(proposal istanbul.Proposal, aggregatedSeal types.IstanbulAggregatedSeal, aggregatedEpochValidatorSetSeal types.IstanbulEpochValidatorSetSeal) error {
 	// Check if the proposal is a valid block
 	block, ok := proposal.(*types.Block)

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -462,8 +462,8 @@ func (sb *Backend) GetValidators(blockNumber *big.Int, headerHash common.Hash) [
 	return validatorSet.List()
 }
 
-// Commit implements istanbul.Backend.Commit, unless this is committing the
-// last block of an epoch the aggregatedEpochValidatorSetSeal will be empty.
+// Commit implements istanbul.Backend.Commit.
+// Unless this is committing the last block of an epoch the aggregatedEpochValidatorSetSeal will be empty.
 func (sb *Backend) Commit(proposal istanbul.Proposal, aggregatedSeal types.IstanbulAggregatedSeal, aggregatedEpochValidatorSetSeal types.IstanbulEpochValidatorSetSeal) error {
 	// Check if the proposal is a valid block
 	block, ok := proposal.(*types.Block)

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -55,9 +55,6 @@ var (
 	// errInvalidSignature is returned when given signature is not signed by given
 	// address.
 	errInvalidSignature = errors.New("invalid signature")
-	// errInsufficientSeals is returned when there is not enough signatures to
-	// pass the quorum check.
-	errInsufficientSeals = errors.New("not enough seals to reach quorum")
 	// errUnknownBlock is returned when the list of validators or header is requested for a block
 	// that is not part of the local blockchain.
 	errUnknownBlock = errors.New("unknown block")

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -977,7 +977,7 @@ func (sb *Backend) addParentSeal(chain consensus.ChainReader, header *types.Head
 		if err != nil {
 			logger.Error("Initial combined ParentAggregatedSeal verification failed", "err", err)
 			// Attempt to remove any bad seals
-			istanbulCore.RemoveInvalidSignatures(logger, seal, istanbulCore.ExtractCommitSeal, parentCommits, parentValidators)
+			istanbulCore.RemoveInvalidSignatures(logger, seal, parentCommits, parentValidators)
 			// Create a new union
 			unionAggregatedSeal, err = istanbulCore.UnionOfSeals(parentExtra.AggregatedSeal, parentCommits)
 			if err != nil {

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -308,7 +308,7 @@ func (sb *Backend) verifyAggregatedSeals(chain consensus.ChainReader, header *ty
 		// parent.Hash() would correspond to the previous epoch
 		// block in ultralight, while the extra.ParentCommit is made on the block which was
 		// immediately before the current block.
-		return istanbulCore.IstanbulAggregatedSeal(extra.AggregatedSeal).Verify(header.ParentHash, parentValidators)
+		return istanbulCore.IstanbulAggregatedSeal(extra.ParentAggregatedSeal).Verify(header.ParentHash, parentValidators)
 	}
 
 	return nil

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -975,7 +975,7 @@ func (sb *Backend) addParentSeal(chain consensus.ChainReader, header *types.Head
 		// only update to use the union if we indeed provided a valid aggregate signature for this block
 		err = seal.VerifyAggregate(parentValidators, unionAggregatedSeal.Signature, unionAggregatedSeal.Bitmap)
 		if err != nil {
-			logger.Error("Initial combined ParentAggregatedSeal verification failed", "err", err)
+			logger.Warn("Initial combined ParentAggregatedSeal verification failed", "err", err)
 			// Attempt to remove any bad seals
 			istanbulCore.RemoveInvalidSignatures(logger, seal, parentCommits, parentValidators)
 			// Create a new union

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -320,7 +320,7 @@ func (sb *Backend) VerifyAggregatedSeal(headerHash common.Hash, validators istan
 		return errInvalidAggregatedSeal
 	}
 
-	proposalSeal := istanbulCore.PrepareCommittedSeal(headerHash, aggregatedSeal.Round)
+	proposalSeal := istanbulCore.NewCommitSeal(headerHash, aggregatedSeal.Round)
 	// Find which public keys signed from the provided validator set
 	publicKeys := []blscrypto.SerializedPublicKey{}
 	for i := 0; i < validators.Size(); i++ {
@@ -335,7 +335,7 @@ func (sb *Backend) VerifyAggregatedSeal(headerHash common.Hash, validators istan
 		logger.Error("Aggregated seal does not aggregate enough seals", "numSeals", len(publicKeys), "minimum quorum size", validators.MinQuorumSize())
 		return errInsufficientSeals
 	}
-	err := blscrypto.VerifyAggregatedSignature(publicKeys, proposalSeal, []byte{}, aggregatedSeal.Signature, false, false)
+	err := proposalSeal.VerifyAggregate(publicKeys, aggregatedSeal.Signature)
 	if err != nil {
 		logger.Error("Unable to verify aggregated signature", "err", err)
 		return errInvalidSignature

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -416,11 +416,6 @@ func (sb *Backend) UpdateValSetDiff(chain consensus.ChainReader, header *types.H
 	return writeValidatorSetDiff(header, []istanbul.ValidatorData{}, []istanbul.ValidatorData{})
 }
 
-// IsLastBlockOfEpoch returns whether or not a particular header represents the last block in the epoch.
-func (sb *Backend) IsLastBlockOfEpoch(header *types.Header) bool {
-	return istanbul.IsLastBlockOfEpoch(header.Number.Uint64(), sb.config.Epoch)
-}
-
 // EpochSize returns the size of epochs in blocks.
 func (sb *Backend) EpochSize() uint64 {
 	return sb.config.Epoch

--- a/consensus/istanbul/backend/internal/enodes/version_certificate_db.go
+++ b/consensus/istanbul/backend/internal/enodes/version_certificate_db.go
@@ -17,18 +17,15 @@
 package enodes
 
 import (
-	"crypto/ecdsa"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 
 	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul/backend/internal/db"
-	"github.com/celo-org/celo-blockchain/crypto"
 	"github.com/celo-org/celo-blockchain/log"
 	"github.com/celo-org/celo-blockchain/rlp"
 )
@@ -43,53 +40,12 @@ type VersionCertificateDB struct {
 	logger log.Logger
 }
 
-// VersionCertificateEntry is an entry in the VersionCertificateDB.
-// It's a signed message from a registered or active validator indicating
-// the most recent version of its enode.
-type VersionCertificateEntry struct {
-	Address   common.Address
-	PublicKey *ecdsa.PublicKey
-	Version   uint
-	Signature []byte
-}
-
-func versionCertificateEntryFromGenericEntry(entry db.GenericEntry) (*VersionCertificateEntry, error) {
-	signedAnnVersionEntry, ok := entry.(*VersionCertificateEntry)
+func versionCertificateEntryFromGenericEntry(entry db.GenericEntry) (*istanbul.VersionCertificateEntry, error) {
+	signedAnnVersionEntry, ok := entry.(*istanbul.VersionCertificateEntry)
 	if !ok {
 		return nil, errIncorrectEntryType
 	}
 	return signedAnnVersionEntry, nil
-}
-
-// EncodeRLP serializes VersionCertificateEntry into the Ethereum RLP format.
-func (entry *VersionCertificateEntry) EncodeRLP(w io.Writer) error {
-	encodedPublicKey := crypto.FromECDSAPub(entry.PublicKey)
-	return rlp.Encode(w, []interface{}{entry.Address, encodedPublicKey, entry.Version, entry.Signature})
-}
-
-// DecodeRLP implements rlp.Decoder, and load the VersionCertificateEntry fields from a RLP stream.
-func (entry *VersionCertificateEntry) DecodeRLP(s *rlp.Stream) error {
-	var content struct {
-		Address   common.Address
-		PublicKey []byte
-		Version   uint
-		Signature []byte
-	}
-
-	if err := s.Decode(&content); err != nil {
-		return err
-	}
-	decodedPublicKey, err := crypto.UnmarshalPubkey(content.PublicKey)
-	if err != nil {
-		return err
-	}
-	entry.Address, entry.PublicKey, entry.Version, entry.Signature = content.Address, decodedPublicKey, content.Version, content.Signature
-	return nil
-}
-
-// String gives a string representation of VersionCertificateEntry
-func (entry *VersionCertificateEntry) String() string {
-	return fmt.Sprintf("{Address: %v, Version: %v, Signature: %v}", entry.Address, entry.Version, hex.EncodeToString(entry.Signature))
 }
 
 // OpenVersionCertificateDB opens a signed announce version database for storing
@@ -119,7 +75,7 @@ func (svdb *VersionCertificateDB) String() string {
 	var b strings.Builder
 	b.WriteString("VersionCertificateDB:")
 
-	err := svdb.iterate(func(address common.Address, entry *VersionCertificateEntry) error {
+	err := svdb.iterate(func(address common.Address, entry *istanbul.VersionCertificateEntry) error {
 		fmt.Fprintf(&b, " [%s => %s]", address.String(), entry.String())
 		return nil
 	})
@@ -133,10 +89,10 @@ func (svdb *VersionCertificateDB) String() string {
 
 // Upsert inserts any new entries or entries with a Version higher than the
 // existing version. Returns any new or updated entries
-func (svdb *VersionCertificateDB) Upsert(savEntries []*VersionCertificateEntry) ([]*VersionCertificateEntry, error) {
+func (svdb *VersionCertificateDB) Upsert(savEntries []*istanbul.VersionCertificateEntry) ([]*istanbul.VersionCertificateEntry, error) {
 	logger := svdb.logger.New("func", "Upsert")
 
-	var newEntries []*VersionCertificateEntry
+	var newEntries []*istanbul.VersionCertificateEntry
 
 	getExistingEntry := func(entry db.GenericEntry) (db.GenericEntry, error) {
 		savEntry, err := versionCertificateEntryFromGenericEntry(entry)
@@ -190,10 +146,10 @@ func (svdb *VersionCertificateDB) Upsert(savEntries []*VersionCertificateEntry) 
 	return newEntries, nil
 }
 
-// Get gets the VersionCertificateEntry entry with address `address`.
+// Get gets the istanbul.VersionCertificateEntry entry with address `address`.
 // Returns an error if no entry exists.
-func (svdb *VersionCertificateDB) Get(address common.Address) (*VersionCertificateEntry, error) {
-	var entry VersionCertificateEntry
+func (svdb *VersionCertificateDB) Get(address common.Address) (*istanbul.VersionCertificateEntry, error) {
+	var entry istanbul.VersionCertificateEntry
 	entryBytes, err := svdb.gdb.Get(addressKey(address))
 	if err != nil {
 		return nil, err
@@ -214,10 +170,10 @@ func (svdb *VersionCertificateDB) GetVersion(address common.Address) (uint, erro
 	return signedAnnVersion.Version, nil
 }
 
-// GetAll gets each VersionCertificateEntry in the db
-func (svdb *VersionCertificateDB) GetAll() ([]*VersionCertificateEntry, error) {
-	var entries []*VersionCertificateEntry
-	err := svdb.iterate(func(address common.Address, entry *VersionCertificateEntry) error {
+// GetAll gets each istanbul.VersionCertificateEntry in the db
+func (svdb *VersionCertificateDB) GetAll() ([]*istanbul.VersionCertificateEntry, error) {
+	var entries []*istanbul.VersionCertificateEntry
+	err := svdb.iterate(func(address common.Address, entry *istanbul.VersionCertificateEntry) error {
 		entries = append(entries, entry)
 		return nil
 	})
@@ -237,7 +193,7 @@ func (svdb *VersionCertificateDB) Remove(address common.Address) error {
 // Prune will remove entries for all addresses not present in addressesToKeep
 func (svdb *VersionCertificateDB) Prune(addressesToKeep map[common.Address]bool) error {
 	batch := new(leveldb.Batch)
-	err := svdb.iterate(func(address common.Address, entry *VersionCertificateEntry) error {
+	err := svdb.iterate(func(address common.Address, entry *istanbul.VersionCertificateEntry) error {
 		if !addressesToKeep[address] {
 			svdb.logger.Trace("Deleting entry", "address", address)
 			batch.Delete(addressKey(address))
@@ -251,13 +207,13 @@ func (svdb *VersionCertificateDB) Prune(addressesToKeep map[common.Address]bool)
 }
 
 // iterate will call `onEntry` for each entry in the db
-func (svdb *VersionCertificateDB) iterate(onEntry func(common.Address, *VersionCertificateEntry) error) error {
+func (svdb *VersionCertificateDB) iterate(onEntry func(common.Address, *istanbul.VersionCertificateEntry) error) error {
 	logger := svdb.logger.New("func", "iterate")
 	// Only target address keys
 	keyPrefix := []byte(dbAddressPrefix)
 
 	onDBEntry := func(key []byte, value []byte) error {
-		var entry VersionCertificateEntry
+		var entry istanbul.VersionCertificateEntry
 		if err := rlp.DecodeBytes(value, &entry); err != nil {
 			return err
 		}
@@ -285,7 +241,7 @@ type VersionCertificateEntryInfo struct {
 // Intended for RPC use
 func (svdb *VersionCertificateDB) Info() (map[string]*VersionCertificateEntryInfo, error) {
 	dbInfo := make(map[string]*VersionCertificateEntryInfo)
-	err := svdb.iterate(func(address common.Address, entry *VersionCertificateEntry) error {
+	err := svdb.iterate(func(address common.Address, entry *istanbul.VersionCertificateEntry) error {
 		dbInfo[address.Hex()] = &VersionCertificateEntryInfo{
 			Address: entry.Address.Hex(),
 			Version: entry.Version,

--- a/consensus/istanbul/backend/internal/enodes/version_certificate_db.go
+++ b/consensus/istanbul/backend/internal/enodes/version_certificate_db.go
@@ -99,7 +99,7 @@ func (svdb *VersionCertificateDB) Upsert(savEntries []*istanbul.VersionCertifica
 		if err != nil {
 			return entry, err
 		}
-		return svdb.Get(savEntry.Address)
+		return svdb.Get(savEntry.Address())
 	}
 
 	onNewEntry := func(batch *leveldb.Batch, entry db.GenericEntry) error {
@@ -111,7 +111,7 @@ func (svdb *VersionCertificateDB) Upsert(savEntries []*istanbul.VersionCertifica
 		if err != nil {
 			return err
 		}
-		batch.Put(addressKey(savEntry.Address), savEntryBytes)
+		batch.Put(addressKey(savEntry.Address()), savEntryBytes)
 		newEntries = append(newEntries, savEntry)
 		logger.Trace("Updating with new entry",
 			"address", savEntry.Address, "new version", savEntry.Version)
@@ -243,7 +243,7 @@ func (svdb *VersionCertificateDB) Info() (map[string]*VersionCertificateEntryInf
 	dbInfo := make(map[string]*VersionCertificateEntryInfo)
 	err := svdb.iterate(func(address common.Address, entry *istanbul.VersionCertificate) error {
 		dbInfo[address.Hex()] = &VersionCertificateEntryInfo{
-			Address: entry.Address.Hex(),
+			Address: entry.Address().Hex(),
 			Version: entry.Version,
 		}
 		return nil

--- a/consensus/istanbul/backend/internal/enodes/version_certificate_db_test.go
+++ b/consensus/istanbul/backend/internal/enodes/version_certificate_db_test.go
@@ -2,6 +2,7 @@ package enodes
 
 import (
 	"bytes"
+	"crypto/ecdsa"
 	"reflect"
 	"testing"
 
@@ -9,19 +10,40 @@ import (
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/crypto"
 	"github.com/celo-org/celo-blockchain/rlp"
+	"github.com/stretchr/testify/require"
 	"github.com/syndtr/goleveldb/leveldb"
 )
+
+var keyA *ecdsa.PrivateKey
+var keyB *ecdsa.PrivateKey
+
+func init() {
+	var err error
+	keyA, err = crypto.GenerateKey()
+	if err != nil {
+		panic(err.Error())
+	}
+	keyB, err = crypto.GenerateKey()
+	if err != nil {
+		panic(err.Error())
+	}
+}
+
+func signA(data []byte) ([]byte, error) {
+	return crypto.Sign(crypto.Keccak256(data), keyA)
+}
+
+func signB(data []byte) ([]byte, error) {
+	return crypto.Sign(crypto.Keccak256(data), keyB)
+}
 
 func TestVersionCertificateDBUpsert(t *testing.T) {
 	table, err := OpenVersionCertificateDB("")
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
-	entryA := &istanbul.VersionCertificate{
-		Address:   addressA,
-		Version:   1,
-		PublicKey: nodeA.Pubkey(),
-	}
+	entryA, err := istanbul.NewVersionCertificate(1, signA)
+	require.NoError(t, err)
 	entriesToUpsert := []*istanbul.VersionCertificate{entryA}
 	newEntries, err := table.Upsert(entriesToUpsert)
 	if err != nil {
@@ -31,7 +53,7 @@ func TestVersionCertificateDBUpsert(t *testing.T) {
 		t.Errorf("Upsert did not return the expected new entries %v != %v", newEntries, entriesToUpsert)
 	}
 
-	entry, err := table.Get(entryA.Address)
+	entry, err := table.Get(entryA.Address())
 	if err != nil {
 		t.Errorf("got %v", err)
 	}
@@ -39,12 +61,8 @@ func TestVersionCertificateDBUpsert(t *testing.T) {
 		t.Error("The upserted entry is not deep equal to the original")
 	}
 
-	entryAOld := &istanbul.VersionCertificate{
-		Address:   addressA,
-		PublicKey: nodeA.Pubkey(),
-		Version:   0,
-		Signature: []byte("foo"),
-	}
+	entryAOld, err := istanbul.NewVersionCertificate(0, signA)
+	require.NoError(t, err)
 	entriesToUpsert = []*istanbul.VersionCertificate{entryAOld}
 	newEntries, err = table.Upsert(entriesToUpsert)
 	if err != nil {
@@ -54,7 +72,7 @@ func TestVersionCertificateDBUpsert(t *testing.T) {
 		t.Errorf("Expected no new entries to be returned by Upsert with old version, got %v", newEntries)
 	}
 
-	entry, err = table.Get(entryA.Address)
+	entry, err = table.Get(entryA.Address())
 	if err != nil {
 		t.Errorf("got %v", err)
 	}
@@ -62,12 +80,8 @@ func TestVersionCertificateDBUpsert(t *testing.T) {
 		t.Error("Upserting an old version gave a new entry")
 	}
 
-	entryANew := &istanbul.VersionCertificate{
-		Address:   addressA,
-		PublicKey: nodeA.Pubkey(),
-		Version:   2,
-		Signature: []byte("foo"),
-	}
+	entryANew, err := istanbul.NewVersionCertificate(2, signA)
+	require.NoError(t, err)
 	entriesToUpsert = []*istanbul.VersionCertificate{entryANew}
 	newEntries, err = table.Upsert(entriesToUpsert)
 	if err != nil {
@@ -77,7 +91,7 @@ func TestVersionCertificateDBUpsert(t *testing.T) {
 		t.Errorf("Expected new entries to be returned by Upsert with new version, got %v", newEntries)
 	}
 
-	entry, err = table.Get(entryA.Address)
+	entry, err = table.Get(entryA.Address())
 	if err != nil {
 		t.Errorf("got %v", err)
 	}
@@ -92,24 +106,20 @@ func TestVersionCertificateDBRemove(t *testing.T) {
 		t.Fatal("Failed to open DB")
 	}
 
-	entryA := &istanbul.VersionCertificate{
-		Address:   addressA,
-		PublicKey: nodeA.Pubkey(),
-		Version:   1,
-		Signature: []byte("foo"),
-	}
+	entryA, err := istanbul.NewVersionCertificate(1, signA)
+	require.NoError(t, err)
 	entriesToUpsert := []*istanbul.VersionCertificate{entryA}
 	_, err = table.Upsert(entriesToUpsert)
 	if err != nil {
 		t.Fatal("Failed to upsert entry")
 	}
 
-	err = table.Remove(entryA.Address)
+	err = table.Remove(entryA.Address())
 	if err != nil {
 		t.Fatal("Failed to delete")
 	}
 
-	if _, err := table.Get(entryA.Address); err != nil {
+	if _, err := table.Get(entryA.Address()); err != nil {
 		if err != leveldb.ErrNotFound {
 			t.Fatalf("Can't get, different error: %v", err)
 		}
@@ -124,20 +134,11 @@ func TestVersionCertificateDBPrune(t *testing.T) {
 		t.Fatal("Failed to open DB")
 	}
 
-	batch := []*istanbul.VersionCertificate{
-		{
-			Address:   addressA,
-			PublicKey: nodeA.Pubkey(),
-			Version:   1,
-			Signature: []byte("foo"),
-		},
-		{
-			Address:   addressB,
-			PublicKey: nodeB.Pubkey(),
-			Version:   1,
-			Signature: []byte("bar"),
-		},
-	}
+	entryA, err := istanbul.NewVersionCertificate(1, signA)
+	require.NoError(t, err)
+	entryB, err := istanbul.NewVersionCertificate(1, signB)
+	require.NoError(t, err)
+	batch := []*istanbul.VersionCertificate{entryA, entryB}
 
 	_, err = table.Upsert(batch)
 	if err != nil {
@@ -145,28 +146,25 @@ func TestVersionCertificateDBPrune(t *testing.T) {
 	}
 
 	addressesToKeep := make(map[common.Address]bool)
-	addressesToKeep[addressB] = true
+	addressesToKeep[entryB.Address()] = true
 
 	table.Prune(addressesToKeep)
 
-	_, err = table.Get(addressB)
+	_, err = table.Get(entryB.Address())
 	if err != nil {
-		t.Errorf("It should have found %s after prune", addressB.Hex())
+		t.Errorf("It should have found %s after prune", entryB.Address().Hex())
 	}
-	_, err = table.Get(addressA)
+	_, err = table.Get(entryA.Address())
 	if err == nil {
-		t.Errorf("It should have NOT found %s after prune", addressA.Hex())
+		t.Errorf("It should have NOT found %s after prune", entryA.Address().Hex())
 	}
 
 }
 
 func TestVersionCertificateEntryRLP(t *testing.T) {
-	original := &istanbul.VersionCertificate{
-		Address:   addressA,
-		PublicKey: nodeA.Pubkey(),
-		Version:   1,
-		Signature: []byte("foo"),
-	}
+
+	original, err := istanbul.NewVersionCertificate(1, signA)
+	require.NoError(t, err)
 
 	rawEntry, err := rlp.EncodeToBytes(original)
 	if err != nil {
@@ -178,8 +176,8 @@ func TestVersionCertificateEntryRLP(t *testing.T) {
 		t.Errorf("Error %v", err)
 	}
 
-	if result.Address.String() != original.Address.String() {
-		t.Errorf("node doesn't match: got: %s expected: %s", result.Address.String(), original.Address.String())
+	if result.Address().String() != original.Address().String() {
+		t.Errorf("node doesn't match: got: %s expected: %s", result.Address().String(), original.Address().String())
 	}
 	if result.Version != original.Version {
 		t.Errorf("version doesn't match: got: %v expected: %v", result.Version, original.Version)
@@ -191,8 +189,8 @@ func TestVersionCertificateEntryRLP(t *testing.T) {
 
 // Compares the field values of two VersionCertificateEntrys
 func versionCertificateEntriesEqual(a, b *istanbul.VersionCertificate) bool {
-	return a.Address == b.Address &&
-		bytes.Equal(crypto.FromECDSAPub(a.PublicKey), crypto.FromECDSAPub(b.PublicKey)) &&
+	return a.Address() == b.Address() &&
+		bytes.Equal(crypto.FromECDSAPub(a.PublicKey()), crypto.FromECDSAPub(b.PublicKey())) &&
 		a.Version == b.Version &&
 		bytes.Equal(a.Signature, b.Signature)
 }

--- a/consensus/istanbul/backend/internal/enodes/version_certificate_db_test.go
+++ b/consensus/istanbul/backend/internal/enodes/version_certificate_db_test.go
@@ -17,12 +17,12 @@ func TestVersionCertificateDBUpsert(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
-	entryA := &istanbul.VersionCertificateEntry{
+	entryA := &istanbul.VersionCertificate{
 		Address:   addressA,
 		Version:   1,
 		PublicKey: nodeA.Pubkey(),
 	}
-	entriesToUpsert := []*istanbul.VersionCertificateEntry{entryA}
+	entriesToUpsert := []*istanbul.VersionCertificate{entryA}
 	newEntries, err := table.Upsert(entriesToUpsert)
 	if err != nil {
 		t.Fatal("Failed to upsert entry")
@@ -39,13 +39,13 @@ func TestVersionCertificateDBUpsert(t *testing.T) {
 		t.Error("The upserted entry is not deep equal to the original")
 	}
 
-	entryAOld := &istanbul.VersionCertificateEntry{
+	entryAOld := &istanbul.VersionCertificate{
 		Address:   addressA,
 		PublicKey: nodeA.Pubkey(),
 		Version:   0,
 		Signature: []byte("foo"),
 	}
-	entriesToUpsert = []*istanbul.VersionCertificateEntry{entryAOld}
+	entriesToUpsert = []*istanbul.VersionCertificate{entryAOld}
 	newEntries, err = table.Upsert(entriesToUpsert)
 	if err != nil {
 		t.Fatal("Failed to upsert old entry")
@@ -62,13 +62,13 @@ func TestVersionCertificateDBUpsert(t *testing.T) {
 		t.Error("Upserting an old version gave a new entry")
 	}
 
-	entryANew := &istanbul.VersionCertificateEntry{
+	entryANew := &istanbul.VersionCertificate{
 		Address:   addressA,
 		PublicKey: nodeA.Pubkey(),
 		Version:   2,
 		Signature: []byte("foo"),
 	}
-	entriesToUpsert = []*istanbul.VersionCertificateEntry{entryANew}
+	entriesToUpsert = []*istanbul.VersionCertificate{entryANew}
 	newEntries, err = table.Upsert(entriesToUpsert)
 	if err != nil {
 		t.Fatal("Failed to upsert old entry")
@@ -92,13 +92,13 @@ func TestVersionCertificateDBRemove(t *testing.T) {
 		t.Fatal("Failed to open DB")
 	}
 
-	entryA := &istanbul.VersionCertificateEntry{
+	entryA := &istanbul.VersionCertificate{
 		Address:   addressA,
 		PublicKey: nodeA.Pubkey(),
 		Version:   1,
 		Signature: []byte("foo"),
 	}
-	entriesToUpsert := []*istanbul.VersionCertificateEntry{entryA}
+	entriesToUpsert := []*istanbul.VersionCertificate{entryA}
 	_, err = table.Upsert(entriesToUpsert)
 	if err != nil {
 		t.Fatal("Failed to upsert entry")
@@ -124,7 +124,7 @@ func TestVersionCertificateDBPrune(t *testing.T) {
 		t.Fatal("Failed to open DB")
 	}
 
-	batch := []*istanbul.VersionCertificateEntry{
+	batch := []*istanbul.VersionCertificate{
 		{
 			Address:   addressA,
 			PublicKey: nodeA.Pubkey(),
@@ -161,7 +161,7 @@ func TestVersionCertificateDBPrune(t *testing.T) {
 }
 
 func TestVersionCertificateEntryRLP(t *testing.T) {
-	original := &istanbul.VersionCertificateEntry{
+	original := &istanbul.VersionCertificate{
 		Address:   addressA,
 		PublicKey: nodeA.Pubkey(),
 		Version:   1,
@@ -173,7 +173,7 @@ func TestVersionCertificateEntryRLP(t *testing.T) {
 		t.Errorf("Error %v", err)
 	}
 
-	var result istanbul.VersionCertificateEntry
+	var result istanbul.VersionCertificate
 	if err = rlp.DecodeBytes(rawEntry, &result); err != nil {
 		t.Errorf("Error %v", err)
 	}
@@ -190,7 +190,7 @@ func TestVersionCertificateEntryRLP(t *testing.T) {
 }
 
 // Compares the field values of two VersionCertificateEntrys
-func versionCertificateEntriesEqual(a, b *istanbul.VersionCertificateEntry) bool {
+func versionCertificateEntriesEqual(a, b *istanbul.VersionCertificate) bool {
 	return a.Address == b.Address &&
 		bytes.Equal(crypto.FromECDSAPub(a.PublicKey), crypto.FromECDSAPub(b.PublicKey)) &&
 		a.Version == b.Version &&

--- a/consensus/istanbul/backend/internal/enodes/version_certificate_db_test.go
+++ b/consensus/istanbul/backend/internal/enodes/version_certificate_db_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/crypto"
 	"github.com/celo-org/celo-blockchain/rlp"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -16,12 +17,12 @@ func TestVersionCertificateDBUpsert(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to open DB")
 	}
-	entryA := &VersionCertificateEntry{
+	entryA := &istanbul.VersionCertificateEntry{
 		Address:   addressA,
 		Version:   1,
 		PublicKey: nodeA.Pubkey(),
 	}
-	entriesToUpsert := []*VersionCertificateEntry{entryA}
+	entriesToUpsert := []*istanbul.VersionCertificateEntry{entryA}
 	newEntries, err := table.Upsert(entriesToUpsert)
 	if err != nil {
 		t.Fatal("Failed to upsert entry")
@@ -38,13 +39,13 @@ func TestVersionCertificateDBUpsert(t *testing.T) {
 		t.Error("The upserted entry is not deep equal to the original")
 	}
 
-	entryAOld := &VersionCertificateEntry{
+	entryAOld := &istanbul.VersionCertificateEntry{
 		Address:   addressA,
 		PublicKey: nodeA.Pubkey(),
 		Version:   0,
 		Signature: []byte("foo"),
 	}
-	entriesToUpsert = []*VersionCertificateEntry{entryAOld}
+	entriesToUpsert = []*istanbul.VersionCertificateEntry{entryAOld}
 	newEntries, err = table.Upsert(entriesToUpsert)
 	if err != nil {
 		t.Fatal("Failed to upsert old entry")
@@ -61,13 +62,13 @@ func TestVersionCertificateDBUpsert(t *testing.T) {
 		t.Error("Upserting an old version gave a new entry")
 	}
 
-	entryANew := &VersionCertificateEntry{
+	entryANew := &istanbul.VersionCertificateEntry{
 		Address:   addressA,
 		PublicKey: nodeA.Pubkey(),
 		Version:   2,
 		Signature: []byte("foo"),
 	}
-	entriesToUpsert = []*VersionCertificateEntry{entryANew}
+	entriesToUpsert = []*istanbul.VersionCertificateEntry{entryANew}
 	newEntries, err = table.Upsert(entriesToUpsert)
 	if err != nil {
 		t.Fatal("Failed to upsert old entry")
@@ -91,13 +92,13 @@ func TestVersionCertificateDBRemove(t *testing.T) {
 		t.Fatal("Failed to open DB")
 	}
 
-	entryA := &VersionCertificateEntry{
+	entryA := &istanbul.VersionCertificateEntry{
 		Address:   addressA,
 		PublicKey: nodeA.Pubkey(),
 		Version:   1,
 		Signature: []byte("foo"),
 	}
-	entriesToUpsert := []*VersionCertificateEntry{entryA}
+	entriesToUpsert := []*istanbul.VersionCertificateEntry{entryA}
 	_, err = table.Upsert(entriesToUpsert)
 	if err != nil {
 		t.Fatal("Failed to upsert entry")
@@ -123,7 +124,7 @@ func TestVersionCertificateDBPrune(t *testing.T) {
 		t.Fatal("Failed to open DB")
 	}
 
-	batch := []*VersionCertificateEntry{
+	batch := []*istanbul.VersionCertificateEntry{
 		{
 			Address:   addressA,
 			PublicKey: nodeA.Pubkey(),
@@ -160,7 +161,7 @@ func TestVersionCertificateDBPrune(t *testing.T) {
 }
 
 func TestVersionCertificateEntryRLP(t *testing.T) {
-	original := &VersionCertificateEntry{
+	original := &istanbul.VersionCertificateEntry{
 		Address:   addressA,
 		PublicKey: nodeA.Pubkey(),
 		Version:   1,
@@ -172,7 +173,7 @@ func TestVersionCertificateEntryRLP(t *testing.T) {
 		t.Errorf("Error %v", err)
 	}
 
-	var result VersionCertificateEntry
+	var result istanbul.VersionCertificateEntry
 	if err = rlp.DecodeBytes(rawEntry, &result); err != nil {
 		t.Errorf("Error %v", err)
 	}
@@ -189,7 +190,7 @@ func TestVersionCertificateEntryRLP(t *testing.T) {
 }
 
 // Compares the field values of two VersionCertificateEntrys
-func versionCertificateEntriesEqual(a, b *VersionCertificateEntry) bool {
+func versionCertificateEntriesEqual(a, b *istanbul.VersionCertificateEntry) bool {
 	return a.Address == b.Address &&
 		bytes.Equal(crypto.FromECDSAPub(a.PublicKey), crypto.FromECDSAPub(b.PublicKey)) &&
 		a.Version == b.Version &&

--- a/consensus/istanbul/backend/test_utils.go
+++ b/consensus/istanbul/backend/test_utils.go
@@ -326,11 +326,11 @@ func signBlock(keys []*ecdsa.PrivateKey, block *types.Block) types.IstanbulAggre
 	headerHash := block.Header().Hash()
 	signatures := make([][]byte, len(keys))
 
-	msg := istanbulCore.PrepareCommittedSeal(headerHash, round)
+	msg := istanbulCore.NewCommitSeal(headerHash, round)
 
 	for i, key := range keys {
 		signFn := SignBLSFn(key)
-		sig, err := signFn(accounts.Account{}, msg, extraData, useComposite, cip22)
+		sig, err := signFn(accounts.Account{}, msg.Seal, extraData, useComposite, cip22)
 		if err != nil {
 			panic("could not sign msg")
 		}

--- a/consensus/istanbul/core/backlog_test.go
+++ b/consensus/istanbul/core/backlog_test.go
@@ -49,6 +49,7 @@ func TestCheckMessage(t *testing.T) {
 	t.Run("invalid view format", func(t *testing.T) {
 		err := c.checkMessage(istanbul.MsgPreprepare, nil)
 		if err != errInvalidMessage {
+			t.Errorf("error mismatch: have %v, want %v", err, errInvalidMessage)
 		}
 	})
 

--- a/consensus/istanbul/core/bls.go
+++ b/consensus/istanbul/core/bls.go
@@ -1,0 +1,219 @@
+package core
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/consensus/istanbul"
+	"github.com/celo-org/celo-blockchain/core/types"
+	blscrypto "github.com/celo-org/celo-blockchain/crypto/bls"
+	"github.com/celo-org/celo-bls-go/bls"
+)
+
+// type BLSSeal interface {
+// 	Seal() []byte
+// 	Verify(key blscrypto.SerializedPublicKey, signature []byte) error
+// }
+
+type BLSSeal struct {
+	Seal            []byte
+	ExtraData       []byte
+	CompositeHasher bool
+	Cip22           bool
+}
+
+func (b *BLSSeal) Verify(key blscrypto.SerializedPublicKey, signature []byte) error {
+	return blscrypto.VerifySignature(key, b.Seal, b.ExtraData, signature, b.CompositeHasher, b.Cip22)
+}
+
+func (b *BLSSeal) VerifyAggregate(publicKeys []blscrypto.SerializedPublicKey, signature []byte) error {
+	publicKeyObjs := []*bls.PublicKey{}
+	for _, publicKey := range publicKeys {
+		publicKeyObj, err := bls.DeserializePublicKeyCached(publicKey[:])
+		if err != nil {
+			return err
+		}
+		defer publicKeyObj.Destroy()
+		publicKeyObjs = append(publicKeyObjs, publicKeyObj)
+	}
+	apk, err := bls.AggregatePublicKeys(publicKeyObjs)
+	if err != nil {
+		return err
+	}
+	defer apk.Destroy()
+
+	signatureObj, err := bls.DeserializeSignature(signature)
+	if err != nil {
+		return err
+	}
+	defer signatureObj.Destroy()
+
+	return apk.VerifySignature(b.Seal, b.ExtraData, signatureObj, b.CompositeHasher, b.Cip22)
+}
+
+// verifyCommittedSeal verifies the commit seal in the received COMMIT message
+func (c *core) verifyCommittedSeal(comSub *istanbul.CommittedSubject, src istanbul.Validator) error {
+	seal, extraData, compositeHasher, cip22, err := PrepareCommitSeal(comSub.Subject.Digest, comSub.Subject.View.Round)
+	if err != nil {
+		return err
+	}
+	return blscrypto.VerifySignature(src.BLSPublicKey(), seal, extraData, comSub.CommittedSeal, compositeHasher, cip22)
+}
+
+// verifyEpochValidatorSetSeal verifies the epoch validator set seal in the received COMMIT message
+func (c *core) verifyEpochValidatorSetSeal(comSub *istanbul.CommittedSubject, blockNumber uint64, newValSet istanbul.ValidatorSet, src istanbul.Validator) error {
+	epochData, epochExtraData, cip22, err := c.generateEpochValidatorSetData(blockNumber, uint8(comSub.Subject.View.Round.Uint64()), comSub.Subject.Digest, newValSet)
+	if err != nil {
+		return err
+	}
+	return blscrypto.VerifySignature(src.BLSPublicKey(), epochData, epochExtraData, comSub.EpochValidatorSetSeal, true, cip22)
+}
+
+func NewCommitSeal(hash common.Hash, round *big.Int) *BLSSeal {
+	var buf bytes.Buffer
+	buf.Write(hash.Bytes())
+	buf.Write(round.Bytes())
+	buf.Write([]byte{byte(istanbul.MsgCommit)})
+	return &BLSSeal{
+		Seal:            buf.Bytes(),
+		ExtraData:       []byte{},
+		CompositeHasher: false,
+		Cip22:           false,
+	}
+}
+
+// PrepareCommitSeal returns a commit seal for the given hash and round number.
+func PrepareCommitSeal(hash common.Hash, round *big.Int) (message []byte, extraData []byte, compositeHasher, cip22 bool, err error) {
+	var buf bytes.Buffer
+	buf.Write(hash.Bytes())
+	buf.Write(round.Bytes())
+	buf.Write([]byte{byte(istanbul.MsgCommit)})
+	return buf.Bytes(), []byte{}, false, false, nil
+}
+
+func NewEpochSeal(keys []blscrypto.SerializedPublicKey, maxNonSigners uint32, epochNum uint16) (*BLSSeal, error) {
+	message, extraData, err = blscrypto.EncodeEpochSnarkData(keys, maxNonSigners, epochNum)
+	// This is before the Donut hardfork, so signify this doesn't use CIP22.
+	return message, extraData, true, false, err
+}
+
+func PrepareEpochDonut(keys []blscrypto.SerializedPublicKey, maxNonSigners uint32, epochNum uint16) (message []byte, extraData []byte, compositeHasher, cip22 bool, err error) {
+	message, extraData, err = blscrypto.EncodeEpochSnarkData(keys, maxNonSigners, epochNum)
+	// This is before the Donut hardfork, so signify this doesn't use CIP22.
+	return message, extraData, true, false, err
+}
+
+// Generates serialized epoch data for use in the Plumo SNARK circuit.
+// Block number and hash may be information for a pending block.
+func (c *core) generateEpochValidatorSetData(blockNumber uint64, round uint8, blockHash common.Hash, newValSet istanbul.ValidatorSet) ([]byte, []byte, bool, error) {
+	// Serialize the public keys for the validators in the validator set.
+	blsPubKeys := []blscrypto.SerializedPublicKey{}
+	for _, v := range newValSet.List() {
+		blsPubKeys = append(blsPubKeys, v.BLSPublicKey())
+	}
+
+	maxNonSigners := uint32(newValSet.Size() - newValSet.MinQuorumSize())
+
+	// Before the Donut fork, use the snark data encoding with epoch entropy.
+	if !c.backend.ChainConfig().IsDonut(big.NewInt(int64(blockNumber))) {
+		message, extraData, err := blscrypto.EncodeEpochSnarkData(
+			blsPubKeys,
+			maxNonSigners,
+			uint16(istanbul.GetEpochNumber(blockNumber, c.config.Epoch)),
+		)
+		// This is before the Donut hardfork, so signify this doesn't use CIP22.
+		return message, extraData, false, err
+	}
+
+	// Retrieve the block hash for the last block of the previous epoch.
+	parentEpochBlockHash := c.backend.HashForBlock(blockNumber - c.config.Epoch)
+	if blockNumber > 0 && parentEpochBlockHash == (common.Hash{}) {
+		return nil, nil, false, errors.New("unknown block")
+	}
+
+	maxNonSigners = maxValidators - uint32(newValSet.MinQuorumSize())
+
+	message, extraData, err := blscrypto.EncodeEpochSnarkDataCIP22(
+		blsPubKeys, maxNonSigners, maxValidators,
+		uint16(istanbul.GetEpochNumber(blockNumber, c.config.Epoch)),
+		round,
+		blscrypto.EpochEntropyFromHash(blockHash),
+		blscrypto.EpochEntropyFromHash(parentEpochBlockHash),
+	)
+	// This is after the Donut hardfork, so signify this uses CIP22.
+	return message, extraData, true, err
+}
+
+// AggregateSeals returns the bls aggregation of the committed seals for the
+// messgages in mset. It returns a big.Int that represents a bitmap where each
+// set bit corresponds to the position of a validator in the list of validators
+// for this epoch that contributed a seal to the returned aggregate. It is
+// assumed that mset contains only commit messages.
+func AggregateSeals(mset MessageSet, sealExtractor func(*istanbul.CommittedSubject) []byte) (bitmap *big.Int, aggregateSeal []byte, err error) {
+	bitmap = big.NewInt(0)
+	committedSeals := make([][]byte, mset.Size())
+	for i, v := range mset.Values() {
+		committedSeals[i] = make([]byte, types.IstanbulExtraBlsSignature)
+
+		commit := v.Commit()
+		copy(committedSeals[i][:], sealExtractor(commit))
+
+		j, err := mset.GetAddressIndex(v.Address)
+		if err != nil {
+			return nil, nil, fmt.Errorf(
+				"missing validator %q for committed seal at %s: %v",
+				v.Address.String(),
+				commit.Subject.View.String(),
+				err,
+			)
+		}
+		bitmap.SetBit(bitmap, int(j), 1)
+	}
+
+	aggregateSeal, err = blscrypto.AggregateSignatures(committedSeals)
+	if err != nil {
+		return nil, nil, fmt.Errorf("aggregating signatures failed: %v", err)
+	}
+
+	return bitmap, aggregateSeal, nil
+}
+
+// UnionOfSeals combines a BLS aggregated signature with an array of signatures. Accounts for
+// double aggregating the same signature by only adding aggregating if the
+// validator was not found in the previous bitmap.
+// This function assumes that the provided seals' validator set is the same one
+// which produced the provided bitmap
+func UnionOfSeals(aggregatedSignature types.IstanbulAggregatedSeal, seals MessageSet) (types.IstanbulAggregatedSeal, error) {
+	// TODO(asa): Check for round equality...
+	// Check who already has signed the message
+	newBitmap := new(big.Int).Set(aggregatedSignature.Bitmap)
+	committedSeals := [][]byte{}
+	committedSeals = append(committedSeals, aggregatedSignature.Signature)
+	for _, v := range seals.Values() {
+		valIndex, err := seals.GetAddressIndex(v.Address)
+		if err != nil {
+			return types.IstanbulAggregatedSeal{}, err
+		}
+
+		// if the bit was not set, this means we should add this signature to
+		// the batch
+		if newBitmap.Bit(int(valIndex)) == 0 {
+			newBitmap.SetBit(newBitmap, (int(valIndex)), 1)
+			committedSeals = append(committedSeals, v.Commit().CommittedSeal)
+		}
+	}
+
+	asig, err := blscrypto.AggregateSignatures(committedSeals)
+	if err != nil {
+		return types.IstanbulAggregatedSeal{}, err
+	}
+
+	return types.IstanbulAggregatedSeal{
+		Bitmap:    newBitmap,
+		Signature: asig,
+		Round:     aggregatedSignature.Round,
+	}, nil
+}

--- a/consensus/istanbul/core/bls.go
+++ b/consensus/istanbul/core/bls.go
@@ -158,12 +158,14 @@ func (c *core) generateEpochValidatorSetData(blockNumber uint64, round uint8, bl
 	return NewEpochSealDonut(blsPubKeys, uint32(newValSet.MinQuorumSize()), epochNum, round, blockHash, parentEpochBlockHash)
 }
 
+type sealExtractorFn func(*istanbul.CommittedSubject) []byte
+
 // AggregateSeals returns the bls aggregation of the committed seals for the
 // messgages in mset. It returns a big.Int that represents a bitmap where each
 // set bit corresponds to the position of a validator in the list of validators
 // for this epoch that contributed a seal to the returned aggregate. It is
 // assumed that mset contains only commit messages.
-func AggregateSeals(mset MessageSet, sealExtractor func(*istanbul.CommittedSubject) []byte) (bitmap *big.Int, aggregateSeal []byte, err error) {
+func AggregateSeals(mset MessageSet, sealExtractor sealExtractorFn) (bitmap *big.Int, aggregateSeal []byte, err error) {
 	bitmap = big.NewInt(0)
 	committedSeals := make([][]byte, mset.Size())
 	for i, v := range mset.Values() {

--- a/consensus/istanbul/core/bls.go
+++ b/consensus/istanbul/core/bls.go
@@ -13,7 +13,8 @@ import (
 	"github.com/celo-org/celo-bls-go/bls"
 )
 
-// Ideally we can move the aggregated seal here
+// Make a local copy of types.IstanbulAggregatedSeal so that we can add functionality to it.
+// Unfortunately it is not easy to move types.IstanbulAggregatedSeal here.
 type IstanbulAggregatedSeal types.IstanbulAggregatedSeal
 
 func (s IstanbulAggregatedSeal) Verify(digest common.Hash, validators istanbul.ValidatorSet) error {

--- a/consensus/istanbul/core/bls.go
+++ b/consensus/istanbul/core/bls.go
@@ -55,11 +55,6 @@ func (b *BLSSeal) VerifyAggregate(publicKeys []blscrypto.SerializedPublicKey, si
 	return apk.VerifySignature(b.Seal, b.ExtraData, signatureObj, b.CompositeHasher, b.Cip22)
 }
 
-// verifyCommittedSeal verifies the commit seal in the received COMMIT message
-func (c *core) verifyCommittedSeal(comSub *istanbul.CommittedSubject, src istanbul.Validator) error {
-	return NewCommitSeal(comSub.Subject.Digest, comSub.Subject.View.Round).Verify(src.BLSPublicKey(), comSub.CommittedSeal)
-}
-
 // verifyEpochValidatorSetSeal verifies the epoch validator set seal in the received COMMIT message
 func (c *core) verifyEpochValidatorSetSeal(comSub *istanbul.CommittedSubject, blockNumber uint64, newValSet istanbul.ValidatorSet, src istanbul.Validator) error {
 	seal, err := c.generateEpochValidatorSetData(blockNumber, uint8(comSub.Subject.View.Round.Uint64()), comSub.Subject.Digest, newValSet)

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -38,15 +38,10 @@ func (c *core) sendCommit() {
 	c.broadcastCommit(sub)
 }
 
-func (c *core) generateCommittedSeal(sub *istanbul.Subject) ([]byte, error) {
-	seal := NewCommitSeal(sub.Digest, sub.View.Round)
-	return seal.Sign(c.backend.SignBLS)
-}
-
 func (c *core) broadcastCommit(sub *istanbul.Subject) {
 	logger := c.newLogger("func", "broadcastCommit")
 
-	committedSeal, err := c.generateCommittedSeal(sub)
+	committedSeal, err := NewCommitSeal(sub.Digest, sub.View.Round).Sign(c.backend.SignBLS)
 	if err != nil {
 		logger.Error("Failed to commit seal", "err", err)
 		return

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -255,7 +255,8 @@ func (c *core) generateAggregateCommittedSeal() (types.IstanbulAggregatedSeal, e
 	}
 
 	aggregatedSeal := types.IstanbulAggregatedSeal{Bitmap: bitmap, Signature: aggregate, Round: c.current.Round()}
-	err = c.backend.VerifyAggregatedSeal(c.current.Proposal().Hash(), c.current.ValidatorSet(), aggregatedSeal)
+
+	err = IstanbulAggregatedSeal(aggregatedSeal).Verify(c.current.Proposal().Hash(), c.current.ValidatorSet())
 	if err != nil {
 		return types.IstanbulAggregatedSeal{}, fmt.Errorf("failed verify aggregate seal: %v", err)
 	}

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -184,9 +184,9 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 		seal := NewCommitSeal(proposal.Hash(), round)
 		sig, bitmap, err := GenerateValidAggregateSignature(logger, seal, commits, validators, extractCommitSignature)
 		if err != nil {
-			// If there an error then sit this round out, we can't continue.
+			// If there was an error then sit this round out, we can't continue.
 			nextRound := new(big.Int).Add(round, common.Big1)
-			logger.Warn("Error on commit, waiting for desired round", "reason", "failed to generate valid aggregate commit seal", "err", err, "desired_round", nextRound)
+			logger.Error("Error on commit, waiting for desired round", "reason", "failed to generate valid aggregate commit seal", "err", err, "desired_round", nextRound)
 			c.waitForDesiredRound(nextRound)
 			return nil
 		}
@@ -207,7 +207,7 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 			seal, err := c.generateEpochValidatorSetData(num, uint8(round.Uint64()), proposal.Hash(), validators)
 			if err != nil {
 				nextRound := new(big.Int).Add(c.current.Round(), common.Big1)
-				logger.Warn("Error on commit, waiting for desired round", "reason", "failed to build epoch seal data", "err", err, "desired_round", nextRound)
+				logger.Error("Error on commit, waiting for desired round", "reason", "failed to build epoch seal data", "err", err, "desired_round", nextRound)
 				c.waitForDesiredRound(nextRound)
 				return nil
 			}
@@ -215,7 +215,7 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 			sig, bitmap, err := GenerateValidAggregateSignature(logger, seal, commits, validators, extractEpochSignature)
 			if err != nil {
 				nextRound := new(big.Int).Add(c.current.Round(), common.Big1)
-				logger.Warn("Error on commit, waiting for desired round", "reason", "failed to generate valid aggregate epoch seal", "err", err, "desired_round", nextRound)
+				logger.Error("Error on commit, waiting for desired round", "reason", "failed to generate valid aggregate epoch seal", "err", err, "desired_round", nextRound)
 				c.waitForDesiredRound(nextRound)
 				return nil
 			}

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -182,7 +182,7 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 		}
 		// Generate aggregate seal
 		seal := NewCommitSeal(proposal.Hash(), round)
-		sig, bitmap, err := GenerateValidAggregateSignature(logger, seal, commits, validators, ExtractCommitSeal)
+		sig, bitmap, err := GenerateValidAggregateSignature(logger, seal, commits, validators, extractCommitSignature)
 		if err != nil {
 			// If there an error then sit this round out, we can't continue.
 			nextRound := new(big.Int).Add(round, common.Big1)
@@ -212,7 +212,7 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 				return nil
 			}
 
-			sig, bitmap, err := GenerateValidAggregateSignature(logger, seal, commits, validators, ExtractEpochSeal)
+			sig, bitmap, err := GenerateValidAggregateSignature(logger, seal, commits, validators, extractEpochSignature)
 			if err != nil {
 				nextRound := new(big.Int).Add(c.current.Round(), common.Big1)
 				logger.Warn("Error on commit, waiting for desired round", "reason", "failed to generate valid aggregate epoch seal", "err", err, "desired_round", nextRound)

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -288,14 +288,11 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 }
 
 // generateAggregateCommittedSeal will generate the aggregate committed seal
-// verify it and return it.
+// verify it and return it. It assumes that there is at least a quorum of
+// commits in the current round state.
 func (c *core) generateAggregateCommittedSeal() (types.IstanbulAggregatedSeal, error) {
-	commits := c.current.Commits()
-	if commits.Size() < c.current.ValidatorSet().MinQuorumSize() {
-		return types.IstanbulAggregatedSeal{}, fmt.Errorf("insufficient commits to construct aggregate seal")
-	}
 	bitmap, aggregate, err := AggregateSeals(
-		commits,
+		c.current.Commits(),
 		func(c *istanbul.CommittedSubject) []byte { return c.CommittedSeal },
 	)
 	if err != nil {

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -120,22 +120,12 @@ func (c *core) broadcastCommit(sub *istanbul.Subject) {
 			return
 		}
 	}
-
-	committedSub := &istanbul.CommittedSubject{
+	istMsg := istanbul.NewMessage(&istanbul.CommittedSubject{
 		Subject:               sub,
 		CommittedSeal:         committedSeal[:],
 		EpochValidatorSetSeal: epochValidatorSetSeal[:],
-	}
-	encodedCommittedSubject, err := Encode(committedSub)
-	if err != nil {
-		logger.Error("Failed to encode committedSubject", committedSub)
-	}
-
-	istMsg := istanbul.Message{
-		Code: istanbul.MsgCommit,
-		Msg:  encodedCommittedSubject,
-	}
-	c.broadcast(&istMsg)
+	}, c.address)
+	c.broadcast(istMsg)
 }
 
 func (c *core) handleCommit(msg *istanbul.Message) error {

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -313,8 +313,8 @@ func (c *core) generateAggregateCommittedSeal() (types.IstanbulAggregatedSeal, e
 // removeInvalidCommittedSeals individually verifies the committed seal on each
 // commit message and discards commits with invalid committed seals.
 //
-// Note that when commit messages are discarded they are not removed from the
-// round state database, this should not pose a problem however because if this
+// Note that commit messages are discarded from memory but the removal is not
+// persisted to disk, this should not pose a problem however because if this
 // step is reached again they will again be discarded.
 func (c *core) removeInvalidCommittedSeals() {
 	commits := c.current.Commits()

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -317,6 +317,7 @@ func (c *core) generateAggregateCommittedSeal() (types.IstanbulAggregatedSeal, e
 // persisted to disk, this should not pose a problem however because if this
 // step is reached again they will again be discarded.
 func (c *core) removeInvalidCommittedSeals() {
+	logger := c.newLogger("func", "removeInvalidCommittedSeals")
 	commits := c.current.Commits()
 	for _, msg := range commits.Values() {
 		// Continue if this commit has already been validated.
@@ -326,6 +327,7 @@ func (c *core) removeInvalidCommittedSeals() {
 		err := c.verifyCommittedSeal(msg.Commit(), c.current.GetValidatorByAddress(msg.Address))
 		if err != nil {
 			commits.Remove(msg.Address)
+			logger.Warn("Invalid committed seal received", "from", msg.Address.String(), "err", err)
 		} else {
 			// Mark this committed seal as valid
 			msg.Commit().SetCommittedSealValid()

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -319,9 +319,16 @@ func (c *core) generateAggregateCommittedSeal() (types.IstanbulAggregatedSeal, e
 func (c *core) removeInvalidCommittedSeals() {
 	commits := c.current.Commits()
 	for _, msg := range commits.Values() {
+		// Continue if this commit has already been validated.
+		if msg.Commit().CommittedSealValid() {
+			continue
+		}
 		err := c.verifyCommittedSeal(msg.Commit(), c.current.GetValidatorByAddress(msg.Address))
 		if err != nil {
 			commits.Remove(msg.Address)
+		} else {
+			// Mark this committed seal as valid
+			msg.Commit().SetCommittedSealValid()
 		}
 	}
 }

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -177,9 +177,6 @@ func (c *core) handleCheckedCommitForPreviousSequence(msg *istanbul.Message, com
 	if validator == nil {
 		return errInvalidValidatorAddress
 	}
-	if err := c.verifyCommittedSeal(commit, validator); err != nil {
-		return errInvalidCommittedSeal
-	}
 	if headBlock.Number().Uint64() > 0 {
 		if err := c.verifyEpochValidatorSetSeal(commit, headBlock.Number().Uint64(), c.current.ValidatorSet(), validator); err != nil {
 			return errInvalidEpochValidatorSetSeal
@@ -207,10 +204,6 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 		return errInvalidValidatorAddress
 	}
 
-	if err := c.verifyCommittedSeal(commit, validator); err != nil {
-		return errInvalidCommittedSeal
-	}
-
 	newValSet, err := c.backend.NextBlockValidators(c.current.Proposal())
 	if err != nil {
 		return err
@@ -230,34 +223,21 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 		logger.Error("Failed to record commit message", "m", msg, "err", err)
 		return err
 	}
-	numberOfCommits := c.current.Commits().Size()
+	commits := c.current.Commits()
+	numberOfCommits := commits.Size()
 	minQuorumSize := c.current.ValidatorSet().MinQuorumSize()
 	logger.Trace("Accepted commit for current sequence", "Number of commits", numberOfCommits)
 
 	// Commit the proposal once we have enough COMMIT messages and we are not in the Committed state.
 	//
-	// If we already have a proposal, we may have chance to speed up the consensus process
-	// by committing the proposal without PREPARE messages.
 	// TODO(joshua): Remove state comparisons (or change the cmp function)
 	if numberOfCommits >= minQuorumSize && c.current.State().Cmp(StateCommitted) < 0 {
-		logger.Trace("Got a quorum of commits", "tag", "stateTransition", "commits", c.current.Commits)
+		logger.Trace("Got a quorum of commits", "tag", "stateTransition", "commits", commits)
 		err := c.commit()
 		if err != nil {
 			logger.Error("Failed to commit()", "err", err)
 			return err
 		}
-
-	} else if c.current.GetPrepareOrCommitSize() >= minQuorumSize && c.current.State().Cmp(StatePrepared) < 0 {
-		err := c.current.TransitionToPrepared(minQuorumSize)
-		if err != nil {
-			logger.Error("Failed to create and set prepared certificate", "err", err)
-			return err
-		}
-		// Process Backlog Messages
-		c.backlog.updateState(c.current.View(), c.current.State())
-
-		logger.Trace("Got quorum prepares or commits", "tag", "stateTransition", "commits", c.current.Commits, "prepares", c.current.Prepares)
-		c.sendCommit()
 	}
 	return nil
 

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
+	"github.com/celo-org/celo-blockchain/core/types"
 	blscrypto "github.com/celo-org/celo-blockchain/crypto/bls"
 )
 
@@ -216,18 +217,20 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 		return errInvalidValidatorAddress
 	}
 
+	// ensure that the commit is for the current proposal
+	if err := c.verifyCommit(commit); err != nil {
+		return err
+	}
+
 	newValSet, err := c.backend.NextBlockValidators(c.current.Proposal())
 	if err != nil {
 		return err
 	}
 
+	// Verifies the individual seal for this commit message for the epoch
+	// block, no-op unless this is the last block of an epoch.
 	if err := c.verifyEpochValidatorSetSeal(commit, c.current.Proposal().Number().Uint64(), newValSet, validator); err != nil {
 		return errInvalidEpochValidatorSetSeal
-	}
-
-	// ensure that the commit is in the current proposal
-	if err := c.verifyCommit(commit); err != nil {
-		return err
 	}
 
 	// Add the COMMIT message to current round state
@@ -235,6 +238,7 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 		logger.Error("Failed to record commit message", "m", msg, "err", err)
 		return err
 	}
+
 	commits := c.current.Commits()
 	numberOfCommits := commits.Size()
 	minQuorumSize := c.current.ValidatorSet().MinQuorumSize()
@@ -244,8 +248,51 @@ func (c *core) handleCheckedCommitForCurrentSequence(msg *istanbul.Message, comm
 	//
 	// TODO(joshua): Remove state comparisons (or change the cmp function)
 	if numberOfCommits >= minQuorumSize && c.current.State().Cmp(StateCommitted) < 0 {
+		proposal := c.current.Proposal()
+		// TODO understand how proposal can be nil.
+		if proposal == nil {
+			return nil
+		}
+
+		// Generate aggregate seal
+		bitmap, aggregate, err := AggregateSeals(
+			c.current.Commits(),
+			func(c *istanbul.CommittedSubject) []byte { return c.CommittedSeal },
+		)
+		if err != nil {
+			nextRound := new(big.Int).Add(c.current.Round(), common.Big1)
+			logger.Warn("Error on commit, waiting for desired round", "reason", "getAggregatedSeal", "err", err, "desired_round", nextRound)
+			c.waitForDesiredRound(nextRound)
+			return nil
+		}
+		aggregatedSeal := types.IstanbulAggregatedSeal{Bitmap: bitmap, Signature: aggregate, Round: c.current.Round()}
+		err = c.backend.VerifyAggregatedSeal(c.current.Proposal().Hash(), c.current.ValidatorSet(), aggregatedSeal)
+		if err != nil {
+			// TODO remove bad seals from message set
+			// return fmt.Errorf("failed to verify epoch validator set seal: %v", err)
+			return nil
+		}
+
+		// Set the epoch aggregate seal if this is the last block of the epoch
+		aggregatedEpochValidatorSetSeal := types.IstanbulEpochValidatorSetSeal{}
+		if istanbul.IsLastBlockOfEpoch(proposal.Number().Uint64(), c.config.Epoch) {
+			epochBitmap, epochAggregate, err := AggregateSeals(
+				c.current.Commits(),
+				func(c *istanbul.CommittedSubject) []byte { return c.EpochValidatorSetSeal },
+			)
+			if err != nil {
+				nextRound := new(big.Int).Add(c.current.Round(), common.Big1)
+				logger.Warn("Error on commit, waiting for desired round", "reason", "getAggregatedSeal", "err", err, "desired_round", nextRound)
+				c.waitForDesiredRound(nextRound)
+				return nil
+			}
+
+			aggregatedEpochValidatorSetSeal.Bitmap = epochBitmap
+			aggregatedEpochValidatorSetSeal.Signature = epochAggregate
+		}
+
 		logger.Trace("Got a quorum of commits", "tag", "stateTransition", "commits", commits)
-		err := c.commit()
+		err = c.commit(aggregatedSeal, aggregatedEpochValidatorSetSeal)
 		if err != nil {
 			logger.Error("Failed to commit()", "err", err)
 			return err

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -170,10 +170,10 @@ func (c *core) handleCommit(msg *istanbul.Message) error {
 }
 
 // handleCheckedCommitForPreviousSequence adds messages for the previous
-// sequence to the parent commit set, if the subject digest of msg does not
-// match that of the previous block or it was not sent by one of the previous
-// block's validators an error is returned. If this is the last block of the
-// epoch then the epoch seal will also be validated.
+// sequence to the parent commit set. 
+// If the subject digest of msg does not match that of the previous block or it
+// was not sent by one of the previous block's validators, an error is returned.
+// If this is the last block of the epoch then the epoch seal will also be validated.
 //
 // The parent commit set is maintained for the sole purpose of tracking uptime,
 // allowing commits that did not arrive in time to be part of their intended

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -213,17 +213,13 @@ OUTER:
 			signature, _ := privateKey.SignMessage(hash, []byte{}, false, false)
 			defer signature.Destroy()
 			signatureBytes, _ := signature.Serialize()
-			committedSubject := &istanbul.CommittedSubject{
-				Subject:       v.engine.(*core).current.Subject(),
-				CommittedSeal: signatureBytes,
-			}
-			m, _ := Encode(committedSubject)
-			if err := r0.handleCommit(&istanbul.Message{
-				Code:      istanbul.MsgCommit,
-				Msg:       m,
-				Address:   validator.Address(),
-				Signature: []byte{},
-			}); err != nil {
+
+			msg := istanbul.NewMessage(
+				&istanbul.CommittedSubject{Subject: v.engine.(*core).current.Subject(), CommittedSeal: signatureBytes},
+				validator.Address(),
+			)
+
+			if err := r0.handleCommit(msg); err != nil {
 				if err != test.expectedErr {
 					t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
 				}

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -430,17 +430,10 @@ func BenchmarkHandleCommit(b *testing.B) {
 		signature, _ := privateKey.SignMessage(hash, []byte{}, false, false)
 		defer signature.Destroy()
 		signatureBytes, _ := signature.Serialize()
-		committedSubject := &istanbul.CommittedSubject{
+		im = istanbul.NewMessage(&istanbul.CommittedSubject{
 			Subject:       v.engine.(*core).current.Subject(),
 			CommittedSeal: signatureBytes,
-		}
-		m, _ := Encode(committedSubject)
-		im = &istanbul.Message{
-			Code:      istanbul.MsgCommit,
-			Msg:       m,
-			Address:   validator.Address(),
-			Signature: []byte{},
-		}
+		}, validator.Address())
 	}
 	// benchmarked portion
 	b.ResetTimer()

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -209,8 +209,8 @@ OUTER:
 			privateKey, _ := bls.DeserializePrivateKey(test.system.validatorsKeys[i])
 			defer privateKey.Destroy()
 
-			hash := PrepareCommittedSeal(v.engine.(*core).current.Proposal().Hash(), v.engine.(*core).current.Round())
-			signature, _ := privateKey.SignMessage(hash, []byte{}, false, false)
+			seal := NewCommitSeal(v.engine.(*core).current.Proposal().Hash(), v.engine.(*core).current.Round())
+			signature, _ := privateKey.SignMessage(seal.Seal, []byte{}, false, false)
 			defer signature.Destroy()
 			signatureBytes, _ := signature.Serialize()
 
@@ -426,8 +426,8 @@ func BenchmarkHandleCommit(b *testing.B) {
 		privateKey, _ := bls.DeserializePrivateKey(sys.validatorsKeys[i])
 		defer privateKey.Destroy()
 
-		hash := PrepareCommittedSeal(v.engine.(*core).current.Proposal().Hash(), v.engine.(*core).current.Round())
-		signature, _ := privateKey.SignMessage(hash, []byte{}, false, false)
+		seal := NewCommitSeal(v.engine.(*core).current.Proposal().Hash(), v.engine.(*core).current.Round())
+		signature, _ := privateKey.SignMessage(seal.Seal, []byte{}, false, false)
 		defer signature.Destroy()
 		signatureBytes, _ := signature.Serialize()
 		im = istanbul.NewMessage(&istanbul.CommittedSubject{

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -29,7 +29,6 @@ import (
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul/validator"
 	"github.com/celo-org/celo-blockchain/core/types"
-	blscrypto "github.com/celo-org/celo-blockchain/crypto/bls"
 	"github.com/celo-org/celo-blockchain/event"
 	"github.com/celo-org/celo-blockchain/log"
 	"github.com/celo-org/celo-blockchain/metrics"
@@ -72,7 +71,7 @@ type CoreBackend interface {
 	Sign([]byte) ([]byte, error)
 
 	// Sign with the data with the BLS key, using either a direct or composite hasher and optional cip22 encoding
-	SignBLS([]byte, []byte, bool, bool) (blscrypto.SerializedSignature, error)
+	SignBLS([]byte, []byte, bool, bool) ([]byte, error)
 
 	// CheckSignature verifies the signature by checking if it's signed by
 	// the given validator

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -100,9 +100,6 @@ type CoreBackend interface {
 
 	IsPrimaryForSeq(seq *big.Int) bool
 	UpdateReplicaState(seq *big.Int)
-
-	// VerifyAggregatedSeal verifies the aggregate bls signature given the header hash and validator set.
-	VerifyAggregatedSeal(headerHash common.Hash, validators istanbul.ValidatorSet, aggregatedSeal types.IstanbulAggregatedSeal) error
 }
 
 type core struct {

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -218,10 +218,6 @@ func PrepareCommittedSeal(hash common.Hash, round *big.Int) []byte {
 	return buf.Bytes()
 }
 
-func (c *core) PrepareEpochValidatorSetSeal(comSub *istanbul.CommittedSubject, newValSet istanbul.ValidatorSet) (seal, sealExtraData []byte, cip22 bool, err error) {
-	return c.generateEpochValidatorSetData(comSub.Subject.View.Sequence.Uint64(), uint8(comSub.Subject.View.Round.Uint64()), comSub.Subject.Digest, newValSet)
-}
-
 // AggregateSeals returns the bls aggregation of the committed seals for the
 // messgages in mset. It returns a big.Int that represents a bitmap where each
 // set bit corresponds to the position of a validator in the list of validators

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -363,14 +363,15 @@ func (c *core) commit() error {
 
 	proposal := c.current.Proposal()
 	if proposal != nil {
-		aggregatedSeal, err := GetAggregatedSeal(c.current.Commits(), c.current.Round())
+		commits := c.current.Commits()
+		aggregatedSeal, err := GetAggregatedSeal(commits, c.current.Round())
 		if err != nil {
 			nextRound := new(big.Int).Add(c.current.Round(), common.Big1)
 			logger.Warn("Error on commit, waiting for desired round", "reason", "getAggregatedSeal", "err", err, "desired_round", nextRound)
 			c.waitForDesiredRound(nextRound)
 			return nil
 		}
-		aggregatedEpochValidatorSetSeal, err := GetAggregatedEpochValidatorSetSeal(proposal.Number().Uint64(), c.config.Epoch, c.current.Commits())
+		aggregatedEpochValidatorSetSeal, err := GetAggregatedEpochValidatorSetSeal(proposal.Number().Uint64(), c.config.Epoch, commits)
 		if err != nil {
 			nextRound := new(big.Int).Add(c.current.Round(), common.Big1)
 			c.logger.Warn("Error on commit, waiting for desired round", "reason", "GetAggregatedEpochValidatorSetSeal", "err", err, "desired_round", nextRound)

--- a/consensus/istanbul/core/core_test.go
+++ b/consensus/istanbul/core/core_test.go
@@ -215,6 +215,7 @@ func TestEpochSnarkData(t *testing.T) {
 	assert.NoError(t, err)
 
 	epochSealDonut, err := backendCore.generateEpochValidatorSetData(2, 0, common.Hash{}, sys.backends[0].Validators(backendCore.current.Proposal()))
+	assert.NoError(t, err)
 	if !epochSealDonut.Cip22 || len(epochSealDonut.ExtraData) == 0 {
 		t.Errorf("Unexpected cip22 (%t != true) or extraData length (%v == 0)", epochSealDonut.Cip22, len(epochSealDonut.ExtraData))
 	}

--- a/consensus/istanbul/core/core_test.go
+++ b/consensus/istanbul/core/core_test.go
@@ -53,7 +53,6 @@ func newTestProposal() istanbul.Proposal {
 var InvalidProposalError = errors.New("invalid proposal")
 
 func TestNewRequest(t *testing.T) {
-
 	testLogger.SetHandler(elog.StdoutHandler)
 
 	N := uint64(4)

--- a/consensus/istanbul/core/errors.go
+++ b/consensus/istanbul/core/errors.go
@@ -33,12 +33,6 @@ var (
 	errOldMessage = errors.New("old message")
 	// errInvalidMessage is returned when the message is malformed.
 	errInvalidMessage = errors.New("invalid message")
-	// errFailedDecodePreprepare is returned when the PREPREPARE message is malformed.
-	errFailedDecodePreprepare = errors.New("failed to decode PREPREPARE")
-	// errFailedDecodePrepare is returned when the PREPARE message is malformed.
-	errFailedDecodePrepare = errors.New("failed to decode PREPARE")
-	// errFailedDecodeCommit is returned when the COMMIT message is malformed.
-	errFailedDecodeCommit = errors.New("failed to decode COMMIT")
 	// errInvalidPreparedCertificateProposal is returned when the PREPARED certificate has an invalid proposal.
 	errInvalidPreparedCertificateProposal = errors.New("invalid proposal in PREPARED certificate")
 	// errInvalidPreparedCertificateNumMsgs is returned when the PREPARED certificate has an incorrect number of messages.

--- a/consensus/istanbul/core/errors.go
+++ b/consensus/istanbul/core/errors.go
@@ -65,8 +65,6 @@ var (
 
 	// errInvalidEpochValidatorSetSeal is returned when a COMMIT message has an invalid epoch validator seal.
 	errInvalidEpochValidatorSetSeal = errors.New("invalid epoch validator set seal in COMMIT message")
-	// errNotLastBlockInEpoch is returned when the block number was not the last block in the epoch
-	errNotLastBlockInEpoch = errors.New("not last block in epoch")
 	// errMissingRoundChangeCertificate is returned when ROUND CHANGE certificate is missing from a PREPREPARE for round > 0.
 	errMissingRoundChangeCertificate = errors.New("missing ROUND CHANGE certificate in PREPREPARE")
 	// errFailedCreateRoundChangeCertificate is returned when there aren't enough ROUND CHANGE messages to create a ROUND CHANGE certificate.

--- a/consensus/istanbul/core/errors.go
+++ b/consensus/istanbul/core/errors.go
@@ -69,8 +69,6 @@ var (
 	// errInvalidRoundChangeCertificateMsgView is returned when the ROUND CHANGE certificate contains a message for the wrong view
 	errInvalidRoundChangeCertificateMsgView = errors.New("message in ROUND CHANGE certificate for wrong view")
 
-	// errInvalidCommittedSeal is returned when a COMMIT message has an invalid committed seal.
-	errInvalidCommittedSeal = errors.New("invalid committed seal in COMMIT message")
 	// errInvalidEpochValidatorSetSeal is returned when a COMMIT message has an invalid epoch validator seal.
 	errInvalidEpochValidatorSetSeal = errors.New("invalid epoch validator set seal in COMMIT message")
 	// errNotLastBlockInEpoch is returned when the block number was not the last block in the epoch

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -22,10 +22,12 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
+	"github.com/stretchr/testify/require"
 )
 
 // notice: the normal case have been tested in integration tests.
 func TestHandleMsg(t *testing.T) {
+	t.Skip()
 	N := uint64(4)
 	F := uint64(1)
 	sys := NewTestSystemWithBackend(N, F)
@@ -50,6 +52,11 @@ func TestHandleMsg(t *testing.T) {
 		Address:   v0.Address(),
 		Signature: []byte{},
 	}
+
+	bytes, err := Encode(msg)
+	require.NoError(t, err)
+	err = msg.FromPayload(bytes, nil)
+	require.NoError(t, err)
 
 	_, val := v0.Validators(nil).GetByAddress(v0.Address())
 	if err := r0.handleCheckedMsg(msg, val); err != errFailedDecodePreprepare {

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -22,12 +22,12 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // notice: the normal case have been tested in integration tests.
 func TestHandleMsg(t *testing.T) {
-	t.Skip()
 	N := uint64(4)
 	F := uint64(1)
 	sys := NewTestSystemWithBackend(N, F)
@@ -38,95 +38,77 @@ func TestHandleMsg(t *testing.T) {
 	v0 := sys.backends[0]
 	r0 := v0.engine.(*core)
 
-	m, _ := Encode(&istanbul.Subject{
+	m := istanbul.NewMessage(&istanbul.Subject{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
 		},
 		Digest: common.BytesToHash([]byte("1234567890")),
-	})
+	}, v0.Address())
+
 	// with a matched payload. istanbul.MsgPreprepare should match with *istanbul.Preprepare in normal case.
-	msg := &istanbul.Message{
-		Code:      istanbul.MsgPreprepare,
-		Msg:       m,
-		Address:   v0.Address(),
-		Signature: []byte{},
-	}
+	m.Code = istanbul.MsgPreprepare
 
-	bytes, err := Encode(msg)
-	require.NoError(t, err)
-	err = msg.FromPayload(bytes, nil)
+	payload, err := m.Payload()
 	require.NoError(t, err)
 
-	_, val := v0.Validators(nil).GetByAddress(v0.Address())
-	if err := r0.handleCheckedMsg(msg, val); err != errFailedDecodePreprepare {
-		t.Errorf("error mismatch: have %v, want %v", err, errFailedDecodePreprepare)
-	}
+	err = r0.handleMsg(payload)
+	assert.Error(t, err)
 
-	m, _ = Encode(&istanbul.Preprepare{
+	m = istanbul.NewMessage(&istanbul.Preprepare{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
 		},
 		Proposal: makeBlock(1),
-	})
+	}, v0.Address())
+
 	// with a unmatched payload. istanbul.MsgPrepare should match with *istanbul.Subject in normal case.
-	msg = &istanbul.Message{
-		Code:      istanbul.MsgPrepare,
-		Msg:       m,
-		Address:   v0.Address(),
-		Signature: []byte{},
-	}
+	m.Code = istanbul.MsgPrepare
 
-	_, val = v0.Validators(nil).GetByAddress(v0.Address())
-	if err := r0.handleCheckedMsg(msg, val); err != errFailedDecodePrepare {
-		t.Errorf("error mismatch: have %v, want %v", err, errFailedDecodePreprepare)
-	}
+	payload, err = m.Payload()
+	require.NoError(t, err)
 
-	m, _ = Encode(&istanbul.Preprepare{
+	err = r0.handleMsg(payload)
+	assert.Error(t, err)
+
+	m = istanbul.NewMessage(&istanbul.Preprepare{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
 		},
 		Proposal: makeBlock(2),
-	})
+	}, v0.Address())
+
 	// with a unmatched payload. istanbul.MsgCommit should match with *istanbul.Subject in normal case.
-	msg = &istanbul.Message{
-		Code:      istanbul.MsgCommit,
-		Msg:       m,
-		Address:   v0.Address(),
-		Signature: []byte{},
-	}
+	m.Code = istanbul.MsgCommit
 
-	_, val = v0.Validators(nil).GetByAddress(v0.Address())
-	if err := r0.handleCheckedMsg(msg, val); err != errFailedDecodeCommit {
-		t.Errorf("error mismatch: have %v, want %v", err, errFailedDecodeCommit)
-	}
+	payload, err = m.Payload()
+	require.NoError(t, err)
 
-	m, _ = Encode(&istanbul.Preprepare{
+	err = r0.handleMsg(payload)
+	assert.Error(t, err)
+
+	m = istanbul.NewMessage(&istanbul.Preprepare{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
 		},
 		Proposal: makeBlock(3),
-	})
-	// invalid message code. message code is not exists in list
-	msg = &istanbul.Message{
-		Code:      uint64(99),
-		Msg:       m,
-		Address:   v0.Address(),
-		Signature: []byte{},
-	}
+	}, v0.Address())
 
-	_, val = v0.Validators(nil).GetByAddress(v0.Address())
-	if err := r0.handleCheckedMsg(msg, val); err == nil {
-		t.Errorf("error mismatch: have %v, want nil", err)
-	}
+	// invalid message code. message code is not exists in list
+	m.Code = uint64(99)
+
+	payload, err = m.Payload()
+	require.NoError(t, err)
+
+	err = r0.handleMsg(payload)
+	assert.Error(t, err)
 
 	// with malicious payload
-	if err := r0.handleMsg([]byte{1}); err == nil {
-		t.Errorf("error mismatch: have %v, want nil", err)
-	}
+	err = r0.handleMsg([]byte{1})
+	assert.Error(t, err)
 }
 
 func BenchmarkHandleMsg(b *testing.B) {

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -228,7 +228,7 @@ func bemchmarkE2EHandleCommit(b *testing.B, sys *testSystem) {
 	c := v0.engine.(*core)
 	subject := v0.engine.(*core).current.Subject()
 
-	committedSeal, err := v0.engine.(*core).generateCommittedSeal(subject)
+	committedSeal, err := NewCommitSeal(subject.Digest, subject.View.Round).Sign(v0.engine.(*core).backend.SignBLS)
 	if err != nil {
 		b.Errorf("Got error: %v", err)
 	}

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -25,18 +25,8 @@ import (
 
 func (c *core) sendPrepare() {
 	logger := c.newLogger("func", "sendPrepare")
-
-	sub := c.current.Subject()
-	encodedSubject, err := Encode(sub)
-	if err != nil {
-		logger.Error("Failed to encode", "subject", sub)
-		return
-	}
 	logger.Debug("Sending prepare")
-	c.broadcast(&istanbul.Message{
-		Code: istanbul.MsgPrepare,
-		Msg:  encodedSubject,
-	})
+	c.broadcast(istanbul.NewMessage(c.current.Subject(), c.address))
 }
 
 // Verify a prepared certificate and return the view that all of its messages pertain to.

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -87,10 +87,14 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 			if err != nil {
 				return nil, err
 			}
-			err = c.verifyEpochValidatorSetSeal(commit, preparedCertificate.Proposal.Number().Uint64(), newValSet, src)
-			if err != nil {
-				logger.Error("Epoch validator set seal seal did not contain signature from message signer.", "err", err)
-				return nil, err
+
+			num := preparedCertificate.Proposal.Number().Uint64()
+			if num > 0 && istanbul.IsLastBlockOfEpoch(num, c.config.Epoch) {
+				err = c.verifyEpochValidatorSetSeal(commit, num, newValSet, src)
+				if err != nil {
+					logger.Error("Epoch validator set seal seal did not contain signature from message signer.", "err", err)
+					return nil, err
+				}
 			}
 
 			subject = commit.Subject

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -81,19 +81,13 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 			return nil, errInvalidPreparedCertificateMsgCode
 		}
 
-		var subject *istanbul.Subject
-
+		// Assume prepare but overwrite if commit
+		subject := message.Prepare()
 		if message.Code == istanbul.MsgCommit {
-			var committedSubject *istanbul.CommittedSubject
-			err := message.Decode(&committedSubject)
-			if err != nil {
-				logger.Error("Failed to decode committedSubject in PREPARED certificate", "err", err)
-				return nil, err
-			}
-
+			commit := message.Commit()
 			// Verify the committedSeal
 			src := c.current.GetValidatorByAddress(signer)
-			err = c.verifyCommittedSeal(committedSubject, src)
+			err = c.verifyCommittedSeal(commit, src)
 			if err != nil {
 				logger.Error("Commit seal did not contain signature from message signer.", "err", err)
 				return nil, err
@@ -103,18 +97,13 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 			if err != nil {
 				return nil, err
 			}
-			err = c.verifyEpochValidatorSetSeal(committedSubject, preparedCertificate.Proposal.Number().Uint64(), newValSet, src)
+			err = c.verifyEpochValidatorSetSeal(commit, preparedCertificate.Proposal.Number().Uint64(), newValSet, src)
 			if err != nil {
 				logger.Error("Epoch validator set seal seal did not contain signature from message signer.", "err", err)
 				return nil, err
 			}
 
-			subject = committedSubject.Subject
-		} else {
-			if err := message.Decode(&subject); err != nil {
-				logger.Error("Failed to decode message in PREPARED certificate", "err", err)
-				return nil, err
-			}
+			subject = commit.Subject
 		}
 
 		msgLogger := logger.New("msg_round", subject.View.Round, "msg_seq", subject.View.Sequence, "msg_digest", subject.Digest.String())
@@ -144,41 +133,23 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 
 // Extract the view from a PreparedCertificate that has already been verified.
 func (c *core) getViewFromVerifiedPreparedCertificate(preparedCertificate istanbul.PreparedCertificate) (*istanbul.View, error) {
-	logger := c.newLogger("func", "getViewFromVerifiedPreparedCertificate", "proposal_number", preparedCertificate.Proposal.Number(), "proposal_hash", preparedCertificate.Proposal.Hash().String())
-
 	if len(preparedCertificate.PrepareOrCommitMessages) < c.current.ValidatorSet().MinQuorumSize() {
 		return nil, errInvalidPreparedCertificateNumMsgs
 	}
 
 	message := preparedCertificate.PrepareOrCommitMessages[0]
 
-	var subject *istanbul.Subject
-
+	// Assume prepare but overwrite if commit
+	subject := message.Prepare()
 	if message.Code == istanbul.MsgCommit {
-		var committedSubject *istanbul.CommittedSubject
-		err := message.Decode(&committedSubject)
-		if err != nil {
-			logger.Error("Failed to decode committedSubject in PREPARED certificate", "err", err)
-			return nil, err
-		}
-		subject = committedSubject.Subject
-	} else {
-		if err := message.Decode(&subject); err != nil {
-			logger.Error("Failed to decode message in PREPARED certificate", "err", err)
-			return nil, err
-		}
+		subject = message.Commit().Subject
 	}
-
 	return subject.View, nil
 }
 
 func (c *core) handlePrepare(msg *istanbul.Message) error {
 	// Decode PREPARE message
-	var prepare *istanbul.Subject
-	err := msg.Decode(&prepare)
-	if err != nil {
-		return errFailedDecodePrepare
-	}
+	prepare := msg.Prepare()
 	logger := c.newLogger("func", "handlePrepare", "tag", "handleMsg", "msg_round", prepare.View.Round, "msg_seq", prepare.View.Sequence, "msg_digest", prepare.Digest.String())
 
 	if err := c.checkMessage(istanbul.MsgPrepare, prepare.View); err != nil {

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -38,14 +38,14 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 		return nil, errInvalidPreparedCertificateProposal
 	}
 
-	if len(preparedCertificate.PrepareOrCommitMessages) > c.current.ValidatorSet().Size() || len(preparedCertificate.PrepareOrCommitMessages) < c.current.ValidatorSet().MinQuorumSize() {
+	if len(preparedCertificate.PrepareMessages) > c.current.ValidatorSet().Size() || len(preparedCertificate.PrepareMessages) < c.current.ValidatorSet().MinQuorumSize() {
 		return nil, errInvalidPreparedCertificateNumMsgs
 	}
 
 	seen := make(map[common.Address]bool)
 
 	var view *istanbul.View
-	for _, message := range preparedCertificate.PrepareOrCommitMessages {
+	for _, message := range preparedCertificate.PrepareMessages {
 		data, err := message.PayloadNoSig()
 		if err != nil {
 			return nil, err
@@ -128,11 +128,11 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 
 // Extract the view from a PreparedCertificate that has already been verified.
 func (c *core) getViewFromVerifiedPreparedCertificate(preparedCertificate istanbul.PreparedCertificate) (*istanbul.View, error) {
-	if len(preparedCertificate.PrepareOrCommitMessages) < c.current.ValidatorSet().MinQuorumSize() {
+	if len(preparedCertificate.PrepareMessages) < c.current.ValidatorSet().MinQuorumSize() {
 		return nil, errInvalidPreparedCertificateNumMsgs
 	}
 
-	message := preparedCertificate.PrepareOrCommitMessages[0]
+	message := preparedCertificate.PrepareMessages[0]
 
 	// Assume prepare but overwrite if commit
 	subject := message.Prepare()

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -77,7 +77,8 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 			commit := message.Commit()
 			// Verify the committedSeal
 			src := c.current.GetValidatorByAddress(signer)
-			err = c.verifyCommittedSeal(commit, src)
+
+			err = NewCommitSeal(commit.Subject.Digest, commit.Subject.View.Round).Verify(src.BLSPublicKey(), commit.CommittedSeal)
 			if err != nil {
 				logger.Error("Commit seal did not contain signature from message signer.", "err", err)
 				return nil, err

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -195,15 +195,15 @@ func (c *core) handlePrepare(msg *istanbul.Message) error {
 		return err
 	}
 
-	preparesAndCommits := c.current.GetPrepareOrCommitSize()
 	minQuorumSize := c.current.ValidatorSet().MinQuorumSize()
-	logger = logger.New("prepares_and_commits", preparesAndCommits, "commits", c.current.Commits().Size(), "prepares", c.current.Prepares().Size())
+	psize := c.current.Prepares().Size()
+	logger = logger.New("prepares", psize)
 	logger.Trace("Accepted prepare")
 
 	// Change to Prepared state if we've received enough PREPARE messages and we are in earlier state
 	// before Prepared state.
 	// TODO(joshua): Remove state comparisons (or change the cmp function)
-	if (preparesAndCommits >= minQuorumSize) && c.current.State().Cmp(StatePrepared) < 0 {
+	if (psize >= minQuorumSize) && c.current.State().Cmp(StatePrepared) < 0 {
 
 		err := c.current.TransitionToPrepared(minQuorumSize)
 		if err != nil {

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -374,12 +374,8 @@ func TestHandlePrepare(t *testing.T) {
 
 			for i, v := range test.system.backends {
 				validator := r0.current.ValidatorSet().GetByIndex(uint64(i))
-				m, _ := Encode(v.engine.(*core).current.Subject())
-				err := r0.handlePrepare(&istanbul.Message{
-					Code:    istanbul.MsgPrepare,
-					Msg:     m,
-					Address: validator.Address(),
-				})
+				msg := istanbul.NewMessage(v.engine.(*core).current.Subject(), validator.Address())
+				err := r0.handlePrepare(msg)
 				if err != nil {
 					if err != test.expectedErr {
 						t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
@@ -421,13 +417,9 @@ func TestHandlePrepare(t *testing.T) {
 			if decodedMsg.Code != istanbul.MsgCommit {
 				t.Errorf("message code mismatch: have %v, want %v", decodedMsg.Code, istanbul.MsgCommit)
 			}
-			var m *istanbul.CommittedSubject
-			err = decodedMsg.Decode(&m)
-			if err != nil {
-				t.Errorf("error mismatch: have %v, want nil", err)
-			}
-			if !reflect.DeepEqual(m.Subject, expectedSubject) {
-				t.Errorf("subject mismatch: have %v, want %v", m, expectedSubject)
+			subject := decodedMsg.Commit().Subject
+			if !reflect.DeepEqual(subject, expectedSubject) {
+				t.Errorf("subject mismatch: have %v, want %v", subject, expectedSubject)
 			}
 		})
 	}

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -58,7 +58,7 @@ func TestVerifyPreparedCertificate(t *testing.T) {
 			"Invalid PREPARED certificate, duplicate message",
 			func() istanbul.PreparedCertificate {
 				preparedCertificate := sys.getPreparedCertificate(t, []istanbul.View{view}, proposal)
-				preparedCertificate.PrepareOrCommitMessages[1] = preparedCertificate.PrepareOrCommitMessages[0]
+				preparedCertificate.PrepareMessages[1] = preparedCertificate.PrepareMessages[0]
 				return preparedCertificate
 			}(),
 			errInvalidPreparedCertificateDuplicate,
@@ -82,7 +82,7 @@ func TestVerifyPreparedCertificate(t *testing.T) {
 			func() istanbul.PreparedCertificate {
 				preparedCertificate := sys.getPreparedCertificate(t, []istanbul.View{view}, proposal)
 				testInvalidMsg, _ := sys.backends[0].getRoundChangeMessage(view, sys.getPreparedCertificate(t, []istanbul.View{view}, proposal))
-				preparedCertificate.PrepareOrCommitMessages[0] = testInvalidMsg
+				preparedCertificate.PrepareMessages[0] = testInvalidMsg
 				return preparedCertificate
 			}(),
 			errInvalidPreparedCertificateMsgCode,
@@ -92,7 +92,7 @@ func TestVerifyPreparedCertificate(t *testing.T) {
 			"Invalid PREPARED certificate, hash mismatch",
 			func() istanbul.PreparedCertificate {
 				preparedCertificate := sys.getPreparedCertificate(t, []istanbul.View{view}, proposal)
-				preparedCertificate.PrepareOrCommitMessages[1] = preparedCertificate.PrepareOrCommitMessages[0]
+				preparedCertificate.PrepareMessages[1] = preparedCertificate.PrepareMessages[0]
 				preparedCertificate.Proposal = makeBlock(1)
 				return preparedCertificate
 			}(),

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -29,23 +29,13 @@ func (c *core) sendPreprepare(request *istanbul.Request, roundChangeCertificate 
 
 	// If I'm the proposer and I have the same sequence with the proposal
 	if c.current.Sequence().Cmp(request.Proposal.Number()) == 0 && c.isProposer() {
-		curView := c.current.View()
-		preprepare, err := Encode(&istanbul.Preprepare{
-			View:                   curView,
+		m := istanbul.NewMessage(&istanbul.Preprepare{
+			View:                   c.current.View(),
 			Proposal:               request.Proposal,
 			RoundChangeCertificate: roundChangeCertificate,
-		})
-		if err != nil {
-			logger.Error("Failed to prepare message")
-			return
-		}
-
-		msg := &istanbul.Message{
-			Code: istanbul.MsgPreprepare,
-			Msg:  preprepare,
-		}
-		logger.Debug("Sending preprepare", "m", msg)
-		c.broadcast(msg)
+		}, c.address)
+		logger.Debug("Sending preprepare", "m", m)
+		c.broadcast(m)
 	}
 }
 

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -53,13 +53,7 @@ func (c *core) handlePreprepare(msg *istanbul.Message) error {
 	logger := c.newLogger("func", "handlePreprepare", "tag", "handleMsg", "from", msg.Address)
 	logger.Trace("Got preprepare message", "m", msg)
 
-	// Decode PREPREPARE
-	var preprepare *istanbul.Preprepare
-	err := msg.Decode(&preprepare)
-	if err != nil || preprepare.Proposal == nil || preprepare.View == nil {
-		return errFailedDecodePreprepare
-	}
-
+	preprepare := msg.Preprepare()
 	logger = logger.New("msg_num", preprepare.Proposal.Number(), "msg_hash", preprepare.Proposal.Hash(), "msg_seq", preprepare.View.Sequence, "msg_round", preprepare.View.Round)
 
 	// Verify that the proposal is for the sequence number of the view we verified.

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -368,11 +368,14 @@ func TestHandlePreprepare(t *testing.T) {
 				preprepareView = &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(5)}
 			}
 
-			preprepare := &istanbul.Preprepare{
-				View:                   preprepareView,
-				Proposal:               test.expectedRequest,
-				RoundChangeCertificate: test.getCert(sys),
-			}
+			msg := istanbul.NewMessage(
+				&istanbul.Preprepare{
+					View:                   preprepareView,
+					Proposal:               test.expectedRequest,
+					RoundChangeCertificate: test.getCert(sys),
+				},
+				v0.Address(),
+			)
 
 			for i, v := range sys.backends {
 				// i == 0 is primary backend, it is responsible for send PRE-PREPARE messages to others.
@@ -382,13 +385,8 @@ func TestHandlePreprepare(t *testing.T) {
 
 				c := v.engine.(*core)
 
-				m, _ := Encode(preprepare)
 				// run each backends and verify handlePreprepare function.
-				if err := c.handlePreprepare(&istanbul.Message{
-					Code:    istanbul.MsgPreprepare,
-					Msg:     m,
-					Address: v0.Address(),
-				}); err != nil {
+				if err := c.handlePreprepare(msg); err != nil {
 					if err != test.expectedErr {
 						t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
 					}
@@ -424,14 +422,9 @@ func TestHandlePreprepare(t *testing.T) {
 					t.Errorf("message code mismatch: have %v, want %v", decodedMsg.Code, expectedCode)
 				}
 
-				var subject *istanbul.Subject
-				var committedSubject *istanbul.CommittedSubject
-
-				if decodedMsg.Code == istanbul.MsgPrepare {
-					err = decodedMsg.Decode(&subject)
-				} else if decodedMsg.Code == istanbul.MsgCommit {
-					err = decodedMsg.Decode(&committedSubject)
-					subject = committedSubject.Subject
+				subject := decodedMsg.Prepare()
+				if decodedMsg.Code == istanbul.MsgCommit {
+					subject = decodedMsg.Commit().Subject
 				}
 
 				if err != nil {
@@ -451,8 +444,8 @@ func TestHandlePreprepare(t *testing.T) {
 				if expectedCode == istanbul.MsgCommit {
 					srcValidator := c.current.GetValidatorByAddress(v.address)
 
-					if err := c.verifyCommittedSeal(committedSubject, srcValidator); err != nil {
-						t.Errorf("invalid seal.  verify commmited seal error: %v, subject: %v, committedSeal: %v", err, expectedSubject, committedSubject.CommittedSeal)
+					if err := c.verifyCommittedSeal(decodedMsg.Commit(), srcValidator); err != nil {
+						t.Errorf("invalid seal.  verify commmited seal error: %v, subject: %v, committedSeal: %v", err, expectedSubject, decodedMsg.Commit().CommittedSeal)
 					}
 				}
 			}

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -444,7 +444,9 @@ func TestHandlePreprepare(t *testing.T) {
 				if expectedCode == istanbul.MsgCommit {
 					srcValidator := c.current.GetValidatorByAddress(v.address)
 
-					if err := c.verifyCommittedSeal(decodedMsg.Commit(), srcValidator); err != nil {
+					commit := decodedMsg.Commit()
+					err := NewCommitSeal(commit.Subject.Digest, commit.Subject.View.Round).Verify(srcValidator.BLSPublicKey(), commit.CommittedSeal)
+					if err != nil {
 						t.Errorf("invalid seal.  verify commmited seal error: %v, subject: %v, committedSeal: %v", err, expectedSubject, decodedMsg.Commit().CommittedSeal)
 					}
 				}

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -117,11 +117,8 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 			return errInvalidRoundChangeCertificateMsgCode
 		}
 
-		var roundChange *istanbul.RoundChange
-		if err := message.Decode(&roundChange); err != nil {
-			logger.Warn("Failed to decode ROUND CHANGE in certificate", "err", err)
-			return err
-		} else if roundChange.View == nil || roundChange.View.Sequence == nil || roundChange.View.Round == nil {
+		roundChange := message.RoundChange()
+		if roundChange.View == nil || roundChange.View.Sequence == nil || roundChange.View.Round == nil {
 			return errInvalidRoundChangeCertificateMsgView
 		}
 
@@ -175,12 +172,7 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 func (c *core) handleRoundChange(msg *istanbul.Message) error {
 	logger := c.newLogger("func", "handleRoundChange", "tag", "handleMsg", "from", msg.Address)
 
-	// Decode ROUND CHANGE message
-	var rc *istanbul.RoundChange
-	if err := msg.Decode(&rc); err != nil {
-		logger.Info("Failed to decode ROUND CHANGE", "err", err)
-		return errInvalidMessage
-	}
+	rc := msg.RoundChange()
 	logger = logger.New("msg_round", rc.View.Round, "msg_seq", rc.View.Sequence)
 
 	// Must be same sequence and future round.

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -29,51 +29,24 @@ import (
 
 // sendRoundChange broadcasts a ROUND CHANGE message with the current desired round.
 func (c *core) sendRoundChange() {
-	logger := c.newLogger("func", "sendRoundChange")
-
-	msg, err := c.buildRoundChangeMsg(c.current.DesiredRound())
-	if err != nil {
-		logger.Error("Could not build round change message", "err", msg)
-		return
-	}
-
-	c.broadcast(msg)
+	c.broadcast(c.buildRoundChangeMsg(c.current.DesiredRound()))
 }
 
 // sendRoundChange sends a ROUND CHANGE message for the current desired round back to a single address
 func (c *core) sendRoundChangeAgain(addr common.Address) {
-	logger := c.newLogger("func", "sendRoundChangeAgain", "to", addr)
-
-	msg, err := c.buildRoundChangeMsg(c.current.DesiredRound())
-	if err != nil {
-		logger.Error("Could not build round change message", "err", err)
-		return
-	}
-
-	c.unicast(msg, addr)
+	c.unicast(c.buildRoundChangeMsg(c.current.DesiredRound()), addr)
 }
 
 // buildRoundChangeMsg creates a round change msg for the given round
-func (c *core) buildRoundChangeMsg(round *big.Int) (*istanbul.Message, error) {
+func (c *core) buildRoundChangeMsg(round *big.Int) *istanbul.Message {
 	nextView := &istanbul.View{
 		Round:    new(big.Int).Set(round),
 		Sequence: new(big.Int).Set(c.current.View().Sequence),
 	}
-
-	rc := &istanbul.RoundChange{
+	return istanbul.NewMessage(&istanbul.RoundChange{
 		View:                nextView,
 		PreparedCertificate: c.current.PreparedCertificate(),
-	}
-
-	payload, err := Encode(rc)
-	if err != nil {
-		return nil, err
-	}
-
-	return &istanbul.Message{
-		Code: istanbul.MsgRoundChange,
-		Msg:  payload,
-	}, nil
+	}, c.address)
 }
 
 func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChangeCertificate istanbul.RoundChangeCertificate) error {

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -266,7 +266,7 @@ func TestHandleRoundChange(t *testing.T) {
 			noopPrepare,
 			func(t *testing.T, sys *testSystem) istanbul.PreparedCertificate {
 				preparedCert := sys.getPreparedCertificate(t, []istanbul.View{*sys.backends[0].engine.(*core).current.View()}, makeBlock(1))
-				preparedCert.PrepareOrCommitMessages[0] = preparedCert.PrepareOrCommitMessages[1]
+				preparedCert.PrepareMessages[0] = preparedCert.PrepareMessages[1]
 				return preparedCert
 			},
 			errInvalidPreparedCertificateDuplicate,

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -336,10 +336,10 @@ func TestHandleRoundChange(t *testing.T) {
 				Sequence: curView.Sequence,
 			}
 
-			roundChange := &istanbul.RoundChange{
+			msg := istanbul.NewMessage(&istanbul.RoundChange{
 				View:                nextView,
 				PreparedCertificate: test.getCert(t, sys),
-			}
+			}, v0.Address())
 
 			for i, v := range sys.backends {
 				// i == 0 is primary backend, it is responsible for send ROUND CHANGE messages to others.
@@ -349,14 +349,8 @@ func TestHandleRoundChange(t *testing.T) {
 
 				c := v.engine.(*core)
 
-				m, _ := Encode(roundChange)
-
 				// run each backends and verify handlePreprepare function.
-				err := c.handleRoundChange(&istanbul.Message{
-					Code:    istanbul.MsgRoundChange,
-					Msg:     m,
-					Address: v0.Address(),
-				})
+				err := c.handleRoundChange(msg)
 				if err != test.expectedErr {
 					t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
 				}

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -39,17 +39,11 @@ func TestRoundChangeSet(t *testing.T) {
 		View:   view,
 		Digest: common.Hash{},
 	}
-	m, _ := Encode(r)
 
 	// Test Add()
 	// Add message from all validators
 	for i, v := range vset.List() {
-		msg := &istanbul.Message{
-			Code:    istanbul.MsgRoundChange,
-			Msg:     m,
-			Address: v.Address(),
-		}
-		rc.Add(view.Round, msg)
+		rc.Add(view.Round, istanbul.NewMessage(r, v.Address()))
 		if rc.msgsForRound[view.Round.Uint64()].Size() != i+1 {
 			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.msgsForRound[view.Round.Uint64()].Size(), i+1)
 		}
@@ -57,12 +51,7 @@ func TestRoundChangeSet(t *testing.T) {
 
 	// Add message again from all validators, but the size should be the same
 	for _, v := range vset.List() {
-		msg := &istanbul.Message{
-			Code:    istanbul.MsgRoundChange,
-			Msg:     m,
-			Address: v.Address(),
-		}
-		rc.Add(view.Round, msg)
+		rc.Add(view.Round, istanbul.NewMessage(r, v.Address()))
 		if rc.msgsForRound[view.Round.Uint64()].Size() != vset.Size() {
 			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.msgsForRound[view.Round.Uint64()].Size(), vset.Size())
 		}
@@ -95,12 +84,7 @@ func TestRoundChangeSet(t *testing.T) {
 	// Test Add()
 	// Add message from all validators
 	for i, v := range vset.List() {
-		msg := &istanbul.Message{
-			Code:    istanbul.MsgRoundChange,
-			Msg:     m,
-			Address: v.Address(),
-		}
-		rc.Add(view.Round, msg)
+		rc.Add(view.Round, istanbul.NewMessage(r, v.Address()))
 		if rc.msgsForRound[view.Round.Uint64()].Size() != i+1 {
 			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.msgsForRound[view.Round.Uint64()].Size(), i+1)
 		}

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -499,6 +499,7 @@ func TestCommitsBlocksAfterRoundChange(t *testing.T) {
 // This tests that when F+1 nodes receive 2F+1 PREPARE messages for a particular proposal, the
 // system enforces that as the only valid proposal for this sequence.
 func TestPreparedCertificatePersistsThroughRoundChanges(t *testing.T) {
+	t.Skip("This test is not working as expected, and was actually committing in the first round")
 	sys := NewTestSystemWithBackend(4, 1)
 
 	for _, b := range sys.backends {

--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -352,8 +352,8 @@ func (rs *roundStateImpl) TransitionToPrepared(quorumSize int) error {
 	}
 
 	rs.preparedCertificate = istanbul.PreparedCertificate{
-		Proposal:                rs.preprepare.Proposal,
-		PrepareOrCommitMessages: messages,
+		Proposal:        rs.preprepare.Proposal,
+		PrepareMessages: messages,
 	}
 	rs.state = StatePrepared
 	return nil

--- a/consensus/istanbul/core/roundstate_save_decorator.go
+++ b/consensus/istanbul/core/roundstate_save_decorator.go
@@ -123,9 +123,6 @@ func (rsp *rsSaveDecorator) PendingRequest() *istanbul.Request { return rsp.rs.P
 // ValidatorSet implements RoundState.ValidatorSet
 func (rsp *rsSaveDecorator) ValidatorSet() istanbul.ValidatorSet { return rsp.rs.ValidatorSet() }
 
-// GetPrepareOrCommitSize implements RoundState.GetPrepareOrCommitSize
-func (rsp *rsSaveDecorator) GetPrepareOrCommitSize() int { return rsp.rs.GetPrepareOrCommitSize() }
-
 // GetValidatorByAddress implements RoundState.GetValidatorByAddress
 func (rsp *rsSaveDecorator) GetValidatorByAddress(address common.Address) istanbul.Validator {
 	return rsp.rs.GetValidatorByAddress(address)

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -158,7 +158,7 @@ func (self *testSystemBackend) Gossip(payload []byte, ethMsgCode uint64) error {
 	return nil
 }
 
-func (self *testSystemBackend) SignBLS(data []byte, extra []byte, useComposite, cip22 bool) (blscrypto.SerializedSignature, error) {
+func (self *testSystemBackend) SignBLS(data []byte, extra []byte, useComposite, cip22 bool) ([]byte, error) {
 	privateKey, _ := bls.DeserializePrivateKey(self.blsKey)
 	defer privateKey.Destroy()
 
@@ -166,7 +166,8 @@ func (self *testSystemBackend) SignBLS(data []byte, extra []byte, useComposite, 
 	defer signature.Destroy()
 	signatureBytes, _ := signature.Serialize()
 
-	return blscrypto.SerializedSignatureFromBytes(signatureBytes)
+	sig, err := blscrypto.SerializedSignatureFromBytes(signatureBytes)
+	return sig[:], err
 }
 
 func (self *testSystemBackend) Commit(proposal istanbul.Proposal, aggregatedSeal types.IstanbulAggregatedSeal, aggregatedEpochValidatorSetSeal types.IstanbulEpochValidatorSetSeal) error {

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -353,20 +353,10 @@ func (self *testSystemBackend) getCommitMessage(view istanbul.View, proposal ist
 }
 
 func (self *testSystemBackend) getRoundChangeMessage(view istanbul.View, preparedCert istanbul.PreparedCertificate) (istanbul.Message, error) {
-	rc := &istanbul.RoundChange{
+	msg := istanbul.NewMessage(&istanbul.RoundChange{
 		View:                &view,
 		PreparedCertificate: preparedCert,
-	}
-
-	payload, err := Encode(rc)
-	if err != nil {
-		return istanbul.Message{}, err
-	}
-
-	msg := &istanbul.Message{
-		Code: istanbul.MsgRoundChange,
-		Msg:  payload,
-	}
+	}, common.Address{})
 
 	return self.finalizeAndReturnMessage(msg)
 }

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -541,8 +541,8 @@ func (t *testSystem) MinQuorumSize() uint64 {
 
 func (sys *testSystem) getPreparedCertificate(t ErrorReporter, views []istanbul.View, proposal istanbul.Proposal) istanbul.PreparedCertificate {
 	preparedCertificate := istanbul.PreparedCertificate{
-		Proposal:                proposal,
-		PrepareOrCommitMessages: []istanbul.Message{},
+		Proposal:        proposal,
+		PrepareMessages: []istanbul.Message{},
 	}
 	for i, backend := range sys.backends {
 		if uint64(i) == sys.MinQuorumSize() {
@@ -558,7 +558,7 @@ func (sys *testSystem) getPreparedCertificate(t ErrorReporter, views []istanbul.
 		if err != nil {
 			t.Errorf("Failed to create message %v: %v", i, err)
 		}
-		preparedCertificate.PrepareOrCommitMessages = append(preparedCertificate.PrepareOrCommitMessages, msg)
+		preparedCertificate.PrepareMessages = append(preparedCertificate.PrepareMessages, msg)
 	}
 	return preparedCertificate
 }

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -299,7 +299,7 @@ func (self *testSystemBackend) getCommitMessage(view istanbul.View, proposal ist
 		Digest: proposal.Hash(),
 	}
 
-	committedSeal, err := self.engine.(*core).generateCommittedSeal(subject)
+	committedSeal, err := NewCommitSeal(subject.Digest, subject.View.Round).Sign(self.engine.(*core).backend.SignBLS)
 	if err != nil {
 		return istanbul.Message{}, err
 	}

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -343,10 +343,6 @@ func (self *testSystemBackend) setVerifyImpl(verifyImpl func(proposal istanbul.P
 	self.verifyImpl = verifyImpl
 }
 
-func (self *testSystemBackend) VerifyAggregatedSeal(headerHash common.Hash, validators istanbul.ValidatorSet, aggregatedSeal types.IstanbulAggregatedSeal) error {
-	return nil
-}
-
 // ==============================================
 //
 // define the struct that need to be provided for integration tests.

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -275,41 +275,20 @@ func (self *testSystemBackend) finalizeAndReturnMessage(msg *istanbul.Message) (
 }
 
 func (self *testSystemBackend) getPreprepareMessage(view istanbul.View, roundChangeCertificate istanbul.RoundChangeCertificate, proposal istanbul.Proposal) (istanbul.Message, error) {
-	preprepare := &istanbul.Preprepare{
+	msg := istanbul.NewMessage(&istanbul.Preprepare{
 		View:                   &view,
 		RoundChangeCertificate: roundChangeCertificate,
 		Proposal:               proposal,
-	}
-
-	payload, err := Encode(preprepare)
-	if err != nil {
-		return istanbul.Message{}, err
-	}
-
-	msg := &istanbul.Message{
-		Code: istanbul.MsgPreprepare,
-		Msg:  payload,
-	}
+	}, self.address)
 
 	return self.finalizeAndReturnMessage(msg)
 }
 
 func (self *testSystemBackend) getPrepareMessage(view istanbul.View, digest common.Hash) (istanbul.Message, error) {
-	prepare := &istanbul.Subject{
+	msg := istanbul.NewMessage(&istanbul.Subject{
 		View:   &view,
 		Digest: digest,
-	}
-
-	payload, err := Encode(prepare)
-	if err != nil {
-		return istanbul.Message{}, err
-	}
-
-	msg := &istanbul.Message{
-		Code: istanbul.MsgPrepare,
-		Msg:  payload,
-	}
-
+	}, self.address)
 	return self.finalizeAndReturnMessage(msg)
 }
 
@@ -324,20 +303,10 @@ func (self *testSystemBackend) getCommitMessage(view istanbul.View, proposal ist
 		return istanbul.Message{}, err
 	}
 
-	committedSubject := &istanbul.CommittedSubject{
+	msg := istanbul.NewMessage(&istanbul.CommittedSubject{
 		Subject:       subject,
 		CommittedSeal: committedSeal[:],
-	}
-
-	payload, err := Encode(committedSubject)
-	if err != nil {
-		return istanbul.Message{}, err
-	}
-
-	msg := &istanbul.Message{
-		Code: istanbul.MsgCommit,
-		Msg:  payload,
-	}
+	}, self.address)
 
 	// // We swap in the provided proposal so that the message is finalized for the provided proposal
 	// // and not for the current preprepare.

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -383,6 +383,10 @@ func (self *testSystemBackend) setVerifyImpl(verifyImpl func(proposal istanbul.P
 	self.verifyImpl = verifyImpl
 }
 
+func (self *testSystemBackend) VerifyAggregatedSeal(headerHash common.Hash, validators istanbul.ValidatorSet, aggregatedSeal types.IstanbulAggregatedSeal) error {
+	return nil
+}
+
 // ==============================================
 //
 // define the struct that need to be provided for integration tests.

--- a/consensus/istanbul/core/testutils_test.go
+++ b/consensus/istanbul/core/testutils_test.go
@@ -86,5 +86,5 @@ func assertEqualRoundState(t *testing.T, have, want RoundState) {
 	havePPBlock := have.PreparedCertificate().Proposal
 	wantPPBlock := want.PreparedCertificate().Proposal
 	testEqual("PreparedCertificate().Proposal.Hash", havePPBlock.Hash(), wantPPBlock.Hash())
-	testEqual("PreparedCertificate().PrepareOrCommitMessages", have.PreparedCertificate().PrepareOrCommitMessages, want.PreparedCertificate().PrepareOrCommitMessages)
+	testEqual("PreparedCertificate().PrepareOrCommitMessages", have.PreparedCertificate().PrepareMessages, want.PreparedCertificate().PrepareMessages)
 }

--- a/consensus/istanbul/core/types_test.go
+++ b/consensus/istanbul/core/types_test.go
@@ -52,12 +52,7 @@ func testPreprepare(t *testing.T) {
 		t.Errorf("error mismatch: have %v, want nil", err)
 	}
 
-	var decodedPP *istanbul.Preprepare
-	err = decodedMsg.Decode(&decodedPP)
-	if err != nil {
-		t.Errorf("error mismatch: have %v, want nil", err)
-	}
-
+	decodedPP := decodedMsg.Preprepare()
 	// if block is encoded/decoded by rlp, we cannot to compare interface data type using reflect.DeepEqual. (like istanbul.Proposal)
 	// so individual comparison here.
 	if !reflect.DeepEqual(pp.Proposal.Hash(), decodedPP.Proposal.Hash()) {
@@ -101,14 +96,8 @@ func testSubject(t *testing.T) {
 		t.Errorf("error mismatch: have %v, want nil", err)
 	}
 
-	var decodedSub *istanbul.Subject
-	err = decodedMsg.Decode(&decodedSub)
-	if err != nil {
-		t.Errorf("error mismatch: have %v, want nil", err)
-	}
-
-	if !reflect.DeepEqual(s, decodedSub) {
-		t.Errorf("subject mismatch: have %v, want %v", decodedSub, s)
+	if !reflect.DeepEqual(s, decodedMsg.Prepare()) {
+		t.Errorf("subject mismatch: have %v, want %v", decodedMsg.Prepare(), s)
 	}
 }
 

--- a/consensus/istanbul/proxy/forward_message.go
+++ b/consensus/istanbul/proxy/forward_message.go
@@ -90,13 +90,7 @@ func (p *proxyEngine) handleForwardMsg(peer consensus.Peer, payload []byte) (boo
 		return true, errUnauthorizedMessageFromProxiedValidator
 	}
 
-	var fwdMsg *istanbul.ForwardMessage
-	err := istMsg.Decode(&fwdMsg)
-	if err != nil {
-		logger.Error("Failed to decode a ForwardMessage", "from", peer.Node().ID(), "err", err)
-		return true, err
-	}
-
+	fwdMsg := istMsg.ForwardMessage()
 	logger.Trace("Forwarding a message", "msg code", fwdMsg.Code)
 	if err := p.backend.Multicast(fwdMsg.DestAddresses, fwdMsg.Msg, fwdMsg.Code, false); err != nil {
 		logger.Error("Error in multicasting a forwarded message", "error", err)

--- a/consensus/istanbul/proxy/forward_message.go
+++ b/consensus/istanbul/proxy/forward_message.go
@@ -20,7 +20,6 @@ import (
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
-	"github.com/celo-org/celo-blockchain/rlp"
 )
 
 func (pv *proxiedValidatorEngine) sendForwardMsg(ps *proxySet, destAddresses []common.Address, ethMsgCode uint64, payload []byte) error {
@@ -33,18 +32,11 @@ func (pv *proxiedValidatorEngine) sendForwardMsg(ps *proxySet, destAddresses []c
 		if proxy.IsPeered() {
 
 			// Convert the message to a fwdMessage
-			fwdMessage := &istanbul.ForwardMessage{
+			msg := istanbul.NewMessage(&istanbul.ForwardMessage{
 				Code:          ethMsgCode,
 				DestAddresses: destAddresses,
 				Msg:           payload,
-			}
-			fwdMsgBytes, err := rlp.EncodeToBytes(fwdMessage)
-			if err != nil {
-				logger.Error("Failed to encode", "fwdMessage", fwdMessage)
-				return err
-			}
-
-			msg := istanbul.Message{Code: istanbul.FwdMsg, Msg: fwdMsgBytes, Address: pv.backend.Address()}
+			}, pv.backend.Address())
 
 			// Sign the message
 			if err := msg.Sign(pv.backend.Sign); err != nil {

--- a/consensus/istanbul/proxy/proxy_engine_test.go
+++ b/consensus/istanbul/proxy/proxy_engine_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/celo-org/celo-blockchain/consensus/istanbul/backend/backendtest"
 	"github.com/celo-org/celo-blockchain/crypto"
 	"github.com/celo-org/celo-blockchain/p2p"
-	"github.com/celo-org/celo-blockchain/rlp"
 	"github.com/davecgh/go-spew/spew"
 )
 
@@ -188,19 +187,10 @@ func testEnodeCertFromRemoteVal(t *testing.T, valBE BackendForProxiedValidatorEn
 }
 
 func testEnodeCertFromUnelectedRemoteVal(t *testing.T, unelectedValBE BackendForProxiedValidatorEngine, unelectedValKey *ecdsa.PrivateKey, unelectedValPeer consensus.Peer, proxyBEi backendtest.TestBackendInterface) {
-	unelectedValEC := &istanbul.EnodeCertificate{
+	ecMsg := istanbul.NewMessage(&istanbul.EnodeCertificate{
 		EnodeURL: unelectedValBE.SelfNode().URLv4(),
 		Version:  1,
-	}
-	ecBytes, err := rlp.EncodeToBytes(unelectedValEC)
-	if err != nil {
-		t.Errorf("Error in encoding enode certificate.  Error: %v", err)
-	}
-	ecMsg := &istanbul.Message{
-		Code:    istanbul.EnodeCertificateMsg,
-		Address: unelectedValBE.Address(),
-		Msg:     ecBytes,
-	}
+	}, unelectedValBE.Address())
 	// Sign the message
 	if err := ecMsg.Sign(func(data []byte) ([]byte, error) {
 		return crypto.Sign(crypto.Keccak256(data), unelectedValKey)

--- a/consensus/istanbul/proxy/types.go
+++ b/consensus/istanbul/proxy/types.go
@@ -19,14 +19,12 @@ package proxy
 import (
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/p2p/enode"
-	"github.com/celo-org/celo-blockchain/rlp"
 )
 
 var (
@@ -182,52 +180,4 @@ type ProxiedValidatorInfo struct {
 	Address  common.Address `json:"address"`
 	IsPeered bool           `json:"isPeered"`
 	Node     *enode.Node    `json:"enodeURL"`
-}
-
-// ==============================================
-//
-// define the validator enode share message
-
-type sharedValidatorEnode struct {
-	Address  common.Address
-	EnodeURL string
-	Version  uint
-}
-
-type valEnodesShareData struct {
-	ValEnodes []sharedValidatorEnode
-}
-
-func (sve *sharedValidatorEnode) String() string {
-	return fmt.Sprintf("{Address: %s, EnodeURL: %v, Version: %v}", sve.Address.Hex(), sve.EnodeURL, sve.Version)
-}
-
-func (sd *valEnodesShareData) String() string {
-	outputStr := "{ValEnodes:"
-	for _, valEnode := range sd.ValEnodes {
-		outputStr = fmt.Sprintf("%s %s", outputStr, valEnode.String())
-	}
-	return fmt.Sprintf("%s}", outputStr)
-}
-
-// ==============================================
-//
-// define the functions that needs to be provided for rlp Encoder/Decoder.
-
-// EncodeRLP serializes sd into the Ethereum RLP format.
-func (sd *valEnodesShareData) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{sd.ValEnodes})
-}
-
-// DecodeRLP implements rlp.Decoder, and load the sd fields from a RLP stream.
-func (sd *valEnodesShareData) DecodeRLP(s *rlp.Stream) error {
-	var msg struct {
-		ValEnodes []sharedValidatorEnode
-	}
-
-	if err := s.Decode(&msg); err != nil {
-		return err
-	}
-	sd.ValEnodes = msg.ValEnodes
-	return nil
 }

--- a/consensus/istanbul/proxy/val_enodes_share.go
+++ b/consensus/istanbul/proxy/val_enodes_share.go
@@ -51,22 +51,9 @@ func (pv *proxiedValidatorEngine) generateValEnodesShareMsg(remoteValidators []c
 		})
 	}
 
-	valEnodesShareData := &istanbul.ValEnodesShareData{
+	msg := istanbul.NewMessage(&istanbul.ValEnodesShareData{
 		ValEnodes: sharedValidatorEnodes,
-	}
-
-	valEnodesShareBytes, err := rlp.EncodeToBytes(valEnodesShareData)
-	if err != nil {
-		logger.Error("Error encoding Istanbul Validator Enodes Share message content", "istanbul.ValEnodesShareData", valEnodesShareData.String(), "err", err)
-		return nil, err
-	}
-
-	msg := &istanbul.Message{
-		Code:      istanbul.ValEnodesShareMsg,
-		Msg:       valEnodesShareBytes,
-		Address:   pv.backend.Address(),
-		Signature: []byte{},
-	}
+	}, pv.backend.Address())
 
 	// Sign the validator enode share message
 	if err := msg.Sign(pv.backend.Sign); err != nil {
@@ -74,7 +61,7 @@ func (pv *proxiedValidatorEngine) generateValEnodesShareMsg(remoteValidators []c
 		return nil, err
 	}
 
-	logger.Trace("Generated a Istanbul Validator Enodes Share message", "IstanbulMsg", msg.String(), "istanbul.ValEnodesShareData", valEnodesShareData.String())
+	logger.Trace("Generated a Istanbul Validator Enodes Share message", "IstanbulMsg", msg.String(), "istanbul.ValEnodesShareData", msg.ValEnodesShareData().String())
 
 	return msg, nil
 }

--- a/consensus/istanbul/proxy/val_enodes_share.go
+++ b/consensus/istanbul/proxy/val_enodes_share.go
@@ -39,25 +39,25 @@ func (pv *proxiedValidatorEngine) generateValEnodesShareMsg(remoteValidators []c
 		return nil, err
 	}
 
-	sharedValidatorEnodes := make([]sharedValidatorEnode, 0, len(vetEntries))
+	sharedValidatorEnodes := make([]istanbul.SharedValidatorEnode, 0, len(vetEntries))
 	for address, vetEntry := range vetEntries {
 		if vetEntry.GetNode() == nil {
 			continue
 		}
-		sharedValidatorEnodes = append(sharedValidatorEnodes, sharedValidatorEnode{
+		sharedValidatorEnodes = append(sharedValidatorEnodes, istanbul.SharedValidatorEnode{
 			Address:  address,
 			EnodeURL: vetEntry.GetNode().String(),
 			Version:  vetEntry.GetVersion(),
 		})
 	}
 
-	valEnodesShareData := &valEnodesShareData{
+	valEnodesShareData := &istanbul.ValEnodesShareData{
 		ValEnodes: sharedValidatorEnodes,
 	}
 
 	valEnodesShareBytes, err := rlp.EncodeToBytes(valEnodesShareData)
 	if err != nil {
-		logger.Error("Error encoding Istanbul Validator Enodes Share message content", "ValEnodesShareData", valEnodesShareData.String(), "err", err)
+		logger.Error("Error encoding Istanbul Validator Enodes Share message content", "istanbul.ValEnodesShareData", valEnodesShareData.String(), "err", err)
 		return nil, err
 	}
 
@@ -74,7 +74,7 @@ func (pv *proxiedValidatorEngine) generateValEnodesShareMsg(remoteValidators []c
 		return nil, err
 	}
 
-	logger.Trace("Generated a Istanbul Validator Enodes Share message", "IstanbulMsg", msg.String(), "ValEnodesShareData", valEnodesShareData.String())
+	logger.Trace("Generated a Istanbul Validator Enodes Share message", "IstanbulMsg", msg.String(), "istanbul.ValEnodesShareData", valEnodesShareData.String())
 
 	return msg, nil
 }
@@ -138,7 +138,7 @@ func (p *proxyEngine) handleValEnodesShareMsg(peer consensus.Peer, payload []byt
 		return true, errUnauthorizedMessageFromProxiedValidator
 	}
 
-	var valEnodesShareData valEnodesShareData
+	var valEnodesShareData istanbul.ValEnodesShareData
 	err = rlp.DecodeBytes(msg.Msg, &valEnodesShareData)
 	if err != nil {
 		logger.Error("Error in decoding received Istanbul Validator Enodes Share message content", "err", err, "IstanbulMsg", msg.String())

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -630,9 +630,26 @@ func (m *Message) QueryEnodeMsg() *QueryEnodeData {
 	return m.queryEnode
 }
 
-// QueryEnode returns forward message if this is a forward message.
+// ForwardMessage returns forward message if this is a forward message.
 func (m *Message) ForwardMessage() *ForwardMessage {
 	return m.forwardMessage
+}
+
+// EnodeCertificate returns the enode certificate if this is an enode
+// certificate message
+func (m *Message) EnodeCertificate() *EnodeCertificate {
+	return m.enodeCertificate
+}
+
+// VersionCertificates returns the version certificate entries if this is a
+// version certificates message.
+func (m *Message) VersionCertificates() []*VersionCertificateEntry {
+	return m.versionCertificates
+}
+
+// ValEnodesShareData returns val enode share data if this is a val enodes share message.
+func (m *Message) ValEnodesShareData() *ValEnodesShareData {
+	return m.valEnodeShareData
 }
 
 func (m *Message) Copy() *Message {

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -506,16 +506,6 @@ func (m *Message) DecodeRLP(stream *rlp.Stream) error {
 			return err
 		}
 		m.prePrepare = p
-		// msgs := p.RoundChangeCertificate.RoundChangeMessages
-		// for i, m := range msgs {
-		// 	msg := &m
-		// 	bytes, err := rlp.EncodeToBytes(msg)
-		// 	if err != nil {
-		// 		return err
-		// 	}
-		// 	msg.FromPayload(bytes, nil)
-		// 	msgs[i] = *msg
-		// }
 	case MsgPrepare:
 		var p *Subject
 		err = m.decode(&p)
@@ -531,16 +521,6 @@ func (m *Message) DecodeRLP(stream *rlp.Stream) error {
 			return err
 		}
 		m.roundChange = p
-		// msgs := p.PreparedCertificate.PrepareOrCommitMessages
-		// for i, m := range msgs {
-		// 	msg := &m
-		// 	bytes, err := rlp.EncodeToBytes(msg)
-		// 	if err != nil {
-		// 		return err
-		// 	}
-		// 	msg.FromPayload(bytes, nil)
-		// 	msgs[i] = *msg
-		// }
 	case QueryEnodeMsg:
 		var q *QueryEnodeData
 		err = m.decode(&q)

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -195,8 +195,8 @@ func (pp *Preprepare) DecodeRLP(s *rlp.Stream) error {
 // ## PreparedCertificate #####################################################
 
 type PreparedCertificate struct {
-	Proposal                Proposal
-	PrepareOrCommitMessages []Message
+	Proposal        Proposal
+	PrepareMessages []Message
 }
 
 type PreparedCertificateData struct {
@@ -221,25 +221,25 @@ func EmptyPreparedCertificate() PreparedCertificate {
 	block = block.WithEpochSnarkData(&types.EmptyEpochSnarkData)
 
 	return PreparedCertificate{
-		Proposal:                block.WithSeal(emptyHeader),
-		PrepareOrCommitMessages: []Message{},
+		Proposal:        block.WithSeal(emptyHeader),
+		PrepareMessages: []Message{},
 	}
 }
 
 func (pc *PreparedCertificate) IsEmpty() bool {
-	return len(pc.PrepareOrCommitMessages) == 0
+	return len(pc.PrepareMessages) == 0
 }
 
 func (pc *PreparedCertificate) AsData() *PreparedCertificateData {
 	return &PreparedCertificateData{
 		Proposal:                pc.Proposal.(*types.Block),
-		PrepareOrCommitMessages: pc.PrepareOrCommitMessages,
+		PrepareOrCommitMessages: pc.PrepareMessages,
 	}
 }
 
 func (pc *PreparedCertificate) Summary() *PreparedCertificateSummary {
 	var prepareSenders, commitSenders []common.Address
-	for _, msg := range pc.PrepareOrCommitMessages {
+	for _, msg := range pc.PrepareMessages {
 		if msg.Code == MsgPrepare {
 			prepareSenders = append(prepareSenders, msg.Address)
 		} else {
@@ -267,7 +267,7 @@ func (pc *PreparedCertificate) DecodeRLP(s *rlp.Stream) error {
 	if err := s.Decode(&data); err != nil {
 		return err
 	}
-	pc.PrepareOrCommitMessages, pc.Proposal = data.PrepareOrCommitMessages, data.Proposal
+	pc.PrepareMessages, pc.Proposal = data.PrepareOrCommitMessages, data.Proposal
 	return nil
 
 }

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -319,6 +319,20 @@ type CommittedSubject struct {
 	Subject               *Subject
 	CommittedSeal         []byte
 	EpochValidatorSetSeal []byte
+	// Cahed result of validating the committed seal
+	committedSealValid bool
+}
+
+// CommittedSealValid returns true if the committed seal is valid, and false if
+// the committed seal has not yet been validated.
+func (c *CommittedSubject) CommittedSealValid() bool {
+	return c.committedSealValid
+}
+
+// SetCommittedSealValid marks this committed subject as having a valid
+// committed seal.
+func (c *CommittedSubject) SetCommittedSealValid() {
+	c.committedSealValid = true
 }
 
 // ## ForwardMessage #################################################################

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -321,18 +321,32 @@ type CommittedSubject struct {
 	EpochValidatorSetSeal []byte
 	// Cahed result of validating the committed seal
 	committedSealValid bool
+	// Cahed result of validating the epoch seal
+	epochSealValid bool
+}
+
+// CommittedSealVerified returns true if the committed seal is valid, and false if
+// the committed seal has not yet been validated.
+func (c *CommittedSubject) CommittedSealVerified() bool {
+	return c.committedSealValid
+}
+
+// SetCommittedSealVerified marks this committed subject as having a valid
+// committed seal.
+func (c *CommittedSubject) SetCommittedSealVerified() {
+	c.committedSealValid = true
 }
 
 // CommittedSealValid returns true if the committed seal is valid, and false if
 // the committed seal has not yet been validated.
-func (c *CommittedSubject) CommittedSealValid() bool {
-	return c.committedSealValid
+func (c *CommittedSubject) EpochSealVerified() bool {
+	return c.epochSealValid
 }
 
-// SetCommittedSealValid marks this committed subject as having a valid
+// SetEpochSealVerified marks this committed subject as having a valid
 // committed seal.
-func (c *CommittedSubject) SetCommittedSealValid() {
-	c.committedSealValid = true
+func (c *CommittedSubject) SetEpochSealVerified() {
+	c.epochSealValid = true
 }
 
 // ## ForwardMessage #################################################################

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -562,7 +562,7 @@ func (m *Message) DecodeRLP(stream *rlp.Stream) error {
 		err = m.decode(&v)
 		m.valEnodeShareData = v
 	default:
-		err = fmt.Errorf("unrecognised message code %q", m.Code)
+		err = fmt.Errorf("unrecognised message code %d", m.Code)
 	}
 	return err
 
@@ -574,81 +574,6 @@ func (m *Message) DecodeRLP(stream *rlp.Stream) error {
 func (m *Message) FromPayload(b []byte, validateFn func([]byte, []byte) (common.Address, error)) error {
 	// Decode Message
 	err := rlp.DecodeBytes(b, &m)
-	if err != nil {
-		return err
-	}
-
-	if len(m.Msg) == 0 && len(m.Signature) == 0 {
-		// Empty validator handshake message
-		return nil
-	}
-
-	switch m.Code {
-	case MsgPreprepare:
-		var p *Preprepare
-		err = m.decode(&p)
-		if err != nil {
-			return err
-		}
-		m.prePrepare = p
-		msgs := p.RoundChangeCertificate.RoundChangeMessages
-		for i, m := range msgs {
-			msg := &m
-			bytes, err := rlp.EncodeToBytes(msg)
-			if err != nil {
-				return err
-			}
-			msg.FromPayload(bytes, nil)
-			msgs[i] = *msg
-		}
-	case MsgPrepare:
-		var p *Subject
-		err = m.decode(&p)
-		m.prepare = p
-	case MsgCommit:
-		var cs *CommittedSubject
-		err = m.decode(&cs)
-		m.committedSubject = cs
-	case MsgRoundChange:
-		var p *RoundChange
-		err = m.decode(&p)
-		if err != nil {
-			return err
-		}
-		m.roundChange = p
-		msgs := p.PreparedCertificate.PrepareOrCommitMessages
-		for i, m := range msgs {
-			msg := &m
-			bytes, err := rlp.EncodeToBytes(msg)
-			if err != nil {
-				return err
-			}
-			msg.FromPayload(bytes, nil)
-			msgs[i] = *msg
-		}
-	case QueryEnodeMsg:
-		var q *QueryEnodeData
-		err = m.decode(&q)
-		m.queryEnode = q
-	case FwdMsg:
-		var f *ForwardMessage
-		err = m.decode(&f)
-		m.forwardMessage = f
-	case EnodeCertificateMsg:
-		var e *EnodeCertificate
-		err = m.decode(&e)
-		m.enodeCertificate = e
-	case VersionCertificatesMsg:
-		var v []*VersionCertificate
-		err = m.decode(&v)
-		m.versionCertificates = v
-	case ValEnodesShareMsg:
-		var v *ValEnodesShareData
-		err = m.decode(&v)
-		m.valEnodeShareData = v
-	default:
-		err = fmt.Errorf("unrecognised message code %q", m.Code)
-	}
 	if err != nil {
 		return err
 	}

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -116,8 +116,8 @@ func dummyRoundChangeCertificate() *RoundChangeCertificate {
 
 func dummyPreparedCertificate() *PreparedCertificate {
 	return &PreparedCertificate{
-		PrepareOrCommitMessages: []Message{*dummyMessage(42), *dummyMessage(32), *dummyMessage(15)},
-		Proposal:                dummyBlock(1),
+		PrepareMessages: []Message{*dummyMessage(42), *dummyMessage(32), *dummyMessage(15)},
+		Proposal:        dummyBlock(1),
 	}
 }
 
@@ -218,7 +218,7 @@ func TestPreparedCertificateRLPEncoding(t *testing.T) {
 	}
 
 	// decoded Blocks don't equal Original ones so we need to check equality differently
-	assertEqual(t, "RLP Encode/Decode mismatch: PrepareOrCommitMessages", result.PrepareOrCommitMessages, original.PrepareOrCommitMessages)
+	assertEqual(t, "RLP Encode/Decode mismatch: PrepareOrCommitMessages", result.PrepareMessages, original.PrepareMessages)
 	assertEqual(t, "RLP Encode/Decode mismatch: BlockHash", result.Proposal.Hash(), original.Proposal.Hash())
 }
 
@@ -240,7 +240,7 @@ func TestRoundChangeRLPEncoding(t *testing.T) {
 
 	// decoded Blocks don't equal Original ones so we need to check equality differently
 	assertEqual(t, "RLP Encode/Decode mismatch: View", result.View, original.View)
-	assertEqual(t, "RLP Encode/Decode mismatch: PreparedCertificate.PrepareOrCommitMessages", result.PreparedCertificate.PrepareOrCommitMessages, original.PreparedCertificate.PrepareOrCommitMessages)
+	assertEqual(t, "RLP Encode/Decode mismatch: PreparedCertificate.PrepareOrCommitMessages", result.PreparedCertificate.PrepareMessages, original.PreparedCertificate.PrepareMessages)
 	assertEqual(t, "RLP Encode/Decode mismatch: PreparedCertificate.BlockHash", result.PreparedCertificate.Proposal.Hash(), original.PreparedCertificate.Proposal.Hash())
 }
 

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -101,13 +101,13 @@ func dummyBlock(number int64) *types.Block {
 	return types.NewBlock(header, []*types.Transaction{tx}, nil, nil)
 }
 func dummyMessage(code uint64) *Message {
-	return &Message{
-		Code:      code,
-		Address:   common.HexToAddress("AABB"),
-		Msg:       []byte{10, 20, 42},
-		Signature: []byte{30, 40, 52},
-	}
+	msg := NewMessage(dummySubject(), common.HexToAddress("AABB"))
+	// Set empty rather than nil signature since this is how rlp decodes non
+	// existent slices.
+	msg.Signature = []byte{}
+	return msg
 }
+
 func dummyRoundChangeCertificate() *RoundChangeCertificate {
 	return &RoundChangeCertificate{
 		RoundChangeMessages: []Message{*dummyMessage(42), *dummyMessage(32), *dummyMessage(15)},

--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -145,32 +145,6 @@ func PrivateToPublic(privateKeyBytes []byte) (SerializedPublicKey, error) {
 	return pubKeyBytesFixed, nil
 }
 
-func VerifyAggregatedSignature(publicKeys []SerializedPublicKey, message []byte, extraData []byte, signature []byte, shouldUseCompositeHasher, cip22 bool) error {
-	publicKeyObjs := []*bls.PublicKey{}
-	for _, publicKey := range publicKeys {
-		publicKeyObj, err := bls.DeserializePublicKeyCached(publicKey[:])
-		if err != nil {
-			return err
-		}
-		defer publicKeyObj.Destroy()
-		publicKeyObjs = append(publicKeyObjs, publicKeyObj)
-	}
-	apk, err := bls.AggregatePublicKeys(publicKeyObjs)
-	if err != nil {
-		return err
-	}
-	defer apk.Destroy()
-
-	signatureObj, err := bls.DeserializeSignature(signature)
-	if err != nil {
-		return err
-	}
-	defer signatureObj.Destroy()
-
-	err = apk.VerifySignature(message, extraData, signatureObj, shouldUseCompositeHasher, cip22)
-	return err
-}
-
 func AggregateSignatures(signatures [][]byte) ([]byte, error) {
 	signatureObjs := []*bls.Signature{}
 	for _, signature := range signatures {

--- a/crypto/bls/bls.go
+++ b/crypto/bls/bls.go
@@ -176,7 +176,7 @@ func AggregateSignatures(signatures [][]byte) ([]byte, error) {
 	for _, signature := range signatures {
 		signatureObj, err := bls.DeserializeSignature(signature)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to deserialize signature: %v", err)
 		}
 		defer signatureObj.Destroy()
 		signatureObjs = append(signatureObjs, signatureObj)
@@ -184,13 +184,13 @@ func AggregateSignatures(signatures [][]byte) ([]byte, error) {
 
 	asig, err := bls.AggregateSignatures(signatureObjs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to aggregate signatures: %v", err)
 	}
 	defer asig.Destroy()
 
 	asigBytes, err := asig.Serialize()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to serialize aggregate signature: %v", err)
 	}
 
 	return asigBytes, nil


### PR DESCRIPTION
### Description

This PR modifies the processing of consensus commit messages so that instead of individually having their BLS signatures verified they now have their signatures verified in aggregate (takes approximately the same time as a single signature verification regardless of the number of signatures aggregated see [here](https://www.notion.so/clabsco/Aggregated-BLS-signature-verification-for-commit-messages-a837c2aac87040cbb08b9fc518c4f701) for more depth).

The reason for doing this is to improve performance, since BLS signature verification is costly and this was identified as a bottleneck in the commit phase of consensus.

The aggregate signature verification occurs once a quorum of commit messages is received by a node, if that fails, the node reverts to checking commit message signatures individually and then building an aggregate from those.

A side effect of this approach is that now, commit messages cannot count towards the transition from preprepared to prepared, because the only point at which we know we have valid commit messages is when we are completing the commit phase. This may impact the performance of the consensus algorithm because it may delay nodes in reaching the prepared phase.

### Other changes

Added a benchmark of BLS signature verification.

### Tested

Tested with a local mycelo testnet, both this branch and a branch where validators introduce bad signatures, see the python notebook [here](https://colab.research.google.com/drive/1LIT-mw8mN7XnSo554ukaL7WwyCIiO-Br#scrollTo=bFMW0TQ2XBPC) for more detail and instructions to recreate. The results showed a small improvement in overall performance.

Also performance tested on 3 large scale networks with 100 validators (80 with proxies). I used 3 different branches for this test:

* [baseline](https://github.com/celo-org/celo-blockchain/tree/piersy/benchmark%2Fbls-aggregate-verification_baseline) - The branch point.
* [good](https://github.com/celo-org/celo-blockchain/tree/piersy/benchmark%2Fbls-aggregate-verification_good) - Essentially these changes but with extra timing metrics.
* [bad-signatures](https://github.com/celo-org/celo-blockchain/tree/piersy/benchmark%2Fbls-aggregate-verification_bad-signatures) - A version where validators produce invalid signatures roughly 1/8th of the time.

None of these tests had any transaction load being applied since the performance enhancement is an improvement of the consensus handling code, so leaving out transactional load gives a clearer view of the gains provided by this change.

I measured 3 metrics for this testing, sleep time (how long do nodes sleep before processing the next block), block period (time between blocks) and consensus time (time between node sending first prepare message to the point they start the next round).

Results of this testing are:

| Branch | Sleep time | Block period | Consensus time | 
| ------------- | ------------- | ------------- | ------------- |
| baseline  | 4.452s  | 5.0375s  | 597ms  |
| good | 4.718s   | 5.042  | 283ms  |
| bad-signatures | 4.490  |5.035s | 1.128s  |

So we can see that we have a saving of 314ms in consensus time from the baseline to the good implementation but that translates into 266ms increase in sleep time. Strangely for the bad-signatures despite consensus time almost doubling (an extra ~530ms)  compared to the baseline the sleep time only reduced by ~40ms compared to the baseline.

Block period doesn't seem to be much affected, although oddly seems to be longer when performing the only aggregate signature verification.

## Related issues

- Fixes #1474
- Fixes #1434 
### Backwards compatibility

This should be backwards compatible, no external/public APIs have changed and the block structure or validation rules have not changed.
