### PR TITLE
mycelo: support new etherbase and tx-fee-recipient flags

### DIFF
--- a/mycelo/cluster/cluster.go
+++ b/mycelo/cluster/cluster.go
@@ -75,13 +75,13 @@ func (cl *Cluster) ensureNodes() []*Node {
 		cl.nodes = make([]*Node, len(validators))
 		for i, validator := range validators {
 			nodeConfig := &NodeConfig{
-				GethPath:   cl.config.GethPath,
-				ExtraFlags: cl.config.ExtraFlags,
-				Number:     i,
-				Account:    validator,
+				GethPath:              cl.config.GethPath,
+				ExtraFlags:            cl.config.ExtraFlags,
+				Number:                i,
+				Account:               validator,
 				TxFeeRecipientAccount: txFeeRecipients[i],
-				Datadir:    cl.env.ValidatorDatadir(i),
-				ChainID:    cl.env.Config.ChainID,
+				Datadir:               cl.env.ValidatorDatadir(i),
+				ChainID:               cl.env.Config.ChainID,
 			}
 			cl.nodes[i] = NewNode(nodeConfig)
 		}

--- a/mycelo/cluster/cluster.go
+++ b/mycelo/cluster/cluster.go
@@ -71,6 +71,7 @@ func (cl *Cluster) ensureNodes() []*Node {
 
 	if cl.nodes == nil {
 		validators := cl.env.Accounts().ValidatorAccounts()
+		txFeeRecipients := cl.env.Accounts().TxFeeRecipientAccounts()
 		cl.nodes = make([]*Node, len(validators))
 		for i, validator := range validators {
 			nodeConfig := &NodeConfig{
@@ -78,6 +79,7 @@ func (cl *Cluster) ensureNodes() []*Node {
 				ExtraFlags: cl.config.ExtraFlags,
 				Number:     i,
 				Account:    validator,
+				TxFeeRecipientAccount: txFeeRecipients[i],
 				Datadir:    cl.env.ValidatorDatadir(i),
 				ChainID:    cl.env.Config.ChainID,
 			}

--- a/mycelo/cluster/node.go
+++ b/mycelo/cluster/node.go
@@ -25,13 +25,14 @@ import (
 
 // NodeConfig represents the configuration of a celo-blockchain node runner
 type NodeConfig struct {
-	GethPath      string
-	ExtraFlags    string
-	ChainID       *big.Int
-	Number        int
-	Account       env.Account
-	OtherAccounts []env.Account
-	Datadir       string
+	GethPath              string
+	ExtraFlags            string
+	ChainID               *big.Int
+	Number                int
+	Account               env.Account
+	TxFeeRecipientAccount env.Account
+	OtherAccounts         []env.Account
+	Datadir               string
 }
 
 // RPCPort is the rpc port this node will use
@@ -165,7 +166,8 @@ func (n *Node) Run(ctx context.Context) error {
 		"--rpcport", strconv.FormatInt(n.RPCPort(), 10),
 		"--rpcapi", "eth,net,web3,debug,admin,personal",
 		// "--nodiscover", "--nousb ",
-		"--etherbase", n.Account.Address.Hex(),
+		"--miner.validator", n.Account.Address.Hex(),
+		"--tx-fee-recipient", n.TxFeeRecipientAccount.Address.Hex(),
 		"--unlock", addressToUnlock,
 		"--password", n.pwdFile(),
 	}

--- a/mycelo/cluster/node.go
+++ b/mycelo/cluster/node.go
@@ -164,7 +164,7 @@ func (n *Node) Run(ctx context.Context) error {
 		"--rpc",
 		"--rpcaddr", "127.0.0.1",
 		"--rpcport", strconv.FormatInt(n.RPCPort(), 10),
-		"--rpcapi", "eth,net,web3,debug,admin,personal",
+		"--rpcapi", "eth,net,web3,debug,admin,personal,istanbul",
 		// "--nodiscover", "--nousb ",
 		"--miner.validator", n.Account.Address.Hex(),
 		"--tx-fee-recipient", n.TxFeeRecipientAccount.Address.Hex(),

--- a/mycelo/env/accounts.go
+++ b/mycelo/env/accounts.go
@@ -123,15 +123,17 @@ var (
 	ValidatorAT      AccountType = 0
 	DeveloperAT      AccountType = 1 // load test
 	TxNodeAT         AccountType = 2
-	FaucetAT         AccountType = 3
-	AttestationAT    AccountType = 4
-	PriceOracleAT    AccountType = 5
-	ProxyAT          AccountType = 6
-	AttestationBotAT AccountType = 7
-	VotingBotAT      AccountType = 8
-	TxNodePrivateAT  AccountType = 9
-	ValidatorGroupAT AccountType = 10 // Not in celotool
-	AdminAT          AccountType = 11 // Not in celotool
+	BootnodeAT       AccountType = 3
+	FaucetAT         AccountType = 4
+	AttestationAT    AccountType = 5
+	PriceOracleAT    AccountType = 6
+	ProxyAT          AccountType = 7
+	AttestationBotAT AccountType = 8
+	VotingBotAT      AccountType = 9
+	TxNodePrivateAT  AccountType = 10
+	ValidatorGroupAT AccountType = 11 // Not in celotool (yet)
+	AdminAT          AccountType = 12 // Not in celotool (yet)
+	TxFeeRecipientAT AccountType = 13 // Not in celotool (yet)
 )
 
 // String implements the stringer interface.

--- a/mycelo/env/types.go
+++ b/mycelo/env/types.go
@@ -69,6 +69,15 @@ func (ac *AccountsConfig) ValidatorAccounts() []Account {
 	return accounts
 }
 
+// ValidatorAccounts returns the environment's validators accounts
+func (ac *AccountsConfig) TxFeeRecipientAccounts() []Account {
+	accounts, err := DeriveAccountList(ac.Mnemonic, TxFeeRecipientAT, ac.NumValidators)
+	if err != nil {
+		panic(err)
+	}
+	return accounts
+}
+
 // ValidatorGroupAccounts returns the environment's validators group accounts
 func (ac *AccountsConfig) ValidatorGroupAccounts() []Account {
 	accounts, err := DeriveAccountList(ac.Mnemonic, ValidatorGroupAT, ac.NumValidatorGroups())


### PR DESCRIPTION
### Description

This PR updates mycelo to use the new `--miner.validator` and `--tx-fee-recipient` flags instead of `--etherbase` if the geth version supports it.

### Other changes

1. Add a new account type for tx fee recipient (a corresponding change should be made in celo-monorepo, to allow it to be used on GCP testnets and to be consistent)
2. Add the bootnode account type, which exists in celo-monorepo but was missing in mycelo, resulting in the subsequent account type values being off by one.
3. Enable the istanbul RPC on the validators nodes (e.g. to get the lookback window)

### Tested

Confirmed to work with both master and v1.2.4

### Backwards compatibility

As some of the account type values have been shifted by one, you could get the wrong value when using `mycelo env account` to generate account information (for account types >= 3) for a mycelo environment that was generated before this PR.  However, mycelo environments are generally not long-lived.  To work around this, either use a new mycelo environment, or generate the account info yourself rather than with mycelo.
