### PR TITLE
Fix load-bot failure with heavy load

### DIFF
--- a/mycelo/loadbot/bot.go
+++ b/mycelo/loadbot/bot.go
@@ -72,8 +72,13 @@ func Start(ctx context.Context, cfg *Config) error {
 				lg.Pending++
 				lg.PendingMu.Unlock()
 			}
+			// We evaluate these here to avoid concurrent access of the state
+			// contained in these closures.
+			sender := nextSender()
+			client := nextClient()
+			recipient := nextRecipient()
 			group.Go(func() error {
-				return runTransaction(ctx, lg, nextSender(), cfg.Verbose, nextClient(), nextRecipient(), cfg.Amount)
+				return runTransaction(ctx, lg, sender, cfg.Verbose, client, recipient, cfg.Amount)
 			})
 		case <-ctx.Done():
 			return group.Wait()

--- a/mycelo/loadbot/bot.go
+++ b/mycelo/loadbot/bot.go
@@ -36,22 +36,22 @@ type Config struct {
 
 // Start will start loads bots
 func Start(ctx context.Context, cfg *Config) error {
-	// Set up round robin selectors that rollover
-	recvIdx := uint(len(cfg.Accounts) / 2)
-	nextRecipient := func() common.Address {
-		recvIdx++
-		return cfg.Accounts[recvIdx%uint(len(cfg.Accounts))].Address
+	// Set up nonces, we have to manage nonces because calling PendingNonceAt
+	// is racy and often results in using the same nonce more than once when
+	// applying heavy load.
+	nonces := make([]uint64, len(cfg.Accounts))
+	for i, a := range cfg.Accounts {
+		nonce, err := cfg.Clients[0].PendingNonceAt(ctx, a.Address)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve pending nonce for account %s: %v", a.Address.String(), err)
+		}
+		nonces[i] = nonce
 	}
-	sendIdx := uint(0)
-	nextSender := func() env.Account {
-		sendIdx++
-		return cfg.Accounts[sendIdx%uint(len(cfg.Accounts))]
-	}
-	clientIdx := uint(0)
-	nextClient := func() *ethclient.Client {
-		clientIdx++
-		return cfg.Clients[clientIdx%uint(len(cfg.Clients))]
-	}
+
+	// Offset the receiver from the sender so that they are different
+	recvIdx := len(cfg.Accounts) / 2
+	sendIdx := 0
+	clientIdx := 0
 
 	// Fire off transactions
 	period := 1 * time.Second / time.Duration(cfg.TransactionsPerSecond)
@@ -60,7 +60,6 @@ func Start(ctx context.Context, cfg *Config) error {
 	lg := &LoadGenerator{
 		MaxPending: cfg.MaxPending,
 	}
-
 	for {
 		select {
 		case <-ticker.C:
@@ -72,13 +71,19 @@ func Start(ctx context.Context, cfg *Config) error {
 				lg.Pending++
 				lg.PendingMu.Unlock()
 			}
-			// We evaluate these here to avoid concurrent access of the state
-			// contained in these closures.
-			sender := nextSender()
-			client := nextClient()
-			recipient := nextRecipient()
+			// We use round robin selectors that rollover
+			recvIdx++
+			recipient := cfg.Accounts[recvIdx%len(cfg.Accounts)].Address
+
+			sendIdx++
+			sender := cfg.Accounts[sendIdx%len(cfg.Accounts)]
+			nonce := nonces[sendIdx%len(cfg.Accounts)]
+			nonces[sendIdx%len(cfg.Accounts)]++
+
+			clientIdx++
+			client := cfg.Clients[clientIdx%len(cfg.Clients)]
 			group.Go(func() error {
-				return runTransaction(ctx, lg, sender, cfg.Verbose, client, recipient, cfg.Amount)
+				return runTransaction(ctx, lg, sender, nonce, cfg.Verbose, client, recipient, cfg.Amount)
 			})
 		case <-ctx.Done():
 			return group.Wait()
@@ -86,7 +91,7 @@ func Start(ctx context.Context, cfg *Config) error {
 	}
 }
 
-func runTransaction(ctx context.Context, lg *LoadGenerator, acc env.Account, verbose bool, client *ethclient.Client, recipient common.Address, value *big.Int) error {
+func runTransaction(ctx context.Context, lg *LoadGenerator, acc env.Account, nonce uint64, verbose bool, client *ethclient.Client, recipient common.Address, value *big.Int) error {
 	defer func() {
 		lg.PendingMu.Lock()
 		if lg.MaxPending != 0 {
@@ -100,6 +105,7 @@ func runTransaction(ctx context.Context, lg *LoadGenerator, acc env.Account, ver
 
 	transactor := bind.NewKeyedTransactor(acc.PrivateKey)
 	transactor.Context = ctx
+	transactor.Nonce = new(big.Int).SetUint64(nonce)
 
 	stableTokenAddress := env.MustProxyAddressFor("StableToken")
 	transactor.FeeCurrency = &stableTokenAddress


### PR DESCRIPTION
### Description

This PR makes load-bot capable of consistently handling heavy load. Prior to this change heavy loads would result in load-bot failing due to resubmitting transactions with the same nonce. This was happening because we were calling `PendingNonceAt` to get the nonce for each transaction before sending it. `PendingNonceAt` looks into the transaction pool to discover the next viable nonce but there is no guarantee that the transaction pool will have updated with the latest sent transactions. This resulted in attempting to submit subsequent transactions with the same nonce.

### Other changes

Also fixed some race conditions in the load-bot.

### Tested

Was now able to successfully run the load-bot with heavy load (~100 tps)

### Related issues

- Fixes #1455 

### Backwards compatibility

These changes change no APIs or interfaces and so should be backwards compatible.
