### PR TITLE
EVM: Removes Knowledge of TobinTax

### DIFF
--- a/core/vm/context.go
+++ b/core/vm/context.go
@@ -17,6 +17,8 @@
 package vm
 
 import (
+	"encoding/binary"
+	goerrors "errors"
 	"math/big"
 
 	"github.com/celo-org/celo-blockchain/common"
@@ -24,6 +26,7 @@ import (
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/core/state"
 	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/log"
 	"github.com/celo-org/celo-blockchain/params"
 )
 
@@ -98,7 +101,7 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, txFeeR
 
 	ctx := Context{
 		CanTransfer: CanTransfer,
-		Transfer:    Transfer,
+		Transfer:    TobinTransfer,
 		GetHash:     GetHashFn(header, chain),
 		VerifySeal:  VerifySealFn(header, chain),
 		Origin:      msg.From(),
@@ -184,4 +187,58 @@ func VerifySealFn(ref *types.Header, chain ChainContext) func(*types.Header) boo
 		// Submit the header to the engine's seal verification function.
 		return chain.Engine().VerifySeal(nil, header) == nil
 	}
+}
+
+func getTobinTax(evm *EVM, sender common.Address) (numerator *big.Int, denominator *big.Int, reserveAddress *common.Address, err error) {
+	reserveAddress, err = GetRegisteredAddressWithEvm(params.ReserveRegistryId, evm)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	ret, _, err := evm.Call(AccountRef(sender), *reserveAddress, params.TobinTaxFunctionSelector, params.MaxGasForGetOrComputeTobinTax, big.NewInt(0))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Expected size of ret is 64 bytes because getOrComputeTobinTax() returns two uint256 values,
+	// each of which is equivalent to 32 bytes
+	if binary.Size(ret) != 64 {
+		return nil, nil, nil, goerrors.New("Length of tobin tax not equal to 64 bytes")
+	}
+	numerator = new(big.Int).SetBytes(ret[0:32])
+	denominator = new(big.Int).SetBytes(ret[32:64])
+	if denominator.Cmp(common.Big0) == 0 {
+		return nil, nil, nil, goerrors.New("Tobin tax denominator equal to zero")
+	}
+	if numerator.Cmp(denominator) == 1 {
+		return nil, nil, nil, goerrors.New("Tobin tax numerator greater than denominator")
+	}
+	return numerator, denominator, reserveAddress, nil
+}
+
+// TobinTransfer performs a transfer that may take a tax from the sent amount and give it to the reserve.
+// If the calculation or transfer of the tax amount fails for any reason, the regular transfer goes ahead.
+// NB: Gas is not charged or accounted for this calculation.
+func TobinTransfer(evm *EVM, sender, recipient common.Address, amount *big.Int) {
+	// Run only primary evm.Call() with tracer
+	if evm.GetDebug() {
+		evm.SetDebug(false)
+		defer func() { evm.SetDebug(true) }()
+	}
+
+	if amount.Cmp(big.NewInt(0)) != 0 {
+		numerator, denominator, reserveAddress, err := getTobinTax(evm, sender)
+		if err == nil {
+			tobinTax := new(big.Int).Div(new(big.Int).Mul(numerator, amount), denominator)
+			Transfer(evm.StateDB, sender, recipient, new(big.Int).Sub(amount, tobinTax))
+			Transfer(evm.StateDB, sender, *reserveAddress, tobinTax)
+			return
+		} else {
+			log.Error("Failed to get tobin tax", "error", err)
+		}
+	}
+
+	// Complete a normal transfer if the amount is 0 or the tobin tax value is unable to be fetched and parsed.
+	// We transfer even when the amount is 0 because state trie clearing [EIP161] is necessary at the end of a transaction
+	Transfer(evm.StateDB, sender, recipient, amount)
 }

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -634,7 +634,7 @@ func (c *transfer) Run(input []byte, caller common.Address, evm *EVM, gas uint64
 			return nil, gas, ErrInsufficientBalance
 		}
 
-		gas, err = evm.TobinTransfer(evm.StateDB, from, to, gas, value)
+		evm.Context.Transfer(evm, from, to, value)
 	}
 
 	return input, gas, err

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -89,7 +89,7 @@ func TestEIP2200(t *testing.T) {
 
 		vmctx := Context{
 			CanTransfer: func(StateDB, common.Address, *big.Int) bool { return true },
-			Transfer:    func(StateDB, common.Address, common.Address, *big.Int) {},
+			Transfer:    func(*EVM, common.Address, common.Address, *big.Int) {},
 		}
 		vmenv := NewEVM(vmctx, statedb, params.IstanbulTestChainConfig, Config{ExtraEips: []int{2200}})
 

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -24,7 +24,7 @@ func NewEnv(cfg *Config) *vm.EVM {
 
 	context := vm.Context{
 		CanTransfer: vm.CanTransfer,
-		Transfer:    vm.Transfer,
+		Transfer:    vm.TobinTransfer,
 
 		GetHash: cfg.GetHashFn,
 

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -104,7 +104,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	origin, _ := signer.Sender(tx)
 	context := vm.Context{
 		CanTransfer: vm.CanTransfer,
-		Transfer:    vm.Transfer,
+		Transfer:    vm.TobinTransfer,
 		Origin:      origin,
 		Coinbase:    common.Address{},
 		BlockNumber: new(big.Int).SetUint64(8000000),

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -129,7 +129,7 @@ func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
 		}
 		return vm.CanTransfer(db, address, amount)
 	}
-	transfer := func(db vm.StateDB, sender, recipient common.Address, amount *big.Int) {}
+	transfer := func(evm *vm.EVM, sender, recipient common.Address, amount *big.Int) {}
 	context := vm.Context{
 		CanTransfer: canTransfer,
 		Transfer:    transfer,


### PR DESCRIPTION
### Description

EVM should be unaware of tobin tax. From the EVM perspective there is
just Context.Transfer() function.

This commit, moves evm.TobinTransfer to replace context.Transfer
function. In so, it removes unnecessary input and output parameters.

### Other changes



### Tested

CI / unit test

