### PR TITLE
EVM: Removes static call to GetRegisteredAddress

### DIFF
--- a/core/vm/context.go
+++ b/core/vm/context.go
@@ -109,6 +109,8 @@ func NewEVMContext(msg Message, header *types.Header, chain ChainContext, txFeeR
 		BlockNumber: new(big.Int).Set(header.Number),
 		Time:        new(big.Int).SetUint64(header.Time),
 		GasPrice:    new(big.Int).Set(msg.GasPrice()),
+
+		GetRegisteredAddress: GetRegisteredAddress,
 	}
 
 	if chain != nil {

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -599,7 +599,7 @@ func (c *transfer) Run(input []byte, caller common.Address, evm *EVM, gas uint64
 	if err != nil {
 		return nil, gas, err
 	}
-	celoGoldAddress, err := GetRegisteredAddressWithEvm(params.GoldTokenRegistryId, evm)
+	celoGoldAddress, err := evm.Context.GetRegisteredAddress(evm, params.GoldTokenRegistryId)
 	if err != nil {
 		return nil, gas, err
 	}
@@ -613,7 +613,7 @@ func (c *transfer) Run(input []byte, caller common.Address, evm *EVM, gas uint64
 		return nil, gas, ErrInputLength
 	}
 
-	if caller != *celoGoldAddress {
+	if caller != celoGoldAddress {
 		return nil, gas, fmt.Errorf("Unable to call transfer from unpermissioned address")
 	}
 	from := common.BytesToAddress(input[0:32])

--- a/core/vm/dynamic_params.go
+++ b/core/vm/dynamic_params.go
@@ -33,6 +33,14 @@ const (
 
 var getAddressForFuncABI, _ = abi.JSON(strings.NewReader(getAddressForABI))
 
+func GetRegisteredAddress(evm *EVM, registryId common.Hash) (common.Address, error) {
+	addr, err := GetRegisteredAddressWithEvm(registryId, evm)
+	if err != nil {
+		return common.ZeroAddress, nil
+	}
+	return *addr, nil
+}
+
 // TODO(kevjue) - Re-Enable caching of the retrieved registered address
 // See this commit for the removed code for caching:  https://github.com/celo-org/geth/commit/43a275273c480d307a3d2b3c55ca3b3ee31ec7dd.
 func GetRegisteredAddressWithEvm(registryId [32]byte, evm *EVM) (*common.Address, error) {

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -56,6 +56,9 @@ type (
 
 	// GetValidatorsFunc is the signature for the GetValidators function
 	GetValidatorsFunc func(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator
+
+	// GetRegisteredAddressFunc returns the address for a registered contract
+	GetRegisteredAddressFunc func(evm *EVM, registryId common.Hash) (common.Address, error)
 )
 
 // run runs the given contract and takes care of running precompiles with a fallback to the byte code interpreter.
@@ -117,8 +120,9 @@ type Context struct {
 
 	Header *types.Header
 
-	EpochSize     uint64
-	GetValidators GetValidatorsFunc
+	EpochSize            uint64
+	GetValidators        GetValidatorsFunc
+	GetRegisteredAddress GetRegisteredAddressFunc
 }
 
 // EVM is the Ethereum Virtual Machine base object and provides

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -33,6 +33,8 @@ func NewEnv(cfg *Config) *vm.EVM {
 		BlockNumber: cfg.BlockNumber,
 		Time:        cfg.Time,
 		GasPrice:    cfg.GasPrice,
+
+		GetRegisteredAddress: vm.GetRegisteredAddress,
 	}
 
 	if cfg.ChainConfig.Istanbul != nil {

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -103,13 +103,14 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	*/
 	origin, _ := signer.Sender(tx)
 	context := vm.Context{
-		CanTransfer: vm.CanTransfer,
-		Transfer:    vm.TobinTransfer,
-		Origin:      origin,
-		Coinbase:    common.Address{},
-		BlockNumber: new(big.Int).SetUint64(8000000),
-		Time:        new(big.Int).SetUint64(5),
-		GasPrice:    big.NewInt(1),
+		CanTransfer:          vm.CanTransfer,
+		Transfer:             vm.TobinTransfer,
+		Origin:               origin,
+		Coinbase:             common.Address{},
+		BlockNumber:          new(big.Int).SetUint64(8000000),
+		Time:                 new(big.Int).SetUint64(5),
+		GasPrice:             big.NewInt(1),
+		GetRegisteredAddress: vm.GetRegisteredAddress,
 	}
 	alloc := core.GenesisAlloc{}
 
@@ -201,6 +202,7 @@ func TestCallTracer(t *testing.T) {
 				Time:        new(big.Int).SetUint64(uint64(test.Context.Time)),
 				GasLimit:    uint64(test.Context.GasLimit),
 				GasPrice:    tx.GasPrice(),
+				GetRegisteredAddress: vm.GetRegisteredAddress,
 			}
 			statedb := tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false)
 

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -131,14 +131,15 @@ func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
 	}
 	transfer := func(evm *vm.EVM, sender, recipient common.Address, amount *big.Int) {}
 	context := vm.Context{
-		CanTransfer: canTransfer,
-		Transfer:    transfer,
-		GetHash:     vmTestBlockHash,
-		Origin:      t.json.Exec.Origin,
-		Coinbase:    t.json.Env.Coinbase,
-		BlockNumber: new(big.Int).SetUint64(t.json.Env.Number),
-		Time:        new(big.Int).SetUint64(t.json.Env.Timestamp),
-		GasPrice:    t.json.Exec.GasPrice,
+		CanTransfer:          canTransfer,
+		Transfer:             transfer,
+		GetHash:              vmTestBlockHash,
+		Origin:               t.json.Exec.Origin,
+		Coinbase:             t.json.Env.Coinbase,
+		BlockNumber:          new(big.Int).SetUint64(t.json.Env.Number),
+		Time:                 new(big.Int).SetUint64(t.json.Env.Timestamp),
+		GasPrice:             t.json.Exec.GasPrice,
+		GetRegisteredAddress: vm.GetRegisteredAddress,
 	}
 	vmconfig.NoRecursion = true
 	return vm.NewEVM(context, statedb, params.MainnetChainConfig, vmconfig)


### PR DESCRIPTION
### Description

This commit removes the use of a static call to obtain a registry
address. This was used on the Transfer precompile to check that the only
caller to the contract is the GoldToken contract.

With this commit, there's a GetRegisteredAddress function on the
evm.Context that is injected at the moment of creating.

For now, this function is hardcoded, but later it will be received as a
parameter to the vm.NewContext()

### Tested

ci & unit tests

