### PR TITLE
EVM module: Removes GetRegistedAddressWithEVM

### DIFF
--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -104,12 +104,12 @@ func (sb *Backend) distributeEpochRewards(header *types.Header, state *state.Sta
 	}
 
 	// Validator rewards were paid in cUSD, convert that amount to cGLD and add it to the Reserve
-	totalValidatorRewardsConvertedToGold, err := currency.Convert(totalValidatorRewards, stableTokenAddress, nil)
+	totalValidatorRewardsConvertedToGold, err := currency.Convert(totalValidatorRewards, &stableTokenAddress, nil)
 	if err != nil {
 		return err
 	}
 
-	if err = gold_token.Mint(header, state, *reserveAddress, totalValidatorRewardsConvertedToGold); err != nil {
+	if err = gold_token.Mint(header, state, reserveAddress, totalValidatorRewardsConvertedToGold); err != nil {
 		return err
 	}
 
@@ -187,11 +187,11 @@ func (sb *Backend) distributeCommunityRewards(header *types.Header, state *state
 		return err
 	}
 
-	if lowReserve && reserveAddress != nil {
-		return gold_token.Mint(header, state, *reserveAddress, communityReward)
-	} else if governanceAddress != nil {
+	if lowReserve && reserveAddress != common.ZeroAddress {
+		return gold_token.Mint(header, state, reserveAddress, communityReward)
+	} else if governanceAddress != common.ZeroAddress {
 		// TODO: How to split eco fund here
-		return gold_token.Mint(header, state, *governanceAddress, communityReward)
+		return gold_token.Mint(header, state, governanceAddress, communityReward)
 	}
 	return nil
 }
@@ -201,7 +201,7 @@ func (sb *Backend) distributeVoterRewards(header *types.Header, state *state.Sta
 	lockedGoldAddress, err := contract_comm.GetRegisteredAddress(params.LockedGoldRegistryId, header, state)
 	if err != nil {
 		return err
-	} else if lockedGoldAddress == nil {
+	} else if lockedGoldAddress == common.ZeroAddress {
 		return errors.New("Unable to fetch locked gold address for epoch rewards distribution")
 	}
 
@@ -227,7 +227,7 @@ func (sb *Backend) distributeVoterRewards(header *types.Header, state *state.Sta
 		return err
 	}
 
-	return gold_token.Mint(header, state, *lockedGoldAddress, electionRewards)
+	return gold_token.Mint(header, state, lockedGoldAddress, electionRewards)
 }
 
 func (sb *Backend) setInitialGoldTokenTotalSupplyIfUnset(header *types.Header, state *state.StateDB) error {

--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -118,7 +118,7 @@ func ConvertToGold(val *big.Int, currencyFrom *common.Address) (*big.Int, error)
 		return val, err
 	}
 
-	if currencyFrom == celoGoldAddress {
+	if *currencyFrom == celoGoldAddress {
 		// This function shouldn't really be called with the token's address, but if it is the value
 		// is correct, so return nil as the error
 		return val, nil

--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -57,12 +57,12 @@ func MakeStaticCallWithAddress(scAddress common.Address, abi abi.ABI, funcName s
 	return makeCallFromSystem(scAddress, abi, funcName, args, returnObj, gas, nil, header, state, true)
 }
 
-func GetRegisteredAddress(registryId [32]byte, header *types.Header, state vm.StateDB) (*common.Address, error) {
+func GetRegisteredAddress(registryId [32]byte, header *types.Header, state vm.StateDB) (common.Address, error) {
 	vmevm, err := createEVM(header, state)
 	if err != nil {
-		return nil, err
+		return common.ZeroAddress, err
 	}
-	return vm.GetRegisteredAddressWithEvm(registryId, vmevm)
+	return vm.GetRegisteredAddress(vmevm, registryId)
 }
 
 func createEVM(header *types.Header, state vm.StateDB) (*vm.EVM, error) {
@@ -147,7 +147,7 @@ func makeCallWithContractId(registryId [32]byte, abi abi.ABI, funcName string, a
 		}
 	}
 
-	gasLeft, err := makeCallFromSystem(*scAddress, abi, funcName, args, returnObj, gas, value, header, state, static)
+	gasLeft, err := makeCallFromSystem(scAddress, abi, funcName, args, returnObj, gas, value, header, state, static)
 	if err != nil {
 		log.Error("Error in executing function on registered contract", "function", funcName, "registryId", hexutil.Encode(registryId[:]), "err", err)
 	}

--- a/contract_comm/gasprice_minimum/gasprice_minimum.go
+++ b/contract_comm/gasprice_minimum/gasprice_minimum.go
@@ -91,7 +91,7 @@ func GetGasPriceSuggestion(currency *common.Address, header *types.Header, state
 }
 
 func GetGasPriceMinimum(currency *common.Address, header *types.Header, state vm.StateDB) (*big.Int, error) {
-	var currencyAddress *common.Address
+	var currencyAddress common.Address
 	var err error
 
 	if currency == nil {
@@ -107,7 +107,7 @@ func GetGasPriceMinimum(currency *common.Address, header *types.Header, state vm
 			return FallbackGasPriceMinimum, err
 		}
 	} else {
-		currencyAddress = currency
+		currencyAddress = *currency
 	}
 
 	var gasPriceMinimum *big.Int

--- a/contract_comm/random/random.go
+++ b/contract_comm/random/random.go
@@ -132,7 +132,7 @@ var (
 	zeroValue                   = common.Big0
 )
 
-func address() *common.Address {
+func address() common.Address {
 	randomAddress, err := contract_comm.GetRegisteredAddress(params.RandomRegistryId, nil, nil)
 	if err == errors.ErrSmartContractNotDeployed || err == errors.ErrRegistryContractNotDeployed {
 		log.Debug("Registry address lookup failed", "err", err, "contract", hexutil.Encode(params.RandomRegistryId[:]))
@@ -144,7 +144,7 @@ func address() *common.Address {
 
 func IsRunning() bool {
 	randomAddress := address()
-	return randomAddress != nil && *randomAddress != common.ZeroAddress
+	return randomAddress != common.ZeroAddress
 }
 
 // GetLastCommitment returns up the last commitment in the smart contract

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -276,7 +276,7 @@ func (st *StateTransition) creditGasFees(
 	from common.Address,
 	feeRecipient common.Address,
 	gatewayFeeRecipient *common.Address,
-	communityFund *common.Address,
+	communityFund common.Address,
 	refund *big.Int,
 	tipTxFee *big.Int,
 	gatewayFee *big.Int,
@@ -285,7 +285,7 @@ func (st *StateTransition) creditGasFees(
 	evm := st.evm
 	// Function is "creditGasFees(address,address,address,address,uint256,uint256,uint256,uint256)"
 	functionSelector := hexutil.MustDecode("0x6a30b253")
-	transactionData := common.GetEncodedAbi(functionSelector, [][]byte{common.AddressToAbi(from), common.AddressToAbi(feeRecipient), common.AddressToAbi(*gatewayFeeRecipient), common.AddressToAbi(*communityFund), common.AmountToAbi(refund), common.AmountToAbi(tipTxFee), common.AmountToAbi(gatewayFee), common.AmountToAbi(baseTxFee)})
+	transactionData := common.GetEncodedAbi(functionSelector, [][]byte{common.AddressToAbi(from), common.AddressToAbi(feeRecipient), common.AddressToAbi(*gatewayFeeRecipient), common.AddressToAbi(communityFund), common.AmountToAbi(refund), common.AmountToAbi(tipTxFee), common.AmountToAbi(gatewayFee), common.AmountToAbi(baseTxFee)})
 
 	// Run only primary evm.Call() with tracer
 	if evm.GetDebug() {
@@ -452,12 +452,12 @@ func (st *StateTransition) distributeTxFees() error {
 		gatewayFeeRecipient = &common.ZeroAddress
 	}
 
-	governanceAddress, err := vm.GetRegisteredAddressWithEvm(params.GovernanceRegistryId, st.evm)
+	governanceAddress, err := vm.GetRegisteredAddress(st.evm, params.GovernanceRegistryId)
 	if err != nil && err != commerrs.ErrSmartContractNotDeployed && err != commerrs.ErrRegistryContractNotDeployed {
 		return err
 	} else if err != nil {
 		log.Trace("Cannot credit gas fee to community fund: refunding fee to sender", "error", err, "fee", baseTxFee)
-		governanceAddress = &common.ZeroAddress
+		governanceAddress = common.ZeroAddress
 		refund.Add(refund, baseTxFee)
 		baseTxFee = new(big.Int)
 	}
@@ -465,13 +465,13 @@ func (st *StateTransition) distributeTxFees() error {
 	log.Trace("distributeTxFees", "from", from, "refund", refund, "feeCurrency", st.msg.FeeCurrency(),
 		"gatewayFeeRecipient", *gatewayFeeRecipient, "gatewayFee", st.msg.GatewayFee(),
 		"coinbaseFeeRecipient", st.evm.Coinbase, "coinbaseFee", tipTxFee,
-		"comunityFundRecipient", *governanceAddress, "communityFundFee", baseTxFee)
+		"comunityFundRecipient", governanceAddress, "communityFundFee", baseTxFee)
 	if feeCurrency == nil {
 		if gatewayFeeRecipient != &common.ZeroAddress {
 			st.state.AddBalance(*gatewayFeeRecipient, st.msg.GatewayFee())
 		}
-		if governanceAddress != &common.ZeroAddress {
-			st.state.AddBalance(*governanceAddress, baseTxFee)
+		if governanceAddress != common.ZeroAddress {
+			st.state.AddBalance(governanceAddress, baseTxFee)
 		}
 		st.state.AddBalance(st.evm.Coinbase, tipTxFee)
 		st.state.AddBalance(from, refund)

--- a/core/vm/context.go
+++ b/core/vm/context.go
@@ -191,29 +191,29 @@ func VerifySealFn(ref *types.Header, chain ChainContext) func(*types.Header) boo
 	}
 }
 
-func getTobinTax(evm *EVM, sender common.Address) (numerator *big.Int, denominator *big.Int, reserveAddress *common.Address, err error) {
-	reserveAddress, err = GetRegisteredAddressWithEvm(params.ReserveRegistryId, evm)
+func getTobinTax(evm *EVM, sender common.Address) (numerator *big.Int, denominator *big.Int, reserveAddress common.Address, err error) {
+	reserveAddress, err = GetRegisteredAddress(evm, params.ReserveRegistryId)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, common.ZeroAddress, err
 	}
 
-	ret, _, err := evm.Call(AccountRef(sender), *reserveAddress, params.TobinTaxFunctionSelector, params.MaxGasForGetOrComputeTobinTax, big.NewInt(0))
+	ret, _, err := evm.Call(AccountRef(sender), reserveAddress, params.TobinTaxFunctionSelector, params.MaxGasForGetOrComputeTobinTax, big.NewInt(0))
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, common.ZeroAddress, err
 	}
 
 	// Expected size of ret is 64 bytes because getOrComputeTobinTax() returns two uint256 values,
 	// each of which is equivalent to 32 bytes
 	if binary.Size(ret) != 64 {
-		return nil, nil, nil, goerrors.New("Length of tobin tax not equal to 64 bytes")
+		return nil, nil, common.ZeroAddress, goerrors.New("Length of tobin tax not equal to 64 bytes")
 	}
 	numerator = new(big.Int).SetBytes(ret[0:32])
 	denominator = new(big.Int).SetBytes(ret[32:64])
 	if denominator.Cmp(common.Big0) == 0 {
-		return nil, nil, nil, goerrors.New("Tobin tax denominator equal to zero")
+		return nil, nil, common.ZeroAddress, goerrors.New("Tobin tax denominator equal to zero")
 	}
 	if numerator.Cmp(denominator) == 1 {
-		return nil, nil, nil, goerrors.New("Tobin tax numerator greater than denominator")
+		return nil, nil, common.ZeroAddress, goerrors.New("Tobin tax numerator greater than denominator")
 	}
 	return numerator, denominator, reserveAddress, nil
 }
@@ -233,7 +233,7 @@ func TobinTransfer(evm *EVM, sender, recipient common.Address, amount *big.Int) 
 		if err == nil {
 			tobinTax := new(big.Int).Div(new(big.Int).Mul(numerator, amount), denominator)
 			Transfer(evm.StateDB, sender, recipient, new(big.Int).Sub(amount, tobinTax))
-			Transfer(evm.StateDB, sender, *reserveAddress, tobinTax)
+			Transfer(evm.StateDB, sender, reserveAddress, tobinTax)
 			return
 		} else {
 			log.Error("Failed to get tobin tax", "error", err)


### PR DESCRIPTION
### Description

Simple refactor, replaces calls to `GetRegistedAddressWithEVM` to the new
version `GetRegistedAddress`.

As a side effect, return type was change from `*common.Address` to
`common.Address` which might be solving a bug, since we found that we are
comparing two pointers when we should be comparing values. (on
`currency.Convert()`)


