### PR TITLE
Move knowledge of tobin out of vm package

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -42,6 +42,7 @@ import (
 	"github.com/celo-org/celo-blockchain/event"
 	"github.com/celo-org/celo-blockchain/params"
 	"github.com/celo-org/celo-blockchain/rpc"
+	"github.com/celo-org/celo-blockchain/tobin"
 )
 
 // This nil assignment ensures compile time that SimulatedBackend implements bind.ContractBackend.
@@ -514,7 +515,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	// Execute the call.
 	msg := callmsg{call}
 
-	evmContext := vm.NewEVMContext(msg, block.Header(), b.blockchain, nil)
+	evmContext := tobin.NewEVMContext(msg, block.Header(), b.blockchain, nil)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(evmContext, statedb, b.config, vm.Config{})

--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -46,6 +46,7 @@ import (
 	"github.com/celo-org/celo-blockchain/params"
 	"github.com/celo-org/celo-blockchain/rlp"
 	"github.com/celo-org/celo-blockchain/rpc"
+	"github.com/celo-org/celo-blockchain/tobin"
 	"github.com/celo-org/celo-blockchain/trie"
 
 	cli "gopkg.in/urfave/cli.v1"
@@ -653,7 +654,7 @@ func (api *RetestethAPI) AccountRange(ctx context.Context,
 		for idx, tx := range block.Transactions() {
 			// Assemble the transaction call message and return if the requested offset
 			msg, _ := tx.AsMessage(signer)
-			context := vm.NewEVMContext(msg, block.Header(), api.blockchain, nil)
+			context := tobin.NewEVMContext(msg, block.Header(), api.blockchain, nil)
 			// Not yet the searched for transaction, execute on top of the current state
 			vmenv := vm.NewEVM(context, statedb, api.blockchain.Config(), vm.Config{})
 			if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
@@ -763,7 +764,7 @@ func (api *RetestethAPI) StorageRangeAt(ctx context.Context,
 		for idx, tx := range block.Transactions() {
 			// Assemble the transaction call message and return if the requested offset
 			msg, _ := tx.AsMessage(signer)
-			context := vm.NewEVMContext(msg, block.Header(), api.blockchain, nil)
+			context := tobin.NewEVMContext(msg, block.Header(), api.blockchain, nil)
 			// Not yet the searched for transaction, execute on top of the current state
 			vmenv := vm.NewEVM(context, statedb, api.blockchain.Config(), vm.Config{})
 			if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {

--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -29,6 +29,7 @@ import (
 	"github.com/celo-org/celo-blockchain/core/vm"
 	"github.com/celo-org/celo-blockchain/log"
 	"github.com/celo-org/celo-blockchain/metrics"
+	"github.com/celo-org/celo-blockchain/tobin"
 )
 
 var (
@@ -89,7 +90,7 @@ func createEVM(header *types.Header, state vm.StateDB) (*vm.EVM, error) {
 
 	// The EVM Context requires a msg, but the actual field values don't really matter for this case.
 	// Putting in zero values.
-	context := vm.NewEVMContext(emptyMessage, header, internalEvmHandlerSingleton.chain, nil)
+	context := tobin.NewEVMContext(emptyMessage, header, internalEvmHandlerSingleton.chain, nil)
 	evm := vm.NewEVM(context, state, internalEvmHandlerSingleton.chain.Config(), *internalEvmHandlerSingleton.chain.GetVMConfig())
 
 	return evm, nil

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -25,6 +25,7 @@ import (
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/core/vm"
 	"github.com/celo-org/celo-blockchain/params"
+	"github.com/celo-org/celo-blockchain/tobin"
 )
 
 // statePrefetcher is a basic Prefetcher, which blindly executes a block on top
@@ -86,7 +87,7 @@ func precacheTransaction(config *params.ChainConfig, bc vm.ChainContext, author 
 		return err
 	}
 	// Create the EVM and execute the transaction
-	context := vm.NewEVMContext(msg, header, bc, author)
+	context := tobin.NewEVMContext(msg, header, bc, author)
 	vm := vm.NewEVM(context, statedb, config, cfg)
 
 	_, err = ApplyMessage(vm, msg, gaspool)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/celo-org/celo-blockchain/core/vm"
 	"github.com/celo-org/celo-blockchain/crypto"
 	"github.com/celo-org/celo-blockchain/params"
+	"github.com/celo-org/celo-blockchain/tobin"
 )
 
 // StateProcessor is a basic Processor, which takes care of transitioning
@@ -121,7 +122,7 @@ func ApplyTransaction(config *params.ChainConfig, bc vm.ChainContext, txFeeRecip
 	}
 
 	// Create a new context to be used in the EVM environment
-	context := vm.NewEVMContext(msg, header, bc, txFeeRecipient)
+	context := tobin.NewEVMContext(msg, header, bc, txFeeRecipient)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(context, statedb, config, cfg)

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -24,10 +24,9 @@ func NewEnv(cfg *Config) *vm.EVM {
 
 	context := vm.Context{
 		CanTransfer: vm.CanTransfer,
-		Transfer:    vm.TobinTransfer,
 
-		GetHash: cfg.GetHashFn,
-
+		Transfer:    cfg.Transfer,
+		GetHash:     cfg.GetHashFn,
 		Origin:      cfg.Origin,
 		Coinbase:    cfg.Coinbase,
 		BlockNumber: cfg.BlockNumber,

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -42,6 +42,7 @@ type Config struct {
 	Value       *big.Int
 	Debug       bool
 	EVMConfig   vm.Config
+	Transfer    vm.TransferFunc
 
 	State     *state.StateDB
 	GetHashFn func(n uint64) common.Hash

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -35,6 +35,7 @@ import (
 	"github.com/celo-org/celo-blockchain/event"
 	"github.com/celo-org/celo-blockchain/params"
 	"github.com/celo-org/celo-blockchain/rpc"
+	"github.com/celo-org/celo-blockchain/tobin"
 )
 
 // EthAPIBackend implements ethapi.Backend for full nodes
@@ -191,7 +192,7 @@ func (b *EthAPIBackend) GetTd(blockHash common.Hash) *big.Int {
 func (b *EthAPIBackend) GetEVM(ctx context.Context, msg vm.Message, header *types.Header, state *state.StateDB) (*vm.EVM, func() error, error) {
 	vmError := func() error { return nil }
 
-	context := vm.NewEVMContext(msg, header, b.eth.BlockChain(), nil)
+	context := tobin.NewEVMContext(msg, header, b.eth.BlockChain(), nil)
 	return vm.NewEVM(context, state, b.eth.blockchain.Config(), *b.eth.blockchain.GetVMConfig()), vmError, nil
 }
 

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -40,6 +40,7 @@ import (
 	"github.com/celo-org/celo-blockchain/log"
 	"github.com/celo-org/celo-blockchain/rlp"
 	"github.com/celo-org/celo-blockchain/rpc"
+	"github.com/celo-org/celo-blockchain/tobin"
 	"github.com/celo-org/celo-blockchain/trie"
 )
 
@@ -206,7 +207,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
 					msg, _ := tx.AsMessage(signer)
-					vmctx := vm.NewEVMContext(msg, task.block.Header(), api.eth.blockchain, nil)
+					vmctx := tobin.NewEVMContext(msg, task.block.Header(), api.eth.blockchain, nil)
 
 					res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)
 					if err != nil {
@@ -480,7 +481,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
 				msg, _ := txs[task.index].AsMessage(signer)
-				vmctx := vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
+				vmctx := tobin.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 				res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)
 				if err != nil {
@@ -499,7 +500,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 
 		// Generate the next state snapshot fast without tracing
 		msg, _ := tx.AsMessage(signer)
-		vmctx := vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
+		vmctx := tobin.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 		vmenv := vm.NewEVM(vmctx, statedb, api.eth.blockchain.Config(), vm.Config{})
 		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas())); err != nil {
@@ -568,7 +569,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		// Prepare the trasaction for un-traced execution
 		var (
 			msg, _ = tx.AsMessage(signer)
-			vmctx  = vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
+			vmctx  = tobin.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 
 			vmConf vm.Config
 			dump   *os.File
@@ -806,7 +807,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 	for idx, tx := range block.Transactions() {
 		// Assemble the transaction call message and return if the requested offset
 		msg, _ := tx.AsMessage(signer)
-		context := vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
+		context := tobin.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 		if idx == txIndex {
 			return msg, context, statedb, nil
 		}

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/celo-org/celo-blockchain/crypto"
 	"github.com/celo-org/celo-blockchain/params"
 	"github.com/celo-org/celo-blockchain/tests"
+	"github.com/celo-org/celo-blockchain/tobin"
 )
 
 // To generate a new callTracer test, copy paste the makeTest method below into
@@ -104,7 +105,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	origin, _ := signer.Sender(tx)
 	context := vm.Context{
 		CanTransfer: vm.CanTransfer,
-		Transfer:    vm.TobinTransfer,
+		Transfer:    tobin.TobinTransfer,
 		Origin:      origin,
 		Coinbase:    common.Address{},
 		BlockNumber: new(big.Int).SetUint64(8000000),

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -37,6 +37,7 @@ import (
 	"github.com/celo-org/celo-blockchain/light"
 	"github.com/celo-org/celo-blockchain/params"
 	"github.com/celo-org/celo-blockchain/rpc"
+	"github.com/celo-org/celo-blockchain/tobin"
 )
 
 type LesApiBackend struct {
@@ -167,7 +168,7 @@ func (b *LesApiBackend) GetTd(hash common.Hash) *big.Int {
 }
 
 func (b *LesApiBackend) GetEVM(ctx context.Context, msg vm.Message, header *types.Header, state *state.StateDB) (*vm.EVM, func() error, error) {
-	context := vm.NewEVMContext(msg, header, b.eth.blockchain, nil)
+	context := tobin.NewEVMContext(msg, header, b.eth.blockchain, nil)
 	return vm.NewEVM(context, state, b.eth.chainConfig, vm.Config{}), state.Error, nil
 }
 

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/state"
+	"github.com/celo-org/celo-blockchain/tobin"
 
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/core/vm"
@@ -132,7 +133,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 
 				msg := callmsg{types.NewMessage(from.Address(), &testContractAddr, 0, new(big.Int), 100000, new(big.Int), nil, nil, new(big.Int), data, false, false)}
 
-				context := vm.NewEVMContext(msg, header, bc, nil)
+				context := tobin.NewEVMContext(msg, header, bc, nil)
 				vmenv := vm.NewEVM(context, statedb, config, vm.Config{})
 
 				//vmenv := core.NewEnv(statedb, config, bc, msg, header, vm.Config{})
@@ -145,7 +146,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 			state := light.NewState(ctx, header, lc.Odr())
 			state.SetBalance(bankAddr, math.MaxBig256)
 			msg := callmsg{types.NewMessage(bankAddr, &testContractAddr, 0, new(big.Int), 100000, new(big.Int), nil, nil, new(big.Int), data, false, false)}
-			context := vm.NewEVMContext(msg, header, lc, nil)
+			context := tobin.NewEVMContext(msg, header, lc, nil)
 			vmenv := vm.NewEVM(context, state, config, vm.Config{})
 			gp := new(core.GasPool).AddGas(math.MaxUint64)
 			result, _ := core.ApplyMessage(vmenv, msg, gp)

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/celo-org/celo-blockchain/ethdb"
 	"github.com/celo-org/celo-blockchain/params"
 	"github.com/celo-org/celo-blockchain/rlp"
+	"github.com/celo-org/celo-blockchain/tobin"
 	"github.com/celo-org/celo-blockchain/trie"
 )
 
@@ -243,7 +244,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 		// Perform read-only call.
 		st.SetBalance(testBankAddress, math.MaxBig256)
 		msg := callmsg{types.NewMessage(testBankAddress, &testContractAddr, 0, new(big.Int), 1000000, new(big.Int), nil, nil, new(big.Int), data, false, false)}
-		context := vm.NewEVMContext(msg, header, chain, nil)
+		context := tobin.NewEVMContext(msg, header, chain, nil)
 		vmenv := vm.NewEVM(context, st, config, vm.Config{})
 		gp := new(core.GasPool).AddGas(math.MaxUint64)
 		result, _ := core.ApplyMessage(vmenv, msg, gp)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/celo-org/celo-blockchain/core/state/snapshot"
+	"github.com/celo-org/celo-blockchain/tobin"
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/hexutil"
@@ -177,7 +178,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	if err != nil {
 		return nil, common.Hash{}, err
 	}
-	context := vm.NewEVMContext(msg, block.Header(), nil, &t.json.Env.Coinbase)
+	context := tobin.NewEVMContext(msg, block.Header(), nil, &t.json.Env.Coinbase)
 	context.GetHash = vmTestBlockHash
 	evm := vm.NewEVM(context, statedb, config, vmconfig)
 

--- a/tobin/tobin.go
+++ b/tobin/tobin.go
@@ -1,0 +1,131 @@
+package tobin
+
+import (
+	"encoding/binary"
+	"errors"
+	"math/big"
+
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/consensus/istanbul"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/core/vm"
+	"github.com/celo-org/celo-blockchain/core/vm/runtime"
+	"github.com/celo-org/celo-blockchain/log"
+	"github.com/celo-org/celo-blockchain/params"
+)
+
+func NewEnv(cfg *runtime.Config) *vm.EVM {
+
+	context := vm.Context{
+		CanTransfer: vm.CanTransfer,
+		Transfer:    TobinTransfer,
+
+		GetHash: cfg.GetHashFn,
+
+		Origin:      cfg.Origin,
+		Coinbase:    cfg.Coinbase,
+		BlockNumber: cfg.BlockNumber,
+		Time:        cfg.Time,
+		GasPrice:    cfg.GasPrice,
+	}
+
+	if cfg.ChainConfig.Istanbul != nil {
+		context.EpochSize = cfg.ChainConfig.Istanbul.Epoch
+	}
+
+	return vm.NewEVM(context, cfg.State, cfg.ChainConfig, cfg.EVMConfig)
+}
+
+// NewEVMContext creates a new context for use in the EVM.
+func NewEVMContext(msg vm.Message, header *types.Header, chain vm.ChainContext, txFeeRecipient *common.Address) vm.Context {
+	// If we don't have an explicit txFeeRecipient (i.e. not mining), extract from the header
+	// The only call that fills the txFeeRecipient, is the ApplyTransaction from the state processor
+	// All the other calls, assume that will be retrieved from the header
+	var beneficiary common.Address
+	if txFeeRecipient == nil {
+		beneficiary = header.Coinbase
+	} else {
+		beneficiary = *txFeeRecipient
+	}
+
+	ctx := vm.Context{
+		CanTransfer: vm.CanTransfer,
+		Transfer:    TobinTransfer,
+		GetHash:     vm.GetHashFn(header, chain),
+		VerifySeal:  vm.VerifySealFn(header, chain),
+		Origin:      msg.From(),
+		Coinbase:    beneficiary,
+		BlockNumber: new(big.Int).Set(header.Number),
+		Time:        new(big.Int).SetUint64(header.Time),
+		GasPrice:    new(big.Int).Set(msg.GasPrice()),
+	}
+
+	if chain != nil {
+		ctx.EpochSize = chain.Engine().EpochSize()
+		ctx.GetValidators = chain.Engine().GetValidators
+		ctx.GetHeaderByNumber = chain.GetHeaderByNumber
+	} else {
+		ctx.GetValidators = func(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator { return nil }
+		ctx.GetHeaderByNumber = func(uint64) *types.Header { panic("evm context without blockchain context") }
+	}
+	return ctx
+}
+
+func getTobinTax(evm *vm.EVM, sender common.Address) (numerator *big.Int, denominator *big.Int, reserveAddress *common.Address, err error) {
+	reserveAddress, err = vm.GetRegisteredAddressWithEvm(params.ReserveRegistryId, evm)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	ret, _, err := evm.Call(vm.AccountRef(sender), *reserveAddress, params.TobinTaxFunctionSelector, params.MaxGasForGetOrComputeTobinTax, big.NewInt(0))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Expected size of ret is 64 bytes because getOrComputeTobinTax() returns two uint256 values,
+	// each of which is equivalent to 32 bytes
+	if binary.Size(ret) != 64 {
+		return nil, nil, nil, errors.New("Length of tobin tax not equal to 64 bytes")
+	}
+	numerator = new(big.Int).SetBytes(ret[0:32])
+	denominator = new(big.Int).SetBytes(ret[32:64])
+	if denominator.Cmp(common.Big0) == 0 {
+		return nil, nil, nil, errors.New("Tobin tax denominator equal to zero")
+	}
+	if numerator.Cmp(denominator) == 1 {
+		return nil, nil, nil, errors.New("Tobin tax numerator greater than denominator")
+	}
+	return numerator, denominator, reserveAddress, nil
+}
+
+func Transfer(db vm.StateDB, sender, recipient common.Address, amount *big.Int) {
+	db.SubBalance(sender, amount)
+	db.AddBalance(recipient, amount)
+}
+
+// TobinTransfer performs a transfer that may take a tax from the sent amount and give it to the reserve.
+// If the calculation or transfer of the tax amount fails for any reason, the regular transfer goes ahead.
+// NB: Gas is not charged or accounted for this calculation.
+func TobinTransfer(evm *vm.EVM, sender, recipient common.Address, amount *big.Int) {
+	// Run only primary evm.Call() with tracer
+	if evm.GetDebug() {
+		evm.SetDebug(false)
+		defer func() { evm.SetDebug(true) }()
+	}
+
+	if amount.Cmp(big.NewInt(0)) != 0 {
+		numerator, denominator, reserveAddress, err := getTobinTax(evm, sender)
+		if err == nil {
+			tobinTax := new(big.Int).Div(new(big.Int).Mul(numerator, amount), denominator)
+			Transfer(evm.StateDB, sender, recipient, new(big.Int).Sub(amount, tobinTax))
+			Transfer(evm.StateDB, sender, *reserveAddress, tobinTax)
+			return
+		} else {
+			log.Error("Failed to get tobin tax", "error", err)
+		}
+	}
+
+	// Complete a normal transfer if the amount is 0 or the tobin tax value is unable to be fetched and parsed.
+	// We transfer even when the amount is 0 because state trie clearing [EIP161] is necessary at the end of a transaction
+	Transfer(evm.StateDB, sender, recipient, amount)
+}


### PR DESCRIPTION
### Description

This shows an approach to remove all knowledge of tobin tax from the vm package.

It's not finished, we would need to updated all current instances of runtime.Config to contain the tobin transfer function, but this should be a mechanical change.
