### PR TITLE
Removes notion of system call & abi on the evm

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -31,6 +31,7 @@ import (
 	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/common/math"
 	mockEngine "github.com/celo-org/celo-blockchain/consensus/consensustest"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/bloombits"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
@@ -514,7 +515,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	// Execute the call.
 	msg := callmsg{call}
 
-	evmContext := vm.NewEVMContext(msg, block.Header(), b.blockchain, nil)
+	evmContext := vm.NewEVMContext(msg, block.Header(), b.blockchain, contracts.Context, nil)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(evmContext, statedb, b.config, vm.Config{})

--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -34,6 +34,7 @@ import (
 	mockEngine "github.com/celo-org/celo-blockchain/consensus/consensustest"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/consensus/misc"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/state"
@@ -653,7 +654,7 @@ func (api *RetestethAPI) AccountRange(ctx context.Context,
 		for idx, tx := range block.Transactions() {
 			// Assemble the transaction call message and return if the requested offset
 			msg, _ := tx.AsMessage(signer)
-			context := vm.NewEVMContext(msg, block.Header(), api.blockchain, nil)
+			context := vm.NewEVMContext(msg, block.Header(), api.blockchain, contracts.Context, nil)
 			// Not yet the searched for transaction, execute on top of the current state
 			vmenv := vm.NewEVM(context, statedb, api.blockchain.Config(), vm.Config{})
 			if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
@@ -763,7 +764,7 @@ func (api *RetestethAPI) StorageRangeAt(ctx context.Context,
 		for idx, tx := range block.Transactions() {
 			// Assemble the transaction call message and return if the requested offset
 			msg, _ := tx.AsMessage(signer)
-			context := vm.NewEVMContext(msg, block.Header(), api.blockchain, nil)
+			context := vm.NewEVMContext(msg, block.Header(), api.blockchain, contracts.Context, nil)
 			// Not yet the searched for transaction, execute on top of the current state
 			vmenv := vm.NewEVM(context, statedb, api.blockchain.Config(), vm.Config{})
 			if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {

--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -25,6 +25,7 @@ import (
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/contract_comm/errors"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/core/vm"
 	"github.com/celo-org/celo-blockchain/log"
@@ -62,7 +63,7 @@ func GetRegisteredAddress(registryId [32]byte, header *types.Header, state vm.St
 	if err != nil {
 		return common.ZeroAddress, err
 	}
-	return vm.GetRegisteredAddress(vmevm, registryId)
+	return contracts.GetRegisteredAddress(vmevm, registryId)
 }
 
 func createEVM(header *types.Header, state vm.StateDB) (*vm.EVM, error) {
@@ -89,7 +90,7 @@ func createEVM(header *types.Header, state vm.StateDB) (*vm.EVM, error) {
 
 	// The EVM Context requires a msg, but the actual field values don't really matter for this case.
 	// Putting in zero values.
-	context := vm.NewEVMContext(emptyMessage, header, internalEvmHandlerSingleton.chain, nil)
+	context := vm.NewEVMContext(emptyMessage, header, internalEvmHandlerSingleton.chain, contracts.Context, nil)
 	evm := vm.NewEVM(context, state, internalEvmHandlerSingleton.chain.Config(), *internalEvmHandlerSingleton.chain.GetVMConfig())
 
 	return evm, nil
@@ -109,9 +110,9 @@ func makeCallFromSystem(scAddress common.Address, abi abi.ABI, funcName string, 
 	var gasLeft uint64
 
 	if static {
-		gasLeft, err = vmevm.StaticCallFromSystem(scAddress, abi, funcName, args, returnObj, gas)
+		gasLeft, err = contracts.StaticCallFromSystem(vmevm, scAddress, abi, funcName, args, returnObj, gas)
 	} else {
-		gasLeft, err = vmevm.CallFromSystem(scAddress, abi, funcName, args, returnObj, gas, value)
+		gasLeft, err = contracts.CallFromSystem(vmevm, scAddress, abi, funcName, args, returnObj, gas, value)
 	}
 	if err != nil {
 		log.Error("Error when invoking evm function", "err", err, "funcName", funcName, "static", static, "address", scAddress, "args", args, "gas", gas, "gasLeft", gasLeft, "value", value)

--- a/contracts/context.go
+++ b/contracts/context.go
@@ -1,0 +1,14 @@
+package contracts
+
+import (
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/core/vm"
+)
+
+type DefaultContext struct{}
+
+func (dc DefaultContext) GetRegisteredAddressFunc(evm *vm.EVM, registryId common.Hash) (common.Address, error) {
+	return GetRegisteredAddress(evm, registryId)
+}
+
+var Context DefaultContext

--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -1,0 +1,88 @@
+package contracts
+
+import (
+	"bytes"
+	"errors"
+	"math/big"
+
+	abipkg "github.com/celo-org/celo-blockchain/accounts/abi"
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/common/hexutil"
+	"github.com/celo-org/celo-blockchain/core/vm"
+	"github.com/celo-org/celo-blockchain/log"
+)
+
+// systemCaller is the caller when the EVM is invoked from the within the blockchain system.
+var systemCaller = vm.AccountRef(common.HexToAddress("0x0"))
+
+func StaticCallFromSystem(evm *vm.EVM, contractAddress common.Address, abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64) (uint64, error) {
+	staticCall := func(transactionData []byte) ([]byte, uint64, error) {
+		return evm.StaticCall(systemCaller, contractAddress, transactionData, gas)
+	}
+
+	return handleABICall(evm, abi, funcName, args, returnObj, staticCall)
+}
+
+func CallFromSystem(evm *vm.EVM, contractAddress common.Address, abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int) (uint64, error) {
+	call := func(transactionData []byte) ([]byte, uint64, error) {
+		return evm.Call(systemCaller, contractAddress, transactionData, gas, value)
+	}
+	return handleABICall(evm, abi, funcName, args, returnObj, call)
+}
+
+var (
+	errorSig     = []byte{0x08, 0xc3, 0x79, 0xa0} // Keccak256("Error(string)")[:4]
+	abiString, _ = abipkg.NewType("string", "", nil)
+)
+
+func unpackError(result []byte) (string, error) {
+	if len(result) < 4 || !bytes.Equal(result[:4], errorSig) {
+		return "<tx result not Error(string)>", errors.New("TX result not of type Error(string)")
+	}
+	vs, err := abipkg.Arguments{{Type: abiString}}.UnpackValues(result[4:])
+	if err != nil {
+		return "<invalid tx result>", err
+	}
+	return vs[0].(string), nil
+}
+
+func handleABICall(evm *vm.EVM, abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, call func([]byte) ([]byte, uint64, error)) (uint64, error) {
+	transactionData, err := abi.Pack(funcName, args...)
+	if err != nil {
+		log.Error("Error in generating the ABI encoding for the function call", "err", err, "funcName", funcName, "args", args)
+		return 0, err
+	}
+
+	ret, leftoverGas, err := call(transactionData)
+
+	if err != nil {
+		msg, _ := unpackError(ret)
+		// Do not log execution reverted as error for getAddressFor. This only happens before the Registry is deployed.
+		// TODO(nategraf): Find a more generic and complete solution to the problem of logging tolerated EVM call failures.
+		if funcName == "getAddressFor" {
+			log.Trace("Error in calling the EVM", "funcName", funcName, "transactionData", hexutil.Encode(transactionData), "err", err, "msg", msg)
+		} else {
+			log.Error("Error in calling the EVM", "funcName", funcName, "transactionData", hexutil.Encode(transactionData), "err", err, "msg", msg)
+		}
+		return leftoverGas, err
+	}
+
+	log.Trace("EVM call successful", "funcName", funcName, "transactionData", hexutil.Encode(transactionData), "ret", hexutil.Encode(ret))
+
+	if returnObj != nil {
+		if err := abi.Unpack(returnObj, funcName, ret); err != nil {
+
+			// TODO (mcortesi) Remove ErrEmptyArguments check after we change Proxy to fail on unset impl
+			// `ErrEmptyArguments` is expected when when syncing & importing blocks
+			// before a contract has been deployed
+			if err == abipkg.ErrEmptyArguments {
+				log.Trace("Error in unpacking EVM call return bytes", "err", err)
+			} else {
+				log.Error("Error in unpacking EVM call return bytes", "err", err)
+			}
+			return leftoverGas, err
+		}
+	}
+
+	return leftoverGas, nil
+}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core/state"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/core/vm"
@@ -86,7 +87,7 @@ func precacheTransaction(config *params.ChainConfig, bc vm.ChainContext, author 
 		return err
 	}
 	// Create the EVM and execute the transaction
-	context := vm.NewEVMContext(msg, header, bc, author)
+	context := vm.NewEVMContext(msg, header, bc, contracts.Context, author)
 	vm := vm.NewEVM(context, statedb, config, cfg)
 
 	_, err = ApplyMessage(vm, msg, gaspool)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/celo-org/celo-blockchain/consensus"
 	"github.com/celo-org/celo-blockchain/consensus/misc"
 	"github.com/celo-org/celo-blockchain/contract_comm/random"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core/state"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/core/vm"
@@ -121,7 +122,7 @@ func ApplyTransaction(config *params.ChainConfig, bc vm.ChainContext, txFeeRecip
 	}
 
 	// Create a new context to be used in the EVM environment
-	context := vm.NewEVMContext(msg, header, bc, txFeeRecipient)
+	context := vm.NewEVMContext(msg, header, bc, contracts.Context, txFeeRecipient)
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(context, statedb, config, cfg)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -26,6 +26,7 @@ import (
 	"github.com/celo-org/celo-blockchain/contract_comm/currency"
 	commerrs "github.com/celo-org/celo-blockchain/contract_comm/errors"
 	gpm "github.com/celo-org/celo-blockchain/contract_comm/gasprice_minimum"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/core/vm"
 	"github.com/celo-org/celo-blockchain/log"
@@ -452,7 +453,7 @@ func (st *StateTransition) distributeTxFees() error {
 		gatewayFeeRecipient = &common.ZeroAddress
 	}
 
-	governanceAddress, err := vm.GetRegisteredAddress(st.evm, params.GovernanceRegistryId)
+	governanceAddress, err := contracts.GetRegisteredAddress(st.evm, params.GovernanceRegistryId)
 	if err != nil && err != commerrs.ErrSmartContractNotDeployed && err != commerrs.ErrRegistryContractNotDeployed {
 		return err
 	} else if err != nil {

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -120,12 +120,21 @@ func (c mockChainContext) Engine() consensus.Engine {
 	return mockEngine{}
 }
 
+type mockContractContext struct {
+	ContractsContext
+}
+
+func (mcc mockContractContext) GetAddressFromRegistry(evm *EVM, registryId common.Hash) (common.Address, error) {
+	return common.ZeroAddress, errors.New("not implemented: GetAddressFromRegistry")
+}
+
 // Create a global mock EVM for use in the following tests.
 var mockEVM = &EVM{
 	Context: NewEVMContext(
 		types.NewMessage(common.HexToAddress("a11ce"), nil, 0, common.Big0, 0, common.Big1, nil, nil, common.Big0, nil, false, false),
 		makeTestHeader(big.NewInt(10000)),
 		mockChainContext{},
+		mockContractContext{},
 		&common.Address{},
 	),
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -17,28 +17,21 @@
 package vm
 
 import (
-	"bytes"
 	"errors"
 	"math/big"
 	"sync/atomic"
 	"time"
 
-	abipkg "github.com/celo-org/celo-blockchain/accounts/abi"
 	"github.com/celo-org/celo-blockchain/common"
-	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/crypto"
-	"github.com/celo-org/celo-blockchain/log"
 	"github.com/celo-org/celo-blockchain/params"
 )
 
 // emptyCodeHash is used by create to ensure deployment is disallowed to already
 // deployed contract addresses (relevant after the account abstraction).
 var emptyCodeHash = crypto.Keccak256Hash(nil)
-
-// systemCaller is the caller when the EVM is invoked from the within the blockchain system.
-var systemCaller = AccountRef(common.HexToAddress("0x0"))
 
 type (
 	// CanTransferFunc is the signature of a transfer guard function
@@ -527,75 +520,3 @@ func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *
 
 // ChainConfig returns the environment's chain configuration
 func (evm *EVM) ChainConfig() *params.ChainConfig { return evm.chainConfig }
-
-func (evm *EVM) StaticCallFromSystem(contractAddress common.Address, abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64) (uint64, error) {
-	staticCall := func(transactionData []byte) ([]byte, uint64, error) {
-		return evm.StaticCall(systemCaller, contractAddress, transactionData, gas)
-	}
-
-	return evm.handleABICall(abi, funcName, args, returnObj, staticCall)
-}
-
-func (evm *EVM) CallFromSystem(contractAddress common.Address, abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int) (uint64, error) {
-	call := func(transactionData []byte) ([]byte, uint64, error) {
-		return evm.Call(systemCaller, contractAddress, transactionData, gas, value)
-	}
-	return evm.handleABICall(abi, funcName, args, returnObj, call)
-}
-
-var (
-	errorSig     = []byte{0x08, 0xc3, 0x79, 0xa0} // Keccak256("Error(string)")[:4]
-	abiString, _ = abipkg.NewType("string", "", nil)
-)
-
-func unpackError(result []byte) (string, error) {
-	if len(result) < 4 || !bytes.Equal(result[:4], errorSig) {
-		return "<tx result not Error(string)>", errors.New("TX result not of type Error(string)")
-	}
-	vs, err := abipkg.Arguments{{Type: abiString}}.UnpackValues(result[4:])
-	if err != nil {
-		return "<invalid tx result>", err
-	}
-	return vs[0].(string), nil
-}
-
-func (evm *EVM) handleABICall(abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, call func([]byte) ([]byte, uint64, error)) (uint64, error) {
-	transactionData, err := abi.Pack(funcName, args...)
-	if err != nil {
-		log.Error("Error in generating the ABI encoding for the function call", "err", err, "funcName", funcName, "args", args)
-		return 0, err
-	}
-
-	ret, leftoverGas, err := call(transactionData)
-
-	if err != nil {
-		msg, _ := unpackError(ret)
-		// Do not log execution reverted as error for getAddressFor. This only happens before the Registry is deployed.
-		// TODO(nategraf): Find a more generic and complete solution to the problem of logging tolerated EVM call failures.
-		if funcName == "getAddressFor" {
-			log.Trace("Error in calling the EVM", "funcName", funcName, "transactionData", hexutil.Encode(transactionData), "err", err, "msg", msg)
-		} else {
-			log.Error("Error in calling the EVM", "funcName", funcName, "transactionData", hexutil.Encode(transactionData), "err", err, "msg", msg)
-		}
-		return leftoverGas, err
-	}
-
-	log.Trace("EVM call successful", "funcName", funcName, "transactionData", hexutil.Encode(transactionData), "ret", hexutil.Encode(ret))
-
-	if returnObj != nil {
-		if err := abi.Unpack(returnObj, funcName, ret); err != nil {
-
-			// TODO (mcortesi) Remove ErrEmptyArguments check after we change Proxy to fail on unset impl
-			// `ErrEmptyArguments` is expected when when syncing & importing blocks
-			// before a contract has been deployed
-			if err == abipkg.ErrEmptyArguments {
-				log.Trace("Error in unpacking EVM call return bytes", "err", err)
-			} else {
-				log.Error("Error in unpacking EVM call return bytes", "err", err)
-			}
-			return leftoverGas, err
-		}
-	}
-
-	return leftoverGas, nil
-}

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -17,6 +17,7 @@
 package runtime
 
 import (
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core/vm"
 )
 
@@ -34,7 +35,7 @@ func NewEnv(cfg *Config) *vm.EVM {
 		Time:        cfg.Time,
 		GasPrice:    cfg.GasPrice,
 
-		GetRegisteredAddress: vm.GetRegisteredAddress,
+		GetRegisteredAddress: contracts.GetRegisteredAddress,
 	}
 
 	if cfg.ChainConfig.Istanbul != nil {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -24,6 +24,7 @@ import (
 	"github.com/celo-org/celo-blockchain/accounts"
 	"github.com/celo-org/celo-blockchain/common"
 	gpm "github.com/celo-org/celo-blockchain/contract_comm/gasprice_minimum"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/bloombits"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
@@ -191,7 +192,7 @@ func (b *EthAPIBackend) GetTd(blockHash common.Hash) *big.Int {
 func (b *EthAPIBackend) GetEVM(ctx context.Context, msg vm.Message, header *types.Header, state *state.StateDB) (*vm.EVM, func() error, error) {
 	vmError := func() error { return nil }
 
-	context := vm.NewEVMContext(msg, header, b.eth.BlockChain(), nil)
+	context := vm.NewEVMContext(msg, header, b.eth.BlockChain(), contracts.Context, nil)
 	return vm.NewEVM(context, state, b.eth.blockchain.Config(), *b.eth.blockchain.GetVMConfig()), vmError, nil
 }
 

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/hexutil"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/state"
@@ -206,7 +207,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
 					msg, _ := tx.AsMessage(signer)
-					vmctx := vm.NewEVMContext(msg, task.block.Header(), api.eth.blockchain, nil)
+					vmctx := vm.NewEVMContext(msg, task.block.Header(), api.eth.blockchain, contracts.Context, nil)
 
 					res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)
 					if err != nil {
@@ -480,7 +481,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
 				msg, _ := txs[task.index].AsMessage(signer)
-				vmctx := vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
+				vmctx := vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, contracts.Context, nil)
 
 				res, err := api.traceTx(ctx, msg, vmctx, task.statedb, config)
 				if err != nil {
@@ -499,7 +500,7 @@ func (api *PrivateDebugAPI) traceBlock(ctx context.Context, block *types.Block, 
 
 		// Generate the next state snapshot fast without tracing
 		msg, _ := tx.AsMessage(signer)
-		vmctx := vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
+		vmctx := vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, contracts.Context, nil)
 
 		vmenv := vm.NewEVM(vmctx, statedb, api.eth.blockchain.Config(), vm.Config{})
 		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas())); err != nil {
@@ -568,7 +569,7 @@ func (api *PrivateDebugAPI) standardTraceBlockToFile(ctx context.Context, block 
 		// Prepare the trasaction for un-traced execution
 		var (
 			msg, _ = tx.AsMessage(signer)
-			vmctx  = vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
+			vmctx  = vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, contracts.Context, nil)
 
 			vmConf vm.Config
 			dump   *os.File
@@ -806,7 +807,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 	for idx, tx := range block.Transactions() {
 		// Assemble the transaction call message and return if the requested offset
 		msg, _ := tx.AsMessage(signer)
-		context := vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
+		context := vm.NewEVMContext(msg, block.Header(), api.eth.blockchain, contracts.Context, nil)
 		if idx == txIndex {
 			return msg, context, statedb, nil
 		}

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/hexutil"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/types"
@@ -110,7 +111,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 		BlockNumber:          new(big.Int).SetUint64(8000000),
 		Time:                 new(big.Int).SetUint64(5),
 		GasPrice:             big.NewInt(1),
-		GetRegisteredAddress: vm.GetRegisteredAddress,
+		GetRegisteredAddress: contracts.GetRegisteredAddress,
 	}
 	alloc := core.GenesisAlloc{}
 
@@ -202,7 +203,7 @@ func TestCallTracer(t *testing.T) {
 				Time:        new(big.Int).SetUint64(uint64(test.Context.Time)),
 				GasLimit:    uint64(test.Context.GasLimit),
 				GasPrice:    tx.GasPrice(),
-				GetRegisteredAddress: vm.GetRegisteredAddress,
+				GetRegisteredAddress: contracts.GetRegisteredAddress,
 			}
 			statedb := tests.MakePreState(rawdb.NewMemoryDatabase(), test.Genesis.Alloc, false)
 

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -24,6 +24,7 @@ import (
 	"github.com/celo-org/celo-blockchain/accounts"
 	"github.com/celo-org/celo-blockchain/common"
 	gpm "github.com/celo-org/celo-blockchain/contract_comm/gasprice_minimum"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/bloombits"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
@@ -167,7 +168,7 @@ func (b *LesApiBackend) GetTd(hash common.Hash) *big.Int {
 }
 
 func (b *LesApiBackend) GetEVM(ctx context.Context, msg vm.Message, header *types.Header, state *state.StateDB) (*vm.EVM, func() error, error) {
-	context := vm.NewEVMContext(msg, header, b.eth.blockchain, nil)
+	context := vm.NewEVMContext(msg, header, b.eth.blockchain, contracts.Context, nil)
 	return vm.NewEVM(context, state, b.eth.chainConfig, vm.Config{}), state.Error, nil
 }
 

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/math"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/state"
@@ -132,7 +133,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 
 				msg := callmsg{types.NewMessage(from.Address(), &testContractAddr, 0, new(big.Int), 100000, new(big.Int), nil, nil, new(big.Int), data, false, false)}
 
-				context := vm.NewEVMContext(msg, header, bc, nil)
+				context := vm.NewEVMContext(msg, header, bc, contracts.Context, nil)
 				vmenv := vm.NewEVM(context, statedb, config, vm.Config{})
 
 				//vmenv := core.NewEnv(statedb, config, bc, msg, header, vm.Config{})
@@ -145,7 +146,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 			state := light.NewState(ctx, header, lc.Odr())
 			state.SetBalance(bankAddr, math.MaxBig256)
 			msg := callmsg{types.NewMessage(bankAddr, &testContractAddr, 0, new(big.Int), 100000, new(big.Int), nil, nil, new(big.Int), data, false, false)}
-			context := vm.NewEVMContext(msg, header, lc, nil)
+			context := vm.NewEVMContext(msg, header, lc, contracts.Context, nil)
 			vmenv := vm.NewEVM(context, state, config, vm.Config{})
 			gp := new(core.GasPool).AddGas(math.MaxUint64)
 			result, _ := core.ApplyMessage(vmenv, msg, gp)

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/math"
 	mockEngine "github.com/celo-org/celo-blockchain/consensus/consensustest"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/state"
@@ -243,7 +244,7 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 		// Perform read-only call.
 		st.SetBalance(testBankAddress, math.MaxBig256)
 		msg := callmsg{types.NewMessage(testBankAddress, &testContractAddr, 0, new(big.Int), 1000000, new(big.Int), nil, nil, new(big.Int), data, false, false)}
-		context := vm.NewEVMContext(msg, header, chain, nil)
+		context := vm.NewEVMContext(msg, header, chain, contracts.Context, nil)
 		vmenv := vm.NewEVM(context, st, config, vm.Config{})
 		gp := new(core.GasPool).AddGas(math.MaxUint64)
 		result, _ := core.ApplyMessage(vmenv, msg, gp)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core/state/snapshot"
 
 	"github.com/celo-org/celo-blockchain/common"
@@ -177,7 +178,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	if err != nil {
 		return nil, common.Hash{}, err
 	}
-	context := vm.NewEVMContext(msg, block.Header(), nil, &t.json.Env.Coinbase)
+	context := vm.NewEVMContext(msg, block.Header(), nil, contracts.Context, &t.json.Env.Coinbase)
 	context.GetHash = vmTestBlockHash
 	evm := vm.NewEVM(context, statedb, config, vmconfig)
 

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -25,6 +25,7 @@ import (
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/common/math"
+	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/state"
@@ -139,7 +140,7 @@ func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
 		BlockNumber:          new(big.Int).SetUint64(t.json.Env.Number),
 		Time:                 new(big.Int).SetUint64(t.json.Env.Timestamp),
 		GasPrice:             t.json.Exec.GasPrice,
-		GetRegisteredAddress: vm.GetRegisteredAddress,
+		GetRegisteredAddress: contracts.GetRegisteredAddress,
 	}
 	vmconfig.NoRecursion = true
 	return vm.NewEVM(context, statedb, params.MainnetChainConfig, vmconfig)


### PR DESCRIPTION
### Description

celo-blockchain added `StaticCallFromSystem` and `CallFromSystem` which
also implied knowledge of the abi module and of the system caller
(address zero)

Both concepts don't belong in the EVM and are better placed on a higher
layer that "uses" the EVM.

This commit extracts those methods, into the `contracts` module.
Decouples the evm from those concept and leaves it closer to upstream's
EVM.

Additionally, `GetRegisteredAddress` is moved to the contracts module.
Decoupling the evm module from the concept of "Registry" and of a
"Registry Contract".

This commit, introduces a new parameter to the vm.NewContext():
ContractsContext which is an interface that provides a
`GetRegisteredAddress` method for use within the EVM. It is a interface
instead of a single function since `getTobinTax` will also be included
there in a follow up PR.

### Tested

CI & unit tests
