### PR TITLE
Refactors contract call logic (prep for caching)

### DIFF
--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -19,7 +19,6 @@ package contract_comm
 import (
 	"math/big"
 	"reflect"
-	"time"
 
 	"github.com/celo-org/celo-blockchain/accounts/abi"
 	"github.com/celo-org/celo-blockchain/common"
@@ -30,7 +29,6 @@ import (
 	"github.com/celo-org/celo-blockchain/core/vm"
 	"github.com/celo-org/celo-blockchain/core/vm/vmcontext"
 	"github.com/celo-org/celo-blockchain/log"
-	"github.com/celo-org/celo-blockchain/metrics"
 )
 
 var (
@@ -42,23 +40,83 @@ type InternalEVMHandler struct {
 	chain vm.ChainContext
 }
 
-func MakeStaticCall(registryId [32]byte, abi abi.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
-	return makeCallWithContractId(registryId, abi, funcName, args, returnObj, gas, nil, header, state, true)
+func MakeStaticCall(registryId common.Hash, abi abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
+	return Query(registryId, &abi, method, args, returnObj, gas, header, state)
 }
 
-func MakeCall(registryId [32]byte, abi abi.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int, header *types.Header, state vm.StateDB, finaliseState bool) (uint64, error) {
-	gasLeft, err := makeCallWithContractId(registryId, abi, funcName, args, returnObj, gas, value, header, state, false)
+func Query(registryId common.Hash, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
+	backend, err := createEVM(header, state)
+	if err != nil {
+		return 0, err
+	}
+
+	contractAddress, err := resolveAddressForCall(backend, registryId, method)
+	if err != nil {
+		return 0, err
+	}
+
+	contract := contracts.NewContract(abi, contractAddress, contracts.SystemCaller)
+	gasLeft, err := contract.Query(contracts.QueryOpts{MaxGas: gas, Backend: backend}, returnObj, method, args...)
+
+	if err != nil {
+		log.Error("Error when invoking evm function", "err", err, "function", method, "address", contractAddress, "args", args, "gas", gas, "gasLeft", gasLeft)
+		return gasLeft, err
+	}
+
+	return gasLeft, nil
+}
+
+func MakeCall(registryId common.Hash, abi abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int, header *types.Header, state vm.StateDB, finaliseState bool) (uint64, error) {
+	return Execute(registryId, &abi, method, args, returnObj, gas, value, header, state, finaliseState)
+}
+
+func Execute(registryId common.Hash, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int, header *types.Header, state vm.StateDB, finaliseState bool) (uint64, error) {
+	backend, err := createEVM(header, state)
+	if err != nil {
+		return 0, err
+	}
+
+	contractAddress, err := resolveAddressForCall(backend, registryId, method)
+	if err != nil {
+		return 0, err
+	}
+
+	contract := contracts.NewContract(abi, contractAddress, contracts.SystemCaller)
+	gasLeft, err := contract.Execute(contracts.ExecOpts{MaxGas: gas, Backend: backend, Value: value}, returnObj, method, args...)
+
+	if err != nil {
+		log.Error("Error when invoking evm function", "err", err, "function", method, "address", contractAddress, "args", args, "gas", gas, "gasLeft", gasLeft)
+		return gasLeft, err
+	}
+
 	if err == nil && finaliseState {
 		state.Finalise(true)
 	}
 	return gasLeft, err
 }
 
-func MakeStaticCallWithAddress(scAddress common.Address, abi abi.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
-	return makeCallFromSystem(scAddress, abi, funcName, args, returnObj, gas, nil, header, state, true)
+func MakeStaticCallWithAddress(scAddress common.Address, abi abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
+	return QueryWithAddress(scAddress, &abi, method, args, returnObj, gas, header, state)
 }
 
-func GetRegisteredAddress(registryId [32]byte, header *types.Header, state vm.StateDB) (common.Address, error) {
+func QueryWithAddress(scAddress common.Address, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
+	backend, err := createEVM(header, state)
+	if err != nil {
+		return 0, err
+	}
+
+	contract := contracts.NewContract(abi, scAddress, contracts.SystemCaller)
+	gasLeft, err := contract.Query(contracts.QueryOpts{MaxGas: gas, Backend: backend}, returnObj, method, args...)
+
+	if err != nil {
+		log.Error("Error when invoking evm function", "err", err, "function", method, "address", scAddress, "args", args, "gas", gas, "gasLeft", gasLeft)
+		return gasLeft, err
+	}
+
+	return gasLeft, nil
+}
+
+func GetRegisteredAddress(registryId common.Hash, header *types.Header, state vm.StateDB) (common.Address, error) {
 	vmevm, err := createEVM(header, state)
 	if err != nil {
 		return common.ZeroAddress, err
@@ -96,32 +154,6 @@ func createEVM(header *types.Header, state vm.StateDB) (*vm.EVM, error) {
 	return evm, nil
 }
 
-func makeCallFromSystem(scAddress common.Address, abi abi.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int, header *types.Header, state vm.StateDB, static bool) (uint64, error) {
-	// Record a metrics data point about execution time.
-	timer := metrics.GetOrRegisterTimer("contract_comm/systemcall/"+funcName, nil)
-	start := time.Now()
-	defer timer.UpdateSince(start)
-
-	vmevm, err := createEVM(header, state)
-	if err != nil {
-		return 0, err
-	}
-
-	var gasLeft uint64
-
-	if static {
-		gasLeft, err = contracts.StaticCallFromSystem(vmevm, scAddress, abi, funcName, args, returnObj, gas)
-	} else {
-		gasLeft, err = contracts.CallFromSystem(vmevm, scAddress, abi, funcName, args, returnObj, gas, value)
-	}
-	if err != nil {
-		log.Error("Error when invoking evm function", "err", err, "funcName", funcName, "static", static, "address", scAddress, "args", args, "gas", gas, "gasLeft", gasLeft, "value", value)
-		return gasLeft, err
-	}
-
-	return gasLeft, nil
-}
-
 func SetInternalEVMHandler(chain vm.ChainContext) {
 	if internalEvmHandlerSingleton == nil {
 		log.Trace("Setting the InternalEVMHandler Singleton")
@@ -132,25 +164,18 @@ func SetInternalEVMHandler(chain vm.ChainContext) {
 	}
 }
 
-func makeCallWithContractId(registryId [32]byte, abi abi.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int, header *types.Header, state vm.StateDB, static bool) (uint64, error) {
-	scAddress, err := GetRegisteredAddress(registryId, header, state)
+func resolveAddressForCall(backend *vm.EVM, registryId common.Hash, method string) (common.Address, error) {
+	contractAddress, err := contracts.GetRegisteredAddress(backend, registryId)
 
 	if err != nil {
 		if err == errors.ErrSmartContractNotDeployed {
-			log.Debug("Contract not yet registered", "function", funcName, "registryId", hexutil.Encode(registryId[:]))
-			return 0, err
+			log.Debug("Contract not yet registered", "function", method, "registryId", hexutil.Encode(registryId[:]))
 		} else if err == errors.ErrRegistryContractNotDeployed {
-			log.Debug("Registry contract not yet deployed", "function", funcName, "registryId", hexutil.Encode(registryId[:]))
-			return 0, err
+			log.Debug("Registry contract not yet deployed", "function", method, "registryId", hexutil.Encode(registryId[:]))
 		} else {
-			log.Error("Error in getting registered address", "function", funcName, "registryId", hexutil.Encode(registryId[:]), "err", err)
-			return 0, err
+			log.Error("Error in getting registered address", "function", method, "registryId", hexutil.Encode(registryId[:]), "err", err)
 		}
+		return common.ZeroAddress, err
 	}
-
-	gasLeft, err := makeCallFromSystem(scAddress, abi, funcName, args, returnObj, gas, value, header, state, static)
-	if err != nil {
-		log.Error("Error in executing function on registered contract", "function", funcName, "registryId", hexutil.Encode(registryId[:]), "err", err)
-	}
-	return gasLeft, err
+	return contractAddress, nil
 }

--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -41,14 +41,15 @@ type InternalEVMHandler struct {
 }
 
 func MakeStaticCall(registryId common.Hash, abi abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
-	return Query(registryId, &abi, method, args, returnObj, gas, header, state)
-}
-
-func Query(registryId common.Hash, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
 	backend, err := createEVM(header, state)
 	if err != nil {
 		return 0, err
 	}
+
+	return Query(backend, registryId, &abi, method, args, returnObj, gas)
+}
+
+func Query(backend *vm.EVM, registryId common.Hash, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64) (uint64, error) {
 
 	contractAddress, err := resolveAddressForCall(backend, registryId, method)
 	if err != nil {
@@ -67,15 +68,21 @@ func Query(registryId common.Hash, abi *abi.ABI, method string, args []interface
 }
 
 func MakeCall(registryId common.Hash, abi abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int, header *types.Header, state vm.StateDB, finaliseState bool) (uint64, error) {
-	return Execute(registryId, &abi, method, args, returnObj, gas, value, header, state, finaliseState)
-}
-
-func Execute(registryId common.Hash, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int, header *types.Header, state vm.StateDB, finaliseState bool) (uint64, error) {
 	backend, err := createEVM(header, state)
 	if err != nil {
 		return 0, err
 	}
 
+	gasLeft, err := Execute(backend, registryId, &abi, method, args, returnObj, gas, value)
+
+	if err == nil && finaliseState {
+		state.Finalise(true)
+	}
+
+	return gasLeft, err
+}
+
+func Execute(backend *vm.EVM, registryId common.Hash, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int) (uint64, error) {
 	contractAddress, err := resolveAddressForCall(backend, registryId, method)
 	if err != nil {
 		return 0, err
@@ -89,27 +96,24 @@ func Execute(registryId common.Hash, abi *abi.ABI, method string, args []interfa
 		return gasLeft, err
 	}
 
-	if err == nil && finaliseState {
-		state.Finalise(true)
-	}
 	return gasLeft, err
 }
 
 func MakeStaticCallWithAddress(scAddress common.Address, abi abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
-	return QueryWithAddress(scAddress, &abi, method, args, returnObj, gas, header, state)
-}
-
-func QueryWithAddress(scAddress common.Address, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
 	backend, err := createEVM(header, state)
 	if err != nil {
 		return 0, err
 	}
 
-	contract := contracts.NewContract(abi, scAddress, contracts.SystemCaller)
+	return QueryWithAddress(backend, scAddress, &abi, method, args, returnObj, gas)
+}
+
+func QueryWithAddress(backend *vm.EVM, contractAddress common.Address, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64) (uint64, error) {
+	contract := contracts.NewContract(abi, contractAddress, contracts.SystemCaller)
 	gasLeft, err := contract.Query(contracts.QueryOpts{MaxGas: gas, Backend: backend}, returnObj, method, args...)
 
 	if err != nil {
-		log.Error("Error when invoking evm function", "err", err, "function", method, "address", scAddress, "args", args, "gas", gas, "gasLeft", gasLeft)
+		log.Error("Error when invoking evm function", "err", err, "function", method, "address", contractAddress, "args", args, "gas", gas, "gasLeft", gasLeft)
 		return gasLeft, err
 	}
 

--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -49,7 +49,7 @@ func MakeStaticCall(registryId common.Hash, abi abi.ABI, method string, args []i
 	return Query(backend, registryId, &abi, method, args, returnObj, gas)
 }
 
-func Query(backend *vm.EVM, registryId common.Hash, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64) (uint64, error) {
+func Query(backend contracts.Backend, registryId common.Hash, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64) (uint64, error) {
 
 	contractAddress, err := resolveAddressForCall(backend, registryId, method)
 	if err != nil {
@@ -82,7 +82,7 @@ func MakeCall(registryId common.Hash, abi abi.ABI, method string, args []interfa
 	return gasLeft, err
 }
 
-func Execute(backend *vm.EVM, registryId common.Hash, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int) (uint64, error) {
+func Execute(backend contracts.Backend, registryId common.Hash, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int) (uint64, error) {
 	contractAddress, err := resolveAddressForCall(backend, registryId, method)
 	if err != nil {
 		return 0, err
@@ -108,7 +108,7 @@ func MakeStaticCallWithAddress(scAddress common.Address, abi abi.ABI, method str
 	return QueryWithAddress(backend, scAddress, &abi, method, args, returnObj, gas)
 }
 
-func QueryWithAddress(backend *vm.EVM, contractAddress common.Address, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64) (uint64, error) {
+func QueryWithAddress(backend contracts.Backend, contractAddress common.Address, abi *abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64) (uint64, error) {
 	contract := contracts.NewContract(abi, contractAddress, contracts.SystemCaller)
 	gasLeft, err := contract.Query(contracts.QueryOpts{MaxGas: gas, Backend: backend}, returnObj, method, args...)
 
@@ -128,7 +128,7 @@ func GetRegisteredAddress(registryId common.Hash, header *types.Header, state vm
 	return contracts.GetRegisteredAddress(vmevm, registryId)
 }
 
-func createEVM(header *types.Header, state vm.StateDB) (*vm.EVM, error) {
+func createEVM(header *types.Header, state vm.StateDB) (contracts.Backend, error) {
 	// Normally, when making an evm call, we should use the current block's state.  However,
 	// there are times (e.g. retrieving the set of validators when an epoch ends) that we need
 	// to call the evm using the currently mined block.  In that case, the header and state params
@@ -168,7 +168,7 @@ func SetInternalEVMHandler(chain vm.ChainContext) {
 	}
 }
 
-func resolveAddressForCall(backend *vm.EVM, registryId common.Hash, method string) (common.Address, error) {
+func resolveAddressForCall(backend contracts.Backend, registryId common.Hash, method string) (common.Address, error) {
 	contractAddress, err := contracts.GetRegisteredAddress(backend, registryId)
 
 	if err != nil {

--- a/contract_comm/evm.go
+++ b/contract_comm/evm.go
@@ -41,7 +41,7 @@ type InternalEVMHandler struct {
 }
 
 func MakeStaticCall(registryId common.Hash, abi abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
-	backend, err := createEVM(header, state)
+	backend, err := createBackend(header, state)
 	if err != nil {
 		return 0, err
 	}
@@ -68,7 +68,7 @@ func Query(backend contracts.Backend, registryId common.Hash, abi *abi.ABI, meth
 }
 
 func MakeCall(registryId common.Hash, abi abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int, header *types.Header, state vm.StateDB, finaliseState bool) (uint64, error) {
-	backend, err := createEVM(header, state)
+	backend, err := createBackend(header, state)
 	if err != nil {
 		return 0, err
 	}
@@ -100,7 +100,7 @@ func Execute(backend contracts.Backend, registryId common.Hash, abi *abi.ABI, me
 }
 
 func MakeStaticCallWithAddress(scAddress common.Address, abi abi.ABI, method string, args []interface{}, returnObj interface{}, gas uint64, header *types.Header, state vm.StateDB) (uint64, error) {
-	backend, err := createEVM(header, state)
+	backend, err := createBackend(header, state)
 	if err != nil {
 		return 0, err
 	}
@@ -121,14 +121,14 @@ func QueryWithAddress(backend contracts.Backend, contractAddress common.Address,
 }
 
 func GetRegisteredAddress(registryId common.Hash, header *types.Header, state vm.StateDB) (common.Address, error) {
-	vmevm, err := createEVM(header, state)
+	vmevm, err := createBackend(header, state)
 	if err != nil {
 		return common.ZeroAddress, err
 	}
 	return contracts.GetRegisteredAddress(vmevm, registryId)
 }
 
-func createEVM(header *types.Header, state vm.StateDB) (contracts.Backend, error) {
+func createBackend(header *types.Header, state vm.StateDB) (contracts.Backend, error) {
 	// Normally, when making an evm call, we should use the current block's state.  However,
 	// there are times (e.g. retrieving the set of validators when an epoch ends) that we need
 	// to call the evm using the currently mined block.  In that case, the header and state params
@@ -153,7 +153,7 @@ func createEVM(header *types.Header, state vm.StateDB) (contracts.Backend, error
 	// The EVM Context requires a msg, but the actual field values don't really matter for this case.
 	// Putting in zero values.
 	context := vmcontext.New(common.ZeroAddress, common.Big0, header, internalEvmHandlerSingleton.chain, nil)
-	evm := vm.NewEVM(context, state, internalEvmHandlerSingleton.chain.Config(), *internalEvmHandlerSingleton.chain.GetVMConfig())
+	evm := contracts.NewEVMBackend(context, state, internalEvmHandlerSingleton.chain.Config(), *internalEvmHandlerSingleton.chain.GetVMConfig())
 
 	return evm, nil
 }

--- a/contracts/backend.go
+++ b/contracts/backend.go
@@ -1,0 +1,60 @@
+package contracts
+
+import (
+	"math/big"
+
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/core/vm"
+	"github.com/celo-org/celo-blockchain/params"
+)
+
+type evmBackend struct {
+	vmConfig    vm.Config
+	vmContext   vm.Context
+	chainConfig *params.ChainConfig
+	state       vm.StateDB
+
+	dontMeterGas bool
+}
+
+func NewEVMBackend(vmContext vm.Context, state vm.StateDB, chainConfig *params.ChainConfig, vmConfig vm.Config) Backend {
+	return &evmBackend{
+		vmConfig:    vmConfig,
+		vmContext:   vmContext,
+		chainConfig: chainConfig,
+		state:       state,
+	}
+}
+
+// Call implements Backend.Call
+func (ev *evmBackend) Call(caller vm.ContractRef, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error) {
+	evm := vm.NewEVM(ev.vmContext, ev.state, ev.chainConfig, ev.vmConfig)
+	if ev.dontMeterGas {
+		evm.StopGasMetering()
+	}
+	return evm.Call(caller, addr, input, gas, value)
+}
+
+// StaticCall implements Backend.StaticCall
+func (ev *evmBackend) StaticCall(caller vm.ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
+	evm := vm.NewEVM(ev.vmContext, ev.state, ev.chainConfig, ev.vmConfig)
+	if ev.dontMeterGas {
+		evm.StopGasMetering()
+	}
+	return evm.StaticCall(caller, addr, input, gas)
+}
+
+// StopGasMetering implements Backend.StopGasMetering
+func (ev *evmBackend) StopGasMetering() {
+	ev.dontMeterGas = true
+}
+
+// StartGasMetering implements Backend.StartGasMetering
+func (ev *evmBackend) StartGasMetering() {
+	ev.dontMeterGas = false
+}
+
+// GetStateDB implements Backend.GetStateDB
+func (ev *evmBackend) GetStateDB() vm.StateDB {
+	return ev.state
+}

--- a/contracts/registry.go
+++ b/contracts/registry.go
@@ -47,17 +47,17 @@ func init() {
 // See this commit for the removed code for caching:  https://github.com/celo-org/geth/commit/43a275273c480d307a3d2b3c55ca3b3ee31ec7dd.
 
 // GetRegisteredAddress returns the address on the registry for a given id
-func GetRegisteredAddress(evm *vm.EVM, registryId common.Hash) (common.Address, error) {
-	evm.DontMeterGas = true
-	defer func() { evm.DontMeterGas = false }()
+func GetRegisteredAddress(backend Backend, registryId common.Hash) (common.Address, error) {
+	backend.StopGasMetering()
+	defer backend.StartGasMetering()
 
 	// TODO(mcortesi) remove registrypoxy deployed at genesis
-	if evm.StateDB.GetCodeSize(params.RegistrySmartContractAddress) == 0 {
+	if backend.GetStateDB().GetCodeSize(params.RegistrySmartContractAddress) == 0 {
 		return common.ZeroAddress, errors.ErrRegistryContractNotDeployed
 	}
 
 	var contractAddress common.Address
-	_, err := registry.Query(QueryOpts{MaxGas: params.MaxGasForGetAddressFor, Backend: evm}, &contractAddress, "getAddressFor", registryId)
+	_, err := registry.Query(QueryOpts{MaxGas: params.MaxGasForGetAddressFor, Backend: backend}, &contractAddress, "getAddressFor", registryId)
 
 	// TODO (mcortesi) Remove ErrEmptyArguments check after we change Proxy to fail on unset impl
 	// TODO(asa): Why was this change necessary?

--- a/contracts/reserve/tobin_tax.go
+++ b/contracts/reserve/tobin_tax.go
@@ -30,7 +30,7 @@ func TobinTax(evm *vm.EVM, sender common.Address) (tax Ratio, reserveAddress com
 		return Ratio{}, common.ZeroAddress, err
 	}
 
-	ret, _, err := evm.Call(contracts.SystemCaller, reserveAddress, params.TobinTaxFunctionSelector, params.MaxGasForGetOrComputeTobinTax, big.NewInt(0))
+	ret, _, err := evm.Call(vm.AccountRef(contracts.SystemCaller), reserveAddress, params.TobinTaxFunctionSelector, params.MaxGasForGetOrComputeTobinTax, big.NewInt(0))
 	if err != nil {
 		return Ratio{}, common.ZeroAddress, err
 	}

--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -26,6 +26,9 @@ type Contract struct {
 type Backend interface {
 	Call(caller vm.ContractRef, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error)
 	StaticCall(caller vm.ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error)
+	StopGasMetering()
+	StartGasMetering()
+	GetStateDB() vm.StateDB
 }
 
 func NewContract(contractAbi *abi.ABI, contractAddress, defaultCaller common.Address) *Contract {

--- a/contracts/utils.go
+++ b/contracts/utils.go
@@ -4,85 +4,147 @@ import (
 	"bytes"
 	"errors"
 	"math/big"
+	"time"
 
-	abipkg "github.com/celo-org/celo-blockchain/accounts/abi"
+	"github.com/celo-org/celo-blockchain/accounts/abi"
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/core/vm"
 	"github.com/celo-org/celo-blockchain/log"
+	"github.com/celo-org/celo-blockchain/metrics"
 )
 
 // SystemCaller is the caller when the EVM is invoked from the within the blockchain system.
-var SystemCaller = vm.AccountRef(common.HexToAddress("0x0"))
+var SystemCaller = common.HexToAddress("0x0")
 
-func StaticCallFromSystem(evm *vm.EVM, contractAddress common.Address, abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64) (uint64, error) {
-	staticCall := func(transactionData []byte) ([]byte, uint64, error) {
-		return evm.StaticCall(SystemCaller, contractAddress, transactionData, gas)
-	}
-
-	return handleABICall(evm, abi, funcName, args, returnObj, staticCall)
+type Contract struct {
+	abi     *abi.ABI
+	address common.Address
+	caller  common.Address
 }
 
-func CallFromSystem(evm *vm.EVM, contractAddress common.Address, abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, gas uint64, value *big.Int) (uint64, error) {
-	call := func(transactionData []byte) ([]byte, uint64, error) {
-		return evm.Call(SystemCaller, contractAddress, transactionData, gas, value)
+type Backend interface {
+	Call(caller vm.ContractRef, addr common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, leftOverGas uint64, err error)
+	StaticCall(caller vm.ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error)
+}
+
+func NewContract(contractAbi *abi.ABI, contractAddress, defaultCaller common.Address) *Contract {
+	return &Contract{
+		abi:     contractAbi,
+		address: contractAddress,
+		caller:  defaultCaller,
 	}
-	return handleABICall(evm, abi, funcName, args, returnObj, call)
+}
+
+type ExecOpts struct {
+	Backend Backend
+	MaxGas  uint64
+	Value   *big.Int
+}
+type QueryOpts struct {
+	Backend Backend
+	MaxGas  uint64
+}
+
+func (c *Contract) Execute(opts ExecOpts, result interface{}, method string, args ...interface{}) (uint64, error) {
+	defer c.meterExecutionTime(method)()
+	logger := log.New("method", method, "args", args)
+
+	input, err := c.abi.Pack(method, args...)
+	if err != nil {
+		logger.Error("Error in generating the ABI encoding for the function call", "err", err)
+		return 0, err
+	}
+
+	output, leftoverGas, err := opts.Backend.Call(vm.AccountRef(c.caller), c.address, input, opts.MaxGas, opts.Value)
+
+	if err != nil {
+		c.logCallError(logger, method, input, output, err)
+		return leftoverGas, err
+	}
+
+	logger.Trace("EVM call successful", "input", hexutil.Encode(input), "output", hexutil.Encode(output))
+
+	if result != nil {
+		if err := c.abi.Unpack(result, method, output); err != nil {
+			c.logUnpackError(logger, err)
+			return leftoverGas, err
+		}
+	}
+
+	return leftoverGas, nil
+}
+
+func (c *Contract) Query(opts QueryOpts, result interface{}, method string, args ...interface{}) (uint64, error) {
+	defer c.meterExecutionTime(method)()
+	logger := log.New("method", method, "args", args)
+
+	input, err := c.abi.Pack(method, args...)
+	if err != nil {
+		logger.Error("Error in generating the ABI encoding for the function call", "err", err)
+		return 0, err
+	}
+
+	output, leftoverGas, err := opts.Backend.StaticCall(vm.AccountRef(c.caller), c.address, input, opts.MaxGas)
+
+	if err != nil {
+		c.logCallError(logger, method, input, output, err)
+		return leftoverGas, err
+	}
+
+	logger.Trace("EVM call successful", "input", hexutil.Encode(input), "output", hexutil.Encode(output))
+
+	if result != nil {
+		if err := c.abi.Unpack(result, method, output); err != nil {
+			c.logUnpackError(logger, err)
+			return leftoverGas, err
+		}
+	}
+
+	return leftoverGas, nil
+}
+
+func (c *Contract) meterExecutionTime(method string) func() {
+	// Record a metrics data point about execution time.
+	timer := metrics.GetOrRegisterTimer("contract_comm/systemcall/"+method, nil)
+	start := time.Now()
+	return func() { timer.UpdateSince(start) }
+}
+
+func (c *Contract) logUnpackError(logger log.Logger, err error) {
+	// TODO (mcortesi) Remove ErrEmptyArguments check after we change Proxy to fail on unset impl
+	// `ErrEmptyArguments` is expected when when syncing & importing blocks
+	// before a contract has been deployed
+	if err == abi.ErrEmptyArguments {
+		logger.Trace("Error in unpacking EVM call return bytes", "err", err)
+	} else {
+		logger.Error("Error in unpacking EVM call return bytes", "err", err)
+	}
+}
+
+func (c *Contract) logCallError(logger log.Logger, method string, input, output []byte, err error) {
+	msg, _ := unpackError(output)
+	// Do not log execution reverted as error for getAddressFor. This only happens before the Registry is deployed.
+	// TODO(nategraf): Find a more generic and complete solution to the problem of logging tolerated EVM call failures.
+	if method == "getAddressFor" {
+		logger.Trace("Error in calling the EVM", "input", hexutil.Encode(input), "err", err, "msg", msg)
+	} else {
+		logger.Error("Error in calling the EVM", "input", hexutil.Encode(input), "err", err, "msg", msg)
+	}
 }
 
 var (
 	errorSig     = []byte{0x08, 0xc3, 0x79, 0xa0} // Keccak256("Error(string)")[:4]
-	abiString, _ = abipkg.NewType("string", "", nil)
+	abiString, _ = abi.NewType("string", "", nil)
 )
 
 func unpackError(result []byte) (string, error) {
 	if len(result) < 4 || !bytes.Equal(result[:4], errorSig) {
 		return "<tx result not Error(string)>", errors.New("TX result not of type Error(string)")
 	}
-	vs, err := abipkg.Arguments{{Type: abiString}}.UnpackValues(result[4:])
+	vs, err := abi.Arguments{{Type: abiString}}.UnpackValues(result[4:])
 	if err != nil {
 		return "<invalid tx result>", err
 	}
 	return vs[0].(string), nil
-}
-
-func handleABICall(evm *vm.EVM, abi abipkg.ABI, funcName string, args []interface{}, returnObj interface{}, call func([]byte) ([]byte, uint64, error)) (uint64, error) {
-	transactionData, err := abi.Pack(funcName, args...)
-	if err != nil {
-		log.Error("Error in generating the ABI encoding for the function call", "err", err, "funcName", funcName, "args", args)
-		return 0, err
-	}
-
-	ret, leftoverGas, err := call(transactionData)
-
-	if err != nil {
-		msg, _ := unpackError(ret)
-		// Do not log execution reverted as error for getAddressFor. This only happens before the Registry is deployed.
-		// TODO(nategraf): Find a more generic and complete solution to the problem of logging tolerated EVM call failures.
-		if funcName == "getAddressFor" {
-			log.Trace("Error in calling the EVM", "funcName", funcName, "transactionData", hexutil.Encode(transactionData), "err", err, "msg", msg)
-		} else {
-			log.Error("Error in calling the EVM", "funcName", funcName, "transactionData", hexutil.Encode(transactionData), "err", err, "msg", msg)
-		}
-		return leftoverGas, err
-	}
-
-	log.Trace("EVM call successful", "funcName", funcName, "transactionData", hexutil.Encode(transactionData), "ret", hexutil.Encode(ret))
-
-	if returnObj != nil {
-		if err := abi.Unpack(returnObj, funcName, ret); err != nil {
-
-			// TODO (mcortesi) Remove ErrEmptyArguments check after we change Proxy to fail on unset impl
-			// `ErrEmptyArguments` is expected when when syncing & importing blocks
-			// before a contract has been deployed
-			if err == abipkg.ErrEmptyArguments {
-				log.Trace("Error in unpacking EVM call return bytes", "err", err)
-			} else {
-				log.Error("Error in unpacking EVM call return bytes", "err", err)
-			}
-			return leftoverGas, err
-		}
-	}
-
-	return leftoverGas, nil
 }

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -153,7 +153,7 @@ type EVM struct {
 	// applied in opCall*.
 	callGasTemp uint64
 
-	DontMeterGas bool
+	dontMeterGas bool
 }
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
@@ -166,7 +166,7 @@ func NewEVM(ctx Context, statedb StateDB, chainConfig *params.ChainConfig, vmCon
 		chainConfig:  chainConfig,
 		chainRules:   chainConfig.Rules(ctx.BlockNumber),
 		interpreters: make([]Interpreter, 0, 1),
-		DontMeterGas: false,
+		dontMeterGas: false,
 	}
 
 	if chainConfig.IsEWASM(ctx.BlockNumber) {
@@ -515,3 +515,11 @@ func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *
 
 // ChainConfig returns the environment's chain configuration
 func (evm *EVM) ChainConfig() *params.ChainConfig { return evm.chainConfig }
+
+func (evm *EVM) StopGasMetering() {
+	evm.dontMeterGas = true
+}
+
+func (evm *EVM) StartGasMetering() {
+	evm.dontMeterGas = false
+}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -209,6 +209,10 @@ func (evm *EVM) Interpreter() Interpreter {
 	return evm.interpreter
 }
 
+func (evm *EVM) GetStateDB() StateDB {
+	return evm.StateDB
+}
+
 func (evm *EVM) GetDebug() bool {
 	return evm.vmConfig.Debug
 }

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -243,7 +243,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		}
 		// Static portion of gas
 		cost = operation.constantGas // For tracing
-		if !in.evm.DontMeterGas && !contract.UseGas(operation.constantGas) {
+		if !in.evm.dontMeterGas && !contract.UseGas(operation.constantGas) {
 			return nil, ErrOutOfGas
 		}
 
@@ -269,7 +269,7 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 		// Dynamic portion of gas
 		// consume the gas and return an error if not enough gas is available.
 		// cost is explicitly set so that the capture state defer method can get the proper cost
-		if !in.evm.DontMeterGas && operation.dynamicGas != nil {
+		if !in.evm.dontMeterGas && operation.dynamicGas != nil {
 			var dynamicCost uint64
 			dynamicCost, err = operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
 			cost += dynamicCost // total cost, for debug tracing

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -17,7 +17,6 @@
 package runtime
 
 import (
-	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core/vm"
 	"github.com/celo-org/celo-blockchain/core/vm/vmcontext"
 )
@@ -36,7 +35,7 @@ func NewEnv(cfg *Config) *vm.EVM {
 		Time:        cfg.Time,
 		GasPrice:    cfg.GasPrice,
 
-		GetRegisteredAddress: contracts.GetRegisteredAddress,
+		GetRegisteredAddress: context.GetRegisteredAddress,
 	}
 
 	if cfg.ChainConfig.Istanbul != nil {

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -35,7 +35,7 @@ func NewEnv(cfg *Config) *vm.EVM {
 		Time:        cfg.Time,
 		GasPrice:    cfg.GasPrice,
 
-		GetRegisteredAddress: context.GetRegisteredAddress,
+		GetRegisteredAddress: vmcontext.GetRegisteredAddress,
 	}
 
 	if cfg.ChainConfig.Istanbul != nil {

--- a/core/vm/vmcontext/context.go
+++ b/core/vm/vmcontext/context.go
@@ -35,7 +35,7 @@ func New(from common.Address, gasPrice *big.Int, header *types.Header, chain vm.
 		Time:        new(big.Int).SetUint64(header.Time),
 		GasPrice:    new(big.Int).Set(gasPrice),
 
-		GetRegisteredAddress: contracts.GetRegisteredAddress,
+		GetRegisteredAddress: GetRegisteredAddress,
 	}
 
 	if chain != nil {
@@ -47,6 +47,10 @@ func New(from common.Address, gasPrice *big.Int, header *types.Header, chain vm.
 		ctx.GetHeaderByNumber = func(uint64) *types.Header { panic("evm context without blockchain context") }
 	}
 	return ctx
+}
+
+func GetRegisteredAddress(evm *vm.EVM, registryId common.Hash) (common.Address, error) {
+	return contracts.GetRegisteredAddress(evm, registryId)
 }
 
 // GetHashFn returns a GetHashFunc which retrieves header hashes by number

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/hexutil"
-	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/types"
@@ -112,7 +111,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 		BlockNumber:          new(big.Int).SetUint64(8000000),
 		Time:                 new(big.Int).SetUint64(5),
 		GasPrice:             big.NewInt(1),
-		GetRegisteredAddress: contracts.GetRegisteredAddress,
+		GetRegisteredAddress: context.GetRegisteredAddress,
 	}
 	alloc := core.GenesisAlloc{}
 

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -111,7 +111,7 @@ func TestPrestateTracerCreate2(t *testing.T) {
 		BlockNumber:          new(big.Int).SetUint64(8000000),
 		Time:                 new(big.Int).SetUint64(5),
 		GasPrice:             big.NewInt(1),
-		GetRegisteredAddress: context.GetRegisteredAddress,
+		GetRegisteredAddress: vmcontext.GetRegisteredAddress,
 	}
 	alloc := core.GenesisAlloc{}
 

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -140,7 +140,7 @@ func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
 		BlockNumber:          new(big.Int).SetUint64(t.json.Env.Number),
 		Time:                 new(big.Int).SetUint64(t.json.Env.Timestamp),
 		GasPrice:             t.json.Exec.GasPrice,
-		GetRegisteredAddress: context.GetRegisteredAddress,
+		GetRegisteredAddress: vmcontext.GetRegisteredAddress,
 	}
 	vmconfig.NoRecursion = true
 	return vm.NewEVM(context, statedb, params.MainnetChainConfig, vmconfig)

--- a/tests/vm_test_util.go
+++ b/tests/vm_test_util.go
@@ -25,7 +25,6 @@ import (
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/common/math"
-	"github.com/celo-org/celo-blockchain/contracts"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/state"
@@ -141,7 +140,7 @@ func (t *VMTest) newEVM(statedb *state.StateDB, vmconfig vm.Config) *vm.EVM {
 		BlockNumber:          new(big.Int).SetUint64(t.json.Env.Number),
 		Time:                 new(big.Int).SetUint64(t.json.Env.Timestamp),
 		GasPrice:             t.json.Exec.GasPrice,
-		GetRegisteredAddress: contracts.GetRegisteredAddress,
+		GetRegisteredAddress: context.GetRegisteredAddress,
 	}
 	vmconfig.NoRecursion = true
 	return vm.NewEVM(context, statedb, params.MainnetChainConfig, vmconfig)


### PR DESCRIPTION
**Note for the reviewer**. This PR is better reviewed by commit. Each commit takes a single step and should be easy enough to follow

### Description

This PR is preparation work for adding a caching layer to contract calls.

It modifies `contracts` and `contract_comm` packages to:

 * Add the concept of `contract.Backend` interface which the EVM already implements, but can be implemented by others (cache for example)
 * Adds variants to contract_comm utility functions that expect a `Backend` instead of `header & state`. It maintains backwards compatibility.
 * Simplifies logic, by removing generic function and adding a little duplication. In this PR's author mind, the code now it's simpler to read than before since code clearly shows the sequence of steps required to do a call (create backend, obtain contract address, pack arguments, make call, unpack result)
 * Variant for `MakeStaticCall` is named `Query` to clearly state this is a read only call
 * Variant for `MakeCall` is named `Execute` to imply it's call with write permissions.

### Other changes

 * As part of the refactor, execution time metering is moved to `contracts` package from `contract_comm` package. This implies that we will be metering all calls, and not just the ones done through `contract_comm`

### Tested

 * unit tests
 * ci

### Backwards compatibility

Changes should be backward compatible. Several considerations have been made to keep compatibility, even when that implied leaving a potentially problematic behaviour.

 * Each call uses it's own EVM when used from contract_comm, and a shared one elsewhere


