### PR TITLE
Cache currency comparisons when building blocks

### DIFF
--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -169,6 +169,10 @@ func NewComparator() *CurrencyComparator {
 }
 
 func (cc *CurrencyComparator) getExchangeRate(currency *common.Address) (*exchangeRate, error) {
+	if currency == nil {
+		return &exchangeRate{cgExchangeRateNum, cgExchangeRateDen}, nil
+	}
+
 	val, ok := cc.exchangeRates[*currency]
 	if ok {
 		return val, nil

--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -158,6 +158,63 @@ func Convert(val *big.Int, currencyFrom *common.Address, currencyTo *common.Addr
 	return new(big.Int).Div(numerator, denominator), nil
 }
 
+type CurrencyComparator struct {
+	exchangeRates map[common.Address]*exchangeRate
+}
+
+func NewComparator() *CurrencyComparator {
+	return &CurrencyComparator{
+		exchangeRates: make(map[common.Address]*exchangeRate),
+	}
+}
+
+func (cc *CurrencyComparator) getExchangeRate(currency *common.Address) (*exchangeRate, error) {
+	val, ok := cc.exchangeRates[*currency]
+	if ok {
+		return val, nil
+	}
+
+	val, err := getExchangeRate(currency)
+	if err != nil {
+		return nil, err
+	}
+
+	cc.exchangeRates[*currency] = val
+
+	return val, nil
+}
+
+func (cc *CurrencyComparator) Cmp(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
+	// Short circuit if the fee currency is the same. nil currency => native currency
+	if (currency1 == nil && currency2 == nil) || (currency1 != nil && currency2 != nil && *currency1 == *currency2) {
+		return val1.Cmp(val2)
+	}
+
+	exchangeRate1, err1 := cc.getExchangeRate(currency1)
+	exchangeRate2, err2 := cc.getExchangeRate(currency2)
+
+	if err1 != nil || err2 != nil {
+		currency1Output := "nil"
+		if currency1 != nil {
+			currency1Output = currency1.Hex()
+		}
+		currency2Output := "nil"
+		if currency2 != nil {
+			currency2Output = currency2.Hex()
+		}
+		log.Warn("Error in retrieving exchange rate.  Will do comparison of two values without exchange rate conversion.", "currency1", currency1Output, "err1", err1, "currency2", currency2Output, "err2", err2)
+		return val1.Cmp(val2)
+	}
+
+	// Below code block is basically evaluating this comparison:
+	// val1 * exchangeRate1.Denominator/exchangeRate1.Numerator < val2 * exchangeRate2.Denominator/exchangeRate2.Numerator
+	// It will transform that comparison to this, to remove having to deal with fractional values.
+	// val1 * exchangeRate1.Denominator * exchangeRate2.Numerator < val2 * exchangeRate2.Denominator * exchangeRate1.Numerator
+	leftSide := new(big.Int).Mul(val1, new(big.Int).Mul(exchangeRate1.Denominator, exchangeRate2.Numerator))
+	rightSide := new(big.Int).Mul(val2, new(big.Int).Mul(exchangeRate2.Denominator, exchangeRate1.Numerator))
+	return leftSide.Cmp(rightSide)
+}
+
 func Cmp(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
 	if currency1 == currency2 {
 		return val1.Cmp(val2)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -309,8 +309,12 @@ func (w *worker) close() {
 	close(w.exitCh)
 }
 
-func (w *worker) txCmp(tx1 *types.Transaction, tx2 *types.Transaction) int {
-	return currency.Cmp(tx1.GasPrice(), tx1.FeeCurrency(), tx2.GasPrice(), tx2.FeeCurrency())
+func (w *worker) createTxCmp() func(tx1 *types.Transaction, tx2 *types.Transaction) int {
+	currencyComparator := currency.NewComparator()
+
+	return func(tx1 *types.Transaction, tx2 *types.Transaction) int {
+		return currencyComparator.Cmp(tx1.GasPrice(), tx1.FeeCurrency(), tx2.GasPrice(), tx2.FeeCurrency())
+	}
 }
 
 // newWorkLoop is a standalone goroutine to submit new mining work upon received events.
@@ -465,7 +469,7 @@ func (w *worker) mainLoop() {
 					txs[acc] = append(txs[acc], tx)
 				}
 
-				txset := types.NewTransactionsByPriceAndNonce(w.current.signer, txs, w.txCmp)
+				txset := types.NewTransactionsByPriceAndNonce(w.current.signer, txs, w.createTxCmp())
 				tcount := w.current.tcount
 				w.commitTransactions(txset, coinbase, nil)
 				// Only update the snapshot if any new transactons were added
@@ -930,14 +934,16 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			localTxs[account] = txs
 		}
 	}
+
+	txComparator := w.createTxCmp()
 	if len(localTxs) > 0 {
-		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, localTxs, w.txCmp)
+		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, localTxs, txComparator)
 		if w.commitTransactions(txs, w.coinbase, interrupt) {
 			return
 		}
 	}
 	if len(remoteTxs) > 0 {
-		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, remoteTxs, w.txCmp)
+		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, remoteTxs, txComparator)
 		if w.commitTransactions(txs, w.coinbase, interrupt) {
 			return
 		}


### PR DESCRIPTION
### Description

This PR introduces a CurrencyComparator object that the miner uses to compare transactions when deciding which transactions to include in their next block proposal. The CurrencyComparator caches exchange rates between different fee currencies to avoid fetching them every time.


### Other changes

None.

### Tested

- Unit tests
- [TODO] Deploy to baklava and alfajores
- [TODO] Load testing

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
