### PR TITLE
Release v1.3.0-beta.2

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1      // Major version component of the current release
-	VersionMinor = 3      // Minor version component of the current release
-	VersionPatch = 0      // Patch version component of the current release
-	VersionMeta  = "beta" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 3        // Minor version component of the current release
+	VersionPatch = 0        // Patch version component of the current release
+	VersionMeta  = "beta.2" // Version metadata to append to the version string
 )
 
 type VersionInfo struct {


### PR DESCRIPTION
### Description

Update version to `1.3.0-beta.2`, which includes the tx comparison caching from v1.2.5.