### PR TITLE
Finalize v1.3.0-beta.2 release: set tx pool size to 2048

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -196,7 +196,7 @@ var DefaultTxPoolConfig = TxPoolConfig{
 	PriceBump:  10,
 
 	AccountSlots: 16,
-	GlobalSlots:  4096,
+	GlobalSlots:  2048,
 	AccountQueue: 64,
 	GlobalQueue:  1024,
 


### PR DESCRIPTION
### Description

When preparing the earlier PR for v1.3.0-beta.2 (which adds the changes from v1.2.5), I missed including the change to the default transaction pool size.  This PR adds that change, and will used for the v1.3.0-beta.2 release.