### PR TITLE
Cherry-pick fix for eth/65 (celo/66) bug which can cause the tx pool to be blocked

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -384,7 +384,7 @@ func (pm *ProtocolManager) handle(p *peer) error {
 	}
 
 	// Register the peer locally
-	if err := pm.peers.Register(p); err != nil {
+	if err := pm.peers.Register(p, pm.removePeer); err != nil {
 		p.Log().Error("Ethereum peer registration failed", "err", err)
 		return err
 	}

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -736,8 +736,9 @@ func (ps *peerSet) Register(p *peer) error {
 
 	go p.broadcastBlocks()
 	go p.broadcastTransactions()
-	go p.announceTransactions()
-
+	if p.version >= eth65 {
+		go p.announceTransactions()
+	}
 	return nil
 }
 

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -130,17 +130,19 @@ func newPeer(version int, p *p2p.Peer, rw p2p.MsgReadWriter, getPooledTx func(ha
 // broadcastBlocks is a write loop that multiplexes blocks and block accouncements
 // to the remote peer. The goal is to have an async writer that does not lock up
 // node internals and at the same time rate limits queued data.
-func (p *peer) broadcastBlocks() {
+func (p *peer) broadcastBlocks(removePeer func(string)) {
 	for {
 		select {
 		case prop := <-p.queuedBlocks:
 			if err := p.SendNewBlock(prop.block, prop.td); err != nil {
+				removePeer(p.id)
 				return
 			}
 			p.Log().Trace("Propagated block", "number", prop.block.Number(), "hash", prop.block.Hash(), "td", prop.td)
 
 		case block := <-p.queuedBlockAnns:
 			if err := p.SendNewBlockHashes([]common.Hash{block.Hash()}, []uint64{block.NumberU64()}); err != nil {
+				removePeer(p.id)
 				return
 			}
 			p.Log().Trace("Announced block", "number", block.Number(), "hash", block.Hash())
@@ -154,7 +156,7 @@ func (p *peer) broadcastBlocks() {
 // broadcastTransactions is a write loop that schedules transaction broadcasts
 // to the remote peer. The goal is to have an async writer that does not lock up
 // node internals and at the same time rate limits queued data.
-func (p *peer) broadcastTransactions() {
+func (p *peer) broadcastTransactions(removePeer func(string)) {
 	var (
 		queue []common.Hash         // Queue of hashes to broadcast as full transactions
 		done  chan struct{}         // Non-nil if background broadcaster is running
@@ -205,6 +207,7 @@ func (p *peer) broadcastTransactions() {
 			done = nil
 
 		case <-fail:
+			removePeer(p.id)
 			return
 
 		case <-p.term:
@@ -216,7 +219,7 @@ func (p *peer) broadcastTransactions() {
 // announceTransactions is a write loop that schedules transaction broadcasts
 // to the remote peer. The goal is to have an async writer that does not lock up
 // node internals and at the same time rate limits queued data.
-func (p *peer) announceTransactions() {
+func (p *peer) announceTransactions(removePeer func(string)) {
 	var (
 		queue []common.Hash         // Queue of hashes to announce as transaction stubs
 		done  chan struct{}         // Non-nil if background announcer is running
@@ -267,6 +270,7 @@ func (p *peer) announceTransactions() {
 			done = nil
 
 		case <-fail:
+			removePeer(p.id)
 			return
 
 		case <-p.term:
@@ -722,7 +726,7 @@ func newPeerSet() *peerSet {
 // Register injects a new peer into the working set, or returns an error if the
 // peer is already known. If a new peer it registered, its broadcast loop is also
 // started.
-func (ps *peerSet) Register(p *peer) error {
+func (ps *peerSet) Register(p *peer, removePeer func(string)) error {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
 
@@ -734,10 +738,10 @@ func (ps *peerSet) Register(p *peer) error {
 	}
 	ps.peers[p.id] = p
 
-	go p.broadcastBlocks()
-	go p.broadcastTransactions()
+	go p.broadcastBlocks(removePeer)
+	go p.broadcastTransactions(removePeer)
 	if p.version >= istanbul.Celo66 {
-		go p.announceTransactions()
+		go p.announceTransactions(removePeer)
 	}
 	return nil
 }

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -736,7 +736,7 @@ func (ps *peerSet) Register(p *peer) error {
 
 	go p.broadcastBlocks()
 	go p.broadcastTransactions()
-	if p.version >= eth65 {
+	if p.version >= istanbul.Celo66 {
 		go p.announceTransactions()
 	}
 	return nil


### PR DESCRIPTION
### Description

This PR cherry-picks from upstream a fix (https://github.com/ethereum/go-ethereum/pull/21255) for a bug introduced in the initial eth/65 (celo/66) implementation, new to our v1.3.x releases.  It also cherry picks a small prior commit (to not run `announceTransactions()` if the peer isn't running celo/66 or newer) since the code in question built on top of that change.

This bug was behind the problems seen on one of the Baklava Forno nodes, reported by @zviadm.  The short of it is that improper cleanup when the `announceTransactions()` goroutine exits with an error meant that one of the subscribers to the transaction pool's `txFeed` feed got stuck, which in turn blocked the transaction pool's `reorg()` goroutine (which prevented future reorgs from even happening again, meaning the transaction pool doesn't handling new blocks properly anymore and also couldn't add transactions via RPC anymore).

After this is merged, I will also open up a PR against the v1.3.x branch.

### Tested

* Automated testing in CI.
* Underlying fix has been in production upstream.

### Backwards compatibility

No backwards compatibility issues.
