### PR TITLE
[Exploration] Introduces notion of BlockContext to process transactions

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -520,7 +520,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	vmenv := vm.NewEVM(evmContext, statedb, b.config, vm.Config{})
 	gaspool := new(core.GasPool).AddGas(math.MaxUint64)
 
-	return core.NewStateTransition(vmenv, msg, gaspool).TransitionDb()
+	return core.NewStateTransition(vmenv, msg, gaspool, core.NewBlockContext(block.Header(), statedb)).TransitionDb()
 }
 
 // SendTransaction updates the pending block to include the given transaction.

--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -169,6 +169,10 @@ func NewComparator() *CurrencyComparator {
 }
 
 func (cc *CurrencyComparator) getExchangeRate(currency *common.Address) (*exchangeRate, error) {
+	if currency == nil {
+		return &exchangeRate{cgExchangeRateNum, cgExchangeRateDen}, nil
+	}
+
 	val, ok := cc.exchangeRates[*currency]
 	if ok {
 		return val, nil

--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -159,12 +159,18 @@ func Convert(val *big.Int, currencyFrom *common.Address, currencyTo *common.Addr
 }
 
 type CurrencyComparator struct {
-	exchangeRates map[common.Address]*exchangeRate
+	exchangeRates    map[common.Address]*exchangeRate
+	_getExchangeRate func(*common.Address) (*exchangeRate, error)
 }
 
 func NewComparator() *CurrencyComparator {
+	return newComparator(getExchangeRate)
+}
+
+func newComparator(_getExchangeRate func(*common.Address) (*exchangeRate, error)) *CurrencyComparator {
 	return &CurrencyComparator{
-		exchangeRates: make(map[common.Address]*exchangeRate),
+		exchangeRates:    make(map[common.Address]*exchangeRate),
+		_getExchangeRate: _getExchangeRate,
 	}
 }
 
@@ -178,7 +184,7 @@ func (cc *CurrencyComparator) getExchangeRate(currency *common.Address) (*exchan
 		return val, nil
 	}
 
-	val, err := getExchangeRate(currency)
+	val, err := cc._getExchangeRate(currency)
 	if err != nil {
 		return nil, err
 	}

--- a/contract_comm/currency/currency_test.go
+++ b/contract_comm/currency/currency_test.go
@@ -1,0 +1,184 @@
+package currency
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/celo-org/celo-blockchain/common"
+	. "github.com/onsi/gomega"
+)
+
+type getExchangeRateMock struct {
+	calls   []*common.Address
+	returns []struct {
+		rate *exchangeRate
+		err  error
+	}
+	returnIdx int
+}
+
+func (m *getExchangeRateMock) totalCalls() int {
+	return len(m.calls)
+}
+
+func (m *getExchangeRateMock) getExchangeRate(currency *common.Address) (*exchangeRate, error) {
+	m.calls = append(m.calls, currency)
+
+	if len(m.returns) <= m.returnIdx {
+		return nil, errors.New("mock: missing return info")
+	}
+
+	ret := m.returns[m.returnIdx]
+	m.returnIdx++
+	return ret.rate, ret.err
+}
+
+func (m *getExchangeRateMock) nextReturn(rate *exchangeRate, err error) {
+	m.returns = append(m.returns, struct {
+		rate *exchangeRate
+		err  error
+	}{
+		rate, err,
+	})
+}
+
+func TestCurrencyComparator(t *testing.T) {
+	twoToOne := exchangeRate{
+		Numerator: common.Big1, Denominator: common.Big2,
+	}
+	oneToTwo := exchangeRate{
+		Numerator: common.Big2, Denominator: common.Big1,
+	}
+
+	t.Run("should not call getExchange rate if both currencies are gold", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		mock := getExchangeRateMock{}
+		comparator := newComparator(mock.getExchangeRate)
+
+		g.Expect(comparator.Cmp(common.Big1, nil, common.Big2, nil)).To(Equal(-1))
+		// no call to getExchange Rate
+		g.Expect(mock.totalCalls()).To(BeZero())
+	})
+
+	t.Run("should not call getExchange rate if both currencies are the same", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		mock := getExchangeRateMock{}
+		comparator := newComparator(mock.getExchangeRate)
+
+		g.Expect(comparator.Cmp(common.Big1, &common.Address{12}, common.Big2, &common.Address{12})).To(Equal(-1))
+		// no call to getExchange Rate
+		g.Expect(mock.totalCalls()).To(BeZero())
+	})
+
+	t.Run("should not call getExchange rate on goldToken currency", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		mock := getExchangeRateMock{}
+
+		mock.nextReturn(&twoToOne, nil)
+
+		comparator := newComparator(mock.getExchangeRate)
+
+		g.Expect(comparator.Cmp(common.Big1, nil, common.Big1, &common.Address{12})).To(Equal(-1))
+		// call to the exchange rate only for non goldToken currency
+		g.Expect(mock.totalCalls()).To(Equal(1))
+		g.Expect(*mock.calls[0]).To(Equal(common.Address{12}))
+	})
+
+	t.Run("should use returned exchange rate", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		mock := getExchangeRateMock{}
+		comparator := newComparator(mock.getExchangeRate)
+
+		// case 1: 2 gold = 1 usd
+		// then 1 gold < 1 usd
+		mock.nextReturn(&twoToOne, nil)
+		g.Expect(comparator.Cmp(common.Big1, nil, common.Big1, &common.Address{10})).To(Equal(-1))
+
+		// case 2: 1 gold = 2 usd
+		// then 1 gold > 1 usd
+		mock.nextReturn(&oneToTwo, nil)
+		g.Expect(comparator.Cmp(common.Big1, nil, common.Big1, &common.Address{20})).To(Equal(1))
+
+		// case 3: 1 gold = 2 usd && 1 gold = 2 eur
+		// then 2 eur > 1 usd
+		mock.nextReturn(&oneToTwo, nil)
+		mock.nextReturn(&oneToTwo, nil)
+		g.Expect(comparator.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{40})).To(Equal(1))
+	})
+
+	t.Run("should work with zero values", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		mock := getExchangeRateMock{}
+		comparator := newComparator(mock.getExchangeRate)
+
+		// case 1: both values == 0
+		g.Expect(comparator.Cmp(common.Big0, nil, common.Big0, nil)).To(Equal(0))
+
+		// case 2: first value == 0
+		g.Expect(comparator.Cmp(common.Big0, nil, common.Big1, nil)).To(Equal(-1))
+
+		// case 3: second value == 0
+		g.Expect(comparator.Cmp(common.Big1, nil, common.Big0, nil)).To(Equal(1))
+	})
+
+	t.Run("should compare value if first get exchange rate fails", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		mock := getExchangeRateMock{}
+		mock.nextReturn(&twoToOne, nil)
+		mock.nextReturn(nil, errors.New("boom!"))
+
+		comparator := newComparator(mock.getExchangeRate)
+		g.Expect(comparator.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+	})
+
+	t.Run("should compare value if second get exchange rate fails", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		mock := getExchangeRateMock{}
+		mock.nextReturn(nil, errors.New("boom!"))
+		mock.nextReturn(&twoToOne, nil)
+
+		comparator := newComparator(mock.getExchangeRate)
+		g.Expect(comparator.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+	})
+
+	t.Run("should cache exchange rate on subsequent calls", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		mock := getExchangeRateMock{}
+		mock.nextReturn(&twoToOne, nil)
+		mock.nextReturn(&oneToTwo, nil)
+
+		comparator := newComparator(mock.getExchangeRate)
+
+		for i := 0; i < 10; i++ {
+			g.Expect(comparator.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+		}
+
+		// call to the exchange rate only for non goldToken currency
+		g.Expect(mock.totalCalls()).To(Equal(2))
+		g.Expect(*mock.calls[0]).To(Equal(common.Address{30}))
+		g.Expect(*mock.calls[1]).To(Equal(common.Address{12}))
+	})
+
+	t.Run("should NOT cache exchange rate on errors", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		mock := getExchangeRateMock{}
+		// default return is an error
+
+		comparator := newComparator(mock.getExchangeRate)
+
+		for i := 0; i < 10; i++ {
+			g.Expect(comparator.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(0))
+		}
+
+		// expect 10 call for address{30} and 10 for address{12}
+		g.Expect(mock.totalCalls()).To(Equal(20))
+	})
+
+}

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -79,7 +79,7 @@ func genValueTx(nbytes int) func(int, *BlockGen) {
 	return func(i int, gen *BlockGen) {
 		toaddr := common.Address{}
 		data := make([]byte, nbytes)
-		gas, _ := IntrinsicGas(data, false, nil, nil, nil, false)
+		gas, _ := IntrinsicGas(data, false, nil, 0, false)
 		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(benchRootAddr), toaddr, big.NewInt(1), gas, nil, nil, nil, nil, data), types.HomesteadSigner{}, benchRootKey)
 		gen.AddTx(tx)
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -94,7 +94,10 @@ func (b *BlockGen) AddTxWithChain(bc vm.ChainContext, tx *types.Transaction) {
 		b.SetCoinbase(common.Address{})
 	}
 	b.statedb.Prepare(tx.Hash(), common.Hash{}, len(b.txs))
-	receipt, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{})
+
+	blockCtx := NewBlockContext(b.header, b.statedb)
+
+	receipt, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{}, blockCtx)
 	if err != nil {
 		panic(err)
 	}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -89,6 +89,6 @@ func precacheTransaction(config *params.ChainConfig, bc vm.ChainContext, author 
 	context := vm.NewEVMContext(msg, header, bc, author)
 	vm := vm.NewEVM(context, statedb, config, cfg)
 
-	_, err = ApplyMessage(vm, msg, gaspool)
+	_, err = ApplyMessage(vm, msg, gaspool, NewBlockContext(header, statedb))
 	return err
 }

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -640,7 +640,10 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return err
 	}
-	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, pool.chain.CurrentBlock().Header(), pool.currentState, tx.FeeCurrency(), pool.istanbul)
+
+	gasForAlternativeCurrency := blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrency(pool.chain.CurrentBlock().Header(), pool.currentState)
+
+	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, tx.FeeCurrency(), gasForAlternativeCurrency, pool.istanbul)
 	if err != nil {
 		log.Debug("validateTx gas less than intrinsic gas", "intrGas", intrGas, "err", err)
 		return err

--- a/eth/api.go
+++ b/eth/api.go
@@ -422,7 +422,7 @@ type storageEntry struct {
 
 // StorageRangeAt returns the storage at the given block height and transaction index.
 func (api *PrivateDebugAPI) StorageRangeAt(blockHash common.Hash, txIndex int, contractAddress common.Address, keyStart hexutil.Bytes, maxResult int) (StorageRangeResult, error) {
-	_, _, statedb, err := api.computeTxEnv(blockHash, txIndex, 0)
+	_, _, statedb, _, err := api.computeTxEnv(blockHash, txIndex, 0)
 	if err != nil {
 		return StorageRangeResult{}, err
 	}

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -138,7 +138,8 @@ func TestPrestateTracerCreate2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to prepare transaction for tracing: %v", err)
 	}
-	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
+
+	st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()), core.NewBlockContext(evm.Header, statedb))
 	if _, err = st.TransitionDb(); err != nil {
 		t.Fatalf("failed to execute transaction: %v", err)
 	}

--- a/les/odr_test.go
+++ b/les/odr_test.go
@@ -137,18 +137,19 @@ func odrContractCall(ctx context.Context, db ethdb.Database, config *params.Chai
 
 				//vmenv := core.NewEnv(statedb, config, bc, msg, header, vm.Config{})
 				gp := new(core.GasPool).AddGas(math.MaxUint64)
-				result, _ := core.ApplyMessage(vmenv, msg, gp)
+				result, _ := core.ApplyMessage(vmenv, msg, gp, core.NewBlockContext(header, statedb))
 				res = append(res, result.Return()...)
 			}
 		} else {
 			header := lc.GetHeaderByHash(bhash)
 			state := light.NewState(ctx, header, lc.Odr())
+
 			state.SetBalance(bankAddr, math.MaxBig256)
 			msg := callmsg{types.NewMessage(bankAddr, &testContractAddr, 0, new(big.Int), 100000, new(big.Int), nil, nil, new(big.Int), data, false, false)}
 			context := vm.NewEVMContext(msg, header, lc, nil)
 			vmenv := vm.NewEVM(context, state, config, vm.Config{})
 			gp := new(core.GasPool).AddGas(math.MaxUint64)
-			result, _ := core.ApplyMessage(vmenv, msg, gp)
+			result, _ := core.ApplyMessage(vmenv, msg, gp, core.NewBlockContext(header, state))
 			if state.Error() == nil {
 				res = append(res, result.Return()...)
 			}

--- a/light/odr_test.go
+++ b/light/odr_test.go
@@ -246,7 +246,8 @@ func odrContractCall(ctx context.Context, db ethdb.Database, bc *core.BlockChain
 		context := vm.NewEVMContext(msg, header, chain, nil)
 		vmenv := vm.NewEVM(context, st, config, vm.Config{})
 		gp := new(core.GasPool).AddGas(math.MaxUint64)
-		result, _ := core.ApplyMessage(vmenv, msg, gp)
+
+		result, _ := core.ApplyMessage(vmenv, msg, gp, core.NewBlockContext(header, st))
 		res = append(res, result.Return()...)
 		if st.Error() != nil {
 			return res, st.Error()

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/contract_comm/blockchain_parameters"
 	"github.com/celo-org/celo-blockchain/contract_comm/freezer"
 	"github.com/celo-org/celo-blockchain/contract_comm/transfer_whitelist"
 	"github.com/celo-org/celo-blockchain/core"
@@ -398,7 +399,9 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 
 	// Should supply enough intrinsic gas
 	header := pool.chain.GetHeaderByHash(pool.head)
-	gas, err := core.IntrinsicGas(tx.Data(), tx.To() == nil, header, currentState, tx.FeeCurrency(), pool.istanbul)
+
+	gasForAlternativeCurrency := blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrency(header, currentState)
+	gas, err := core.IntrinsicGas(tx.Data(), tx.To() == nil, tx.FeeCurrency(), gasForAlternativeCurrency, pool.istanbul)
 	if err != nil {
 		return err
 	}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -184,9 +184,11 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	gaspool := new(core.GasPool)
 	gaspool.AddGas(core.CalcGasLimit(block, statedb))
 	snapshot := statedb.Snapshot()
-	if _, err := core.ApplyMessage(evm, msg, gaspool); err != nil {
+
+	if _, err := core.ApplyMessage(evm, msg, gaspool, core.NewBlockContext(block.Header(), statedb)); err != nil {
 		statedb.RevertToSnapshot(snapshot)
 	}
+
 	// Commit block
 	statedb.Commit(config.IsEIP158(block.Number()))
 	// Add 0-value mining reward. This only makes a difference in the cases

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -55,7 +55,7 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 			return nil, nil, err
 		}
 		// Intrinsic gas
-		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.To() == nil, nil, nil, nil, false)
+		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.To() == nil, nil, 0, false)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
### Description

**This is a Hardfork change.** 

**Before:** For every transaction we make several EVM calls (getGasPriceMinimun, getGasForAlternativeCurrencies, IsWhitelisted(currency)). 

With this PR, instead, at the beginning of each block, we fetch all necessary EVM state and use it for all the transactions. This means that if a governance proposal or any other transaction changes the value of a parameter mid-block we won't see it until the next block. There is no problem in delaying this, and it's actually more simpler to reason about. But it does make this change a hardfork.

### Tested

* CI

### Backwards compatibility

Hardfork change
