### PR TITLE
Uses block context within txpool

### DIFF
--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -103,8 +103,10 @@ func (sb *Backend) distributeEpochRewards(header *types.Header, state *state.Sta
 		return err
 	}
 
+	currencyManager := currency.NewManager(nil, nil)
+
 	// Validator rewards were paid in cUSD, convert that amount to cGLD and add it to the Reserve
-	totalValidatorRewardsConvertedToGold, err := currency.Convert(totalValidatorRewards, stableTokenAddress, nil)
+	totalValidatorRewardsConvertedToGold, err := currencyManager.ToGold(totalValidatorRewards, stableTokenAddress)
 	if err != nil {
 		return err
 	}

--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -94,89 +94,119 @@ const (
 )
 
 var (
-	cgExchangeRateNum = big.NewInt(1)
-	cgExchangeRateDen = big.NewInt(1)
-
 	medianRateFuncABI, _   = abi.JSON(strings.NewReader(medianRateABI))
 	balanceOfFuncABI, _    = abi.JSON(strings.NewReader(balanceOfABI))
 	getWhitelistFuncABI, _ = abi.JSON(strings.NewReader(getWhitelistABI))
 )
 
-type exchangeRate struct {
-	Numerator   *big.Int
-	Denominator *big.Int
+// ExchangeRate represent the exchangeRate for the pair (base, token)
+// Follows the equation: 1 base * ExchangeRate = X token
+type ExchangeRate struct {
+	numerator   *big.Int
+	denominator *big.Int
 }
 
-func ConvertToGold(val *big.Int, currencyFrom *common.Address) (*big.Int, error) {
-	if currencyFrom == nil {
-		return val, nil
-	}
+// NoopExchangeRate returns the noop rate
+// which results in a 1:1 conversion
+func NoopExchangeRate() *ExchangeRate { return nil }
 
-	celoGoldAddress, err := contract_comm.GetRegisteredAddress(params.GoldTokenRegistryId, nil, nil)
-	if err == errors.ErrSmartContractNotDeployed || err == errors.ErrRegistryContractNotDeployed {
-		log.Warn("Registry address lookup failed", "err", err)
-		return val, err
+// MustNewExchangeRate creates an exchange rate, panic on error
+func MustNewExchangeRate(numerator *big.Int, denominator *big.Int) *ExchangeRate {
+	rate, err := NewExchangeRate(numerator, denominator)
+	if err != nil {
+		panic(err)
 	}
-
-	if currencyFrom == celoGoldAddress {
-		// This function shouldn't really be called with the token's address, but if it is the value
-		// is correct, so return nil as the error
-		return val, nil
-	} else if err != nil {
-		log.Error(err.Error())
-		return val, err
-	}
-	return Convert(val, currencyFrom, nil)
+	return rate
 }
 
-// NOTE (jarmg 4/24/19): values are rounded down which can cause
-// an estimate to be off by 1 (at most)
-func Convert(val *big.Int, currencyFrom *common.Address, currencyTo *common.Address) (*big.Int, error) {
-	exchangeRateFrom, err1 := getExchangeRate(currencyFrom)
-	exchangeRateTo, err2 := getExchangeRate(currencyTo)
-
-	if err1 != nil || err2 != nil {
-		log.Error("Convert - Error in retreiving currency exchange rates")
-		if err1 != nil {
-			return nil, err1
-		}
-		if err2 != nil {
-			return nil, err2
-		}
-	}
-
-	// Given value of val and rates n1/d1 and n2/d2 the function below does
-	// (val * d1 * n2) / (n1 * d2)
-	numerator := new(big.Int).Mul(val, new(big.Int).Mul(exchangeRateFrom.Denominator, exchangeRateTo.Numerator))
-	denominator := new(big.Int).Mul(exchangeRateFrom.Numerator, exchangeRateTo.Denominator)
-
-	if denominator.Sign() == 0 {
-		log.Error("Convert - Error in retreiving currency exchange rates")
+// NewExchangeRate creates an exchange rate.
+// Requires numerator >=0 && denominator >= 0
+func NewExchangeRate(numerator *big.Int, denominator *big.Int) (*ExchangeRate, error) {
+	if numerator == nil || common.Big0.Cmp(numerator) >= 0 {
 		return nil, errors.ErrExchangeRateZero
 	}
-
-	return new(big.Int).Div(numerator, denominator), nil
+	if denominator == nil || common.Big0.Cmp(denominator) >= 0 {
+		return nil, errors.ErrExchangeRateZero
+	}
+	return &ExchangeRate{numerator, denominator}, nil
 }
 
-type CurrencyComparator struct {
-	exchangeRates    map[common.Address]*exchangeRate
-	_getExchangeRate func(*common.Address) (*exchangeRate, error)
+// ToBase converts from token to base
+func (er *ExchangeRate) ToBase(tokenAmount *big.Int) *big.Int {
+	// check noop rate (cGLD rate)
+	if er == nil {
+		return new(big.Int).Set(tokenAmount)
+	}
+
+	return new(big.Int).Div(new(big.Int).Mul(tokenAmount, er.denominator), er.numerator)
 }
 
-func NewComparator() *CurrencyComparator {
-	return newComparator(getExchangeRate)
+// FromGold converts from base to token
+func (er *ExchangeRate) FromBase(goldAmount *big.Int) *big.Int {
+	// check noop rate (cGLD rate)
+	if er == nil {
+		return new(big.Int).Set(goldAmount)
+	}
+
+	return new(big.Int).Div(new(big.Int).Mul(goldAmount, er.numerator), er.denominator)
 }
 
-func newComparator(_getExchangeRate func(*common.Address) (*exchangeRate, error)) *CurrencyComparator {
-	return &CurrencyComparator{
-		exchangeRates:    make(map[common.Address]*exchangeRate),
+func (er *ExchangeRate) CmpValues(amount *big.Int, anotherTokenAmount *big.Int, anotherTokenRate *ExchangeRate) int {
+	// if both rates are noop rate (cGLD rate), compare values
+	if er == nil && anotherTokenRate == nil {
+		return amount.Cmp(anotherTokenAmount)
+	}
+
+	// if both exchangeRate are the same
+	if er != nil && anotherTokenRate != nil && *er == *anotherTokenRate {
+		return amount.Cmp(anotherTokenAmount)
+	}
+
+	// Below code block is basically evaluating this comparison:
+	// amount * er.denominator / er.numerator < anotherTokenAmount * anotherTokenRate.denominator / anotherTokenRate.numerator
+	// It will transform that comparison to this, to remove having to deal with fractional values.
+	// amount * er.denominator * anotherTokenRate.numerator < anotherTokenAmount * anotherTokenRate.denominator * er.numerator
+
+	// when either er or anotherTokenRate are nil, we assume rate = 1/1 (as in cGLD)
+	var leftSide, rightSide *big.Int
+	if er == nil {
+		leftSide = new(big.Int).Mul(amount, anotherTokenRate.numerator)
+		rightSide = new(big.Int).Mul(anotherTokenAmount, anotherTokenRate.denominator)
+	} else if anotherTokenRate == nil {
+		leftSide = new(big.Int).Mul(amount, er.denominator)
+		rightSide = new(big.Int).Mul(anotherTokenAmount, er.numerator)
+	} else {
+		leftSide = new(big.Int).Mul(amount, new(big.Int).Mul(er.denominator, anotherTokenRate.numerator))
+		rightSide = new(big.Int).Mul(anotherTokenAmount, new(big.Int).Mul(anotherTokenRate.denominator, er.numerator))
+	}
+
+	return leftSide.Cmp(rightSide)
+}
+
+type CurrencyManager struct {
+	header *types.Header
+	state  vm.StateDB
+
+	exchangeRates    map[common.Address]*ExchangeRate                                        // map of exchange rates of the form (cGLD, token)
+	_getExchangeRate func(*common.Address, *types.Header, vm.StateDB) (*ExchangeRate, error) // function to obtain exchange rate from blockchain state
+}
+
+func NewManager(header *types.Header, state vm.StateDB) *CurrencyManager {
+	return newManager(GetExchangeRate, header, state)
+}
+
+func newManager(_getExchangeRate func(*common.Address, *types.Header, vm.StateDB) (*ExchangeRate, error), header *types.Header, state vm.StateDB) *CurrencyManager {
+	return &CurrencyManager{
+		header:           header,
+		state:            state,
+		exchangeRates:    make(map[common.Address]*ExchangeRate),
 		_getExchangeRate: _getExchangeRate,
 	}
 }
 
-func (cc *CurrencyComparator) getExchangeRate(currency *common.Address) (*exchangeRate, error) {
+func (cc *CurrencyManager) GetExchangeRate(currency *common.Address) (*ExchangeRate, error) {
 	if currency == nil {
-		return &exchangeRate{cgExchangeRateNum, cgExchangeRateDen}, nil
+		return NoopExchangeRate(), nil
 	}
 
 	val, ok := cc.exchangeRates[*currency]
@@ -184,7 +214,7 @@ func (cc *CurrencyComparator) getExchangeRate(currency *common.Address) (*exchan
 		return val, nil
 	}
 
-	val, err := cc._getExchangeRate(currency)
+	val, err := cc._getExchangeRate(currency, cc.header, cc.state)
 	if err != nil {
 		return nil, err
 	}
@@ -194,14 +224,14 @@ func (cc *CurrencyComparator) getExchangeRate(currency *common.Address) (*exchan
 	return val, nil
 }
 
-func (cc *CurrencyComparator) Cmp(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
+func (cc *CurrencyManager) Cmp(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
 	// Short circuit if the fee currency is the same. nil currency => native currency
 	if (currency1 == nil && currency2 == nil) || (currency1 != nil && currency2 != nil && *currency1 == *currency2) {
 		return val1.Cmp(val2)
 	}
 
-	exchangeRate1, err1 := cc.getExchangeRate(currency1)
-	exchangeRate2, err2 := cc.getExchangeRate(currency2)
+	exchangeRate1, err1 := cc.GetExchangeRate(currency1)
+	exchangeRate2, err2 := cc.GetExchangeRate(currency2)
 
 	if err1 != nil || err2 != nil {
 		currency1Output := "nil"
@@ -216,67 +246,49 @@ func (cc *CurrencyComparator) Cmp(val1 *big.Int, currency1 *common.Address, val2
 		return val1.Cmp(val2)
 	}
 
-	// Below code block is basically evaluating this comparison:
-	// val1 * exchangeRate1.Denominator/exchangeRate1.Numerator < val2 * exchangeRate2.Denominator/exchangeRate2.Numerator
-	// It will transform that comparison to this, to remove having to deal with fractional values.
-	// val1 * exchangeRate1.Denominator * exchangeRate2.Numerator < val2 * exchangeRate2.Denominator * exchangeRate1.Numerator
-	leftSide := new(big.Int).Mul(val1, new(big.Int).Mul(exchangeRate1.Denominator, exchangeRate2.Numerator))
-	rightSide := new(big.Int).Mul(val2, new(big.Int).Mul(exchangeRate2.Denominator, exchangeRate1.Numerator))
-	return leftSide.Cmp(rightSide)
+	return exchangeRate1.CmpValues(val1, val2, exchangeRate2)
 }
 
-func Cmp(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
-	// Short circuit if the fee currency is the same. nil currency => native currency
-	if (currency1 == nil && currency2 == nil) || (currency1 != nil && currency2 != nil && *currency1 == *currency2) {
-		return val1.Cmp(val2)
+func (cc *CurrencyManager) ToGold(amount *big.Int, currency *common.Address) (*big.Int, error) {
+	rate, err := cc.GetExchangeRate(currency)
+	if err != nil {
+		return nil, err
 	}
-
-	exchangeRate1, err1 := getExchangeRate(currency1)
-	exchangeRate2, err2 := getExchangeRate(currency2)
-
-	if err1 != nil || err2 != nil {
-		currency1Output := "nil"
-		if currency1 != nil {
-			currency1Output = currency1.Hex()
-		}
-		currency2Output := "nil"
-		if currency2 != nil {
-			currency2Output = currency2.Hex()
-		}
-		log.Warn("Error in retrieving exchange rate.  Will do comparison of two values without exchange rate conversion.", "currency1", currency1Output, "err1", err1, "currency2", currency2Output, "err2", err2)
-		return val1.Cmp(val2)
-	}
-
-	// Below code block is basically evaluating this comparison:
-	// val1 * exchangeRate1.Denominator/exchangeRate1.Numerator < val2 * exchangeRate2.Denominator/exchangeRate2.Numerator
-	// It will transform that comparison to this, to remove having to deal with fractional values.
-	// val1 * exchangeRate1.Denominator * exchangeRate2.Numerator < val2 * exchangeRate2.Denominator * exchangeRate1.Numerator
-	leftSide := new(big.Int).Mul(val1, new(big.Int).Mul(exchangeRate1.Denominator, exchangeRate2.Numerator))
-	rightSide := new(big.Int).Mul(val2, new(big.Int).Mul(exchangeRate2.Denominator, exchangeRate1.Numerator))
-	return leftSide.Cmp(rightSide)
+	return rate.ToBase(amount), nil
 }
 
-func getExchangeRate(currencyAddress *common.Address) (*exchangeRate, error) {
-	var (
-		returnArray [2]*big.Int
-		leftoverGas uint64
-	)
-
+func GetExchangeRate(currencyAddress *common.Address, header *types.Header, state vm.StateDB) (*ExchangeRate, error) {
 	if currencyAddress == nil {
-		return &exchangeRate{cgExchangeRateNum, cgExchangeRateDen}, nil
-	} else {
-		if leftoverGas, err := contract_comm.MakeStaticCall(params.SortedOraclesRegistryId, medianRateFuncABI, "medianRate", []interface{}{currencyAddress}, &returnArray, params.MaxGasForMedianRate, nil, nil); err != nil {
-			if err == errors.ErrSmartContractNotDeployed {
-				log.Warn("Registry address lookup failed", "err", err)
-				return &exchangeRate{big.NewInt(1), big.NewInt(1)}, err
-			} else {
-				log.Error("medianRate invocation error", "feeCurrencyAddress", currencyAddress.Hex(), "leftoverGas", leftoverGas, "err", err)
-				return &exchangeRate{big.NewInt(1), big.NewInt(1)}, err
-			}
-		}
+		return NoopExchangeRate(), nil
 	}
+
+	celoGoldAddress, err := contract_comm.GetRegisteredAddress(params.GoldTokenRegistryId, nil, nil)
+	if err == errors.ErrSmartContractNotDeployed || err == errors.ErrRegistryContractNotDeployed {
+		return nil, err
+	}
+
+	if currencyAddress == celoGoldAddress {
+		// This function shouldn't really be called with the token's address, but if it is the value
+		// is correct, so return nil as the error
+		return NoopExchangeRate(), nil
+	} else if err != nil {
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	var returnArray [2]*big.Int
+	leftoverGas, err := contract_comm.MakeStaticCall(params.SortedOraclesRegistryId, medianRateFuncABI, "medianRate", []interface{}{currencyAddress}, &returnArray, params.MaxGasForMedianRate, header, state)
+
+	if err == errors.ErrSmartContractNotDeployed {
+		log.Warn("Registry address lookup failed", "err", err)
+		return NoopExchangeRate(), nil
+	} else if err != nil {
+		log.Error("medianRate invocation error", "feeCurrencyAddress", currencyAddress.Hex(), "leftoverGas", leftoverGas, "err", err)
+		return NoopExchangeRate(), nil
+	}
+
 	log.Trace("medianRate invocation success", "feeCurrencyAddress", currencyAddress, "returnArray", returnArray, "leftoverGas", leftoverGas)
-	return &exchangeRate{returnArray[0], returnArray[1]}, nil
+	return NewExchangeRate(returnArray[0], returnArray[1])
 }
 
 // This function will retrieve the balance of an ERC20 token.
@@ -284,60 +296,32 @@ func GetBalanceOf(accountOwner common.Address, contractAddress common.Address, g
 	log.Trace("GetBalanceOf() Called", "accountOwner", accountOwner.Hex(), "contractAddress", contractAddress, "gas", gas)
 
 	leftoverGas, err := contract_comm.MakeStaticCallWithAddress(contractAddress, balanceOfFuncABI, "balanceOf", []interface{}{accountOwner}, &result, gas, header, state)
+	gasUsed = gas - leftoverGas
 
 	if err != nil {
 		log.Error("GetBalanceOf evm invocation error", "leftoverGas", leftoverGas, "err", err)
-		gasUsed = gas - leftoverGas
-		return
 	} else {
-		gasUsed = gas - leftoverGas
 		log.Trace("GetBalanceOf evm invocation success", "accountOwner", accountOwner.Hex(), "Balance", result.String(), "gas used", gasUsed)
-		return
 	}
+
+	return result, gasUsed, err
 }
 
 // ------------------------------
 // FeeCurrencyWhiteList Functions
 //-------------------------------
-func retrieveWhitelist(header *types.Header, state vm.StateDB) ([]common.Address, error) {
+func CurrencyWhitelist(header *types.Header, state vm.StateDB) ([]common.Address, error) {
 	returnList := []common.Address{}
 
 	_, err := contract_comm.MakeStaticCall(params.FeeCurrencyWhitelistRegistryId, getWhitelistFuncABI, "getWhitelist", []interface{}{}, &returnList, params.MaxGasForGetWhiteList, header, state)
-	if err != nil {
-		if err == errors.ErrSmartContractNotDeployed {
-			log.Warn("Registry address lookup failed", "err", err)
-		} else {
-			log.Error("getWhitelist invocation failed", "err", err)
-		}
-		return returnList, err
+
+	if err == errors.ErrSmartContractNotDeployed {
+		log.Warn("Registry address lookup failed", "err", err)
+	} else if err != nil {
+		log.Error("getWhitelist invocation failed", "err", err)
+	} else {
+		log.Trace("getWhitelist invocation success")
 	}
 
-	log.Trace("getWhitelist invocation success")
 	return returnList, err
-}
-
-func IsWhitelisted(currencyAddress common.Address, header *types.Header, state vm.StateDB) bool {
-	whitelist, err := retrieveWhitelist(header, state)
-	if err != nil {
-		log.Warn("Failed to get fee currency whitelist", "err", err)
-		return true
-	}
-	return containsCurrency(currencyAddress, whitelist)
-}
-
-func containsCurrency(currencyAddr common.Address, currencyList []common.Address) bool {
-	for _, addr := range currencyList {
-		if addr == currencyAddr {
-			return true
-		}
-	}
-	return false
-}
-
-func CurrencyWhitelist(header *types.Header, state vm.StateDB) ([]common.Address, error) {
-	whitelist, err := retrieveWhitelist(header, state)
-	if err != nil {
-		log.Warn("Failed to get fee currency whitelist", "err", err)
-	}
-	return whitelist, err
 }

--- a/contract_comm/currency/currency_test.go
+++ b/contract_comm/currency/currency_test.go
@@ -2,16 +2,19 @@ package currency
 
 import (
 	"errors"
+	"math/big"
 	"testing"
 
 	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/core/vm"
 	. "github.com/onsi/gomega"
 )
 
 type getExchangeRateMock struct {
 	calls   []*common.Address
 	returns []struct {
-		rate *exchangeRate
+		rate *ExchangeRate
 		err  error
 	}
 	returnIdx int
@@ -21,7 +24,7 @@ func (m *getExchangeRateMock) totalCalls() int {
 	return len(m.calls)
 }
 
-func (m *getExchangeRateMock) getExchangeRate(currency *common.Address) (*exchangeRate, error) {
+func (m *getExchangeRateMock) getExchangeRate(currency *common.Address, header *types.Header, state vm.StateDB) (*ExchangeRate, error) {
 	m.calls = append(m.calls, currency)
 
 	if len(m.returns) <= m.returnIdx {
@@ -33,29 +36,25 @@ func (m *getExchangeRateMock) getExchangeRate(currency *common.Address) (*exchan
 	return ret.rate, ret.err
 }
 
-func (m *getExchangeRateMock) nextReturn(rate *exchangeRate, err error) {
+func (m *getExchangeRateMock) nextReturn(rate *ExchangeRate, err error) {
 	m.returns = append(m.returns, struct {
-		rate *exchangeRate
+		rate *ExchangeRate
 		err  error
 	}{
 		rate, err,
 	})
 }
 
-func TestCurrencyComparator(t *testing.T) {
-	twoToOne := exchangeRate{
-		Numerator: common.Big1, Denominator: common.Big2,
-	}
-	oneToTwo := exchangeRate{
-		Numerator: common.Big2, Denominator: common.Big1,
-	}
+func TestCurrencyManager(t *testing.T) {
+	twoToOne := MustNewExchangeRate(common.Big1, common.Big2)
+	oneToTwo := MustNewExchangeRate(common.Big2, common.Big1)
 
 	t.Run("should not call getExchange rate if both currencies are gold", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := getExchangeRateMock{}
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
-		g.Expect(comparator.Cmp(common.Big1, nil, common.Big2, nil)).To(Equal(-1))
+		g.Expect(manager.Cmp(common.Big1, nil, common.Big2, nil)).To(Equal(-1))
 		// no call to getExchange Rate
 		g.Expect(mock.totalCalls()).To(BeZero())
 	})
@@ -63,9 +62,9 @@ func TestCurrencyComparator(t *testing.T) {
 	t.Run("should not call getExchange rate if both currencies are the same", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := getExchangeRateMock{}
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
-		g.Expect(comparator.Cmp(common.Big1, &common.Address{12}, common.Big2, &common.Address{12})).To(Equal(-1))
+		g.Expect(manager.Cmp(common.Big1, &common.Address{12}, common.Big2, &common.Address{12})).To(Equal(-1))
 		// no call to getExchange Rate
 		g.Expect(mock.totalCalls()).To(BeZero())
 	})
@@ -75,11 +74,11 @@ func TestCurrencyComparator(t *testing.T) {
 
 		mock := getExchangeRateMock{}
 
-		mock.nextReturn(&twoToOne, nil)
+		mock.nextReturn(twoToOne, nil)
 
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
-		g.Expect(comparator.Cmp(common.Big1, nil, common.Big1, &common.Address{12})).To(Equal(-1))
+		g.Expect(manager.Cmp(common.Big1, nil, common.Big1, &common.Address{12})).To(Equal(-1))
 		// call to the exchange rate only for non goldToken currency
 		g.Expect(mock.totalCalls()).To(Equal(1))
 		g.Expect(*mock.calls[0]).To(Equal(common.Address{12}))
@@ -89,50 +88,50 @@ func TestCurrencyComparator(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		mock := getExchangeRateMock{}
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
 		// case 1: 2 gold = 1 usd
 		// then 1 gold < 1 usd
-		mock.nextReturn(&twoToOne, nil)
-		g.Expect(comparator.Cmp(common.Big1, nil, common.Big1, &common.Address{10})).To(Equal(-1))
+		mock.nextReturn(twoToOne, nil)
+		g.Expect(manager.Cmp(common.Big1, nil, common.Big1, &common.Address{10})).To(Equal(-1))
 
 		// case 2: 1 gold = 2 usd
 		// then 1 gold > 1 usd
-		mock.nextReturn(&oneToTwo, nil)
-		g.Expect(comparator.Cmp(common.Big1, nil, common.Big1, &common.Address{20})).To(Equal(1))
+		mock.nextReturn(oneToTwo, nil)
+		g.Expect(manager.Cmp(common.Big1, nil, common.Big1, &common.Address{20})).To(Equal(1))
 
 		// case 3: 1 gold = 2 usd && 1 gold = 2 eur
 		// then 2 eur > 1 usd
-		mock.nextReturn(&oneToTwo, nil)
-		mock.nextReturn(&oneToTwo, nil)
-		g.Expect(comparator.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{40})).To(Equal(1))
+		mock.nextReturn(oneToTwo, nil)
+		mock.nextReturn(oneToTwo, nil)
+		g.Expect(manager.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{40})).To(Equal(1))
 	})
 
 	t.Run("should work with zero values", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		mock := getExchangeRateMock{}
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
 		// case 1: both values == 0
-		g.Expect(comparator.Cmp(common.Big0, nil, common.Big0, nil)).To(Equal(0))
+		g.Expect(manager.Cmp(common.Big0, nil, common.Big0, nil)).To(Equal(0))
 
 		// case 2: first value == 0
-		g.Expect(comparator.Cmp(common.Big0, nil, common.Big1, nil)).To(Equal(-1))
+		g.Expect(manager.Cmp(common.Big0, nil, common.Big1, nil)).To(Equal(-1))
 
 		// case 3: second value == 0
-		g.Expect(comparator.Cmp(common.Big1, nil, common.Big0, nil)).To(Equal(1))
+		g.Expect(manager.Cmp(common.Big1, nil, common.Big0, nil)).To(Equal(1))
 	})
 
 	t.Run("should compare value if first get exchange rate fails", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		mock := getExchangeRateMock{}
-		mock.nextReturn(&twoToOne, nil)
+		mock.nextReturn(twoToOne, nil)
 		mock.nextReturn(nil, errors.New("boom!"))
 
-		comparator := newComparator(mock.getExchangeRate)
-		g.Expect(comparator.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+		manager := newManager(mock.getExchangeRate, nil, nil)
+		g.Expect(manager.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
 	})
 
 	t.Run("should compare value if second get exchange rate fails", func(t *testing.T) {
@@ -140,23 +139,23 @@ func TestCurrencyComparator(t *testing.T) {
 
 		mock := getExchangeRateMock{}
 		mock.nextReturn(nil, errors.New("boom!"))
-		mock.nextReturn(&twoToOne, nil)
+		mock.nextReturn(twoToOne, nil)
 
-		comparator := newComparator(mock.getExchangeRate)
-		g.Expect(comparator.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+		manager := newManager(mock.getExchangeRate, nil, nil)
+		g.Expect(manager.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
 	})
 
 	t.Run("should cache exchange rate on subsequent calls", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		mock := getExchangeRateMock{}
-		mock.nextReturn(&twoToOne, nil)
-		mock.nextReturn(&oneToTwo, nil)
+		mock.nextReturn(twoToOne, nil)
+		mock.nextReturn(oneToTwo, nil)
 
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
 		for i := 0; i < 10; i++ {
-			g.Expect(comparator.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+			g.Expect(manager.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
 		}
 
 		// call to the exchange rate only for non goldToken currency
@@ -171,14 +170,61 @@ func TestCurrencyComparator(t *testing.T) {
 		mock := getExchangeRateMock{}
 		// default return is an error
 
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
 		for i := 0; i < 10; i++ {
-			g.Expect(comparator.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(0))
+			g.Expect(manager.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(0))
 		}
 
 		// expect 10 call for address{30} and 10 for address{12}
 		g.Expect(mock.totalCalls()).To(Equal(20))
+	})
+
+}
+
+func EqualBigInt(n int64) OmegaMatcher {
+	return WithTransform(func(b *big.Int) int64 { return b.Int64() }, Equal(n))
+}
+
+func TestExchangeRate(t *testing.T) {
+
+	t.Run("can't create with numerator <= 0", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		_, err := NewExchangeRate(common.Big0, common.Big1)
+		g.Expect(err).Should((HaveOccurred()))
+
+		_, err = NewExchangeRate(big.NewInt(-1), common.Big1)
+		g.Expect(err).Should((HaveOccurred()))
+	})
+
+	t.Run("can't create with denomniator <= 0", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		_, err := NewExchangeRate(common.Big1, common.Big0)
+		g.Expect(err).Should((HaveOccurred()))
+
+		_, err = NewExchangeRate(common.Big1, big.NewInt(-1))
+		g.Expect(err).Should((HaveOccurred()))
+	})
+
+	t.Run("should convert to base and back", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		twoToOne := MustNewExchangeRate(common.Big2, common.Big1)
+
+		g.Expect(twoToOne.FromBase(common.Big1)).Should(EqualBigInt(2))
+		g.Expect(twoToOne.ToBase(common.Big2)).Should(EqualBigInt(1))
+	})
+
+	t.Run("should compare two token values", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// 1 gold => 2 expensiveToken
+		expensiveToken := MustNewExchangeRate(common.Big2, common.Big1)
+		// 1 gold => 5 cheapToken
+		cheapToken := MustNewExchangeRate(big.NewInt(5), common.Big1)
+
+		g.Expect(expensiveToken.CmpValues(big.NewInt(10), big.NewInt(10), cheapToken)).Should(Equal(1))
 	})
 
 }

--- a/core/tx_list_test.go
+++ b/core/tx_list_test.go
@@ -35,7 +35,7 @@ func TestStrictTxListAdd(t *testing.T) {
 		txs[i] = transaction(uint64(i), 0, key)
 	}
 	// Insert the transactions in a random order
-	list := newTxList(true)
+	list := newTxList(true, nil)
 	for _, v := range rand.Perm(len(txs)) {
 		list.Add(txs[v], DefaultTxPoolConfig.PriceBump)
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -321,10 +321,11 @@ func (w *worker) close() {
 }
 
 func (w *worker) createTxCmp() func(tx1 *types.Transaction, tx2 *types.Transaction) int {
-	currencyComparator := currency.NewComparator()
+	// TODO specify header & state
+	currencyManager := currency.NewManager(nil, nil)
 
 	return func(tx1 *types.Transaction, tx2 *types.Transaction) int {
-		return currencyComparator.Cmp(tx1.GasPrice(), tx1.FeeCurrency(), tx2.GasPrice(), tx2.FeeCurrency())
+		return currencyManager.Cmp(tx1.GasPrice(), tx1.FeeCurrency(), tx2.GasPrice(), tx2.FeeCurrency())
 	}
 }
 


### PR DESCRIPTION
**This PR shows blockcontext HF + txpool caching. It's an exploration, not to be merged**

### Description

We use txpool.reset() which is the moment on which the txpool updates to
a new blockchain HEAD; to create a blockContext. The reset was already
being used for:

 * removes txs mined on previous blocks
 * updates block max gas limit
 * upddates pool.currentState

So it's only natural to create a block context there.

Thanks to doing this we avoid calls for every tx on:
 * gaspriceminimun for every tx
 * gas for alternative currency
 * whitelisted currencies
