### PR TITLE
Make --proxy.proxyenodeurlpairs optional if --proxy.proxied specified

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1508,10 +1508,6 @@ func SetProxyConfig(ctx *cli.Context, nodeCfg *node.Config, ethCfg *eth.Config) 
 			Fatalf("Option --%s must be used if option --%s is used", MiningEnabledFlag.Name, ProxiedFlag.Name)
 		}
 
-		if !ctx.GlobalIsSet(ProxyEnodeURLPairsFlag.Name) && !ctx.GlobalIsSet(LegacyProxyEnodeURLPairsFlag.Name) {
-			Fatalf("Option --%s must be used if option --%s is used", ProxyEnodeURLPairsFlag.Name, ProxiedFlag.Name)
-		}
-
 		// Extract the proxy enode url pairs, new flag overriding legacy one
 		var proxyEnodeURLPairs []string
 


### PR DESCRIPTION
### Description

Documentation implies this behavior is intended. For example,
https://docs.celo.org/validator-guide/proxy.

This facilitates running geth without initially configuring a proxy and adding
proxies later via RPCs. For example, like
https://github.com/mantalabs/proxy-informer.

### Tested

Ad hoc testing locally.

### Backwards compatibility

This change is technically a breaking one because it changes the behavior of the
(deprecated) --proxy.proxyenodeurlpair option from required to
optional. This will break uses where --proxy.proxyenodeurlpair is elided and
there's an expectation that geth will fail to start.