### PR TITLE
txpool: contract call caching & remove gpm check

### DIFF
--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -106,10 +106,11 @@ func (sb *Backend) distributeEpochRewards(header *types.Header, state *state.Sta
 	currencyManager := currency.NewManager(nil, nil)
 
 	// Validator rewards were paid in cUSD, convert that amount to CELO and add it to the Reserve
-	totalValidatorRewardsConvertedToCelo, err := currencyManager.ToCelo(totalValidatorRewards, &stableTokenAddress)
+	stableTokenCurrency, err := currencyManager.GetCurrency(&stableTokenAddress)
 	if err != nil {
 		return err
 	}
+	totalValidatorRewardsConvertedToCelo := stableTokenCurrency.ToCELO(totalValidatorRewards)
 
 	if err = gold_token.Mint(header, state, reserveAddress, totalValidatorRewardsConvertedToCelo); err != nil {
 		return err

--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -103,8 +103,10 @@ func (sb *Backend) distributeEpochRewards(header *types.Header, state *state.Sta
 		return err
 	}
 
+	currencyManager := currency.NewManager(nil, nil)
+
 	// Validator rewards were paid in cUSD, convert that amount to cGLD and add it to the Reserve
-	totalValidatorRewardsConvertedToGold, err := currency.Convert(totalValidatorRewards, &stableTokenAddress, nil)
+	totalValidatorRewardsConvertedToGold, err := currencyManager.ToGold(totalValidatorRewards, &stableTokenAddress)
 	if err != nil {
 		return err
 	}

--- a/consensus/istanbul/backend/pos.go
+++ b/consensus/istanbul/backend/pos.go
@@ -105,13 +105,13 @@ func (sb *Backend) distributeEpochRewards(header *types.Header, state *state.Sta
 
 	currencyManager := currency.NewManager(nil, nil)
 
-	// Validator rewards were paid in cUSD, convert that amount to cGLD and add it to the Reserve
-	totalValidatorRewardsConvertedToGold, err := currencyManager.ToGold(totalValidatorRewards, &stableTokenAddress)
+	// Validator rewards were paid in cUSD, convert that amount to CELO and add it to the Reserve
+	totalValidatorRewardsConvertedToCelo, err := currencyManager.ToCelo(totalValidatorRewards, &stableTokenAddress)
 	if err != nil {
 		return err
 	}
 
-	if err = gold_token.Mint(header, state, reserveAddress, totalValidatorRewardsConvertedToGold); err != nil {
+	if err = gold_token.Mint(header, state, reserveAddress, totalValidatorRewardsConvertedToCelo); err != nil {
 		return err
 	}
 

--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -130,6 +130,7 @@ func (er *ExchangeRate) FromBase(goldAmount *big.Int) *big.Int {
 	return new(big.Int).Div(new(big.Int).Mul(goldAmount, er.numerator), er.denominator)
 }
 
+// CmpValues compares two values with potentially different exchange rates
 func (er *ExchangeRate) CmpValues(amount *big.Int, anotherTokenAmount *big.Int, anotherTokenRate *ExchangeRate) int {
 	// if both rates are noop rate (CELO rate), compare values
 	if er == nil && anotherTokenRate == nil {
@@ -159,6 +160,7 @@ type CurrencyManager struct {
 	_getExchangeRate func(*common.Address, *types.Header, vm.StateDB) (*ExchangeRate, error) // function to obtain exchange rate from blockchain state
 }
 
+// NewManager creates a new CurrencyManager
 func NewManager(header *types.Header, state vm.StateDB) *CurrencyManager {
 	return newManager(GetExchangeRate, header, state)
 }
@@ -192,7 +194,8 @@ func (cc *CurrencyManager) GetExchangeRate(currency *common.Address) (*ExchangeR
 	return val, nil
 }
 
-func (cc *CurrencyManager) Cmp(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
+// CmpValues compares values of potentially differeny currencies
+func (cc *CurrencyManager) CmpValues(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
 	// Short circuit if the fee currency is the same. nil currency => native currency
 	if (currency1 == nil && currency2 == nil) || (currency1 != nil && currency2 != nil && *currency1 == *currency2) {
 		return val1.Cmp(val2)
@@ -217,6 +220,7 @@ func (cc *CurrencyManager) Cmp(val1 *big.Int, currency1 *common.Address, val2 *b
 	return exchangeRate1.CmpValues(val1, val2, exchangeRate2)
 }
 
+// ToCelo converts an amount on a given currency to CELO token
 func (cc *CurrencyManager) ToCelo(amount *big.Int, currency *common.Address) (*big.Int, error) {
 	rate, err := cc.GetExchangeRate(currency)
 	if err != nil {
@@ -225,6 +229,7 @@ func (cc *CurrencyManager) ToCelo(amount *big.Int, currency *common.Address) (*b
 	return rate.ToBase(amount), nil
 }
 
+// GetExchangeRate retrieves the exchange rate from the blockchain state
 func GetExchangeRate(currencyAddress *common.Address, header *types.Header, state vm.StateDB) (*ExchangeRate, error) {
 	if currencyAddress == nil {
 		return &NoopExchangeRate, nil

--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -94,89 +94,119 @@ const (
 )
 
 var (
-	cgExchangeRateNum = big.NewInt(1)
-	cgExchangeRateDen = big.NewInt(1)
-
 	medianRateFuncABI, _   = abi.JSON(strings.NewReader(medianRateABI))
 	balanceOfFuncABI, _    = abi.JSON(strings.NewReader(balanceOfABI))
 	getWhitelistFuncABI, _ = abi.JSON(strings.NewReader(getWhitelistABI))
 )
 
-type exchangeRate struct {
-	Numerator   *big.Int
-	Denominator *big.Int
+// ExchangeRate represent the exchangeRate for the pair (base, token)
+// Follows the equation: 1 base * ExchangeRate = X token
+type ExchangeRate struct {
+	numerator   *big.Int
+	denominator *big.Int
 }
 
-func ConvertToGold(val *big.Int, currencyFrom *common.Address) (*big.Int, error) {
-	if currencyFrom == nil {
-		return val, nil
-	}
+// NoopExchangeRate returns the noop rate
+// which results in a 1:1 conversion
+func NoopExchangeRate() *ExchangeRate { return nil }
 
-	celoGoldAddress, err := contract_comm.GetRegisteredAddress(params.GoldTokenRegistryId, nil, nil)
-	if err == errors.ErrSmartContractNotDeployed || err == errors.ErrRegistryContractNotDeployed {
-		log.Warn("Registry address lookup failed", "err", err)
-		return val, err
+// MustNewExchangeRate creates an exchange rate, panic on error
+func MustNewExchangeRate(numerator *big.Int, denominator *big.Int) *ExchangeRate {
+	rate, err := NewExchangeRate(numerator, denominator)
+	if err != nil {
+		panic(err)
 	}
-
-	if *currencyFrom == celoGoldAddress {
-		// This function shouldn't really be called with the token's address, but if it is the value
-		// is correct, so return nil as the error
-		return val, nil
-	} else if err != nil {
-		log.Error(err.Error())
-		return val, err
-	}
-	return Convert(val, currencyFrom, nil)
+	return rate
 }
 
-// NOTE (jarmg 4/24/19): values are rounded down which can cause
-// an estimate to be off by 1 (at most)
-func Convert(val *big.Int, currencyFrom *common.Address, currencyTo *common.Address) (*big.Int, error) {
-	exchangeRateFrom, err1 := getExchangeRate(currencyFrom)
-	exchangeRateTo, err2 := getExchangeRate(currencyTo)
-
-	if err1 != nil || err2 != nil {
-		log.Error("Convert - Error in retreiving currency exchange rates")
-		if err1 != nil {
-			return nil, err1
-		}
-		if err2 != nil {
-			return nil, err2
-		}
-	}
-
-	// Given value of val and rates n1/d1 and n2/d2 the function below does
-	// (val * d1 * n2) / (n1 * d2)
-	numerator := new(big.Int).Mul(val, new(big.Int).Mul(exchangeRateFrom.Denominator, exchangeRateTo.Numerator))
-	denominator := new(big.Int).Mul(exchangeRateFrom.Numerator, exchangeRateTo.Denominator)
-
-	if denominator.Sign() == 0 {
-		log.Error("Convert - Error in retreiving currency exchange rates")
+// NewExchangeRate creates an exchange rate.
+// Requires numerator >=0 && denominator >= 0
+func NewExchangeRate(numerator *big.Int, denominator *big.Int) (*ExchangeRate, error) {
+	if numerator == nil || common.Big0.Cmp(numerator) >= 0 {
 		return nil, errors.ErrExchangeRateZero
 	}
-
-	return new(big.Int).Div(numerator, denominator), nil
+	if denominator == nil || common.Big0.Cmp(denominator) >= 0 {
+		return nil, errors.ErrExchangeRateZero
+	}
+	return &ExchangeRate{numerator, denominator}, nil
 }
 
-type CurrencyComparator struct {
-	exchangeRates    map[common.Address]*exchangeRate
-	_getExchangeRate func(*common.Address) (*exchangeRate, error)
+// ToBase converts from token to base
+func (er *ExchangeRate) ToBase(tokenAmount *big.Int) *big.Int {
+	// check noop rate (cGLD rate)
+	if er == nil {
+		return new(big.Int).Set(tokenAmount)
+	}
+
+	return new(big.Int).Div(new(big.Int).Mul(tokenAmount, er.denominator), er.numerator)
 }
 
-func NewComparator() *CurrencyComparator {
-	return newComparator(getExchangeRate)
+// FromGold converts from base to token
+func (er *ExchangeRate) FromBase(goldAmount *big.Int) *big.Int {
+	// check noop rate (cGLD rate)
+	if er == nil {
+		return new(big.Int).Set(goldAmount)
+	}
+
+	return new(big.Int).Div(new(big.Int).Mul(goldAmount, er.numerator), er.denominator)
 }
 
-func newComparator(_getExchangeRate func(*common.Address) (*exchangeRate, error)) *CurrencyComparator {
-	return &CurrencyComparator{
-		exchangeRates:    make(map[common.Address]*exchangeRate),
+func (er *ExchangeRate) CmpValues(amount *big.Int, anotherTokenAmount *big.Int, anotherTokenRate *ExchangeRate) int {
+	// if both rates are noop rate (cGLD rate), compare values
+	if er == nil && anotherTokenRate == nil {
+		return amount.Cmp(anotherTokenAmount)
+	}
+
+	// if both exchangeRate are the same
+	if er != nil && anotherTokenRate != nil && *er == *anotherTokenRate {
+		return amount.Cmp(anotherTokenAmount)
+	}
+
+	// Below code block is basically evaluating this comparison:
+	// amount * er.denominator / er.numerator < anotherTokenAmount * anotherTokenRate.denominator / anotherTokenRate.numerator
+	// It will transform that comparison to this, to remove having to deal with fractional values.
+	// amount * er.denominator * anotherTokenRate.numerator < anotherTokenAmount * anotherTokenRate.denominator * er.numerator
+
+	// when either er or anotherTokenRate are nil, we assume rate = 1/1 (as in cGLD)
+	var leftSide, rightSide *big.Int
+	if er == nil {
+		leftSide = new(big.Int).Mul(amount, anotherTokenRate.numerator)
+		rightSide = new(big.Int).Mul(anotherTokenAmount, anotherTokenRate.denominator)
+	} else if anotherTokenRate == nil {
+		leftSide = new(big.Int).Mul(amount, er.denominator)
+		rightSide = new(big.Int).Mul(anotherTokenAmount, er.numerator)
+	} else {
+		leftSide = new(big.Int).Mul(amount, new(big.Int).Mul(er.denominator, anotherTokenRate.numerator))
+		rightSide = new(big.Int).Mul(anotherTokenAmount, new(big.Int).Mul(anotherTokenRate.denominator, er.numerator))
+	}
+
+	return leftSide.Cmp(rightSide)
+}
+
+type CurrencyManager struct {
+	header *types.Header
+	state  vm.StateDB
+
+	exchangeRates    map[common.Address]*ExchangeRate                                        // map of exchange rates of the form (cGLD, token)
+	_getExchangeRate func(*common.Address, *types.Header, vm.StateDB) (*ExchangeRate, error) // function to obtain exchange rate from blockchain state
+}
+
+func NewManager(header *types.Header, state vm.StateDB) *CurrencyManager {
+	return newManager(GetExchangeRate, header, state)
+}
+
+func newManager(_getExchangeRate func(*common.Address, *types.Header, vm.StateDB) (*ExchangeRate, error), header *types.Header, state vm.StateDB) *CurrencyManager {
+	return &CurrencyManager{
+		header:           header,
+		state:            state,
+		exchangeRates:    make(map[common.Address]*ExchangeRate),
 		_getExchangeRate: _getExchangeRate,
 	}
 }
 
-func (cc *CurrencyComparator) getExchangeRate(currency *common.Address) (*exchangeRate, error) {
+func (cc *CurrencyManager) GetExchangeRate(currency *common.Address) (*ExchangeRate, error) {
 	if currency == nil {
-		return &exchangeRate{cgExchangeRateNum, cgExchangeRateDen}, nil
+		return NoopExchangeRate(), nil
 	}
 
 	val, ok := cc.exchangeRates[*currency]
@@ -184,7 +214,7 @@ func (cc *CurrencyComparator) getExchangeRate(currency *common.Address) (*exchan
 		return val, nil
 	}
 
-	val, err := cc._getExchangeRate(currency)
+	val, err := cc._getExchangeRate(currency, cc.header, cc.state)
 	if err != nil {
 		return nil, err
 	}
@@ -194,14 +224,14 @@ func (cc *CurrencyComparator) getExchangeRate(currency *common.Address) (*exchan
 	return val, nil
 }
 
-func (cc *CurrencyComparator) Cmp(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
+func (cc *CurrencyManager) Cmp(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
 	// Short circuit if the fee currency is the same. nil currency => native currency
 	if (currency1 == nil && currency2 == nil) || (currency1 != nil && currency2 != nil && *currency1 == *currency2) {
 		return val1.Cmp(val2)
 	}
 
-	exchangeRate1, err1 := cc.getExchangeRate(currency1)
-	exchangeRate2, err2 := cc.getExchangeRate(currency2)
+	exchangeRate1, err1 := cc.GetExchangeRate(currency1)
+	exchangeRate2, err2 := cc.GetExchangeRate(currency2)
 
 	if err1 != nil || err2 != nil {
 		currency1Output := "nil"
@@ -216,67 +246,49 @@ func (cc *CurrencyComparator) Cmp(val1 *big.Int, currency1 *common.Address, val2
 		return val1.Cmp(val2)
 	}
 
-	// Below code block is basically evaluating this comparison:
-	// val1 * exchangeRate1.Denominator/exchangeRate1.Numerator < val2 * exchangeRate2.Denominator/exchangeRate2.Numerator
-	// It will transform that comparison to this, to remove having to deal with fractional values.
-	// val1 * exchangeRate1.Denominator * exchangeRate2.Numerator < val2 * exchangeRate2.Denominator * exchangeRate1.Numerator
-	leftSide := new(big.Int).Mul(val1, new(big.Int).Mul(exchangeRate1.Denominator, exchangeRate2.Numerator))
-	rightSide := new(big.Int).Mul(val2, new(big.Int).Mul(exchangeRate2.Denominator, exchangeRate1.Numerator))
-	return leftSide.Cmp(rightSide)
+	return exchangeRate1.CmpValues(val1, val2, exchangeRate2)
 }
 
-func Cmp(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
-	// Short circuit if the fee currency is the same. nil currency => native currency
-	if (currency1 == nil && currency2 == nil) || (currency1 != nil && currency2 != nil && *currency1 == *currency2) {
-		return val1.Cmp(val2)
+func (cc *CurrencyManager) ToGold(amount *big.Int, currency *common.Address) (*big.Int, error) {
+	rate, err := cc.GetExchangeRate(currency)
+	if err != nil {
+		return nil, err
 	}
-
-	exchangeRate1, err1 := getExchangeRate(currency1)
-	exchangeRate2, err2 := getExchangeRate(currency2)
-
-	if err1 != nil || err2 != nil {
-		currency1Output := "nil"
-		if currency1 != nil {
-			currency1Output = currency1.Hex()
-		}
-		currency2Output := "nil"
-		if currency2 != nil {
-			currency2Output = currency2.Hex()
-		}
-		log.Warn("Error in retrieving exchange rate.  Will do comparison of two values without exchange rate conversion.", "currency1", currency1Output, "err1", err1, "currency2", currency2Output, "err2", err2)
-		return val1.Cmp(val2)
-	}
-
-	// Below code block is basically evaluating this comparison:
-	// val1 * exchangeRate1.Denominator/exchangeRate1.Numerator < val2 * exchangeRate2.Denominator/exchangeRate2.Numerator
-	// It will transform that comparison to this, to remove having to deal with fractional values.
-	// val1 * exchangeRate1.Denominator * exchangeRate2.Numerator < val2 * exchangeRate2.Denominator * exchangeRate1.Numerator
-	leftSide := new(big.Int).Mul(val1, new(big.Int).Mul(exchangeRate1.Denominator, exchangeRate2.Numerator))
-	rightSide := new(big.Int).Mul(val2, new(big.Int).Mul(exchangeRate2.Denominator, exchangeRate1.Numerator))
-	return leftSide.Cmp(rightSide)
+	return rate.ToBase(amount), nil
 }
 
-func getExchangeRate(currencyAddress *common.Address) (*exchangeRate, error) {
-	var (
-		returnArray [2]*big.Int
-		leftoverGas uint64
-	)
-
+func GetExchangeRate(currencyAddress *common.Address, header *types.Header, state vm.StateDB) (*ExchangeRate, error) {
 	if currencyAddress == nil {
-		return &exchangeRate{cgExchangeRateNum, cgExchangeRateDen}, nil
-	} else {
-		if leftoverGas, err := contract_comm.MakeStaticCall(params.SortedOraclesRegistryId, medianRateFuncABI, "medianRate", []interface{}{currencyAddress}, &returnArray, params.MaxGasForMedianRate, nil, nil); err != nil {
-			if err == errors.ErrSmartContractNotDeployed {
-				log.Warn("Registry address lookup failed", "err", err)
-				return &exchangeRate{big.NewInt(1), big.NewInt(1)}, err
-			} else {
-				log.Error("medianRate invocation error", "feeCurrencyAddress", currencyAddress.Hex(), "leftoverGas", leftoverGas, "err", err)
-				return &exchangeRate{big.NewInt(1), big.NewInt(1)}, err
-			}
-		}
+		return NoopExchangeRate(), nil
 	}
+
+	celoGoldAddress, err := contract_comm.GetRegisteredAddress(params.GoldTokenRegistryId, nil, nil)
+	if err == errors.ErrSmartContractNotDeployed || err == errors.ErrRegistryContractNotDeployed {
+		return nil, err
+	}
+
+	if *currencyAddress == celoGoldAddress {
+		// This function shouldn't really be called with the token's address, but if it is the value
+		// is correct, so return nil as the error
+		return NoopExchangeRate(), nil
+	} else if err != nil {
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	var returnArray [2]*big.Int
+	leftoverGas, err := contract_comm.MakeStaticCall(params.SortedOraclesRegistryId, medianRateFuncABI, "medianRate", []interface{}{currencyAddress}, &returnArray, params.MaxGasForMedianRate, header, state)
+
+	if err == errors.ErrSmartContractNotDeployed {
+		log.Warn("Registry address lookup failed", "err", err)
+		return NoopExchangeRate(), nil
+	} else if err != nil {
+		log.Error("medianRate invocation error", "feeCurrencyAddress", currencyAddress.Hex(), "leftoverGas", leftoverGas, "err", err)
+		return NoopExchangeRate(), nil
+	}
+
 	log.Trace("medianRate invocation success", "feeCurrencyAddress", currencyAddress, "returnArray", returnArray, "leftoverGas", leftoverGas)
-	return &exchangeRate{returnArray[0], returnArray[1]}, nil
+	return NewExchangeRate(returnArray[0], returnArray[1])
 }
 
 // This function will retrieve the balance of an ERC20 token.
@@ -284,60 +296,50 @@ func GetBalanceOf(accountOwner common.Address, contractAddress common.Address, g
 	log.Trace("GetBalanceOf() Called", "accountOwner", accountOwner.Hex(), "contractAddress", contractAddress, "gas", gas)
 
 	leftoverGas, err := contract_comm.MakeStaticCallWithAddress(contractAddress, balanceOfFuncABI, "balanceOf", []interface{}{accountOwner}, &result, gas, header, state)
+	gasUsed = gas - leftoverGas
 
 	if err != nil {
 		log.Error("GetBalanceOf evm invocation error", "leftoverGas", leftoverGas, "err", err)
-		gasUsed = gas - leftoverGas
-		return
 	} else {
-		gasUsed = gas - leftoverGas
 		log.Trace("GetBalanceOf evm invocation success", "accountOwner", accountOwner.Hex(), "Balance", result.String(), "gas used", gasUsed)
-		return
 	}
+
+	return result, gasUsed, err
 }
 
 // ------------------------------
 // FeeCurrencyWhiteList Functions
 //-------------------------------
-func retrieveWhitelist(header *types.Header, state vm.StateDB) ([]common.Address, error) {
+func CurrencyWhitelist(header *types.Header, state vm.StateDB) ([]common.Address, error) {
 	returnList := []common.Address{}
 
 	_, err := contract_comm.MakeStaticCall(params.FeeCurrencyWhitelistRegistryId, getWhitelistFuncABI, "getWhitelist", []interface{}{}, &returnList, params.MaxGasForGetWhiteList, header, state)
-	if err != nil {
-		if err == errors.ErrSmartContractNotDeployed {
-			log.Warn("Registry address lookup failed", "err", err)
-		} else {
-			log.Error("getWhitelist invocation failed", "err", err)
-		}
-		return returnList, err
+
+	if err == errors.ErrSmartContractNotDeployed {
+		log.Warn("Registry address lookup failed", "err", err)
+	} else if err != nil {
+		log.Error("getWhitelist invocation failed", "err", err)
+	} else {
+		log.Trace("getWhitelist invocation success")
 	}
 
-	log.Trace("getWhitelist invocation success")
 	return returnList, err
 }
 
-func IsWhitelisted(currencyAddress common.Address, header *types.Header, state vm.StateDB) bool {
-	whitelist, err := retrieveWhitelist(header, state)
-	if err != nil {
-		log.Warn("Failed to get fee currency whitelist", "err", err)
+func IsWhitelisted(feeCurrency *common.Address, header *types.Header, state vm.StateDB) bool {
+	if feeCurrency == nil {
 		return true
 	}
-	return containsCurrency(currencyAddress, whitelist)
-}
 
-func containsCurrency(currencyAddr common.Address, currencyList []common.Address) bool {
-	for _, addr := range currencyList {
-		if addr == currencyAddr {
+	whitelistedCurrencies, err := CurrencyWhitelist(header, state)
+	if err != nil {
+		return true
+	}
+
+	for _, addr := range whitelistedCurrencies {
+		if addr == *feeCurrency {
 			return true
 		}
 	}
 	return false
-}
-
-func CurrencyWhitelist(header *types.Header, state vm.StateDB) ([]common.Address, error) {
-	whitelist, err := retrieveWhitelist(header, state)
-	if err != nil {
-		log.Warn("Failed to get fee currency whitelist", "err", err)
-	}
-	return whitelist, err
 }

--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -235,20 +235,6 @@ func GetExchangeRate(currencyAddress *common.Address, header *types.Header, stat
 		return &NoopExchangeRate, nil
 	}
 
-	celoGoldAddress, err := contract_comm.GetRegisteredAddress(params.GoldTokenRegistryId, nil, nil)
-	if err == errors.ErrSmartContractNotDeployed || err == errors.ErrRegistryContractNotDeployed {
-		return nil, err
-	}
-
-	if *currencyAddress == celoGoldAddress {
-		// This function shouldn't really be called with the token's address, but if it is the value
-		// is correct, so return nil as the error
-		return &NoopExchangeRate, nil
-	} else if err != nil {
-		log.Error(err.Error())
-		return nil, err
-	}
-
 	var returnArray [2]*big.Int
 	leftoverGas, err := contract_comm.MakeStaticCall(params.SortedOraclesRegistryId, medianRateFuncABI, "medianRate", []interface{}{currencyAddress}, &returnArray, params.MaxGasForMedianRate, header, state)
 

--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -240,7 +240,7 @@ func (cc *CurrencyManager) Cmp(val1 *big.Int, currency1 *common.Address, val2 *b
 	return exchangeRate1.CmpValues(val1, val2, exchangeRate2)
 }
 
-func (cc *CurrencyManager) ToGold(amount *big.Int, currency *common.Address) (*big.Int, error) {
+func (cc *CurrencyManager) ToCelo(amount *big.Int, currency *common.Address) (*big.Int, error) {
 	rate, err := cc.GetExchangeRate(currency)
 	if err != nil {
 		return nil, err

--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -110,15 +110,6 @@ type ExchangeRate struct {
 // which results in a 1:1 conversion
 func NoopExchangeRate() *ExchangeRate { return nil }
 
-// MustNewExchangeRate creates an exchange rate, panic on error
-func MustNewExchangeRate(numerator *big.Int, denominator *big.Int) *ExchangeRate {
-	rate, err := NewExchangeRate(numerator, denominator)
-	if err != nil {
-		panic(err)
-	}
-	return rate
-}
-
 // NewExchangeRate creates an exchange rate.
 // Requires numerator >=0 && denominator >= 0
 func NewExchangeRate(numerator *big.Int, denominator *big.Int) (*ExchangeRate, error) {
@@ -152,7 +143,7 @@ func (er *ExchangeRate) FromBase(goldAmount *big.Int) *big.Int {
 }
 
 func (er *ExchangeRate) CmpValues(amount *big.Int, anotherTokenAmount *big.Int, anotherTokenRate *ExchangeRate) int {
-	// if both rates are noop rate (cGLD rate), compare values
+	// if both rates are noop rate (CELO rate), compare values
 	if er == nil && anotherTokenRate == nil {
 		return amount.Cmp(anotherTokenAmount)
 	}

--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -194,7 +194,7 @@ func (cc *CurrencyManager) GetExchangeRate(currency *common.Address) (*ExchangeR
 	return val, nil
 }
 
-// CmpValues compares values of potentially differeny currencies
+// CmpValues compares values of potentially different currencies
 func (cc *CurrencyManager) CmpValues(val1 *big.Int, currency1 *common.Address, val2 *big.Int, currency2 *common.Address) int {
 	// Short circuit if the fee currency is the same. nil currency => native currency
 	if (currency1 == nil && currency2 == nil) || (currency1 != nil && currency2 != nil && *currency1 == *currency2) {

--- a/contract_comm/currency/currency_test.go
+++ b/contract_comm/currency/currency_test.go
@@ -182,6 +182,15 @@ func TestCurrencyManager(t *testing.T) {
 
 }
 
+// MustNewExchangeRate creates an exchange rate, panic on error
+func MustNewExchangeRate(numerator *big.Int, denominator *big.Int) *ExchangeRate {
+	rate, err := NewExchangeRate(numerator, denominator)
+	if err != nil {
+		panic(err)
+	}
+	return rate
+}
+
 func EqualBigInt(n int64) OmegaMatcher {
 	return WithTransform(func(b *big.Int) int64 { return b.Int64() }, Equal(n))
 }
@@ -198,7 +207,7 @@ func TestExchangeRate(t *testing.T) {
 		g.Expect(err).Should((HaveOccurred()))
 	})
 
-	t.Run("can't create with denomniator <= 0", func(t *testing.T) {
+	t.Run("can't create with denominator <= 0", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		_, err := NewExchangeRate(common.Big1, common.Big0)

--- a/contract_comm/currency/currency_test.go
+++ b/contract_comm/currency/currency_test.go
@@ -225,7 +225,11 @@ func TestExchangeRate(t *testing.T) {
 		g.Expect(twoToOne.ToBase(common.Big2)).Should(EqualBigInt(1))
 	})
 
-	t.Run("should compare two token values", func(t *testing.T) {
+}
+
+func TestCurrency(t *testing.T) {
+
+	t.Run("should compare with another currency values", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		// 1 gold => 2 expensiveToken
@@ -233,7 +237,15 @@ func TestExchangeRate(t *testing.T) {
 		// 1 gold => 5 cheapToken
 		cheapToken := MustNewExchangeRate(big.NewInt(5), common.Big1)
 
-		g.Expect(expensiveToken.CmpValues(big.NewInt(10), big.NewInt(10), cheapToken)).Should(Equal(1))
-	})
+		expensiveCurrency := Currency{
+			Address:    common.HexToAddress("0x1"),
+			toCELORate: *expensiveToken,
+		}
+		cheapCurrency := Currency{
+			Address:    common.HexToAddress("0x2"),
+			toCELORate: *cheapToken,
+		}
 
+		g.Expect(expensiveCurrency.CmpToCurrency(big.NewInt(10), big.NewInt(10), &cheapCurrency)).Should(Equal(1))
+	})
 }

--- a/contract_comm/currency/currency_test.go
+++ b/contract_comm/currency/currency_test.go
@@ -2,16 +2,19 @@ package currency
 
 import (
 	"errors"
+	"math/big"
 	"testing"
 
 	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/core/vm"
 	. "github.com/onsi/gomega"
 )
 
 type getExchangeRateMock struct {
 	calls   []*common.Address
 	returns []struct {
-		rate *exchangeRate
+		rate *ExchangeRate
 		err  error
 	}
 	returnIdx int
@@ -21,7 +24,7 @@ func (m *getExchangeRateMock) totalCalls() int {
 	return len(m.calls)
 }
 
-func (m *getExchangeRateMock) getExchangeRate(currency *common.Address) (*exchangeRate, error) {
+func (m *getExchangeRateMock) getExchangeRate(currency *common.Address, header *types.Header, state vm.StateDB) (*ExchangeRate, error) {
 	m.calls = append(m.calls, currency)
 
 	if len(m.returns) <= m.returnIdx {
@@ -33,29 +36,25 @@ func (m *getExchangeRateMock) getExchangeRate(currency *common.Address) (*exchan
 	return ret.rate, ret.err
 }
 
-func (m *getExchangeRateMock) nextReturn(rate *exchangeRate, err error) {
+func (m *getExchangeRateMock) nextReturn(rate *ExchangeRate, err error) {
 	m.returns = append(m.returns, struct {
-		rate *exchangeRate
+		rate *ExchangeRate
 		err  error
 	}{
 		rate, err,
 	})
 }
 
-func TestCurrencyComparator(t *testing.T) {
-	twoToOne := exchangeRate{
-		Numerator: common.Big1, Denominator: common.Big2,
-	}
-	oneToTwo := exchangeRate{
-		Numerator: common.Big2, Denominator: common.Big1,
-	}
+func TestCurrencyManager(t *testing.T) {
+	twoToOne := MustNewExchangeRate(common.Big1, common.Big2)
+	oneToTwo := MustNewExchangeRate(common.Big2, common.Big1)
 
 	t.Run("should not call getExchange rate if both currencies are gold", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := getExchangeRateMock{}
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
-		g.Expect(comparator.Cmp(common.Big1, nil, common.Big2, nil)).To(Equal(-1))
+		g.Expect(manager.Cmp(common.Big1, nil, common.Big2, nil)).To(Equal(-1))
 		// no call to getExchange Rate
 		g.Expect(mock.totalCalls()).To(BeZero())
 	})
@@ -63,9 +62,9 @@ func TestCurrencyComparator(t *testing.T) {
 	t.Run("should not call getExchange rate if both currencies are the same", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 		mock := getExchangeRateMock{}
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
-		g.Expect(comparator.Cmp(common.Big1, &common.Address{12}, common.Big2, &common.Address{12})).To(Equal(-1))
+		g.Expect(manager.Cmp(common.Big1, &common.Address{12}, common.Big2, &common.Address{12})).To(Equal(-1))
 		// no call to getExchange Rate
 		g.Expect(mock.totalCalls()).To(BeZero())
 	})
@@ -75,11 +74,11 @@ func TestCurrencyComparator(t *testing.T) {
 
 		mock := getExchangeRateMock{}
 
-		mock.nextReturn(&twoToOne, nil)
+		mock.nextReturn(twoToOne, nil)
 
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
-		g.Expect(comparator.Cmp(common.Big1, nil, common.Big1, &common.Address{12})).To(Equal(-1))
+		g.Expect(manager.Cmp(common.Big1, nil, common.Big1, &common.Address{12})).To(Equal(-1))
 		// call to the exchange rate only for non goldToken currency
 		g.Expect(mock.totalCalls()).To(Equal(1))
 		g.Expect(*mock.calls[0]).To(Equal(common.Address{12}))
@@ -89,50 +88,50 @@ func TestCurrencyComparator(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		mock := getExchangeRateMock{}
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
 		// case 1: 2 gold = 1 usd
 		// then 1 gold < 1 usd
-		mock.nextReturn(&twoToOne, nil)
-		g.Expect(comparator.Cmp(common.Big1, nil, common.Big1, &common.Address{10})).To(Equal(-1))
+		mock.nextReturn(twoToOne, nil)
+		g.Expect(manager.Cmp(common.Big1, nil, common.Big1, &common.Address{10})).To(Equal(-1))
 
 		// case 2: 1 gold = 2 usd
 		// then 1 gold > 1 usd
-		mock.nextReturn(&oneToTwo, nil)
-		g.Expect(comparator.Cmp(common.Big1, nil, common.Big1, &common.Address{20})).To(Equal(1))
+		mock.nextReturn(oneToTwo, nil)
+		g.Expect(manager.Cmp(common.Big1, nil, common.Big1, &common.Address{20})).To(Equal(1))
 
 		// case 3: 1 gold = 2 usd && 1 gold = 2 eur
 		// then 2 eur > 1 usd
-		mock.nextReturn(&oneToTwo, nil)
-		mock.nextReturn(&oneToTwo, nil)
-		g.Expect(comparator.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{40})).To(Equal(1))
+		mock.nextReturn(oneToTwo, nil)
+		mock.nextReturn(oneToTwo, nil)
+		g.Expect(manager.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{40})).To(Equal(1))
 	})
 
 	t.Run("should work with zero values", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		mock := getExchangeRateMock{}
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
 		// case 1: both values == 0
-		g.Expect(comparator.Cmp(common.Big0, nil, common.Big0, nil)).To(Equal(0))
+		g.Expect(manager.Cmp(common.Big0, nil, common.Big0, nil)).To(Equal(0))
 
 		// case 2: first value == 0
-		g.Expect(comparator.Cmp(common.Big0, nil, common.Big1, nil)).To(Equal(-1))
+		g.Expect(manager.Cmp(common.Big0, nil, common.Big1, nil)).To(Equal(-1))
 
 		// case 3: second value == 0
-		g.Expect(comparator.Cmp(common.Big1, nil, common.Big0, nil)).To(Equal(1))
+		g.Expect(manager.Cmp(common.Big1, nil, common.Big0, nil)).To(Equal(1))
 	})
 
 	t.Run("should compare value if first get exchange rate fails", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		mock := getExchangeRateMock{}
-		mock.nextReturn(&twoToOne, nil)
+		mock.nextReturn(twoToOne, nil)
 		mock.nextReturn(nil, errors.New("boom!"))
 
-		comparator := newComparator(mock.getExchangeRate)
-		g.Expect(comparator.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+		manager := newManager(mock.getExchangeRate, nil, nil)
+		g.Expect(manager.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
 	})
 
 	t.Run("should compare value if second get exchange rate fails", func(t *testing.T) {
@@ -140,23 +139,23 @@ func TestCurrencyComparator(t *testing.T) {
 
 		mock := getExchangeRateMock{}
 		mock.nextReturn(nil, errors.New("boom!"))
-		mock.nextReturn(&twoToOne, nil)
+		mock.nextReturn(twoToOne, nil)
 
-		comparator := newComparator(mock.getExchangeRate)
-		g.Expect(comparator.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+		manager := newManager(mock.getExchangeRate, nil, nil)
+		g.Expect(manager.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
 	})
 
 	t.Run("should cache exchange rate on subsequent calls", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		mock := getExchangeRateMock{}
-		mock.nextReturn(&twoToOne, nil)
-		mock.nextReturn(&oneToTwo, nil)
+		mock.nextReturn(twoToOne, nil)
+		mock.nextReturn(oneToTwo, nil)
 
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
 		for i := 0; i < 10; i++ {
-			g.Expect(comparator.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+			g.Expect(manager.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
 		}
 
 		// call to the exchange rate only for non goldToken currency
@@ -171,14 +170,61 @@ func TestCurrencyComparator(t *testing.T) {
 		mock := getExchangeRateMock{}
 		// default return is an error
 
-		comparator := newComparator(mock.getExchangeRate)
+		manager := newManager(mock.getExchangeRate, nil, nil)
 
 		for i := 0; i < 10; i++ {
-			g.Expect(comparator.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(0))
+			g.Expect(manager.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(0))
 		}
 
 		// expect 10 call for address{30} and 10 for address{12}
 		g.Expect(mock.totalCalls()).To(Equal(20))
+	})
+
+}
+
+func EqualBigInt(n int64) OmegaMatcher {
+	return WithTransform(func(b *big.Int) int64 { return b.Int64() }, Equal(n))
+}
+
+func TestExchangeRate(t *testing.T) {
+
+	t.Run("can't create with numerator <= 0", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		_, err := NewExchangeRate(common.Big0, common.Big1)
+		g.Expect(err).Should((HaveOccurred()))
+
+		_, err = NewExchangeRate(big.NewInt(-1), common.Big1)
+		g.Expect(err).Should((HaveOccurred()))
+	})
+
+	t.Run("can't create with denomniator <= 0", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		_, err := NewExchangeRate(common.Big1, common.Big0)
+		g.Expect(err).Should((HaveOccurred()))
+
+		_, err = NewExchangeRate(common.Big1, big.NewInt(-1))
+		g.Expect(err).Should((HaveOccurred()))
+	})
+
+	t.Run("should convert to base and back", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		twoToOne := MustNewExchangeRate(common.Big2, common.Big1)
+
+		g.Expect(twoToOne.FromBase(common.Big1)).Should(EqualBigInt(2))
+		g.Expect(twoToOne.ToBase(common.Big2)).Should(EqualBigInt(1))
+	})
+
+	t.Run("should compare two token values", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		// 1 gold => 2 expensiveToken
+		expensiveToken := MustNewExchangeRate(common.Big2, common.Big1)
+		// 1 gold => 5 cheapToken
+		cheapToken := MustNewExchangeRate(big.NewInt(5), common.Big1)
+
+		g.Expect(expensiveToken.CmpValues(big.NewInt(10), big.NewInt(10), cheapToken)).Should(Equal(1))
 	})
 
 }

--- a/contract_comm/currency/currency_test.go
+++ b/contract_comm/currency/currency_test.go
@@ -54,7 +54,7 @@ func TestCurrencyManager(t *testing.T) {
 		mock := getExchangeRateMock{}
 		manager := newManager(mock.getExchangeRate, nil, nil)
 
-		g.Expect(manager.Cmp(common.Big1, nil, common.Big2, nil)).To(Equal(-1))
+		g.Expect(manager.CmpValues(common.Big1, nil, common.Big2, nil)).To(Equal(-1))
 		// no call to getExchange Rate
 		g.Expect(mock.totalCalls()).To(BeZero())
 	})
@@ -64,7 +64,7 @@ func TestCurrencyManager(t *testing.T) {
 		mock := getExchangeRateMock{}
 		manager := newManager(mock.getExchangeRate, nil, nil)
 
-		g.Expect(manager.Cmp(common.Big1, &common.Address{12}, common.Big2, &common.Address{12})).To(Equal(-1))
+		g.Expect(manager.CmpValues(common.Big1, &common.Address{12}, common.Big2, &common.Address{12})).To(Equal(-1))
 		// no call to getExchange Rate
 		g.Expect(mock.totalCalls()).To(BeZero())
 	})
@@ -78,7 +78,7 @@ func TestCurrencyManager(t *testing.T) {
 
 		manager := newManager(mock.getExchangeRate, nil, nil)
 
-		g.Expect(manager.Cmp(common.Big1, nil, common.Big1, &common.Address{12})).To(Equal(-1))
+		g.Expect(manager.CmpValues(common.Big1, nil, common.Big1, &common.Address{12})).To(Equal(-1))
 		// call to the exchange rate only for non goldToken currency
 		g.Expect(mock.totalCalls()).To(Equal(1))
 		g.Expect(*mock.calls[0]).To(Equal(common.Address{12}))
@@ -93,18 +93,18 @@ func TestCurrencyManager(t *testing.T) {
 		// case 1: 2 gold = 1 usd
 		// then 1 gold < 1 usd
 		mock.nextReturn(twoToOne, nil)
-		g.Expect(manager.Cmp(common.Big1, nil, common.Big1, &common.Address{10})).To(Equal(-1))
+		g.Expect(manager.CmpValues(common.Big1, nil, common.Big1, &common.Address{10})).To(Equal(-1))
 
 		// case 2: 1 gold = 2 usd
 		// then 1 gold > 1 usd
 		mock.nextReturn(oneToTwo, nil)
-		g.Expect(manager.Cmp(common.Big1, nil, common.Big1, &common.Address{20})).To(Equal(1))
+		g.Expect(manager.CmpValues(common.Big1, nil, common.Big1, &common.Address{20})).To(Equal(1))
 
 		// case 3: 1 gold = 2 usd && 1 gold = 2 eur
 		// then 2 eur > 1 usd
 		mock.nextReturn(oneToTwo, nil)
 		mock.nextReturn(oneToTwo, nil)
-		g.Expect(manager.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{40})).To(Equal(1))
+		g.Expect(manager.CmpValues(common.Big2, &common.Address{30}, common.Big1, &common.Address{40})).To(Equal(1))
 	})
 
 	t.Run("should work with zero values", func(t *testing.T) {
@@ -114,13 +114,13 @@ func TestCurrencyManager(t *testing.T) {
 		manager := newManager(mock.getExchangeRate, nil, nil)
 
 		// case 1: both values == 0
-		g.Expect(manager.Cmp(common.Big0, nil, common.Big0, nil)).To(Equal(0))
+		g.Expect(manager.CmpValues(common.Big0, nil, common.Big0, nil)).To(Equal(0))
 
 		// case 2: first value == 0
-		g.Expect(manager.Cmp(common.Big0, nil, common.Big1, nil)).To(Equal(-1))
+		g.Expect(manager.CmpValues(common.Big0, nil, common.Big1, nil)).To(Equal(-1))
 
 		// case 3: second value == 0
-		g.Expect(manager.Cmp(common.Big1, nil, common.Big0, nil)).To(Equal(1))
+		g.Expect(manager.CmpValues(common.Big1, nil, common.Big0, nil)).To(Equal(1))
 	})
 
 	t.Run("should compare value if first get exchange rate fails", func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestCurrencyManager(t *testing.T) {
 		mock.nextReturn(nil, errors.New("boom!"))
 
 		manager := newManager(mock.getExchangeRate, nil, nil)
-		g.Expect(manager.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+		g.Expect(manager.CmpValues(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
 	})
 
 	t.Run("should compare value if second get exchange rate fails", func(t *testing.T) {
@@ -142,7 +142,7 @@ func TestCurrencyManager(t *testing.T) {
 		mock.nextReturn(twoToOne, nil)
 
 		manager := newManager(mock.getExchangeRate, nil, nil)
-		g.Expect(manager.Cmp(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+		g.Expect(manager.CmpValues(common.Big2, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
 	})
 
 	t.Run("should cache exchange rate on subsequent calls", func(t *testing.T) {
@@ -155,7 +155,7 @@ func TestCurrencyManager(t *testing.T) {
 		manager := newManager(mock.getExchangeRate, nil, nil)
 
 		for i := 0; i < 10; i++ {
-			g.Expect(manager.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
+			g.Expect(manager.CmpValues(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(1))
 		}
 
 		// call to the exchange rate only for non goldToken currency
@@ -173,7 +173,7 @@ func TestCurrencyManager(t *testing.T) {
 		manager := newManager(mock.getExchangeRate, nil, nil)
 
 		for i := 0; i < 10; i++ {
-			g.Expect(manager.Cmp(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(0))
+			g.Expect(manager.CmpValues(common.Big1, &common.Address{30}, common.Big1, &common.Address{12})).To(Equal(0))
 		}
 
 		// expect 10 call for address{30} and 10 for address{12}

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -79,7 +79,7 @@ func genValueTx(nbytes int) func(int, *BlockGen) {
 	return func(i int, gen *BlockGen) {
 		toaddr := common.Address{}
 		data := make([]byte, nbytes)
-		gas, _ := IntrinsicGas(data, false, nil, nil, nil, false)
+		gas, _ := IntrinsicGas(data, false, nil, 0, false)
 		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(benchRootAddr), toaddr, big.NewInt(1), gas, nil, nil, nil, nil, data), types.HomesteadSigner{}, benchRootKey)
 		gen.AddTx(tx)
 	}

--- a/core/block_context.go
+++ b/core/block_context.go
@@ -45,8 +45,8 @@ func NewBlockContext(header *types.Header, state vm.StateDB) BlockContext {
 		whitelistedCurrencies = []common.Address{}
 	}
 
-	goldGasPriceMinimum, err := gpm.GetGasPriceMinimum(nil, header, state)
-	_ = err // Ignore the error since gpm.GetGasPriceMinimum returns the Fallback value on error
+	// Ignore the error since gpm.GetGasPriceMinimum returns the Fallback value on error
+	goldGasPriceMinimum, _ := gpm.GetGasPriceMinimum(nil, header, state)
 
 	nonGoldGasPriceMinimums := make(map[common.Address]*big.Int, len(whitelistedCurrencies))
 	for _, currency := range whitelistedCurrencies {

--- a/core/block_context.go
+++ b/core/block_context.go
@@ -13,21 +13,7 @@ import (
 
 // BlockContext represents contextual information about the blockchain state
 // for a given block
-type BlockContext interface {
-	// GetGoldGasPriceMinimum retrieves the gas price minimum for the CELO token
-	GetGoldGasPriceMinimum() *big.Int
-
-	// GetGasPriceMinimum retrieves the gas price minimum for any currency
-	// Also indicates if the currency is not whitelisted
-	GetGasPriceMinimum(feeCurrency *common.Address) (gpm *big.Int, isWhitelisted bool)
-
-	// GetIntrinsicGasForAlternativeFeeCurrency retrieves intrisic gas to be paid for
-	// any tx with a non native fee currency
-	GetIntrinsicGasForAlternativeFeeCurrency() uint64
-}
-
-// defaultBlockContext is the default implementation of BlockContext
-type defaultBlockContext struct {
+type BlockContext struct {
 	goldGasPriceMinimum     *big.Int
 	nonGoldGasPriceMinimums map[common.Address]*big.Int
 
@@ -58,7 +44,7 @@ func NewBlockContext(header *types.Header, state vm.StateDB) BlockContext {
 		nonGoldGasPriceMinimums[currency] = gpm
 	}
 
-	return &defaultBlockContext{
+	return BlockContext{
 		nonGoldGasPriceMinimums:   nonGoldGasPriceMinimums,
 		gasForAlternativeCurrency: gasForAlternativeCurrency,
 		goldGasPriceMinimum:       goldGasPriceMinimum,
@@ -67,18 +53,18 @@ func NewBlockContext(header *types.Header, state vm.StateDB) BlockContext {
 
 // GetIntrinsicGasForAlternativeFeeCurrency retrieves intrisic gas to be paid for
 // any tx with a non native fee currency
-func (bc *defaultBlockContext) GetIntrinsicGasForAlternativeFeeCurrency() uint64 {
+func (bc *BlockContext) GetIntrinsicGasForAlternativeFeeCurrency() uint64 {
 	return bc.gasForAlternativeCurrency
 }
 
 // GetGoldGasPriceMinimum retrieves the gas price minimum for the CELO token
-func (bc *defaultBlockContext) GetGoldGasPriceMinimum() *big.Int {
+func (bc *BlockContext) GetGoldGasPriceMinimum() *big.Int {
 	return bc.goldGasPriceMinimum
 }
 
 // GetGasPriceMinimum retrieves the gas price minimum for any currency
 // Also indicates if the currency is not whitelisted
-func (bc *defaultBlockContext) GetGasPriceMinimum(feeCurrency *common.Address) (gpm *big.Int, isWhitelisted bool) {
+func (bc *BlockContext) GetGasPriceMinimum(feeCurrency *common.Address) (gpm *big.Int, isWhitelisted bool) {
 	if feeCurrency == nil {
 		return bc.goldGasPriceMinimum, true
 	}

--- a/core/block_context.go
+++ b/core/block_context.go
@@ -1,0 +1,93 @@
+package core
+
+import (
+	"math/big"
+
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/contract_comm/blockchain_parameters"
+	"github.com/celo-org/celo-blockchain/contract_comm/currency"
+	gpm "github.com/celo-org/celo-blockchain/contract_comm/gasprice_minimum"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/core/vm"
+)
+
+type BlockContext interface {
+	GetGasPriceMinimum(feeCurrency *common.Address) *big.Int
+	IsWhitelisted(feeCurrency *common.Address) bool
+	GetIntrinsicGasForAlternativeFeeCurrency() uint64
+}
+
+type defaultBlockContext struct {
+	goldGasPriceMinimum *big.Int
+	gasPriceMinimum     map[common.Address]*big.Int
+
+	whitelistedCurrencies     []common.Address
+	noCurrencies              bool
+	gasForAlternativeCurrency uint64
+}
+
+func NewBlockContext(header *types.Header, state vm.StateDB) BlockContext {
+	gasForAlternativeCurrency := blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrency(header, state)
+
+	var noCurrencies bool
+	whitelistedCurrencies, err := currency.CurrencyWhitelist(header, state)
+	if err != nil {
+		whitelistedCurrencies = []common.Address{}
+		noCurrencies = true
+	}
+
+	goldGasPriceMinimum, err := gpm.GetGasPriceMinimum(nil, header, state)
+	_ = err // Ignore the error since gpm.GetGasPriceMinimum returns the Fallback value on error
+	// TODO clean this up
+
+	gasPriceMinimum := make(map[common.Address]*big.Int, len(whitelistedCurrencies))
+	for _, currency := range whitelistedCurrencies {
+		gpm, err := gpm.GetGasPriceMinimum(&currency, header, state)
+		_ = err // Ignore the error since gpm.GetGasPriceMinimum returns the Fallback value on error
+		// TODO clean this up
+		gasPriceMinimum[currency] = gpm
+	}
+
+	return &defaultBlockContext{
+		whitelistedCurrencies:     whitelistedCurrencies,
+		noCurrencies:              noCurrencies,
+		gasForAlternativeCurrency: gasForAlternativeCurrency,
+		gasPriceMinimum:           gasPriceMinimum,
+		goldGasPriceMinimum:       goldGasPriceMinimum,
+	}
+}
+
+func (bc *defaultBlockContext) GetIntrinsicGasForAlternativeFeeCurrency() uint64 {
+	return bc.gasForAlternativeCurrency
+}
+
+func (bc *defaultBlockContext) IsWhitelisted(feeCurrency *common.Address) bool {
+	if bc.noCurrencies {
+		return true
+	}
+
+	if feeCurrency == nil {
+		return true
+	}
+
+	for _, addr := range bc.whitelistedCurrencies {
+		if addr == *feeCurrency {
+			return true
+		}
+	}
+	return false
+}
+
+func (bc *defaultBlockContext) GetGasPriceMinimum(feeCurrency *common.Address) *big.Int {
+	if feeCurrency == nil {
+		return bc.goldGasPriceMinimum
+	}
+
+	gpm, ok := bc.gasPriceMinimum[*feeCurrency]
+	if !ok {
+		// TODO what to do here?
+		return common.Big0
+	}
+
+	return gpm
+}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -409,6 +409,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	// Calculate intrinsic gas, check clauses 5-6
 	gasForAlternativeCurrency := uint64(0)
+	// If the fee currency is nil, do not retrieve the intrinsic gas adjustment from the chain state, as it will not be used.
 	if msg.FeeCurrency() != nil {
 		gasForAlternativeCurrency = blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrency(st.evm.Header, st.state)
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -237,7 +237,7 @@ func (st *StateTransition) to() common.Address {
 
 // payFees deducts gas and gateway fees from sender balance and adds the purchased amount of gas to the state.
 func (st *StateTransition) payFees() error {
-	if st.msg.FeeCurrency() != nil && (!currency.IsWhitelisted(*st.msg.FeeCurrency(), st.evm.Header, st.evm.StateDB)) {
+	if !currency.IsWhitelisted(st.msg.FeeCurrency(), st.evm.Header, st.evm.StateDB) {
 		log.Trace("Fee currency not whitelisted", "fee currency address", st.msg.FeeCurrency())
 		return ErrNonWhitelistedFeeCurrency
 	}
@@ -408,15 +408,11 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	contractCreation := msg.To() == nil
 
 	// Calculate intrinsic gas, check clauses 5-6
-<<<<<<< HEAD
-	gas, err := IntrinsicGas(st.data, contractCreation, st.evm.Header, st.state, msg.FeeCurrency(), istanbul)
-=======
 	gasForAlternativeCurrency := uint64(0)
 	if msg.FeeCurrency() != nil {
-		gasForAlternativeCurrency = blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrency(st.evm.GetHeader(), st.state)
+		gasForAlternativeCurrency = blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrency(st.evm.Header, st.state)
 	}
 	gas, err := IntrinsicGas(st.data, contractCreation, msg.FeeCurrency(), gasForAlternativeCurrency, istanbul)
->>>>>>> 2ac899bcb (Adds BlockContext type)
 	if err != nil {
 		return nil, err
 	}

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -278,14 +278,14 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 			newPrice = tx.GasPrice()
 		} else {
 			if fc := old.FeeCurrency(); fc != nil {
-				if oldPrice, err = l.ctx.ToGold(old.GasPrice(), fc); err != nil {
+				if oldPrice, err = l.ctx.ToCelo(old.GasPrice(), fc); err != nil {
 					return false, nil
 				}
 			} else {
 				oldPrice = old.GasPrice()
 			}
 			if fc := tx.FeeCurrency(); fc != nil {
-				if newPrice, err = l.ctx.ToGold(tx.GasPrice(), fc); err != nil {
+				if newPrice, err = l.ctx.ToCelo(tx.GasPrice(), fc); err != nil {
 					return false, nil
 				}
 			} else {

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -625,7 +625,7 @@ func (l *txPricedList) Cap(cgThreshold *big.Int, local *accountSet) types.Transa
 			continue
 		}
 
-		if l.ctx.Cmp(tx.GasPrice(), tx.FeeCurrency(), cgThreshold, nil) >= 0 {
+		if l.ctx.CmpValues(tx.GasPrice(), tx.FeeCurrency(), cgThreshold, nil) >= 0 {
 			save = append(save, tx)
 			break
 		}
@@ -667,7 +667,7 @@ func (l *txPricedList) Underpriced(tx *types.Transaction, local *accountSet) boo
 	}
 
 	cheapest := l.getMinPricedTx()
-	return l.ctx.Cmp(cheapest.GasPrice(), cheapest.FeeCurrency(), tx.GasPrice(), tx.FeeCurrency()) >= 0
+	return l.ctx.CmpValues(cheapest.GasPrice(), cheapest.FeeCurrency(), tx.GasPrice(), tx.FeeCurrency()) >= 0
 }
 
 // Discard finds a number of most underpriced transactions, removes them from the
@@ -715,7 +715,7 @@ func (l *txPricedList) getHeapWithMinHead() (*priceHeap, *types.Transaction) {
 				cheapestTxn = []*types.Transaction(*cheapestHeap)[0]
 			} else {
 				txn := []*types.Transaction(*priceHeap)[0]
-				if l.ctx.Cmp(txn.GasPrice(), txn.FeeCurrency(), cheapestTxn.GasPrice(), cheapestTxn.FeeCurrency()) < 0 {
+				if l.ctx.CmpValues(txn.GasPrice(), txn.FeeCurrency(), cheapestTxn.GasPrice(), cheapestTxn.FeeCurrency()) < 0 {
 					cheapestHeap = priceHeap
 				}
 			}

--- a/core/tx_list_test.go
+++ b/core/tx_list_test.go
@@ -35,7 +35,7 @@ func TestStrictTxListAdd(t *testing.T) {
 		txs[i] = transaction(uint64(i), 0, key)
 	}
 	// Insert the transactions in a random order
-	list := newTxList(true)
+	list := newTxList(true, nil)
 	for _, v := range rand.Perm(len(txs)) {
 		list.Add(txs[v], DefaultTxPoolConfig.PriceBump)
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -641,7 +641,10 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return err
 	}
-	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, pool.chain.CurrentBlock().Header(), pool.currentState, tx.FeeCurrency(), pool.istanbul)
+
+	gasForAlternativeCurrency := blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrency(pool.chain.CurrentBlock().Header(), pool.currentState)
+
+	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, tx.FeeCurrency(), gasForAlternativeCurrency, pool.istanbul)
 	if err != nil {
 		log.Debug("validateTx gas less than intrinsic gas", "intrGas", intrGas, "err", err)
 		return err

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1276,6 +1276,9 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	pool.currentCtx.BlockContext = NewBlockContext(newHead, statedb)
 	pool.currentCtx.CurrencyManager = currency.NewManager(newHead, statedb)
 
+	// update gasPriceMinimum metric
+	gasPriceMinimumGauge.Update(pool.currentCtx.GetGasPriceMinimum(nil).Int64())
+
 	// Inject any transactions discarded due to reorgs
 	log.Debug("Reinjecting stale transactions", "count", len(reinject))
 	senderCacher.recover(pool.signer, reinject)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -633,7 +633,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 
 	// Drop non-local transactions under our own minimal accepted gas price
 	local = local || pool.locals.contains(from) // account may be local even if the transaction arrived from the network
-	if !local && pool.currentCtx.Cmp(pool.gasPrice, nil, tx.GasPrice(), tx.FeeCurrency()) > 0 {
+	if !local && pool.currentCtx.CmpValues(pool.gasPrice, nil, tx.GasPrice(), tx.FeeCurrency()) > 0 {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -237,6 +237,11 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 	return conf
 }
 
+type txPoolContext struct {
+	BlockContext
+	*currency.CurrencyManager
+}
+
 // TxPool contains all currently known transactions. Transactions
 // enter the pool when they are received from the network or submitted
 // locally. They exit the pool when they are included in the blockchain.
@@ -257,10 +262,10 @@ type TxPool struct {
 	istanbul bool // Fork indicator whether we are in the istanbul stage.
 	donut    bool // Fork indicator for the Donut fork.
 
-	currentState    *state.StateDB // Current state in the blockchain head
-	pendingNonces   *txNoncer      // Pending state tracking virtual nonces
-	currentMaxGas   uint64         // Current gas limit for transaction caps
-	currentBlockCtx BlockContext   // Current block context
+	currentState  *state.StateDB // Current state in the blockchain head
+	pendingNonces *txNoncer      // Pending state tracking virtual nonces
+	currentMaxGas uint64         // Current gas limit for transaction caps
+	currentCtx    txPoolContext  // Current block context
 
 	locals  *accountSet // Set of local transaction to exempt from eviction rules
 	journal *txJournal  // Journal of local transaction to back up to disk
@@ -314,7 +319,7 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 		log.Info("Setting new local account", "address", addr)
 		pool.locals.add(addr)
 	}
-	pool.priced = newTxPricedList(pool.all)
+	pool.priced = newTxPricedList(pool.all, &pool.currentCtx)
 
 	pool.reset(nil, chain.CurrentBlock().Header())
 
@@ -622,13 +627,13 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 
 	// Ensure the fee currency is native or whitelisted.
-	if !pool.currentBlockCtx.IsWhitelisted(tx.FeeCurrency()) {
+	if !pool.currentCtx.IsWhitelisted(tx.FeeCurrency()) {
 		return ErrNonWhitelistedFeeCurrency
 	}
 
 	// Drop non-local transactions under our own minimal accepted gas price
 	local = local || pool.locals.contains(from) // account may be local even if the transaction arrived from the network
-	if !local && currency.Cmp(pool.gasPrice, nil, tx.GasPrice(), tx.FeeCurrency()) > 0 {
+	if !local && pool.currentCtx.Cmp(pool.gasPrice, nil, tx.GasPrice(), tx.FeeCurrency()) > 0 {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering
@@ -641,7 +646,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return err
 	}
 
-	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, tx.FeeCurrency(), pool.currentBlockCtx.GetIntrinsicGasForAlternativeFeeCurrency(), pool.istanbul)
+	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, tx.FeeCurrency(), pool.currentCtx.GetIntrinsicGasForAlternativeFeeCurrency(), pool.istanbul)
 	if err != nil {
 		log.Debug("validateTx gas less than intrinsic gas", "intrGas", intrGas, "err", err)
 		return err
@@ -651,7 +656,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrIntrinsicGas
 	}
 
-	gasPriceMinimum := pool.currentBlockCtx.GetGasPriceMinimum(tx.FeeCurrency())
+	gasPriceMinimum := pool.currentCtx.GetGasPriceMinimum(tx.FeeCurrency())
 	// gasPriceMinimum, err := gpm.GetGasPriceMinimum(tx.FeeCurrency(), nil, nil)
 	// if err != nil && err != ccerrors.ErrSmartContractNotDeployed && err != ccerrors.ErrRegistryContractNotDeployed {
 	// 	log.Debug("unable to fetch gas price minimum", "err", err)
@@ -756,7 +761,7 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction) (bool, er
 	// Try to insert the transaction into the future queue
 	from, _ := types.Sender(pool.signer, tx) // already validated
 	if pool.queue[from] == nil {
-		pool.queue[from] = newTxList(false)
+		pool.queue[from] = newTxList(false, &pool.currentCtx)
 	}
 	inserted, old := pool.queue[from].Add(tx, pool.config.PriceBump)
 	if !inserted {
@@ -803,7 +808,7 @@ func (pool *TxPool) journalTx(from common.Address, tx *types.Transaction) {
 func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.Transaction) bool {
 	// Try to insert the transaction into the pending queue
 	if pool.pending[addr] == nil {
-		pool.pending[addr] = newTxList(true)
+		pool.pending[addr] = newTxList(true, &pool.currentCtx)
 	}
 	list := pool.pending[addr]
 
@@ -1266,7 +1271,10 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	pool.currentState = statedb
 	pool.pendingNonces = newTxNoncer(statedb)
 	pool.currentMaxGas = CalcGasLimit(pool.chain.CurrentBlock(), statedb)
-	pool.currentBlockCtx = NewBlockContext(newHead, statedb)
+
+	// we don't replace currentCtx, since it's shared with all txLists
+	pool.currentCtx.BlockContext = NewBlockContext(newHead, statedb)
+	pool.currentCtx.CurrencyManager = currency.NewManager(newHead, statedb)
 
 	// Inject any transactions discarded due to reorgs
 	log.Debug("Reinjecting stale transactions", "count", len(reinject))
@@ -1311,7 +1319,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 			balances[feeCurrency] = feeCurrencyBalance
 		}
 		// Drop all transactions that are too costly (low balance or out of gas)
-		drops, _ := list.Filter(pool.currentState.GetBalance(addr), balances, pool.currentBlockCtx, pool.currentMaxGas)
+		drops, _ := list.Filter(pool.currentState.GetBalance(addr), balances, pool.currentCtx, pool.currentMaxGas)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
@@ -1511,7 +1519,7 @@ func (pool *TxPool) demoteUnexecutables() {
 			balances[feeCurrency] = feeCurrencyBalance
 		}
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
-		drops, invalids := list.Filter(pool.currentState.GetBalance(addr), balances, pool.currentBlockCtx, pool.currentMaxGas)
+		drops, invalids := list.Filter(pool.currentState.GetBalance(addr), balances, pool.currentCtx, pool.currentMaxGas)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			log.Trace("Removed unpayable pending transaction", "hash", hash)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1325,7 +1325,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 			balances[feeCurrency] = feeCurrencyBalance
 		}
 		// Drop all transactions that are too costly (low balance or out of gas)
-		drops, _ := list.Filter(pool.currentState.GetBalance(addr), balances, pool.ctx(), pool.currentMaxGas)
+		drops, _ := list.Filter(pool.currentState.GetBalance(addr), balances, pool.ctx().BlockContext, pool.currentMaxGas)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			pool.all.Remove(hash)
@@ -1525,7 +1525,7 @@ func (pool *TxPool) demoteUnexecutables() {
 			balances[feeCurrency] = feeCurrencyBalance
 		}
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
-		drops, invalids := list.Filter(pool.currentState.GetBalance(addr), balances, pool.ctx(), pool.currentMaxGas)
+		drops, invalids := list.Filter(pool.currentState.GetBalance(addr), balances, pool.ctx().BlockContext, pool.currentMaxGas)
 		for _, tx := range drops {
 			hash := tx.Hash()
 			log.Trace("Removed unpayable pending transaction", "hash", hash)

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -398,7 +398,11 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 	// Should supply enough intrinsic gas
 	header := pool.chain.GetHeaderByHash(pool.head)
 
-	gasForAlternativeCurrency := blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrency(header, currentState)
+	gasForAlternativeCurrency := uint64(0)
+	// If the fee currency is nil, do not retrieve the intrinsic gas adjustment from the chain state, as it will not be used.
+	if tx.FeeCurrency() != nil {
+		gasForAlternativeCurrency = blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrency(header, currentState)
+	}
 	gas, err := core.IntrinsicGas(tx.Data(), tx.To() == nil, tx.FeeCurrency(), gasForAlternativeCurrency, pool.istanbul)
 	if err != nil {
 		return err

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/contract_comm/blockchain_parameters"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/state"
@@ -396,7 +397,9 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 
 	// Should supply enough intrinsic gas
 	header := pool.chain.GetHeaderByHash(pool.head)
-	gas, err := core.IntrinsicGas(tx.Data(), tx.To() == nil, header, currentState, tx.FeeCurrency(), pool.istanbul)
+
+	gasForAlternativeCurrency := blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrency(header, currentState)
+	gas, err := core.IntrinsicGas(tx.Data(), tx.To() == nil, tx.FeeCurrency(), gasForAlternativeCurrency, pool.istanbul)
 	if err != nil {
 		return err
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -322,10 +322,11 @@ func (w *worker) close() {
 }
 
 func (w *worker) createTxCmp() func(tx1 *types.Transaction, tx2 *types.Transaction) int {
-	currencyComparator := currency.NewComparator()
+	// TODO specify header & state
+	currencyManager := currency.NewManager(nil, nil)
 
 	return func(tx1 *types.Transaction, tx2 *types.Transaction) int {
-		return currencyComparator.Cmp(tx1.GasPrice(), tx1.FeeCurrency(), tx2.GasPrice(), tx2.FeeCurrency())
+		return currencyManager.Cmp(tx1.GasPrice(), tx1.FeeCurrency(), tx2.GasPrice(), tx2.FeeCurrency())
 	}
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -326,7 +326,7 @@ func (w *worker) createTxCmp() func(tx1 *types.Transaction, tx2 *types.Transacti
 	currencyManager := currency.NewManager(nil, nil)
 
 	return func(tx1 *types.Transaction, tx2 *types.Transaction) int {
-		return currencyManager.Cmp(tx1.GasPrice(), tx1.FeeCurrency(), tx2.GasPrice(), tx2.FeeCurrency())
+		return currencyManager.CmpValues(tx1.GasPrice(), tx1.FeeCurrency(), tx2.GasPrice(), tx2.FeeCurrency())
 	}
 }
 

--- a/tests/transaction_test_util.go
+++ b/tests/transaction_test_util.go
@@ -55,7 +55,7 @@ func (tt *TransactionTest) Run(config *params.ChainConfig) error {
 			return nil, nil, err
 		}
 		// Intrinsic gas
-		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.To() == nil, nil, nil, nil, false)
+		requiredGas, err := core.IntrinsicGas(tx.Data(), tx.To() == nil, nil, 0, false)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
### Description

#### Contract Call Caching 

This PR adds a caching layer to the txpool. It works as follows:

Cache has 2 parts:

 * `BlockContext` which represents contract's information required to process a block. (gasPriceMinimum per currency, whitelistedCurrencies, gasForAlternativeCurrency)
 * `CurrencyManager` object which is able to make currency conversion, and maintains al local cache of exchange rates

Both objects are part of the `txpoolContext`, and they are recreated with every `reset()`. This means they are recreated everytime the txpools learns about a new block.

#### TXPool Behaviour Changes

1. txpool no longer checks for gas price minimum (see https://github.com/celo-org/celo-blockchain/pull/1499#issuecomment-819089144)
2. If `getCurrencyWhitelist()` fails, then assume no custom fee currency
is whitelisted (before: any fee currency was whitelisted)

### Other changes

* Refactors `currency.go` and cleans it up

### Tested

 * ci, unit tests

### Backwards compatibility

YES
