### PR TITLE
Remove error log when gas < intrinsic gas.

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -416,10 +416,6 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	// If the intrinsic gas is more than provided in the tx, return without failing.
 	if gas > st.msg.Gas() {
-		log.Error("Transaction failed provide intrinsic gas", "err", err,
-			"gas required", gas,
-			"gas provided", st.msg.Gas(),
-			"fee currency", st.msg.FeeCurrency())
 		return nil, ErrIntrinsicGas
 	}
 	// Check clauses 3-4, pay the fees (which buys gas), and subtract the intrinsic gas


### PR DESCRIPTION
### Description

This gets rid of the infamous `Transaction failed provide intrinsic gas` error log statement which has often been taken to indicate a problem with gas estimation (e.g. returning an incorrect value) when in fact it was happening as a normal part of gas estimation's binary search.

This log statement was being hit as part of gas estimation if using non-Celo currencies for the fees.  However, this is a normal part of gas estimation's binary search, which sets the search's bottom at 21k gas and doesn't account for intrinsic gas being higher in some cases.  As such, it should not log an error message.  An alternative solution, if we wanted to keep this log statement, would be to calculate the intrinsic gas taking into account the fee currency and use that as the low end of the binary search.  However, it seems unnecessary becayse: (a) if this error were encountered during mining it would be logged there anyway at debug level (https://github.com/celo-org/celo-blockchain/blob/5ee083ab02a0d00ff85d89d98e4e2018828892df/miner/worker.go#L790), (b) if this error is encountered as part of `eth_call`, the error will be returned to the caller, and it's not clear the node should log it at all.

I wasn't sure about removing the similar error a few lines below this one (`Transaction failed to buy gas`) for which similar considerations apply.  I kept it simply because it's not an error that appears as a matter of course (since gas estimation uses gas price zero and eth_call does unless you actively specify a higher gas price).  But I'd be open to removing it too.
