### PR TITLE
Fix homebrew error in CI (due to outdated version).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
       - run:
           name: Setup Go language
           command: |
+            brew update
             brew install go@1.16
             brew link go@1.16
             # Check that homebrew installed the expected go version


### PR DESCRIPTION
### Description

This fixes the error seen on the ios build in CI:

```
==> Downloading https://homebrew.bintray.com/go-1.16.3.catalina.bottle.tar.gz
##O#- #                                                                       
curl: (22) The requested URL returned error: 403 Forbidden
Trying a mirror...
==> Downloading https://ghcr.io/v2/homebrew/core/go-1.16.3.catalina.bottle.tar.g
==> Downloading from https://github.com/-/v2/packages/container/package/homebrew
#=#=#                                                                         
curl: (22) The requested URL returned error: 404 
Error: Failed to download resource "go"
Download failed: https://ghcr.io/v2/homebrew/core/go-1.16.3.catalina.bottle.tar.gz
Exited with code exit status 1
CircleCI received exit code 1
```

The fix comes recommended from https://github.com/Homebrew/brew/issues/11119.

### Tested

Confirmed as working by the CI checks.
