### PR TITLE
Set activation blocks for Churrito and Donut on Alfajores and mainnet.

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -62,8 +62,8 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		ChurritoBlock:       nil,
-		DonutBlock:          nil,
+		ChurritoBlock:       big.NewInt(6774000),
+		DonutBlock:          big.NewInt(6774000),
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -110,8 +110,8 @@ var (
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
-		ChurritoBlock:       nil,
-		DonutBlock:          nil,
+		ChurritoBlock:       big.NewInt(4960000),
+		DonutBlock:          big.NewInt(4960000),
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,


### PR DESCRIPTION
* Alfajores is set for May 4, 2021
* Mainnet is set for May 19, 2021

### Description

This PR sets the hard fork block activation numbers for Churrito and Donut (set to activate together) for the Alfajores testnet and mainnet.

### Tested

* Local testing

### Backwards compatibility

No incompatibility until reaching the activation block.
