### PR TITLE
Migrates minimun version check to new contract layer

### DIFF
--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -273,7 +273,7 @@ var AppHelpFlagGroups = []flagGroup{
 	{
 		Name: "MISC",
 		Flags: []cli.Flag{
-			utils.VersionCheckFlag,
+			utils.DisableVersionCheckFlag,
 			utils.SnapshotFlag,
 			cli.HelpFlag,
 		},

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -628,7 +628,7 @@ var (
 		Usage: "Specifies whether to use an in memory discovery table",
 	}
 
-	VersionCheckFlag = cli.BoolFlag{
+	DisableVersionCheckFlag = cli.BoolFlag{
 		Name:  "disable-version-check",
 		Usage: "Disable version check. Use if the parameter is set erroneously",
 	}


### PR DESCRIPTION
### Description

Migrates the minimun version check to the new contract layer

### Other changes

* Adds to `Ethereum` and `LightEthereum` objects an `evmCallerFactory` which they create (as they are the ones with blockchain objects)

* Renames version check flag to `DisableVersionCheck` since it's a disable flag, not an enable one
### Tested

 - Would be nice to do some

### Backwards compatibility

Yes
