### PR TITLE
Add block production and consensus cycle metrics

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -209,6 +209,7 @@ var (
 		utils.MetricsInfluxDBUsernameFlag,
 		utils.MetricsInfluxDBPasswordFlag,
 		utils.MetricsInfluxDBTagsFlag,
+		utils.MetricsLoadTestCSVFlag,
 	}
 )
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -706,9 +706,10 @@ var (
 		Usage: "Comma-separated InfluxDB tags (key/values) attached to all measurements",
 		Value: "host=localhost",
 	}
-	MetricsLoadTestCSVFlag = cli.BoolFlag{
-		Name:  "metrics.loadtestcsvrecorder",
-		Usage: "Write a csv with information about the block production cycle to stdout",
+	MetricsLoadTestCSVFlag = cli.StringFlag{
+		Name:  "metrics.loadtestcsvfile",
+		Usage: "Write a csv with information about the block production cycle to the given file name. If passed an empty string or non-existant, do not output csv metrics.",
+		Value: "",
 	}
 
 	EWASMInterpreterFlag = cli.StringFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -706,6 +706,10 @@ var (
 		Usage: "Comma-separated InfluxDB tags (key/values) attached to all measurements",
 		Value: "host=localhost",
 	}
+	MetricsLoadTestCSVFlag = cli.BoolFlag{
+		Name:  "metrics.loadtestcsvrecorder",
+		Usage: "Write a csv with information about the block production cycle to stdout",
+	}
 
 	EWASMInterpreterFlag = cli.StringFlag{
 		Name:  "vm.ewasm",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1458,6 +1458,9 @@ func setIstanbul(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	cfg.Istanbul.RoundStateDBPath = stack.ResolvePath(cfg.Istanbul.RoundStateDBPath)
 	cfg.Istanbul.Validator = ctx.GlobalIsSet(MiningEnabledFlag.Name) || ctx.GlobalIsSet(DeveloperFlag.Name)
 	cfg.Istanbul.Replica = ctx.GlobalIsSet(IstanbulReplicaFlag.Name)
+	if ctx.GlobalIsSet(MetricsLoadTestCSVFlag.Name) {
+		cfg.Istanbul.LoadTestCSVFile = ctx.GlobalString(MetricsLoadTestCSVFlag.Name)
+	}
 }
 
 func setProxyP2PConfig(ctx *cli.Context, proxyCfg *p2p.Config) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -708,7 +708,7 @@ var (
 	}
 	MetricsLoadTestCSVFlag = cli.StringFlag{
 		Name:  "metrics.loadtestcsvfile",
-		Usage: "Write a csv with information about the block production cycle to the given file name. If passed an empty string or non-existant, do not output csv metrics.",
+		Usage: "Write a csv with information about the block production cycle to the given file name. If passed an empty string or non-existent, do not output csv metrics.",
 		Value: "",
 	}
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -1038,12 +1038,12 @@ func (sb *Backend) recordBlockProductionTimes(blockNumber, txCount, gasUsed, rou
 	sleepGauge := sb.sleepGauge
 	consensusGauge := metrics.Get("consensus/istanbul/core/consensus_commit").(metrics.Gauge)
 	verifyGauge := metrics.Get("consensus/istanbul/core/verify").(metrics.Gauge)
-	blockConstructGuage := metrics.Get("miner/worker/block_construct").(metrics.Gauge)
+	blockConstructGauge := metrics.Get("miner/worker/block_construct").(metrics.Gauge)
 	cpuSysLoadGauge := metrics.Get("system/cpu/sysload").(metrics.Gauge)
 	cpuSysWaitGauge := metrics.Get("system/cpu/syswait").(metrics.Gauge)
 	cpuProcLoadGauge := metrics.Get("system/cpu/procload").(metrics.Gauge)
 
 	sb.csvRecorder.WriteRow(blockNumber, txCount, gasUsed, round,
-		cycle.Nanoseconds(), sleepGauge.Value(), consensusGauge.Value(), verifyGauge.Value(), blockConstructGuage.Value(),
+		cycle.Nanoseconds(), sleepGauge.Value(), consensusGauge.Value(), verifyGauge.Value(), blockConstructGauge.Value(),
 		cpuSysLoadGauge.Value(), cpuSysWaitGauge.Value(), cpuProcLoadGauge.Value())
 }

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -113,7 +113,7 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 		blocksFinalizedGasUsedGauge:        metrics.NewRegisteredGauge("consensus/istanbul/blocks/gasused", nil),
 		sleepGauge:                         metrics.NewRegisteredGauge("consensus/istanbul/backend/sleep", nil),
 	}
-	if metrics.EnabledLoadTest {
+	if config.LoadTestCSVFile != "" {
 		backend.csvRecorder = metrics.NewStdoutCSVRecorder("blockNumber", "txCount", "gasUsed", "round",
 			"cycle", "sleep", "consensus", "block_verify", "block_construct",
 			"sysload", "syswait", "procload")
@@ -497,7 +497,7 @@ func (sb *Backend) Commit(proposal istanbul.Proposal, aggregatedSeal types.Istan
 		Bitmap:    aggregatedEpochValidatorSetSeal.Bitmap,
 		Signature: aggregatedEpochValidatorSetSeal.Signature,
 	})
-	if metrics.EnabledLoadTest {
+	if sb.csvRecorder != nil {
 		sb.recordBlockProductionTimes(block.Header().Number.Uint64(), uint64(len(block.Transactions())), block.GasUsed(), aggregatedSeal.Round.Uint64())
 	}
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -495,7 +495,9 @@ func (sb *Backend) Commit(proposal istanbul.Proposal, aggregatedSeal types.Istan
 		Bitmap:    aggregatedEpochValidatorSetSeal.Bitmap,
 		Signature: aggregatedEpochValidatorSetSeal.Signature,
 	})
-	// TODO: Do record CSV metrics here
+	if metrics.EnabledLoadTest {
+		sb.recordBlockProductionTimes(block.Header().Number.Uint64(), uint64(len(block.Transactions())), block.GasUsed(), aggregatedSeal.Round.Uint64())
+	}
 
 	sb.logger.Info("Committed", "address", sb.Address(), "round", aggregatedSeal.Round.Uint64(), "hash", proposal.Hash(), "number", proposal.Number().Uint64())
 	// - if the proposed and committed blocks are the same, send the proposed hash

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -1057,5 +1057,6 @@ func (sb *Backend) recordBlockProductionTimes(blockNumber, txCount, gasUsed, rou
 	for _, v := range vals {
 		strs = append(strs, fmt.Sprintf("%v", v))
 	}
+	sb.csvRecorder.Write(strs)
 
 }

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -113,9 +113,11 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 		blocksFinalizedGasUsedGauge:        metrics.NewRegisteredGauge("consensus/istanbul/blocks/gasused", nil),
 		sleepGauge:                         metrics.NewRegisteredGauge("consensus/istanbul/backend/sleep", nil),
 	}
-	backend.csvRecorder = metrics.NewStdoutCSVRecorder("blockNumber", "txCount", "gasUsed", "round",
-		"cycle", "sleep", "consensus", "block_verify", "block_construct",
-		"sysload", "syswait", "procload")
+	if metrics.EnabledLoadTest {
+		backend.csvRecorder = metrics.NewStdoutCSVRecorder("blockNumber", "txCount", "gasUsed", "round",
+			"cycle", "sleep", "consensus", "block_verify", "block_construct",
+			"sysload", "syswait", "procload")
+	}
 
 	backend.core = istanbulCore.New(backend, backend.config)
 

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -505,7 +505,7 @@ func (sb *Backend) Commit(proposal istanbul.Proposal, aggregatedSeal types.Istan
 		Signature: aggregatedEpochValidatorSetSeal.Signature,
 	})
 	if sb.csvRecorder != nil {
-		sb.recordBlockProductionTimes(block.Header().Number.Uint64(), uint64(len(block.Transactions())), block.GasUsed(), aggregatedSeal.Round.Uint64())
+		sb.recordBlockProductionTimes(block.Header().Number.Int64(), int64(len(block.Transactions())), int64(block.GasUsed()), aggregatedSeal.Round.Int64())
 	}
 
 	sb.logger.Info("Committed", "address", sb.Address(), "round", aggregatedSeal.Round.Uint64(), "hash", proposal.Hash(), "number", proposal.Number().Uint64())
@@ -1039,7 +1039,7 @@ func (sb *Backend) UpdateReplicaState(seq *big.Int) {
 }
 
 // recordBlockProductionTimes records information about the block production cycle and reports it through the CSVRecorder
-func (sb *Backend) recordBlockProductionTimes(blockNumber, txCount, gasUsed, round uint64) {
+func (sb *Backend) recordBlockProductionTimes(blockNumber, txCount, gasUsed, round int64) {
 	cycle := time.Since(sb.cycleStart)
 	sb.cycleStart = time.Now()
 	sleepGauge := sb.sleepGauge
@@ -1050,7 +1050,12 @@ func (sb *Backend) recordBlockProductionTimes(blockNumber, txCount, gasUsed, rou
 	cpuSysWaitGauge := metrics.Get("system/cpu/syswait").(metrics.Gauge)
 	cpuProcLoadGauge := metrics.Get("system/cpu/procload").(metrics.Gauge)
 
-	sb.csvRecorder.WriteRow(blockNumber, txCount, gasUsed, round,
+	vals := [...]int64{blockNumber, txCount, gasUsed, round,
 		cycle.Nanoseconds(), sleepGauge.Value(), consensusGauge.Value(), verifyGauge.Value(), blockConstructGauge.Value(),
-		cpuSysLoadGauge.Value(), cpuSysWaitGauge.Value(), cpuProcLoadGauge.Value())
+		cpuSysLoadGauge.Value(), cpuSysWaitGauge.Value(), cpuProcLoadGauge.Value()}
+	var strs []string
+	for _, v := range vals {
+		strs = append(strs, fmt.Sprintf("%v", v))
+	}
+
 }

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -111,6 +111,7 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 		blocksDowntimeEventMeter:           metrics.NewRegisteredMeter("consensus/istanbul/blocks/downtimeevent", nil),
 		blocksFinalizedTransactionsGauge:   metrics.NewRegisteredGauge("consensus/istanbul/blocks/transactions", nil),
 		blocksFinalizedGasUsedGauge:        metrics.NewRegisteredGauge("consensus/istanbul/blocks/gasused", nil),
+		sleepGauge:                         metrics.NewRegisteredGauge("consensus/istanbul/backend/sleep", nil),
 	}
 
 	backend.core = istanbulCore.New(backend, backend.config)
@@ -275,6 +276,9 @@ type Backend struct {
 
 	// Gauge counting the gas used in the last block
 	blocksFinalizedGasUsedGauge metrics.Gauge
+
+	// Gauge reporting how many nanoseconds were spent sleeping
+	sleepGauge metrics.Gauge
 
 	// Cache for the return values of the method RetrieveValidatorConnSet
 	cachedValidatorConnSet         map[common.Address]bool

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -390,6 +390,11 @@ func (sb *Backend) Prepare(chain consensus.ChainReader, header *types.Header) er
 	// wait for the timestamp of header, use this to adjust the block period
 	delay := time.Unix(int64(header.Time), 0).Sub(now())
 	time.Sleep(delay)
+	if delay < 0 {
+		sb.sleepGauge.Update(0)
+	} else {
+		sb.sleepGauge.Update(delay.Nanoseconds())
+	}
 
 	return sb.addParentSeal(chain, header)
 }

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -67,6 +67,9 @@ type Config struct {
 	AnnounceQueryEnodeGossipPeriod                 uint64 `toml:",omitempty"` // Time duration (in seconds) between gossiped query enode messages
 	AnnounceAggressiveQueryEnodeGossipOnEnablement bool   `toml:",omitempty"` // Specifies if this node should aggressively query enodes on announce enablement
 	AnnounceAdditionalValidatorsToGossip           int64  `toml:",omitempty"` // Specifies the number of additional non-elected validators to gossip an announce
+
+	// Load test config
+	LoadTestCSVFile string `toml:",omitempty"` // If non-empty, specifies the file to write out csv metrics about the block production cycle to.
 }
 
 // ProxyConfig represents the configuration for validator's proxies
@@ -96,6 +99,7 @@ var DefaultConfig = &Config{
 	AnnounceQueryEnodeGossipPeriod: 300, // 5 minutes
 	AnnounceAggressiveQueryEnodeGossipOnEnablement: true,
 	AnnounceAdditionalValidatorsToGossip:           10,
+	LoadTestCSVFile:                                "", // disable by default
 }
 
 //ApplyParamsChainConfigToConfig applies the istanbul config values from params.chainConfig to the istanbul.Config config

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -138,7 +138,7 @@ func (c *core) broadcastCommit(sub *istanbul.Subject) {
 }
 
 func (c *core) handleCommit(msg *istanbul.Message) error {
-	defer func(start time.Time) { c.handleCommitTimer.UpdateSince(start) }(time.Now())
+	defer c.handleCommitTimer.UpdateSince(time.Now())
 	// Decode COMMIT message
 	var commit *istanbul.CommittedSubject
 	err := msg.Decode(&commit)

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"math/big"
 	"reflect"
+	"time"
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
@@ -137,6 +138,8 @@ func (c *core) broadcastCommit(sub *istanbul.Subject) {
 }
 
 func (c *core) handleCommit(msg *istanbul.Message) error {
+	start := time.Now()
+	defer func() { c.handleCommitTimer.UpdateSince(start) }()
 	// Decode COMMIT message
 	var commit *istanbul.CommittedSubject
 	err := msg.Decode(&commit)

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -138,8 +138,7 @@ func (c *core) broadcastCommit(sub *istanbul.Subject) {
 }
 
 func (c *core) handleCommit(msg *istanbul.Message) error {
-	start := time.Now()
-	defer func() { c.handleCommitTimer.UpdateSince(start) }()
+	defer func(start time.Time) { c.handleCommitTimer.UpdateSince(start) }(time.Now())
 	// Decode COMMIT message
 	var commit *istanbul.CommittedSubject
 	err := msg.Decode(&commit)

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -794,8 +794,7 @@ func (c *core) verifyProposal(proposal istanbul.Proposal) (time.Duration, error)
 		return 0, verificationStatus
 	} else {
 		logger.Trace("verification status cache miss")
-		start := time.Now()
-		defer func() { c.verifyGauge.Update(time.Since(start).Nanoseconds()) }()
+		defer func(start time.Time) { c.verifyGauge.Update(time.Since(start).Nanoseconds()) }(time.Now())
 
 		duration, err := c.backend.Verify(proposal)
 		logger.Trace("proposal verify return values", "duration", duration, "err", err)

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -134,8 +134,15 @@ type core struct {
 
 	consensusTimestamp time.Time
 
-	// the timer to record consensus duration (from accepting a preprepare to final committed stage)
-	consensusTimer metrics.Timer
+	// Time from accepting a pre-prepare (after block verifcation) to preparing or committing
+	consensusPrepareTimeGuage metrics.Gauge
+	consensusCommitTimeGuage  metrics.Gauge
+	// Time to verify blocks. Only records cache misses.
+	verifyGauge metrics.Gauge
+	// Historgram of the time to handle each message type
+	handlePrePrepareTimer metrics.Timer
+	handlePrepareTimer    metrics.Timer
+	handleCommitTimer     metrics.Timer
 }
 
 // New creates an Istanbul consensus core
@@ -146,17 +153,22 @@ func New(backend CoreBackend, config *istanbul.Config) Engine {
 	}
 
 	c := &core{
-		config:             config,
-		address:            backend.Address(),
-		logger:             log.New(),
-		selectProposer:     validator.GetProposerSelector(config.ProposerPolicy),
-		handlerWg:          new(sync.WaitGroup),
-		backend:            backend,
-		pendingRequests:    prque.New(nil),
-		pendingRequestsMu:  new(sync.Mutex),
-		consensusTimestamp: time.Time{},
-		rsdb:               rsdb,
-		consensusTimer:     metrics.NewRegisteredTimer("consensus/istanbul/core/consensus", nil),
+		config:                    config,
+		address:                   backend.Address(),
+		logger:                    log.New(),
+		selectProposer:            validator.GetProposerSelector(config.ProposerPolicy),
+		handlerWg:                 new(sync.WaitGroup),
+		backend:                   backend,
+		pendingRequests:           prque.New(nil),
+		pendingRequestsMu:         new(sync.Mutex),
+		consensusTimestamp:        time.Time{},
+		rsdb:                      rsdb,
+		consensusPrepareTimeGuage: metrics.NewRegisteredGauge("consensus/istanbul/core/consensus_prepare", nil),
+		consensusCommitTimeGuage:  metrics.NewRegisteredGauge("consensus/istanbul/core/consensus_commit", nil),
+		verifyGauge:               metrics.NewRegisteredGauge("consensus/istanbul/core/verify", nil),
+		handlePrePrepareTimer:     metrics.NewRegisteredTimer("consensus/istanbul/core/handle_preprepare", nil),
+		handlePrepareTimer:        metrics.NewRegisteredTimer("consensus/istanbul/core/handle_prepare", nil),
+		handleCommitTimer:         metrics.NewRegisteredTimer("consensus/istanbul/core/handle_commit", nil),
 	}
 	msgBacklog := newMsgBacklog(
 		func(msg *istanbul.Message) {
@@ -358,6 +370,12 @@ func (c *core) commit() error {
 		return err
 	}
 
+	// Update metrics.
+	if !c.consensusTimestamp.IsZero() {
+		c.consensusCommitTimeGuage.Update(time.Since(c.consensusTimestamp).Nanoseconds())
+		c.consensusTimestamp = time.Time{}
+	}
+
 	// Process Backlog Messages
 	c.backlog.updateState(c.current.View(), c.current.State())
 
@@ -528,11 +546,6 @@ func (c *core) startNewSequence() error {
 		// TODO(Joshua): figure out if we need to wait for the next block to be mined here
 		// This function is called on a final committed event which should occur once the block is inserted into the chain.
 		return nil
-	}
-	// Update metrics.
-	if !c.consensusTimestamp.IsZero() {
-		c.consensusTimer.UpdateSince(c.consensusTimestamp)
-		c.consensusTimestamp = time.Time{}
 	}
 
 	// Generate next view and preprepare
@@ -781,6 +794,8 @@ func (c *core) verifyProposal(proposal istanbul.Proposal) (time.Duration, error)
 		return 0, verificationStatus
 	} else {
 		logger.Trace("verification status cache miss")
+		start := time.Now()
+		defer func() { c.verifyGauge.Update(time.Since(start).Nanoseconds()) }()
 
 		duration, err := c.backend.Verify(proposal)
 		logger.Trace("proposal verify return values", "duration", duration, "err", err)

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -135,8 +135,8 @@ type core struct {
 	consensusTimestamp time.Time
 
 	// Time from accepting a pre-prepare (after block verifcation) to preparing or committing
-	consensusPrepareTimeGuage metrics.Gauge
-	consensusCommitTimeGuage  metrics.Gauge
+	consensusPrepareTimeGauge metrics.Gauge
+	consensusCommitTimeGauge  metrics.Gauge
 	// Time to verify blocks. Only records cache misses.
 	verifyGauge metrics.Gauge
 	// Historgram of the time to handle each message type
@@ -163,8 +163,8 @@ func New(backend CoreBackend, config *istanbul.Config) Engine {
 		pendingRequestsMu:         new(sync.Mutex),
 		consensusTimestamp:        time.Time{},
 		rsdb:                      rsdb,
-		consensusPrepareTimeGuage: metrics.NewRegisteredGauge("consensus/istanbul/core/consensus_prepare", nil),
-		consensusCommitTimeGuage:  metrics.NewRegisteredGauge("consensus/istanbul/core/consensus_commit", nil),
+		consensusPrepareTimeGauge: metrics.NewRegisteredGauge("consensus/istanbul/core/consensus_prepare", nil),
+		consensusCommitTimeGauge:  metrics.NewRegisteredGauge("consensus/istanbul/core/consensus_commit", nil),
 		verifyGauge:               metrics.NewRegisteredGauge("consensus/istanbul/core/verify", nil),
 		handlePrePrepareTimer:     metrics.NewRegisteredTimer("consensus/istanbul/core/handle_preprepare", nil),
 		handlePrepareTimer:        metrics.NewRegisteredTimer("consensus/istanbul/core/handle_prepare", nil),
@@ -372,7 +372,7 @@ func (c *core) commit() error {
 
 	// Update metrics.
 	if !c.consensusTimestamp.IsZero() {
-		c.consensusCommitTimeGuage.Update(time.Since(c.consensusTimestamp).Nanoseconds())
+		c.consensusCommitTimeGauge.Update(time.Since(c.consensusTimestamp).Nanoseconds())
 		c.consensusTimestamp = time.Time{}
 	}
 

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -215,7 +215,7 @@ func (c *core) handlePrepare(msg *istanbul.Message) error {
 		logger.Trace("Got quorum prepares or commits", "tag", "stateTransition")
 		// Update metrics.
 		if !c.consensusTimestamp.IsZero() {
-			c.consensusPrepareTimeGuage.Update(time.Since(c.consensusTimestamp).Nanoseconds())
+			c.consensusPrepareTimeGauge.Update(time.Since(c.consensusTimestamp).Nanoseconds())
 		}
 
 		// Process Backlog Messages

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -174,8 +174,7 @@ func (c *core) getViewFromVerifiedPreparedCertificate(preparedCertificate istanb
 }
 
 func (c *core) handlePrepare(msg *istanbul.Message) error {
-	start := time.Now()
-	defer func() { c.handlePrepareTimer.UpdateSince(start) }()
+	defer func(start time.Time) { c.handlePrepareTimer.UpdateSince(start) }(time.Now())
 	// Decode PREPARE message
 	var prepare *istanbul.Subject
 	err := msg.Decode(&prepare)

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -174,7 +174,7 @@ func (c *core) getViewFromVerifiedPreparedCertificate(preparedCertificate istanb
 }
 
 func (c *core) handlePrepare(msg *istanbul.Message) error {
-	defer func(start time.Time) { c.handlePrepareTimer.UpdateSince(start) }(time.Now())
+	defer c.handlePrepareTimer.UpdateSince(time.Now())
 	// Decode PREPARE message
 	var prepare *istanbul.Subject
 	err := msg.Decode(&prepare)

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -50,7 +50,7 @@ func (c *core) sendPreprepare(request *istanbul.Request, roundChangeCertificate 
 }
 
 func (c *core) handlePreprepare(msg *istanbul.Message) error {
-	defer func(start time.Time) { c.handlePrePrepareTimer.UpdateSince(start) }(time.Now())
+	defer c.handlePrePrepareTimer.UpdateSince(time.Now())
 
 	logger := c.newLogger("func", "handlePreprepare", "tag", "handleMsg", "from", msg.Address)
 	logger.Trace("Got preprepare message", "m", msg)

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -50,6 +50,9 @@ func (c *core) sendPreprepare(request *istanbul.Request, roundChangeCertificate 
 }
 
 func (c *core) handlePreprepare(msg *istanbul.Message) error {
+	start := time.Now()
+	defer func() { c.handlePrePrepareTimer.UpdateSince(start) }()
+
 	logger := c.newLogger("func", "handlePreprepare", "tag", "handleMsg", "from", msg.Address)
 	logger.Trace("Got preprepare message", "m", msg)
 

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -50,8 +50,7 @@ func (c *core) sendPreprepare(request *istanbul.Request, roundChangeCertificate 
 }
 
 func (c *core) handlePreprepare(msg *istanbul.Message) error {
-	start := time.Now()
-	defer func() { c.handlePrePrepareTimer.UpdateSince(start) }()
+	defer func(start time.Time) { c.handlePrePrepareTimer.UpdateSince(start) }(time.Now())
 
 	logger := c.newLogger("func", "handlePreprepare", "tag", "handleMsg", "from", msg.Address)
 	logger.Trace("Got preprepare message", "m", msg)

--- a/metrics/csv_metrics.go
+++ b/metrics/csv_metrics.go
@@ -40,6 +40,7 @@ func NewStdoutCSVRecorder(fields ...string) *CSVRecorder {
 }
 
 // NewStdoutCSVRecorder creates a CSV recorder that writes to the supplied writer.
+// The writer is aborbed into the recorder and the user is responsible for calling CSVRecorder.Close()
 // The header is immediately written upon construction.
 func NewCSVRecorder(w io.Writer, fields ...string) *CSVRecorder {
 	fmt.Fprintln(w, strings.Join(fields, ","))
@@ -69,4 +70,20 @@ func (c *CSVRecorder) WriteRow(values ...interface{}) {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 	fmt.Fprintf(c.writer, c.format, values...)
+}
+
+// Close closes the writer iff it is an io.WriterCloser
+// This is a no-op for non Closers or a nil receiver.
+func (c *CSVRecorder) Close() error {
+	fmt.Println("closing csv reader")
+	defer fmt.Println("close complete")
+	if c == nil {
+		return nil
+	}
+	if wc, ok := c.writer.(io.WriteCloser); ok {
+		err := wc.Close()
+		fmt.Println("closed writer")
+		return err
+	}
+	return nil
 }

--- a/metrics/csv_metrics.go
+++ b/metrics/csv_metrics.go
@@ -51,7 +51,7 @@ func NewCSVRecorder(w io.Writer, fields ...string) *CSVRecorder {
 }
 
 // WriteRow writes out as csv row. Will convert the values to a string.
-func (c *CSVRecorder) Write(values ...string) {
+func (c *CSVRecorder) Write(values []string) {
 	if c == nil {
 		return
 	}

--- a/metrics/csv_metrics.go
+++ b/metrics/csv_metrics.go
@@ -1,0 +1,72 @@
+// Copyright 2021 The Celo Authors
+// This file is part of the celo library.
+//
+// The celo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The celo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the celo library. If not, see <http://www.gnu.org/licenses/>.
+
+package metrics
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+// A CSVRecorder enables easy writing of CSV data a specified writer.
+// The header is written on creation. Writing is thread safe.
+type CSVRecorder struct {
+	header  []string
+	writer  io.Writer
+	format  string
+	writeMu sync.Mutex
+}
+
+// NewStdoutCSVRecorder creates a CSV recorder to standard out
+// The header is immediately written upon construction.
+func NewStdoutCSVRecorder(fields ...string) *CSVRecorder {
+	return NewCSVRecorder(os.Stdout, fields...)
+}
+
+// NewStdoutCSVRecorder creates a CSV recorder that writes to the supplied writer.
+// The header is immediately written upon construction.
+func NewCSVRecorder(w io.Writer, fields ...string) *CSVRecorder {
+	fmt.Fprintln(w, strings.Join(fields, ","))
+	return &CSVRecorder{
+		header: fields,
+		writer: w,
+		format: rowFormatString(len(fields))}
+}
+
+// rowFormatString creates the string "%v,%v[,%v]...\n" where "%v" is repeated fieldCount times.
+func rowFormatString(fieldCount int) string {
+	var b strings.Builder
+	b.WriteString("%v")
+	for i := 1; i < fieldCount; i++ {
+		b.WriteString(",%v")
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+// WriteRow writes out as csv row. Each value is printed with "%v"
+// The length of the values must match the length of the header.
+func (c *CSVRecorder) WriteRow(values ...interface{}) {
+	if len(values) != len(c.header) {
+		panic("Dev error: Value length does not match the header length")
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	fmt.Fprintf(c.writer, c.format, values...)
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -34,19 +34,11 @@ var Enabled = false
 // for health monitoring and debug metrics that might impact runtime performance.
 var EnabledExpensive = false
 
-// EnabledLoadTest is a soft-flag meant for external packages to check if load
-// test metrics gathering is allowed or not. This currently writes a CSV to
-// stdout.
-var EnabledLoadTest = false
-
 // enablerFlags is the CLI flag names to use to enable metrics collections.
 var enablerFlags = []string{"metrics"}
 
 // expensiveEnablerFlags is the CLI flag names to use to enable metrics collections.
 var expensiveEnablerFlags = []string{"metrics.expensive"}
-
-// loadtestEnablerFlags is the CLI flag names to use to enable metrics collections.
-var loadtestEnablerFlags = []string{"metrics.loadtestcsvrecorder"}
 
 // Init enables or disables the metrics system. Since we need this to run before
 // any other code gets to create meters and timers, we'll actually do an ugly hack
@@ -70,13 +62,6 @@ func init() {
 			if !EnabledExpensive && flag == enabler {
 				log.Info("Enabling expensive metrics collection")
 				EnabledExpensive = true
-			}
-		}
-
-		for _, enabler := range loadtestEnablerFlags {
-			if !EnabledLoadTest && flag == enabler {
-				log.Info("Enabling load test metrics collection")
-				EnabledLoadTest = true
 			}
 		}
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -34,11 +34,19 @@ var Enabled = false
 // for health monitoring and debug metrics that might impact runtime performance.
 var EnabledExpensive = false
 
+// EnabledLoadTest is a soft-flag meant for external packages to check if load
+// test metrics gathering is allowed or not. This currently writes a CSV to
+// stdout.
+var EnabledLoadTest = false
+
 // enablerFlags is the CLI flag names to use to enable metrics collections.
 var enablerFlags = []string{"metrics"}
 
 // expensiveEnablerFlags is the CLI flag names to use to enable metrics collections.
 var expensiveEnablerFlags = []string{"metrics.expensive"}
+
+// loadtestEnablerFlags is the CLI flag names to use to enable metrics collections.
+var loadtestEnablerFlags = []string{"metrics.loadtestcsvrecorder"}
 
 // Init enables or disables the metrics system. Since we need this to run before
 // any other code gets to create meters and timers, we'll actually do an ugly hack
@@ -62,6 +70,13 @@ func init() {
 			if !EnabledExpensive && flag == enabler {
 				log.Info("Enabling expensive metrics collection")
 				EnabledExpensive = true
+			}
+		}
+
+		for _, enabler := range loadtestEnablerFlags {
+			if !EnabledLoadTest && flag == enabler {
+				log.Info("Enabling load test metrics collection")
+				EnabledLoadTest = true
 			}
 		}
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -193,30 +193,33 @@ type worker struct {
 
 	// Needed for randomness
 	db ethdb.Database
+
+	blockConstructGuage metrics.Gauge
 }
 
 func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, isLocalBlock func(*types.Block) bool, db ethdb.Database, init bool) *worker {
 	worker := &worker{
-		config:             config,
-		chainConfig:        chainConfig,
-		engine:             engine,
-		eth:                eth,
-		mux:                mux,
-		chain:              eth.BlockChain(),
-		isLocalBlock:       isLocalBlock,
-		unconfirmed:        newUnconfirmedBlocks(eth.BlockChain(), miningLogAtDepth),
-		pendingTasks:       make(map[common.Hash]*task),
-		txsCh:              make(chan core.NewTxsEvent, txChanSize),
-		chainHeadCh:        make(chan core.ChainHeadEvent, chainHeadChanSize),
-		chainSideCh:        make(chan core.ChainSideEvent, chainSideChanSize),
-		newWorkCh:          make(chan *newWorkReq),
-		taskCh:             make(chan *task),
-		resultCh:           make(chan *types.Block, resultQueueSize),
-		exitCh:             make(chan struct{}),
-		startCh:            make(chan struct{}, 1),
-		resubmitIntervalCh: make(chan time.Duration),
-		resubmitAdjustCh:   make(chan *intervalAdjust, resubmitAdjustChanSize),
-		db:                 db,
+		config:              config,
+		chainConfig:         chainConfig,
+		engine:              engine,
+		eth:                 eth,
+		mux:                 mux,
+		chain:               eth.BlockChain(),
+		isLocalBlock:        isLocalBlock,
+		unconfirmed:         newUnconfirmedBlocks(eth.BlockChain(), miningLogAtDepth),
+		pendingTasks:        make(map[common.Hash]*task),
+		txsCh:               make(chan core.NewTxsEvent, txChanSize),
+		chainHeadCh:         make(chan core.ChainHeadEvent, chainHeadChanSize),
+		chainSideCh:         make(chan core.ChainSideEvent, chainSideChanSize),
+		newWorkCh:           make(chan *newWorkReq),
+		taskCh:              make(chan *task),
+		resultCh:            make(chan *types.Block, resultQueueSize),
+		exitCh:              make(chan struct{}),
+		startCh:             make(chan struct{}, 1),
+		resubmitIntervalCh:  make(chan time.Duration),
+		resubmitAdjustCh:    make(chan *intervalAdjust, resubmitAdjustChanSize),
+		db:                  db,
+		blockConstructGuage: metrics.NewRegisteredGauge("miner/worker/block_construct", nil),
 	}
 	// Subscribe NewTxsEvent for tx pool
 	worker.txsSub = eth.TxPool().SubscribeNewTxsEvent(worker.txsCh)
@@ -873,6 +876,10 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		log.Error("Failed to prepare header for mining", "err", err)
 		return
 	}
+	// Start record block construction time after `engine.Prepare` to exclude the sleep time
+	start := time.Now()
+	defer func() { w.blockConstructGuage.Update(time.Since(start).Nanoseconds()) }()
+
 	// If we are care about TheDAO hard-fork check whether to override the extra-data or not
 	if daoBlock := w.chainConfig.DAOForkBlock; daoBlock != nil {
 		// Check whether the block is among the fork extra-override range

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -877,8 +877,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		return
 	}
 	// Start record block construction time after `engine.Prepare` to exclude the sleep time
-	start := time.Now()
-	defer func() { w.blockConstructGauge.Update(time.Since(start).Nanoseconds()) }()
+	defer func(start time.Time) { w.blockConstructGauge.Update(time.Since(start).Nanoseconds()) }(time.Now())
 
 	// If we are care about TheDAO hard-fork check whether to override the extra-data or not
 	if daoBlock := w.chainConfig.DAOForkBlock; daoBlock != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -194,7 +194,7 @@ type worker struct {
 	// Needed for randomness
 	db ethdb.Database
 
-	blockConstructGuage metrics.Gauge
+	blockConstructGauge metrics.Gauge
 }
 
 func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, isLocalBlock func(*types.Block) bool, db ethdb.Database, init bool) *worker {
@@ -219,7 +219,7 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		resubmitIntervalCh:  make(chan time.Duration),
 		resubmitAdjustCh:    make(chan *intervalAdjust, resubmitAdjustChanSize),
 		db:                  db,
-		blockConstructGuage: metrics.NewRegisteredGauge("miner/worker/block_construct", nil),
+		blockConstructGauge: metrics.NewRegisteredGauge("miner/worker/block_construct", nil),
 	}
 	// Subscribe NewTxsEvent for tx pool
 	worker.txsSub = eth.TxPool().SubscribeNewTxsEvent(worker.txsCh)
@@ -878,7 +878,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	}
 	// Start record block construction time after `engine.Prepare` to exclude the sleep time
 	start := time.Now()
-	defer func() { w.blockConstructGuage.Update(time.Since(start).Nanoseconds()) }()
+	defer func() { w.blockConstructGauge.Update(time.Since(start).Nanoseconds()) }()
 
 	// If we are care about TheDAO hard-fork check whether to override the extra-data or not
 	if daoBlock := w.chainConfig.DAOForkBlock; daoBlock != nil {


### PR DESCRIPTION
### Description

Adds better metrics for load testing.
Also adds a command line option `--metrics.loadtestcsvfile` to specify a file to write out information about the block production and consensus cycle in a CSV format. This was previously on a separate branch that was cherry-picked onto the branch that we wanted to loadtest.

### Tested

Local load test.

### Related issues

- Fixes #1511 

