### PR TITLE
Release celo-blockchain v1.3.0-stable

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 3        // Minor version component of the current release
 	VersionPatch = 0        // Patch version component of the current release
-	VersionMeta  = "beta.3" // Version metadata to append to the version string
+	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 
 type VersionInfo struct {


### PR DESCRIPTION
### Description

Set the version to 1.3.0-stable, to then use this commit for the tag and release.
