### PR TITLE
Removes unnecessary arguments/returns to GetBalance

### DIFF
--- a/contract_comm/currency/currency.go
+++ b/contract_comm/currency/currency.go
@@ -282,19 +282,18 @@ func GetExchangeRate(currencyAddress *common.Address, header *types.Header, stat
 }
 
 // GetBalanceOf returns an account's balance on a given ERC20 currency
-func GetBalanceOf(accountOwner common.Address, contractAddress common.Address, gas uint64, header *types.Header, state vm.StateDB) (result *big.Int, gasUsed uint64, err error) {
-	log.Trace("GetBalanceOf() Called", "accountOwner", accountOwner.Hex(), "contractAddress", contractAddress, "gas", gas)
+func GetBalanceOf(accountOwner common.Address, contractAddress common.Address, header *types.Header, state vm.StateDB) (result *big.Int, err error) {
+	log.Trace("GetBalanceOf() Called", "accountOwner", accountOwner.Hex(), "contractAddress", contractAddress)
 
-	leftoverGas, err := contract_comm.MakeStaticCallWithAddress(contractAddress, balanceOfFuncABI, "balanceOf", []interface{}{accountOwner}, &result, gas, header, state)
-	gasUsed = gas - leftoverGas
+	leftoverGas, err := contract_comm.MakeStaticCallWithAddress(contractAddress, balanceOfFuncABI, "balanceOf", []interface{}{accountOwner}, &result, params.MaxGasToReadErc20Balance, header, state)
 
 	if err != nil {
 		log.Error("GetBalanceOf evm invocation error", "leftoverGas", leftoverGas, "err", err)
 	} else {
-		log.Trace("GetBalanceOf evm invocation success", "accountOwner", accountOwner.Hex(), "Balance", result.String(), "gas used", gasUsed)
+		log.Trace("GetBalanceOf evm invocation success", "accountOwner", accountOwner.Hex(), "Balance", result.String(), "leftoverGas", leftoverGas)
 	}
 
-	return result, gasUsed, err
+	return result, err
 }
 
 // CurrencyWhitelist retrieves the list of currencies that can be used to pay transaction fees

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -267,8 +267,7 @@ func (st *StateTransition) canPayFee(accountOwner common.Address, fee *big.Int, 
 		return st.state.GetBalance(accountOwner).Cmp(fee) >= 0
 	}
 
-	balanceOf, gasUsed, err := currency.GetBalanceOf(accountOwner, *feeCurrency, params.MaxGasToReadErc20Balance, st.evm.Header, st.evm.StateDB)
-	log.Debug("balanceOf called", "feeCurrency", *feeCurrency, "gasUsed", gasUsed)
+	balanceOf, err := currency.GetBalanceOf(accountOwner, *feeCurrency, st.evm.Header, st.evm.StateDB)
 
 	if err != nil {
 		return false

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1309,7 +1309,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		balances := make(map[common.Address]*big.Int)
 		allCurrencies := list.FeeCurrencies()
 		for _, feeCurrency := range allCurrencies {
-			feeCurrencyBalance, _, _ := currency.GetBalanceOf(addr, feeCurrency, params.MaxGasToReadErc20Balance, nil, nil)
+			feeCurrencyBalance, _ := currency.GetBalanceOf(addr, feeCurrency, nil, nil)
 			balances[feeCurrency] = feeCurrencyBalance
 		}
 		// Drop all transactions that are too costly (low balance or out of gas)
@@ -1509,7 +1509,7 @@ func (pool *TxPool) demoteUnexecutables() {
 		balances := make(map[common.Address]*big.Int)
 		allCurrencies := list.FeeCurrencies()
 		for _, feeCurrency := range allCurrencies {
-			feeCurrencyBalance, _, _ := currency.GetBalanceOf(addr, feeCurrency, params.MaxGasToReadErc20Balance, nil, nil)
+			feeCurrencyBalance, _ := currency.GetBalanceOf(addr, feeCurrency, nil, nil)
 			balances[feeCurrency] = feeCurrencyBalance
 		}
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
@@ -1557,7 +1557,7 @@ func ValidateTransactorBalanceCoversTx(tx *types.Transaction, from common.Addres
 			"value", tx.Value(), "fee currency", tx.FeeCurrency(), "balance", currentState.GetBalance(from))
 		return ErrInsufficientFunds
 	} else if tx.FeeCurrency() != nil {
-		feeCurrencyBalance, _, err := currency.GetBalanceOf(from, *tx.FeeCurrency(), params.MaxGasToReadErc20Balance, nil, nil)
+		feeCurrencyBalance, err := currency.GetBalanceOf(from, *tx.FeeCurrency(), nil, nil)
 
 		if err != nil {
 			log.Debug("validateTx error in getting fee currency balance", "feeCurrency", tx.FeeCurrency(), "error", err)


### PR DESCRIPTION

### Description

Everycall used the same maxGas parameter, so instead of passing it, we
use it directly. This is what every other call in the system does.

Also, usedGas was not really used as a return parameter, so removed

### Tested

* unit tests, ci

