### PR TITLE
Fix ios build in CI (again)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,6 @@ jobs:
       - run:
           name: Setup Go language
           command: |
-            brew update
             brew install go@1.16
             brew link go@1.16
             # Check that homebrew installed the expected go version


### PR DESCRIPTION
### Description

We previously added `brew update` in #1503.  However, since then `brew update` has started giving the following error:

```
Error: 
  homebrew-core is a shallow clone.
  homebrew-cask is a shallow clone.
To `brew update`, first run:
  git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
  git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
These commands may take a few minutes to run due to the large size of the repositories.
This restriction has been made on GitHub's request because updating shallow
clones is an extremely expensive operation due to the tree layout and traffic of
Homebrew/homebrew-core and Homebrew/homebrew-cask. We don't do this for you
automatically to avoid repeatedly performing an expensive unshallow operation in
CI systems (which should instead be fixed to not use shallow clones). Sorry for
the inconvenience!
```

This PR removes the `brew update`, which should work if CI now has a recent version of homebrew.

### Tested

* We'll see in CI