### PR TITLE
Use Go v1.16.4 and release celo-blockchain v1.3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: celohq/node10-gcloud:v3
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
-      GO_VERSION: "1.16.2"
+      GO_VERSION: "1.16.4"
       CELO_MONOREPO_BRANCH_TO_TEST: master
       GITHUB_RSA_FINGERPRINT: SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
 jobs:

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -29,7 +29,7 @@ RUN rustup target add x86_64-linux-android
 # go and node installations command expect to run as root
 USER root
 
-RUN curl https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz | tar -xz
+RUN curl https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz | tar -xz
 ENV PATH=/go/bin:$PATH
 ENV GOROOT=/go
 ENV GOPATH=$HOME/go

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,8 +9,8 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add aarch64-unknown-linux-gnu
-RUN wget https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz && \
-    tar xf go1.16.2.linux-amd64.tar.gz -C /usr/local
+RUN wget https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz && \
+    tar xf go1.16.4.linux-amd64.tar.gz -C /usr/local
 
 COPY . /go-ethereum
 WORKDIR /go-ethereum

--- a/params/version.go
+++ b/params/version.go
@@ -23,7 +23,7 @@ import (
 const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 3        // Minor version component of the current release
-	VersionPatch = 1        // Patch version component of the current release
+	VersionPatch = 2        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
The `golang:alpine-1.16` docker image has not been updated yet, contrary to what it says on docker hub's website.  Once it's updated, I will amend commit and force push to trigger a new build which will use 1.16.4

### Description

Within less than an hour after we released v1.3.1, a Golang security patch was announced: https://groups.google.com/g/golang-announce/c/cu9SP4eSXMc/m/vBLImzQOAgAJ .  This PR updates celo-blockchain to use the new Golang release, and set the celo-blockchain version to v1.3.2.  

### Tested

* CI
* Confirmed that the generated docker image uses go version 1.16.4:

```
❯ docker run -it us.gcr.io/celo-testnet/geth:2ea8e9c0f9f7483bb6cfb3ad8410791fb8bd6acc version
Celo
Version: 1.3.2-stable
Architecture: amd64
Protocol Versions: [66 65 64]
Go Version: go1.16.4
Operating System: linux
GOPATH=
GOROOT=/usr/local/go
```

### Backwards compatibility

No backwards compatibility issues.
