### PR TITLE
Use golang v1.16.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
       - image: celohq/node10-gcloud:v3
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
-      GO_VERSION: "1.16.2"
+      GO_VERSION: "1.16.4"
       CELO_MONOREPO_BRANCH_TO_TEST: master
       GITHUB_RSA_FINGERPRINT: SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
 jobs:

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -29,7 +29,7 @@ RUN rustup target add x86_64-linux-android
 # go and node installations command expect to run as root
 USER root
 
-RUN curl https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz | tar -xz
+RUN curl https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz | tar -xz
 ENV PATH=/go/bin:$PATH
 ENV GOROOT=/go
 ENV GOPATH=$HOME/go

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -9,8 +9,8 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add aarch64-unknown-linux-gnu
-RUN wget https://dl.google.com/go/go1.16.2.linux-amd64.tar.gz && \
-    tar xf go1.16.2.linux-amd64.tar.gz -C /usr/local
+RUN wget https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz && \
+    tar xf go1.16.4.linux-amd64.tar.gz -C /usr/local
 
 COPY . /go-ethereum
 WORKDIR /go-ethereum


### PR DESCRIPTION
### Description

Go v1.16.4 is a security release.  We've upgraded to it in celo-blockchain v1.3.1 (#1535).  This PR also upgrades on master.  Note that, as usual, the places where we use the `golang:1.16-alpine` image don't need to be modified as the newest 1.16 image will be used automatically.

### Tested

* CI

### Backwards compatibility

No incompatibilities.
