### PR TITLE
Removes the miner's pending cache

### DIFF
--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -239,12 +239,8 @@ func (e *NoRewardEngine) FinalizeAndAssemble(chain consensus.ChainReader, header
 	}
 }
 
-func (e *NoRewardEngine) Seal(chain consensus.ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
-	return e.inner.Seal(chain, block, results, stop)
-}
-
-func (e *NoRewardEngine) SealHash(header *types.Header) common.Hash {
-	return e.inner.SealHash(header)
+func (e *NoRewardEngine) Seal(chain consensus.ChainReader, block *types.Block) error {
+	return e.inner.Seal(chain, block)
 }
 
 func (e *NoRewardEngine) GetValidators(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator {

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -92,15 +92,10 @@ type Engine interface {
 	// consensus rules that happen at finalization (e.g. block rewards).
 	FinalizeAndAssemble(chain ChainReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, receipts []*types.Receipt, randomness *types.Randomness) (*types.Block, error)
 
-	// Seal generates a new sealing request for the given input block and pushes
-	// the result into the given channel.
+	// Seal generates a new sealing request for the given input block.
 	//
-	// Note, the method returns immediately and will send the result async. More
-	// than one result may also be returned depending on the consensus algorithm.
-	Seal(chain ChainReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error
-
-	// SealHash returns the hash of a block prior to it being sealed.
-	SealHash(header *types.Header) common.Hash
+	// Note: The engine will insert the resulting block.
+	Seal(chain ChainReader, block *types.Block) error
 
 	// GetValidators returns the list of current validators.
 	GetValidators(blockNumber *big.Int, headerHash common.Hash) []istanbul.Validator

--- a/consensus/consensustest/mockprotocol.go
+++ b/consensus/consensustest/mockprotocol.go
@@ -28,7 +28,6 @@ import (
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/consensus"
-	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/state"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/crypto"
@@ -352,10 +351,15 @@ func (e *MockEngine) Prepare(chain consensus.ChainReader, header *types.Header) 
 	return nil
 }
 
+type fullChain interface {
+	CurrentBlock() *types.Block
+	StateAt(common.Hash) (*state.StateDB, error)
+}
+
 func (e *MockEngine) Seal(chain consensus.ChainReader, block *types.Block) error {
 	header := block.Header()
 	finalBlock := block.WithHeader(header)
-	c := chain.(*core.BlockChain)
+	c := chain.(fullChain)
 
 	parent := c.CurrentBlock()
 

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -177,7 +177,9 @@ func TestGetProposer(t *testing.T) {
 	numValidators := 1
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)
 	chain, engine, _ := newBlockChainWithKeys(false, common.Address{}, false, genesisCfg, nodeKeys[0])
-	makeBlock(nodeKeys, chain, engine, chain.Genesis())
+	if _, err := makeBlock(nodeKeys, chain, engine, chain.Genesis()); err != nil {
+		t.Errorf("Failed to make a block: %v", err)
+	}
 
 	expected := engine.AuthorForBlock(1)
 	actual := engine.Address()

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -111,7 +111,6 @@ func TestCheckValidatorSignature(t *testing.T) {
 }
 
 func TestCommit(t *testing.T) {
-	t.Skip("deadlock")
 	backend := newBackend()
 
 	commitCh := make(chan *types.Block)

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -174,16 +174,15 @@ func TestCommit(t *testing.T) {
 }
 
 func TestGetProposer(t *testing.T) {
-	t.Skip("panics")
 	numValidators := 1
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)
 	chain, engine, _ := newBlockChainWithKeys(false, common.Address{}, false, genesisCfg, nodeKeys[0])
+	makeBlock(nodeKeys, chain, engine, chain.Genesis())
 
-	block, _ := makeBlock(nodeKeys, chain, engine, chain.Genesis())
-	chain.InsertChain(types.Blocks{block})
 	expected := engine.AuthorForBlock(1)
 	actual := engine.Address()
 	if actual != expected {
 		t.Errorf("proposer mismatch: have %v, want %v, currentblock: %v", actual.Hex(), expected.Hex(), chain.CurrentBlock().Number())
 	}
+
 }

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -111,6 +111,7 @@ func TestCheckValidatorSignature(t *testing.T) {
 }
 
 func TestCommit(t *testing.T) {
+	t.Skip("deadlock")
 	backend := newBackend()
 
 	commitCh := make(chan *types.Block)
@@ -173,6 +174,7 @@ func TestCommit(t *testing.T) {
 }
 
 func TestGetProposer(t *testing.T) {
+	t.Skip("panics")
 	numValidators := 1
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)
 	chain, engine, _ := newBlockChainWithKeys(false, common.Address{}, false, genesisCfg, nodeKeys[0])

--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
+	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/crypto"
 )
@@ -110,65 +111,46 @@ func TestCheckValidatorSignature(t *testing.T) {
 	}
 }
 
-func TestCommit(t *testing.T) {
-	backend := newBackend()
+func TestNormalCommit(t *testing.T) {
 
-	commitCh := make(chan *types.Block)
-	// Case: it's a proposer, so the backend.commit will receive channel result from backend.Commit function
-	testCases := []struct {
-		expectedErr       error
-		expectedSignature []byte
-		expectedBlock     func() *types.Block
-	}{
-		{
-			// normal case
-			nil,
-			make([]byte, types.IstanbulExtraBlsSignature),
-			func() *types.Block {
-				chain, engine := newBlockChain(1, true)
-				block := makeBlockWithoutSeal(chain, engine, chain.Genesis())
-				expectedBlock, _ := engine.signBlock(block)
-				return expectedBlock
-			},
-		},
-		{
-			// invalid signature
-			errInvalidAggregatedSeal,
-			nil,
-			func() *types.Block {
-				chain, engine := newBlockChain(1, true)
-				block := makeBlockWithoutSeal(chain, engine, chain.Genesis())
-				expectedBlock, _ := engine.signBlock(block)
-				return expectedBlock
-			},
-		},
+	chain, backend := newBlockChain(1, true)
+	block := makeBlockWithoutSeal(chain, backend, chain.Genesis())
+	expBlock, _ := backend.signBlock(block)
+	expectedSignature := make([]byte, types.IstanbulExtraBlsSignature)
+
+	newHeadCh := make(chan core.ChainHeadEvent, 10)
+	sub := chain.SubscribeChainHeadEvent(newHeadCh)
+	defer sub.Unsubscribe()
+
+	if err := backend.Commit(expBlock, types.IstanbulAggregatedSeal{Round: big.NewInt(0), Bitmap: big.NewInt(0), Signature: expectedSignature}, types.IstanbulEpochValidatorSetSeal{Bitmap: big.NewInt(0), Signature: nil}, nil); err != nil {
+		if err != nil {
+			t.Errorf("error mismatch: have %v, want %v", err, nil)
+		}
 	}
 
-	for _, test := range testCases {
-		expBlock := test.expectedBlock()
-		go func() {
-			result := <-backend.commitCh
-			commitCh <- result
-		}()
+	// to avoid race condition is occurred by goroutine
+	select {
+	case result := <-newHeadCh:
+		if result.Block.Hash() != expBlock.Hash() {
+			t.Errorf("hash mismatch: have %v, want %v", result.Block.Hash(), expBlock.Hash())
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout")
+	}
 
-		backend.proposedBlockHash = expBlock.Hash()
-		if err := backend.Commit(expBlock, types.IstanbulAggregatedSeal{Round: big.NewInt(0), Bitmap: big.NewInt(0), Signature: test.expectedSignature}, types.IstanbulEpochValidatorSetSeal{Bitmap: big.NewInt(0), Signature: nil}, nil); err != nil {
-			if err != test.expectedErr {
-				t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
-			}
+}
+
+func TestInvalidCommit(t *testing.T) {
+
+	chain, backend := newBlockChain(1, true)
+	block := makeBlockWithoutSeal(chain, backend, chain.Genesis())
+	expBlock, _ := backend.signBlock(block)
+
+	if err := backend.Commit(expBlock, types.IstanbulAggregatedSeal{Round: big.NewInt(0), Bitmap: big.NewInt(0), Signature: nil}, types.IstanbulEpochValidatorSetSeal{Bitmap: big.NewInt(0), Signature: nil}, nil); err != nil {
+		if err != errInvalidAggregatedSeal {
+			t.Errorf("error mismatch: have %v, want %v", err, errInvalidAggregatedSeal)
 		}
 
-		if test.expectedErr == nil {
-			// to avoid race condition is occurred by goroutine
-			select {
-			case result := <-commitCh:
-				if result.Hash() != expBlock.Hash() {
-					t.Errorf("hash mismatch: have %v, want %v", result.Hash(), expBlock.Hash())
-				}
-			case <-time.After(10 * time.Second):
-				t.Fatal("timeout")
-			}
-		}
 	}
 }
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -657,13 +657,6 @@ func (sb *Backend) StartValidating() error {
 		return errors.New("Must SetBlockProcessors prior to StartValidating")
 	}
 
-	// clear previous data
-	sb.proposedBlockHash = common.Hash{}
-	if sb.commitCh != nil {
-		close(sb.commitCh)
-	}
-	sb.commitCh = make(chan *types.Block, 1)
-
 	sb.logger.Info("Starting istanbul.Engine validating")
 	if err := sb.core.Start(); err != nil {
 		return err

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -56,7 +56,6 @@ func TestPrepare(t *testing.T) {
 func TestMakeBlockWithSignature(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	// TODO: To test more validators, need to go round robin between the engines (or submit async to makeBlock)
 	numValidators := 1
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)
 	chain, engine, _ := newBlockChainWithKeys(false, common.Address{}, false, genesisCfg, nodeKeys[0])
@@ -141,9 +140,8 @@ func TestVerifyHeader(t *testing.T) {
 }
 
 func TestVerifySeal(t *testing.T) {
-	t.Skip("deadlock")
 	g := NewGomegaWithT(t)
-	numValidators := 4
+	numValidators := 1
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)
 	chain, engine, _ := newBlockChainWithKeys(false, common.Address{}, false, genesisCfg, nodeKeys[0])
 	defer stopEngine(engine)
@@ -155,7 +153,8 @@ func TestVerifySeal(t *testing.T) {
 	g.Expect(err).Should(BeIdenticalTo(errUnknownBlock))
 
 	// should verify
-	block, _ := makeBlock(nodeKeys, chain, engine, genesis)
+	block, err := makeBlock(nodeKeys, chain, engine, genesis)
+	g.Expect(err).ToNot(HaveOccurred())
 	header := block.Header()
 	err = engine.VerifySeal(chain, header)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -188,9 +187,7 @@ func TestVerifySeal(t *testing.T) {
 }
 
 func TestVerifyHeaders(t *testing.T) {
-	t.Skip("deadlock")
-
-	numValidators := 4
+	numValidators := 1
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)
 	chain, engine, _ := newBlockChainWithKeys(false, common.Address{}, false, genesisCfg, nodeKeys[0])
 	defer stopEngine(engine)

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -54,12 +54,13 @@ func TestPrepare(t *testing.T) {
 }
 
 func TestMakeBlockWithSignature(t *testing.T) {
-	t.Skip("deadlocks")
 	g := NewGomegaWithT(t)
 
-	numValidators := 4
+	// TODO: To test more validators, need to go round robin between the engines (or submit async to makeBlock)
+	numValidators := 1
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)
 	chain, engine, _ := newBlockChainWithKeys(false, common.Address{}, false, genesisCfg, nodeKeys[0])
+
 	defer stopEngine(engine)
 	genesis := chain.Genesis()
 

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -53,6 +53,7 @@ func TestPrepare(t *testing.T) {
 }
 
 func TestMakeBlockWithSignature(t *testing.T) {
+	t.Skip("deadlocks")
 	g := NewGomegaWithT(t)
 
 	numValidators := 4
@@ -157,6 +158,7 @@ func TestVerifyHeader(t *testing.T) {
 }
 
 func TestVerifySeal(t *testing.T) {
+	t.Skip("deadlock")
 	g := NewGomegaWithT(t)
 	numValidators := 4
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)
@@ -203,6 +205,7 @@ func TestVerifySeal(t *testing.T) {
 }
 
 func TestVerifyHeaders(t *testing.T) {
+	t.Skip("deadlock")
 
 	numValidators := 4
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -72,34 +72,6 @@ func TestMakeBlockWithSignature(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 }
 
-// TestSealCommittedOtherHash checks that when Seal() ask for a commit, if we send a
-// different block hash, it will abort
-func TestSealCommittedOtherHash(t *testing.T) {
-	for numValidators := 1; numValidators < 5; numValidators++ {
-		testSealCommittedOtherHash(t, numValidators)
-	}
-}
-
-func testSealCommittedOtherHash(t *testing.T, numValidators int) {
-	g := NewGomegaWithT(t)
-
-	chain, engine := newBlockChain(numValidators, true)
-	defer stopEngine(engine)
-	block := makeBlockWithoutSeal(chain, engine, chain.Genesis())
-	// create a second block which will have a different hash
-	h := block.Header()
-	h.ParentHash = block.Hash()
-	otherBlock := types.NewBlock(h, nil, nil, nil)
-	g.Expect(block.Hash()).NotTo(Equal(otherBlock.Hash()), "did not create different blocks")
-
-	engine.Seal(chain, block)
-
-	// this commit should _NOT_ push a new message to the queue
-	engine.Commit(otherBlock, types.IstanbulAggregatedSeal{}, types.IstanbulEpochValidatorSetSeal{}, nil)
-
-	//g.Consistently(results, "100ms").ShouldNot(Receive(), "seal should not be completed")
-}
-
 func TestSealCommitted(t *testing.T) {
 	g := NewGomegaWithT(t)
 	chain, engine := newBlockChain(1, true)

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -80,6 +80,7 @@ func TestIstanbulMessage(t *testing.T) {
 }
 
 func TestRecentMessageCaches(t *testing.T) {
+	t.Skip("deadlock")
 	// Define the various voting scenarios to test
 	tests := []struct {
 		ethMsgCode  uint64

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -80,7 +80,6 @@ func TestIstanbulMessage(t *testing.T) {
 }
 
 func TestRecentMessageCaches(t *testing.T) {
-	t.Skip("deadlock")
 	// Define the various voting scenarios to test
 	tests := []struct {
 		ethMsgCode  uint64

--- a/consensus/istanbul/backend/test_utils.go
+++ b/consensus/istanbul/backend/test_utils.go
@@ -5,7 +5,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"math/big"
 	"strings"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"github.com/celo-org/celo-blockchain/consensus/consensustest"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul/backend/backendtest"
-	istanbulCore "github.com/celo-org/celo-blockchain/consensus/istanbul/core"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul/validator"
 	"github.com/celo-org/celo-blockchain/contract_comm"
 	"github.com/celo-org/celo-blockchain/core"
@@ -351,82 +349,6 @@ func SignHashFn(key *ecdsa.PrivateKey) istanbul.HashSignerFn {
 	return func(_ accounts.Account, data []byte) ([]byte, error) {
 		return crypto.Sign(data, key)
 	}
-}
-
-// this will return an aggregate sig by the BLS keys corresponding to the `keys` array over the
-// block's hash, on consensus round 0, without a composite hasher
-func signBlock(keys []*ecdsa.PrivateKey, block *types.Block) types.IstanbulAggregatedSeal {
-	extraData := []byte{}
-	useComposite := false
-	cip22 := false
-	round := big.NewInt(0)
-	headerHash := block.Header().Hash()
-	signatures := make([][]byte, len(keys))
-
-	msg := istanbulCore.PrepareCommittedSeal(headerHash, round)
-
-	for i, key := range keys {
-		signFn := SignBLSFn(key)
-		sig, err := signFn(accounts.Account{}, msg, extraData, useComposite, cip22)
-		if err != nil {
-			panic("could not sign msg")
-		}
-		signatures[i] = sig[:]
-	}
-
-	asigBytes, err := blscrypto.AggregateSignatures(signatures)
-	if err != nil {
-		panic("could not aggregate sigs")
-	}
-
-	// create the bitmap from the validators
-	bitmap := big.NewInt(0)
-	for i := 0; i < len(keys); i++ {
-		bitmap.SetBit(bitmap, i, 1)
-	}
-
-	asig := types.IstanbulAggregatedSeal{
-		Bitmap:    bitmap,
-		Round:     round,
-		Signature: asigBytes,
-	}
-
-	return asig
-}
-
-// this will return an aggregate sig by the BLS keys corresponding to the `keys` array over
-// an abtirary message
-func signEpochSnarkData(keys []*ecdsa.PrivateKey, message, extraData []byte) types.IstanbulEpochValidatorSetSeal {
-	useComposite := true
-	cip22 := true
-	signatures := make([][]byte, len(keys))
-
-	for i, key := range keys {
-		signFn := SignBLSFn(key)
-		sig, err := signFn(accounts.Account{}, message, extraData, useComposite, cip22)
-		if err != nil {
-			panic("could not sign msg")
-		}
-		signatures[i] = sig[:]
-	}
-
-	asigBytes, err := blscrypto.AggregateSignatures(signatures)
-	if err != nil {
-		panic("could not aggregate sigs")
-	}
-
-	// create the bitmap from the validators
-	bitmap := big.NewInt(0)
-	for i := 0; i < len(keys); i++ {
-		bitmap.SetBit(bitmap, i, 1)
-	}
-
-	asig := types.IstanbulEpochValidatorSetSeal{
-		Bitmap:    bitmap,
-		Signature: asigBytes,
-	}
-
-	return asig
 }
 
 func newBackend() (b *Backend) {

--- a/consensus/istanbul/backend/test_utils.go
+++ b/consensus/istanbul/backend/test_utils.go
@@ -206,9 +206,10 @@ func makeBlock(keys []*ecdsa.PrivateKey, chain *core.BlockChain, engine *Backend
 		return nil, err
 	}
 
-	// Wait for the mined block.
+	// Wait for and then save the mined block.
 	select {
-	case <-chainHeadCh:
+	case ev := <-chainHeadCh:
+		block = ev.Block
 	case <-time.After(6 * time.Second):
 		return nil, errors.New("Timed out when making a block")
 	}

--- a/consensus/istanbul/backend/test_utils.go
+++ b/consensus/istanbul/backend/test_utils.go
@@ -197,7 +197,7 @@ func makeBlock(keys []*ecdsa.PrivateKey, chain *core.BlockChain, engine *Backend
 	results := make(chan *types.Block)
 
 	// start seal request (this is non blocking)
-	err := engine.Seal(chain, block, results, nil)
+	err := engine.Seal(chain, block)
 	if err != nil {
 		return nil, err
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -41,9 +41,6 @@ import (
 )
 
 const (
-	// resultQueueSize is the size of channel listening to sealing result.
-	resultQueueSize = 10
-
 	// txChanSize is the size of channel listening to NewTxsEvent.
 	// The number is referenced from the size of tx pool.
 	txChanSize = 4096
@@ -75,13 +72,7 @@ const (
 	// intervalAdjustBias is applied during the new resubmit interval calculation in favor of
 	// increasing upper limit or decreasing lower limit so that the limit can be reachable.
 	intervalAdjustBias = 200 * 1000.0 * 1000.0
-
-	// staleThreshold is the maximum depth of the acceptable stale block.
-	staleThreshold = 7
 )
-
-// Gauge used to measure block finalization time from created to after written to chain.
-var blockFinalizationTimeGauge = metrics.NewRegisteredGauge("miner/block/finalizationTime", nil)
 
 type callBackEngine interface {
 	// SetCallBacks sets call back functions

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -150,7 +150,6 @@ type worker struct {
 	// Channels
 	newWorkCh          chan *newWorkReq
 	taskCh             chan *task
-	resultCh           chan *types.Block
 	startCh            chan struct{}
 	exitCh             chan struct{}
 	resubmitIntervalCh chan time.Duration
@@ -163,9 +162,6 @@ type worker struct {
 	validator      common.Address
 	txFeeRecipient common.Address
 	extra          []byte
-
-	pendingMu    sync.RWMutex
-	pendingTasks map[common.Hash]*task
 
 	snapshotMu    sync.RWMutex // The lock used to protect the block snapshot and state snapshot
 	snapshotBlock *types.Block
@@ -207,13 +203,11 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		chain:               eth.BlockChain(),
 		isLocalBlock:        isLocalBlock,
 		unconfirmed:         newUnconfirmedBlocks(eth.BlockChain(), miningLogAtDepth),
-		pendingTasks:        make(map[common.Hash]*task),
 		txsCh:               make(chan core.NewTxsEvent, txChanSize),
 		chainHeadCh:         make(chan core.ChainHeadEvent, chainHeadChanSize),
 		chainSideCh:         make(chan core.ChainSideEvent, chainSideChanSize),
 		newWorkCh:           make(chan *newWorkReq),
 		taskCh:              make(chan *task),
-		resultCh:            make(chan *types.Block, resultQueueSize),
 		exitCh:              make(chan struct{}),
 		startCh:             make(chan struct{}, 1),
 		resubmitIntervalCh:  make(chan time.Duration),
@@ -236,7 +230,6 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 
 	go worker.mainLoop()
 	go worker.newWorkLoop(recommit)
-	go worker.resultLoop()
 	go worker.taskLoop()
 
 	// Submit first work to initialize pending state.
@@ -405,27 +398,14 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		}
 		recommit = time.Duration(int64(next))
 	}
-	// clearPending cleans the stale pending tasks.
-	clearPending := func(number uint64) {
-		w.pendingMu.Lock()
-		for h, t := range w.pendingTasks {
-			if t.block.NumberU64()+staleThreshold <= number {
-				delete(w.pendingTasks, h)
-			}
-		}
-		w.pendingMu.Unlock()
-	}
 
 	for {
 		select {
 		case <-w.startCh:
-			clearPending(w.chain.CurrentBlock().NumberU64())
 			timestamp = time.Now().Unix()
 			commit(false, commitInterruptNewHead)
 
-		case head := <-w.chainHeadCh:
-			headNumber := head.Block.NumberU64()
-			clearPending(headNumber)
+		case <-w.chainHeadCh:
 			timestamp = time.Now().Unix()
 			commit(false, commitInterruptNewHead)
 
@@ -546,118 +526,21 @@ func (w *worker) mainLoop() {
 // taskLoop is a standalone goroutine to fetch sealing task from the generator and
 // push them to consensus engine.
 func (w *worker) taskLoop() {
-	var (
-		stopCh chan struct{}
-		prev   common.Hash
-	)
 
-	// interrupt aborts the in-flight sealing task.
-	interrupt := func() {
-		if stopCh != nil {
-			close(stopCh)
-			stopCh = nil
-		}
-	}
 	for {
 		select {
 		case task := <-w.taskCh:
 			if w.newTaskHook != nil {
 				w.newTaskHook(task)
 			}
-			// Reject duplicate sealing work due to resubmitting.
-			sealHash := w.engine.SealHash(task.block.Header())
-			if sealHash == prev {
-				continue
-			}
-			// Interrupt previous sealing operation
-			interrupt()
-			stopCh, prev = make(chan struct{}), sealHash
 
 			if w.skipSealHook != nil && w.skipSealHook(task) {
 				continue
 			}
-			w.pendingMu.Lock()
-			w.pendingTasks[w.engine.SealHash(task.block.Header())] = task
-			w.pendingMu.Unlock()
 
-			if err := w.engine.Seal(w.chain, task.block, w.resultCh, stopCh); err != nil {
+			if err := w.engine.Seal(w.chain, task.block); err != nil {
 				log.Warn("Block sealing failed", "err", err)
 			}
-		case <-w.exitCh:
-			interrupt()
-			return
-		}
-	}
-}
-
-// resultLoop is a standalone goroutine to handle sealing result submitting
-// and flush relative data to the database.
-func (w *worker) resultLoop() {
-	for {
-		select {
-		case block := <-w.resultCh:
-			// Short circuit when receiving empty result.
-			if block == nil {
-				continue
-			}
-			// Short circuit when receiving duplicate result caused by resubmitting.
-			if w.chain.HasBlock(block.Hash(), block.NumberU64()) {
-				continue
-			}
-			var (
-				sealhash = w.engine.SealHash(block.Header())
-				hash     = block.Hash()
-			)
-			w.pendingMu.RLock()
-			task, exist := w.pendingTasks[sealhash]
-			w.pendingMu.RUnlock()
-			if !exist {
-				log.Error("Block found but no relative pending task", "number", block.Number(), "sealhash", sealhash, "hash", hash)
-				continue
-			}
-			// Different block could share same sealhash, deep copy here to prevent write-write conflict.
-			var (
-				receipts = make([]*types.Receipt, len(task.receipts))
-				logs     []*types.Log
-			)
-			for i, receipt := range task.receipts {
-				// add block location fields
-				receipt.BlockHash = hash
-				receipt.BlockNumber = block.Number()
-				receipt.TransactionIndex = uint(i)
-
-				receipts[i] = new(types.Receipt)
-				*receipts[i] = *receipt
-				// Update the block hash in all logs since it is now available and not when the
-				// receipt/log of individual transactions were created.
-				for _, log := range receipt.Logs {
-					log.BlockHash = hash
-					// Handle block finalization receipt
-					if (log.TxHash == common.Hash{}) {
-						log.TxHash = hash
-					}
-				}
-				logs = append(logs, receipt.Logs...)
-			}
-			// Commit block and state to database.
-			if err := w.chain.InsertPreprocessedBlock(block, receipts, logs, task.state); err != nil {
-				if err == core.ErrNotHeadBlock {
-					log.Warn("Tried to insert duplicated produced block", "blockNumber", block.Number(), "hash", block.Hash(), "err", err)
-				} else {
-					log.Error("Failed writing block to chain", "blockNumber", block.Number(), "hash", block.Hash(), "err", err)
-				}
-				continue
-			}
-			blockFinalizationTimeGauge.Update(time.Now().UnixNano() - int64(block.Time())*1000000000)
-			log.Info("Successfully sealed new block", "number", block.Number(), "sealhash", sealhash, "hash", hash,
-				"elapsed", common.PrettyDuration(time.Since(task.createdAt)))
-
-			// Broadcast the block and announce chain insertion event
-			w.mux.Post(core.NewMinedBlockEvent{Block: block})
-
-			// Insert the block into the set of pending ones to resultLoop for confirmations
-			w.unconfirmed.Insert(block.NumberU64(), block.Hash())
-
 		case <-w.exitCh:
 			return
 		}
@@ -1071,8 +954,8 @@ func (w *worker) commit(interval func(), update bool, start time.Time) error {
 			}
 			feesEth := new(big.Float).Quo(new(big.Float).SetInt(feesWei), new(big.Float).SetInt(big.NewInt(params.Ether)))
 
-			log.Info("Commit new mining work", "number", block.Number(), "sealhash", w.engine.SealHash(block.Header()),
-				"txs", w.current.tcount, "gas", block.GasUsed(), "fees", feesEth, "elapsed", common.PrettyDuration(time.Since(start)))
+			log.Info("Commit new mining work", "number", block.Number(), "txs", w.current.tcount, "gas", block.GasUsed(),
+				"fees", feesEth, "elapsed", common.PrettyDuration(time.Since(start)))
 		case <-w.exitCh:
 			log.Info("Worker has exited")
 		}

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -224,10 +224,12 @@ func TestGenerateBlockAndImport(t *testing.T) {
 		b.txPool.AddLocal(b.newRandomTx(false))
 		select {
 		case ev := <-sub.Chan():
-			block := ev.Data.(core.NewMinedBlockEvent).Block
-			if _, err := chain.InsertChain([]*types.Block{block}); err != nil {
-				t.Fatalf("failed to insert new mined block %d: %v", block.NumberU64(), err)
-			}
+			_ = ev.Data.(core.NewMinedBlockEvent).Block
+
+			// block := ev.Data.(core.NewMinedBlockEvent).Block
+			// if _, err := chain.InsertChain([]*types.Block{block}); err != nil {
+			// 	t.Fatalf("failed to insert new mined block %d: %v", block.NumberU64(), err)
+			// }
 		case <-time.After(3 * time.Second): // Worker needs 1s to include new changes.
 			t.Fatalf("timeout")
 		}

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -224,12 +224,9 @@ func TestGenerateBlockAndImport(t *testing.T) {
 		b.txPool.AddLocal(b.newRandomTx(false))
 		select {
 		case ev := <-sub.Chan():
-			_ = ev.Data.(core.NewMinedBlockEvent).Block
-
-			// block := ev.Data.(core.NewMinedBlockEvent).Block
-			// if _, err := chain.InsertChain([]*types.Block{block}); err != nil {
-			// 	t.Fatalf("failed to insert new mined block %d: %v", block.NumberU64(), err)
-			// }
+			if _, ok := ev.Data.(core.NewMinedBlockEvent); !ok {
+				t.Fatal("Could not decode NewMinedBlockEvent from subscription channel")
+			}
 		case <-time.After(3 * time.Second): // Worker needs 1s to include new changes.
 			t.Fatalf("timeout")
 		}


### PR DESCRIPTION
### Description

This modifies the miner <-> engine interface to remove the results channel from the engine to the miner.
With https://github.com/celo-org/celo-blockchain/pull/1394, validators save the results of processing the block
and use them while inserting the block. This cache is the the engine. Prior to this change, there was a similar
cache in the miner, but it would only be hit when the block was proposed by the node (1/100 hit rate).

Thus this simplifies the miner and the interface between the engine and the miner.

A portion of changes are in the tests.

- With the remove of the results channel, tests need to subscribe to `ChainHeadEvents`
- I had to modify the miner to work with the fake consensus engine (to allow the miner to inject the block processing callbacks)
- There were several tests that I changed from 4 validators to 1 validator. The reason is that the block will to go through consensus unless `makeBlock` is called with the engine of the next proposer.
- I simplified some tests which were inserting the block multiple times.

### Tested

Unit tests pass.

