### PR TITLE
Run full network tests in under 1 second (pure go)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,20 @@
 version: 2.1
+parameters:
+  # Use this git tag or commit of the monorepo to build the system contracts. 
+  system-contracts-monorepo-version:
+    type: string
+    default: "celo-core-contracts-v3.rc0"
+  system-contracts-path:
+    type: string
+    default: "geth/monorepo/packages/protocol/build"
 executors:
   golang:
     docker:
       - image: circleci/golang:1.16
+    working_directory: ~/repos/geth
+  node-v10:
+    docker:
+      - image: celohq/node10-gcloud:v3
     working_directory: ~/repos/geth
   e2e:
     docker:
@@ -32,6 +44,38 @@ jobs:
           root: ~/repos
           paths:
             - geth
+
+  prepare-system-contracts:
+    executor: node-v10
+    resource_class: medium+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>
+      - attach_workspace:
+          at: ~/repos
+      - run:
+          name: prepare system contracts
+          # Runs make prepare-system-contracts and sets the MONOREPO_COMMIT to
+          # use We also need to add the fingerprint id for the github ssh key
+          # to our known hosts in order for the monorepo post install script to
+          # work. We only do this if the cache has not been restored.
+          command: |
+            set -e
+            if [ ! -d ~/repos/<<pipeline.parameters.system-contracts-path>> ]; then
+              mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+              make prepare-system-contracts MONOREPO_COMMIT=<<pipeline.parameters.system-contracts-monorepo-version>>
+            fi
+      - save_cache:
+          key: system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>
+          paths:
+            - ~/repos/<<pipeline.parameters.system-contracts-path>>
+      - persist_to_workspace:
+          root: ~/repos
+          paths:
+            - <<pipeline.parameters.system-contracts-path>>
+
   unit-tests:
     executor: golang
     resource_class: medium+
@@ -260,6 +304,7 @@ workflows:
     jobs:
       - checkout-monorepo
       - build-geth
+      - prepare-system-contracts
       - check-imports
       - lint:
           requires:
@@ -267,9 +312,11 @@ workflows:
       - unit-tests:
           requires:
             - build-geth
+            - prepare-system-contracts
       - coverage:
           requires:
             - build-geth
+            - prepare-system-contracts
       - android
       - ios
       - publish-mobile-client:

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ vendor/**/Cargo.lock
 docs/Gemfile.lock
 docs/_site
 docs/.jekyll-metadata
+
+# Ignore monorepo checkout
+./monorepo

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ The Celo blockchain client comes with several wrappers/executables found in the 
 | `gethrpctest` | Developer utility tool to support the [ethereum/rpc-test](https://github.com/ethereum/rpc-tests) test suite which validates baseline conformity to the [Ethereum JSON RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC) specs. Please see the [ethereum test suite's readme](https://github.com/ethereum/rpc-tests/blob/master/README.md) for details. |
 | `rlpdump` | Developer utility tool to convert binary RLP ([Recursive Length Prefix](https://github.com/ethereum/wiki/wiki/RLP)) dumps (data encoding used by the Celo protocol both network as well as consensus wise) to user friendlier hierarchical representation (e.g. `rlpdump --hex CE0183FFFFFFC4C304050583616263`). |
 
+## Running tests
+
+Prior to running tests you will need to run `make prepare-system-contracts`.
+This will checkout the celo-monorepo and compile the system contracts for use in
+full network tests.
+
+Without first running this certain tests will fail with errors such as:
+
+```
+panic: Can't read bytecode for monorepo/packages/protocol/build/contracts/FixidityLib.json: open
+```
+
 ## Running Celo
 
 Please see the [docs.celo.org/getting-started](https://docs.celo.org/getting-started) for instructions on how to run a node connected the Celo network using the prebuilt Docker image.

--- a/cmd/geth/accountcmd.go
+++ b/cmd/geth/accountcmd.go
@@ -438,14 +438,14 @@ func accountCreate(ctx *cli.Context) error {
 		}
 	}
 	utils.SetNodeConfig(ctx, &cfg.Node)
-	scryptN, scryptP, keydir, err := cfg.Node.AccountConfig()
-
+	keydir, err := cfg.Node.GetKeyStoreDir()
 	if err != nil {
-		utils.Fatalf("Failed to read configuration: %v", err)
+		utils.Fatalf("Failed get keystore dir: %v", err)
 	}
 
 	password := utils.GetPassPhraseWithList("Your new account is locked with a password. Please give a password. Do not forget this password.", true, 0, utils.MakePasswordList(ctx))
 
+	scryptN, scryptP := cfg.Node.KeystoreEncryptionParams()
 	account, err := keystore.StoreKey(keydir, password, scryptN, scryptP)
 
 	if err != nil {

--- a/cmd/mycelo/templates.go
+++ b/cmd/mycelo/templates.go
@@ -3,11 +3,8 @@ package main
 import (
 	"math/big"
 	"math/rand"
-	"time"
 
-	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/decimal/fixed"
-	"github.com/celo-org/celo-blockchain/common/decimal/token"
 	"github.com/celo-org/celo-blockchain/mycelo/env"
 	"github.com/celo-org/celo-blockchain/mycelo/genesis"
 	"github.com/celo-org/celo-blockchain/params"
@@ -28,52 +25,6 @@ func templateFromString(templateStr string) template {
 		return monorepoEnv{}
 	}
 	return localEnv{}
-}
-
-// createCommonGenesisConfig generates a config starting point which templates can then customize further
-func createCommonGenesisConfig(env *env.Environment, istanbulConfig params.IstanbulConfig) *genesis.Config {
-	genesisConfig := genesis.BaseConfig()
-	genesisConfig.ChainID = env.Config.ChainID
-	genesisConfig.GenesisTimestamp = uint64(time.Now().Unix())
-	genesisConfig.Istanbul = istanbulConfig
-	genesisConfig.Hardforks = genesis.HardforkConfig{
-		ChurritoBlock: common.Big0,
-		DonutBlock:    common.Big0,
-	}
-	genesisConfig.Blockchain.UptimeLookbackWindow = genesisConfig.Istanbul.LookbackWindow
-
-	// Make admin account manager of Governance & Reserve
-	adminMultisig := genesis.MultiSigParameters{
-		Signatories:                      []common.Address{env.Accounts().AdminAccount().Address},
-		NumRequiredConfirmations:         1,
-		NumInternalRequiredConfirmations: 1,
-	}
-
-	genesisConfig.ReserveSpenderMultiSig = adminMultisig
-	genesisConfig.GovernanceApproverMultiSig = adminMultisig
-
-	// Ensure nothing is frozen
-	genesisConfig.GoldToken.Frozen = false
-	genesisConfig.StableToken.Frozen = false
-	genesisConfig.Exchange.Frozen = false
-	genesisConfig.Reserve.FrozenAssetsDays = 0
-	genesisConfig.EpochRewards.Frozen = false
-
-	return genesisConfig
-}
-
-func fundAccounts(genesisConfig *genesis.Config, accounts []env.Account) {
-	cusdBalances := make([]genesis.Balance, len(accounts))
-	ceurBalances := make([]genesis.Balance, len(accounts))
-	goldBalances := make([]genesis.Balance, len(accounts))
-	for i, acc := range accounts {
-		cusdBalances[i] = genesis.Balance{Account: acc.Address, Amount: (*big.Int)(token.MustNew("50000"))} // 50k cUSD
-		ceurBalances[i] = genesis.Balance{Account: acc.Address, Amount: (*big.Int)(token.MustNew("50000"))} // 50k cEUR
-		goldBalances[i] = genesis.Balance{Account: acc.Address, Amount: (*big.Int)(token.MustNew("50000"))} // 50k CELO
-	}
-	genesisConfig.StableTokenEUR.InitialBalances = ceurBalances
-	genesisConfig.StableToken.InitialBalances = cusdBalances
-	genesisConfig.GoldToken.InitialBalances = goldBalances
 }
 
 type localEnv struct{}
@@ -98,7 +49,7 @@ func (e localEnv) createEnv(workdir string) (*env.Environment, error) {
 
 func (e localEnv) createGenesisConfig(env *env.Environment) (*genesis.Config, error) {
 
-	genesisConfig := createCommonGenesisConfig(env, params.IstanbulConfig{
+	genesisConfig := genesis.CreateCommonGenesisConfig(env.Config.ChainID, env.Accounts().AdminAccount().Address, params.IstanbulConfig{
 		Epoch:          10,
 		ProposerPolicy: 2,
 		LookbackWindow: 3,
@@ -107,7 +58,7 @@ func (e localEnv) createGenesisConfig(env *env.Environment) (*genesis.Config, er
 	})
 
 	// Add balances to developer accounts
-	fundAccounts(genesisConfig, env.Accounts().DeveloperAccounts())
+	genesis.FundAccounts(genesisConfig, env.Accounts().DeveloperAccounts())
 
 	return genesisConfig, nil
 }
@@ -134,7 +85,7 @@ func (e loadtestEnv) createEnv(workdir string) (*env.Environment, error) {
 }
 
 func (e loadtestEnv) createGenesisConfig(env *env.Environment) (*genesis.Config, error) {
-	genesisConfig := createCommonGenesisConfig(env, params.IstanbulConfig{
+	genesisConfig := genesis.CreateCommonGenesisConfig(env.Config.ChainID, env.Accounts().AdminAccount().Address, params.IstanbulConfig{
 		Epoch:          1000,
 		ProposerPolicy: 2,
 		LookbackWindow: 3,
@@ -146,7 +97,7 @@ func (e loadtestEnv) createGenesisConfig(env *env.Environment) (*genesis.Config,
 	genesisConfig.Blockchain.BlockGasLimit = 1000000000
 
 	// Add balances to developer accounts
-	fundAccounts(genesisConfig, env.Accounts().DeveloperAccounts())
+	genesis.FundAccounts(genesisConfig, env.Accounts().DeveloperAccounts())
 
 	genesisConfig.StableToken.InflationFactorUpdatePeriod = 1 * genesis.Year
 
@@ -179,7 +130,7 @@ func (e monorepoEnv) createEnv(workdir string) (*env.Environment, error) {
 }
 
 func (e monorepoEnv) createGenesisConfig(env *env.Environment) (*genesis.Config, error) {
-	genesisConfig := createCommonGenesisConfig(env, params.IstanbulConfig{
+	genesisConfig := genesis.CreateCommonGenesisConfig(env.Config.ChainID, env.Accounts().AdminAccount().Address, params.IstanbulConfig{
 		Epoch:          10,
 		ProposerPolicy: 2,
 		LookbackWindow: 3,
@@ -188,7 +139,7 @@ func (e monorepoEnv) createGenesisConfig(env *env.Environment) (*genesis.Config,
 	})
 
 	// Add balances to validator accounts instead of developer accounts
-	fundAccounts(genesisConfig, env.Accounts().ValidatorAccounts())
+	genesis.FundAccounts(genesisConfig, env.Accounts().ValidatorAccounts())
 
 	return genesisConfig, nil
 }

--- a/crypto/celo_crypto.go
+++ b/crypto/celo_crypto.go
@@ -1,0 +1,42 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+)
+
+func PrivECDSAToHex(k *ecdsa.PrivateKey) []byte {
+	return hexEncode(FromECDSA(k))
+}
+
+func PubECDSAToHex(k *ecdsa.PublicKey) []byte {
+	return hexEncode(FromECDSAPub(k))
+}
+
+func PrivECDSAFromHex(k []byte) (*ecdsa.PrivateKey, error) {
+	data, err := hexDecode(k)
+	if err != nil {
+		return nil, err
+	}
+	return ToECDSA(data)
+}
+
+func PubECDSAFromHex(k []byte) (*ecdsa.PublicKey, error) {
+	data, err := hexDecode(k)
+	if err != nil {
+		return nil, err
+	}
+	return UnmarshalPubkey(data)
+}
+
+func hexEncode(src []byte) []byte {
+	dst := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(dst, src)
+	return dst
+}
+
+func hexDecode(src []byte) ([]byte, error) {
+	dst := make([]byte, hex.DecodedLen(len(src)))
+	_, err := hex.Decode(dst, src)
+	return dst, err
+}

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -1,0 +1,38 @@
+package e2e_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/celo-org/celo-blockchain/test"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	// This statement is commented out but left here since its very useful for
+	// debugging problems and its non trivial to construct.
+	//
+	//log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
+}
+
+// This test starts a network submits a transaction and waits for the whole
+// network to process the transaction.
+func TestSendCelo(t *testing.T) {
+	accounts := test.Accounts(3)
+	gc := test.GenesisConfig(accounts)
+	network, err := test.NewNetwork(accounts, gc)
+	require.NoError(t, err)
+	defer network.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	// Send 1 celo from the dev account attached to node 0 to the dev account
+	// attached to node 1.
+	tx, err := network[0].SendCelo(ctx, network[1].DevAddress, 1)
+	require.NoError(t, err)
+
+	// Wait for the whole network to process the transaction.
+	err = network.AwaitTransactions(ctx, tx)
+	require.NoError(t, err)
+}

--- a/mycelo/genesis/genesis.go
+++ b/mycelo/genesis/genesis.go
@@ -2,11 +2,14 @@ package genesis
 
 import (
 	"math/big"
+	"time"
 
 	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/common/decimal/token"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/types"
 	blscrypto "github.com/celo-org/celo-blockchain/crypto/bls"
+	"github.com/celo-org/celo-blockchain/params"
 
 	"github.com/celo-org/celo-blockchain/mycelo/env"
 	"github.com/celo-org/celo-blockchain/rlp"
@@ -14,6 +17,52 @@ import (
 
 // Keccak256 of "The Times 09/Apr/2020 With $2.3 Trillion Injection, Fed’s Plan Far Exceeds Its 2008 Rescue"
 var genesisMsgHash = common.HexToHash("ecc833a7747eaa8327335e8e0c6b6d8aa3a38d0063591e43ce116ccf5c89753e")
+
+// CreateCommonGenesisConfig generates a config starting point which templates can then customize further
+func CreateCommonGenesisConfig(chainID *big.Int, adminAccountAddress common.Address, istanbulConfig params.IstanbulConfig) *Config {
+	genesisConfig := BaseConfig()
+	genesisConfig.ChainID = chainID
+	genesisConfig.GenesisTimestamp = uint64(time.Now().Unix())
+	genesisConfig.Istanbul = istanbulConfig
+	genesisConfig.Hardforks = HardforkConfig{
+		ChurritoBlock: common.Big0,
+		DonutBlock:    common.Big0,
+	}
+	genesisConfig.Blockchain.UptimeLookbackWindow = genesisConfig.Istanbul.LookbackWindow
+
+	// Make admin account manager of Governance & Reserve
+	adminMultisig := MultiSigParameters{
+		Signatories:                      []common.Address{adminAccountAddress},
+		NumRequiredConfirmations:         1,
+		NumInternalRequiredConfirmations: 1,
+	}
+
+	genesisConfig.ReserveSpenderMultiSig = adminMultisig
+	genesisConfig.GovernanceApproverMultiSig = adminMultisig
+
+	// Ensure nothing is frozen
+	genesisConfig.GoldToken.Frozen = false
+	genesisConfig.StableToken.Frozen = false
+	genesisConfig.Exchange.Frozen = false
+	genesisConfig.Reserve.FrozenAssetsDays = 0
+	genesisConfig.EpochRewards.Frozen = false
+
+	return genesisConfig
+}
+
+func FundAccounts(genesisConfig *Config, accounts []env.Account) {
+	cusdBalances := make([]Balance, len(accounts))
+	ceurBalances := make([]Balance, len(accounts))
+	goldBalances := make([]Balance, len(accounts))
+	for i, acc := range accounts {
+		cusdBalances[i] = Balance{Account: acc.Address, Amount: (*big.Int)(token.MustNew("50000"))} // 50k cUSD
+		ceurBalances[i] = Balance{Account: acc.Address, Amount: (*big.Int)(token.MustNew("50000"))} // 50k cEUR
+		goldBalances[i] = Balance{Account: acc.Address, Amount: (*big.Int)(token.MustNew("50000"))} // 50k CELO
+	}
+	genesisConfig.StableTokenEUR.InitialBalances = ceurBalances
+	genesisConfig.StableToken.InitialBalances = cusdBalances
+	genesisConfig.GoldToken.InitialBalances = goldBalances
+}
 
 // GenerateGenesis will create a new genesis block with full celo blockchain already configured
 func GenerateGenesis(accounts *env.AccountsConfig, cfg *Config, contractsBuildPath string) (*core.Genesis, error) {

--- a/node/config.go
+++ b/node/config.go
@@ -93,6 +93,10 @@ type Config struct {
 	// scrypt KDF at the expense of security.
 	UseLightweightKDF bool `toml:",omitempty"`
 
+	// UsePlaintextKeystore stores keys in plain text without any encryption,
+	// this should only be used for testing.
+	UsePlaintextKeystore bool `toml:",omitempty"`
+
 	// InsecureUnlockAllowed allows user to unlock accounts in unsafe http environment.
 	InsecureUnlockAllowed bool `toml:",omitempty"`
 
@@ -442,19 +446,53 @@ func (c *Config) parsePersistentNodes(w *bool, path string) []*enode.Node {
 	return nodes
 }
 
-// AccountConfig determines the settings for scrypt and keydirectory
-func (c *Config) AccountConfig() (int, int, string, error) {
-	scryptN := keystore.StandardScryptN
-	scryptP := keystore.StandardScryptP
+// KeystoreEncryptionParams returns the scrypt N and P parameters, that control
+// the level of encryption used in keystore operations.
+func (c *Config) KeystoreEncryptionParams() (scryptN, scryptP int) {
+	scryptN = keystore.StandardScryptN
+	scryptP = keystore.StandardScryptP
 	if c.UseLightweightKDF {
 		scryptN = keystore.LightScryptN
 		scryptP = keystore.LightScryptP
 	}
+	return scryptN, scryptP
+}
 
-	var (
-		keydir string
-		err    error
-	)
+// GetKeyStore returns a keystore, and if no keystore path was provided in the
+// config, it returns the ephemeral path that has been generated for this keystore.
+func (c *Config) GetKeyStore() (store *keystore.KeyStore, ephemeralPath string, err error) {
+	path, err := c.GetKeyStoreDir()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get the path for the keystore: %v", err)
+	}
+	if path == "" {
+		// There is no datadir, make an ephemeral one
+		path, err = ioutil.TempDir("", "go-ethereum-keystore")
+		if err != nil {
+			return nil, "", fmt.Errorf("failed make the keystore directory: %v", err)
+		}
+		ephemeralPath = path
+	} else {
+		err = os.MkdirAll(path, 0700)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed make the keystore directory: %v", err)
+		}
+	}
+
+	switch {
+	case c.UseLightweightKDF:
+		return keystore.NewKeyStore(path, keystore.LightScryptN, keystore.LightScryptP), ephemeralPath, nil
+	case c.UsePlaintextKeystore:
+		return keystore.NewPlaintextKeyStore(path), ephemeralPath, nil
+	}
+	return keystore.NewKeyStore(path, keystore.StandardScryptN, keystore.StandardScryptP), ephemeralPath, nil
+
+}
+
+// GetKeyStoreDir returns the absolute path of the keystore, if KeyStoreDir is
+// not set this function will generae a path from the data dir. If neither are
+// set this function will return the empty string.
+func (c *Config) GetKeyStoreDir() (keydir string, err error) {
 	switch {
 	case filepath.IsAbs(c.KeyStoreDir):
 		keydir = c.KeyStoreDir
@@ -467,24 +505,10 @@ func (c *Config) AccountConfig() (int, int, string, error) {
 	case c.KeyStoreDir != "":
 		keydir, err = filepath.Abs(c.KeyStoreDir)
 	}
-	return scryptN, scryptP, keydir, err
+	return keydir, err
 }
 
 func makeAccountManager(conf *Config) (*accounts.Manager, string, error) {
-	scryptN, scryptP, keydir, err := conf.AccountConfig()
-	var ephemeral string
-	if keydir == "" {
-		// There is no datadir.
-		keydir, err = ioutil.TempDir("", "go-ethereum-keystore")
-		ephemeral = keydir
-	}
-
-	if err != nil {
-		return nil, "", err
-	}
-	if err := os.MkdirAll(keydir, 0700); err != nil {
-		return nil, "", err
-	}
 	// Assemble the account manager and supported backends
 	var backends []accounts.Backend
 	if len(conf.ExternalSigner) > 0 {
@@ -495,12 +519,20 @@ func makeAccountManager(conf *Config) (*accounts.Manager, string, error) {
 			return nil, "", fmt.Errorf("error connecting to external signer: %v", err)
 		}
 	}
+	var ephemeral string
 	if len(backends) == 0 {
+		var ks *keystore.KeyStore
+		var err error
+		ks, ephemeral, err = conf.GetKeyStore()
+		if err != nil {
+			return nil, "", err
+		}
 		// For now, we're using EITHER external signer OR local signers.
 		// If/when we implement some form of lockfile for USB and keystore wallets,
 		// we can have both, but it's very confusing for the user to see the same
 		// accounts in both externally and locally, plus very racey.
-		backends = append(backends, keystore.NewKeyStore(keydir, scryptN, scryptP))
+		backends = append(backends, ks)
+
 		if !conf.NoUSB {
 			// Start a USB hub for Ledger hardware wallets
 			if ledgerhub, err := usbwallet.NewLedgerHub(); err != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -226,11 +226,16 @@ type ChainConfig struct {
 
 // IstanbulConfig is the consensus engine configs for Istanbul based sealing.
 type IstanbulConfig struct {
-	Epoch          uint64 `json:"epoch"`                    // Epoch length to reset votes and checkpoint
-	ProposerPolicy uint64 `json:"policy"`                   // The policy for proposer selection
-	LookbackWindow uint64 `json:"lookbackwindow"`           // The number of blocks to look back when calculating uptime
-	BlockPeriod    uint64 `json:"blockperiod,omitempty"`    // Default minimum difference between two consecutive block's timestamps in second
-	RequestTimeout uint64 `json:"requesttimeout,omitempty"` // The timeout for each Istanbul round in milliseconds.
+	Epoch          uint64 `json:"epoch"`                 // Epoch length to reset votes and checkpoint
+	ProposerPolicy uint64 `json:"policy"`                // The policy for proposer selection
+	LookbackWindow uint64 `json:"lookbackwindow"`        // The number of blocks to look back when calculating uptime
+	BlockPeriod    uint64 `json:"blockperiod,omitempty"` // Default minimum difference between two consecutive block's timestamps in second
+
+	// The base timeout for each Istanbul round in milliseconds. The first
+	// round will have a timeout of exactly this and subsequent rounds will
+	// have timeouts of this + additional time that increases with round
+	// number.
+	RequestTimeout uint64 `json:"requesttimeout,omitempty"`
 }
 
 // String implements the stringer interface, returning the consensus engine details.

--- a/test/node.go
+++ b/test/node.go
@@ -60,6 +60,11 @@ var (
 		TxPool:          core.DefaultTxPoolConfig,
 		Istanbul: istanbul.Config{
 			Validator: true,
+			// Set announce gossip period to 1 minute, if not set this results
+			// in a panic when trying to set a timer with a zero value. We
+			// don't actually rely on this mechanism in the tests because we
+			// pre share all the enode certificates.
+			AnnounceQueryEnodeGossipPeriod: 60,
 		},
 	}
 )

--- a/test/node.go
+++ b/test/node.go
@@ -388,14 +388,13 @@ func NewNetwork(accounts *env.AccountsConfig, gc *genesis.Config) (Network, erro
 	// Connect nodes to each other, although this means that nodes can reach
 	// each other nodes don't start sending consensus messages to another node
 	// until they have received an enode certificate from that node.
-	for i := range network {
-		en := enodes[i]
-		for j := range network {
+	for i, en := range enodes {
+		for j, n := range network {
 			if j == i {
 				continue
 			}
-			network[j].Server().AddPeer(en, p2p.ValidatorPurpose)
-			network[j].Server().AddTrustedPeer(en, p2p.ValidatorPurpose)
+			n.Server().AddPeer(en, p2p.ValidatorPurpose)
+			n.Server().AddTrustedPeer(en, p2p.ValidatorPurpose)
 		}
 	}
 

--- a/test/node.go
+++ b/test/node.go
@@ -1,0 +1,567 @@
+package test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"os"
+	"strconv"
+	"time"
+
+	ethereum "github.com/celo-org/celo-blockchain"
+
+	"github.com/celo-org/celo-blockchain/accounts/keystore"
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/consensus/istanbul"
+	"github.com/celo-org/celo-blockchain/consensus/istanbul/backend"
+	"github.com/celo-org/celo-blockchain/core"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/crypto"
+	"github.com/celo-org/celo-blockchain/eth"
+	"github.com/celo-org/celo-blockchain/eth/downloader"
+	"github.com/celo-org/celo-blockchain/ethclient"
+	"github.com/celo-org/celo-blockchain/log"
+	"github.com/celo-org/celo-blockchain/mycelo/env"
+	"github.com/celo-org/celo-blockchain/mycelo/genesis"
+	"github.com/celo-org/celo-blockchain/node"
+	"github.com/celo-org/celo-blockchain/p2p"
+	"github.com/celo-org/celo-blockchain/p2p/enode"
+	"github.com/celo-org/celo-blockchain/params"
+	"github.com/celo-org/celo-blockchain/rlp"
+)
+
+var (
+	baseNodeConfig *node.Config = &node.Config{
+		Name:    "celo",
+		Version: params.Version,
+		P2P: p2p.Config{
+			MaxPeers:    100,
+			NoDiscovery: true,
+			ListenAddr:  "0.0.0.0:0",
+		},
+		NoUSB: true,
+		// It is important that HTTPHost and WSHost remain the same. This
+		// ensures that only one server is started up on the HTTPHost. That one
+		// server can still handle both http and ws connectons.
+		HTTPHost:             "0.0.0.0",
+		WSHost:               "0.0.0.0",
+		UsePlaintextKeystore: true,
+	}
+
+	baseEthConfig = &eth.Config{
+		SyncMode:        downloader.FullSync,
+		DatabaseCache:   256,
+		DatabaseHandles: 256,
+		TxPool:          core.DefaultTxPoolConfig,
+	}
+)
+
+// Node provides an enhanced interface to node.Node with useful additions, the
+// *node.Node is embedded so that its api is available through Node.
+type Node struct {
+	*node.Node
+	Config        *node.Config
+	P2PListenAddr string
+	Eth           *eth.Ethereum
+	EthConfig     *eth.Config
+	WsClient      *ethclient.Client
+	Nonce         uint64
+	Key           *ecdsa.PrivateKey
+	Address       common.Address
+	DevKey        *ecdsa.PrivateKey
+	DevAddress    common.Address
+	Tracker       *TransactionTracker
+	// The transactions that this node has sent.
+	SentTxs []*types.Transaction
+}
+
+// NewNode creates a new running node with the provided config.
+func NewNode(c *NodeConfig, genesis *core.Genesis) (*Node, error) {
+
+	// p2p key and address
+	c.P2P.PrivateKey = c.ValidatorAccount.PrivateKey
+
+	// Make temp datadir
+	datadir, err := ioutil.TempDir("", "celo_datadir")
+	if err != nil {
+		return nil, err
+	}
+	c.DataDir = datadir
+
+	// copy the base eth config, so we can modify it without damaging the
+	// original.
+	ec := &eth.Config{}
+	err = copyObject(baseEthConfig, ec)
+	if err != nil {
+		return nil, err
+	}
+	ec.Genesis = genesis
+	ec.NetworkId = genesis.Config.ChainID.Uint64()
+
+	node := &Node{
+		Config:     c.Config,
+		EthConfig:  ec,
+		Key:        c.ValidatorAccount.PrivateKey,
+		Address:    c.ValidatorAccount.Address,
+		DevAddress: c.DevAccount.Address,
+		DevKey:     c.DevAccount.PrivateKey,
+		Tracker:    NewTransactionTracker(),
+	}
+
+	return node, node.Start()
+}
+
+// Start creates the node.Node and eth.Ethereum and starts the node.Node and
+// starts eth.Ethereum mining.
+func (n *Node) Start() error {
+	// Provide a copy of the config to node.New, so that we can rely on
+	// Node.Config field not being manipulated by node and hence use our copy
+	// for black box testing.
+	nodeConfigCopy := &node.Config{}
+	err := copyNodeConfig(n.Config, nodeConfigCopy)
+	if err != nil {
+		return err
+	}
+
+	// Give this logger context based on the node address so that we can easily
+	// trace single node execution in the logs. We set the logger only on the
+	// copy, since it is not useful for black box testing and it is also not
+	// marshalable since the implementation contains unexported fields.
+	//
+	// Note unfortunately there are many other loggers created in geth separate
+	// from this one, which means we still see a lot of output that is not
+	// attributable to a specific node.
+	nodeConfigCopy.Logger = log.New("node", n.Address.String()[2:7])
+	nodeConfigCopy.Logger.SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
+
+	n.Node, err = node.New(nodeConfigCopy)
+	if err != nil {
+		return err
+	}
+
+	// This registers the ethereum service on n.Node, so that calling
+	// n.Node.Stop will also close the eth service. Again we provide a copy of
+	// the EthConfig so that we can use our copy for black box testing.
+	ethConfigCopy := &eth.Config{}
+	err = copyObject(n.EthConfig, ethConfigCopy)
+	if err != nil {
+		return err
+	}
+	ethConfigCopy.Miner.Validator = n.Address
+	ethConfigCopy.TxFeeRecipient = n.Address
+	ethConfigCopy.Istanbul.AnnounceQueryEnodeGossipPeriod = 60
+	ethConfigCopy.Istanbul.Validator = true
+	// ethConfigCopy.Istanbul.BlockPeriod = 0
+	// Somehow this is not being honored, its being set to 3000
+	// ethConfigCopy.Istanbul.RequestTimeout = 100
+	ethConfigCopy.Istanbul.TimeoutBackoffFactor = 10
+	ethConfigCopy.Istanbul.MinResendRoundChangeTimeout = 15 * 1000
+	ethConfigCopy.Istanbul.MaxResendRoundChangeTimeout = 2 * 60 * 1000
+	// ethConfigCopy.Istanbul.Epoch = 100
+
+	// Register eth service
+	err = n.Register(func(ctx *node.ServiceContext) (node.Service, error) {
+		return eth.New(ctx, ethConfigCopy)
+	})
+	if err != nil {
+		return err
+	}
+
+	err = n.Node.Start()
+	if err != nil {
+		return err
+	}
+
+	// The ListenAddr is set at p2p server startup, save it here.
+	n.P2PListenAddr = n.Node.Server().ListenAddr
+
+	// Import the node key into the keystore and then unlock it, the keystore
+	// is the interface used for signing operations so the node key needs to be
+	// inside it.
+	ks := n.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
+	account, err := ks.ImportECDSA(n.Key, "")
+	if err != nil {
+		return err
+	}
+	err = ks.TimedUnlock(account, "", 0)
+	if err != nil {
+		return err
+	}
+	// Get the eth service back from the node for easy access.
+	err = n.Service(&n.Eth)
+	if err != nil {
+		return err
+	}
+	_, _, err = core.SetupGenesisBlock(n.Eth.ChainDb(), n.EthConfig.Genesis)
+	if err != nil {
+		return err
+	}
+	n.WsClient, err = ethclient.Dial("ws://" + n.HTTPEndpoint())
+	if err != nil {
+		return err
+	}
+	n.Nonce, err = n.WsClient.PendingNonceAt(context.Background(), n.DevAddress)
+	if err != nil {
+		return err
+	}
+	err = n.Tracker.StartTracking(n.WsClient)
+	if err != nil {
+		return err
+	}
+	return n.Eth.StartMining()
+}
+
+// Close shuts down the node and releases all resources and removes the datadir
+// unless an error is returned, in which case there is no guarantee that all
+// resources are released.
+func (n *Node) Close() error {
+	err := n.Tracker.StopTracking()
+	if err != nil {
+		return err
+	}
+	n.WsClient.Close()
+	if n.Node != nil {
+		err = n.Node.Close() // This also shuts down the Eth service
+	}
+	os.RemoveAll(n.Config.DataDir)
+	return err
+}
+
+// SendCeloTracked functions like SendCelo but also waits for the transaction to be processed.
+func (n *Node) SendCeloTracked(ctx context.Context, recipient common.Address, value int64) (*types.Transaction, error) {
+	tx, err := n.SendCelo(ctx, recipient, value)
+	if err != nil {
+		return nil, err
+	}
+	err = n.AwaitTransactions(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	return n.Tracker.GetProcessedTx(tx.Hash()), nil
+}
+
+// SendCelo submits a value transfer transaction to the network to send celo to
+// the recipient. The submitted transaction is returned.
+func (n *Node) SendCelo(ctx context.Context, recipient common.Address, value int64) (*types.Transaction, error) {
+	signer := types.MakeSigner(n.EthConfig.Genesis.Config, common.Big0)
+	tx, err := ValueTransferTransaction(
+		n.WsClient,
+		n.DevKey,
+		n.DevAddress,
+		recipient,
+		n.Nonce,
+		big.NewInt(value),
+		signer)
+
+	if err != nil {
+		return nil, err
+	}
+	err = n.WsClient.SendTransaction(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	n.Nonce++
+	n.SentTxs = append(n.SentTxs, tx)
+	return tx, nil
+}
+
+// AwaitTransactions awaits all the provided transactions.
+func (n *Node) AwaitTransactions(ctx context.Context, txs ...*types.Transaction) error {
+	sentHashes := make([]common.Hash, len(txs))
+	for i, tx := range txs {
+		sentHashes[i] = tx.Hash()
+	}
+	return n.Tracker.AwaitTransactions(ctx, sentHashes)
+}
+
+// AwaitSentTransactions awaits all the transactions that this node has sent
+// via SendCelo.
+func (n *Node) AwaitSentTransactions(ctx context.Context) error {
+	return n.AwaitTransactions(ctx, n.SentTxs...)
+}
+
+// ProcessedTxBlock returns the block that the given transaction was processed
+// in, nil will be retuned if the transaction has not been processed by this node.
+func (n *Node) ProcessedTxBlock(tx *types.Transaction) *types.Block {
+	return n.Tracker.GetProcessedBlock(tx.Hash())
+}
+
+// TxFee returns the gas fee for the given transaction.
+func (n *Node) TxFee(ctx context.Context, tx *types.Transaction) (*big.Int, error) {
+	r, err := n.WsClient.TransactionReceipt(ctx, tx.Hash())
+	if err != nil {
+		return nil, err
+	}
+	return big.NewInt(0).Mul(new(big.Int).SetUint64(r.GasUsed), tx.GasPrice()), nil
+}
+
+// Network represents a network of nodes and provides functionality to easily
+// create, start and stop a collection of nodes.
+type Network []*Node
+
+type NodeConfig struct {
+	ValidatorAccount *env.Account
+	DevAccount       *env.Account
+	*node.Config
+}
+
+func NewNodeConfig(validatorAccount, devAccount *env.Account) *NodeConfig {
+	confCopy := *baseNodeConfig
+	return &NodeConfig{
+		ValidatorAccount: validatorAccount,
+		DevAccount:       devAccount,
+		Config:           &confCopy,
+	}
+}
+
+func Accounts(numValidators int) *env.AccountsConfig {
+	return &env.AccountsConfig{
+		Mnemonic:             env.MustNewMnemonic(),
+		NumValidators:        numValidators,
+		ValidatorsPerGroup:   1,
+		NumDeveloperAccounts: numValidators,
+	}
+}
+
+func GenesisConfig(accounts *env.AccountsConfig) *genesis.Config {
+	gc := genesis.CreateCommonGenesisConfig(
+		big.NewInt(1),
+		accounts.AdminAccount().Address,
+		params.IstanbulConfig{
+			Epoch:          10,
+			ProposerPolicy: uint64(istanbul.ShuffledRoundRobin),
+			LookbackWindow: 3,
+			BlockPeriod:    0,
+
+			// 50ms is a really low timeout, we set this here because nodes
+			// fail the first round of consensus and so setting this higher
+			// makes tests run slower.
+			RequestTimeout: 50,
+		},
+	)
+	genesis.FundAccounts(gc, accounts.DeveloperAccounts())
+	return gc
+}
+
+// NewNetwork generates a network of nodes that are running and mining. For
+// each provided validator account a corresponding node is created and each
+// node is also assigned a developer account, there must be at least as many
+// developer accounts provided as validator accounts. If there is an error it
+// will be returned immediately, meaning that some nodes may be running and
+// others not.
+func NewNetwork(accounts *env.AccountsConfig, gc *genesis.Config) (Network, error) {
+
+	genesis, err := genesis.GenerateGenesis(accounts, gc, "../monorepo/packages/protocol/build/contracts")
+	if err != nil {
+		return nil, err
+	}
+
+	validatorAccounts := accounts.ValidatorAccounts()
+	network := make([]*Node, len(validatorAccounts))
+	for i := range validatorAccounts {
+		conf := NewNodeConfig(&validatorAccounts[i], &accounts.DeveloperAccounts()[i])
+		n, err := NewNode(conf, genesis)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build node for network: %v", err)
+		}
+		network[i] = n
+	}
+
+	enodes := make([]*enode.Node, len(network))
+	for i, n := range network {
+		host, port, err := net.SplitHostPort(n.P2PListenAddr)
+		if err != nil {
+			return nil, err
+		}
+		portNum, err := strconv.Atoi(port)
+		if err != nil {
+			return nil, err
+		}
+		en := enode.NewV4(&n.Key.PublicKey, net.ParseIP(host), portNum, portNum)
+		enodes[i] = en
+	}
+	// Connect nodes to each other, although this means that nodes can reach
+	// each other nodes don't start sending consensus messages to another node
+	// until they have received an enode certificate from that node.
+	for i := range network {
+		en := enodes[i]
+		for j := range network {
+			if j == i {
+				continue
+			}
+			network[j].Server().AddPeer(en, p2p.ValidatorPurpose)
+			network[j].Server().AddTrustedPeer(en, p2p.ValidatorPurpose)
+		}
+	}
+
+	// Give nodes some time to connect. Also there is a race condition in
+	// miner.worker its field snapshotBlock is set only when new transactions
+	// are received or commitNewWork is called. But both of these happen in
+	// goroutines separate to the call to miner.Start and miner.Start does not
+	// wait for snapshotBlock to be set. Therefore there is currently no way to
+	// know when it is safe to call estimate gas.  What we do here is sleep a
+	// bit and cross our fingers.
+	time.Sleep(25 * time.Millisecond)
+
+	version := uint(time.Now().Unix())
+
+	// Share enode certificates between nodes, nodes wont consider other nodes
+	// valid validators without seeing an enode certificate message from them.
+	for i := range network {
+		enodeCertificate := &istanbul.EnodeCertificate{
+			EnodeURL: enodes[i].URLv4(),
+			Version:  version,
+		}
+		enodeCertificateBytes, err := rlp.EncodeToBytes(enodeCertificate)
+		if err != nil {
+			return nil, err
+		}
+
+		b := network[i].Eth.Engine().(*backend.Backend)
+		msg := &istanbul.Message{
+			Code:    istanbul.EnodeCertificateMsg,
+			Address: b.Address(),
+			Msg:     enodeCertificateBytes,
+		}
+		// Sign the message
+		if err := msg.Sign(b.Sign); err != nil {
+			return nil, err
+		}
+		p, err := msg.Payload()
+		if err != nil {
+			return nil, err
+		}
+
+		err = b.Gossip(p, istanbul.EnodeCertificateMsg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return network, nil
+}
+
+// AwaitTransactions ensures that the entire network has processed the provided transactions.
+func (n Network) AwaitTransactions(ctx context.Context, txs ...*types.Transaction) error {
+	for _, node := range n {
+		err := node.AwaitTransactions(ctx, txs...)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Shutdown closes all nodes in the network, any errors that are encountered are
+// printed to stdout.
+func (n Network) Shutdown() {
+	for _, node := range n {
+		if node != nil {
+			err := node.Close()
+			if err != nil {
+				fmt.Printf("error shutting down node %v: %v", node.Address.String(), err)
+			}
+		}
+	}
+}
+
+// ValueTransferTransaction builds a signed value transfer transaction from the
+// sender to the recipient with the given value and nonce, it uses the client
+// to suggest a gas price and to estimate the gas.
+func ValueTransferTransaction(
+	client *ethclient.Client,
+	senderKey *ecdsa.PrivateKey,
+	sender,
+	recipient common.Address,
+	nonce uint64,
+	value *big.Int,
+	signer types.Signer,
+) (*types.Transaction, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	// Figure out the gas allowance and gas price values
+	gasPrice, err := client.SuggestGasPrice(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to suggest gas price: %v", err)
+	}
+
+	msg := ethereum.CallMsg{From: sender, To: &recipient, GasPrice: gasPrice, Value: value}
+	gasLimit, err := client.EstimateGas(ctx, msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to estimate gas needed: %v", err)
+	}
+
+	// Create the transaction and sign it
+	rawTx := types.NewTransactionEthCompatible(nonce, recipient, value, gasLimit, gasPrice, nil)
+	signed, err := types.SignTx(rawTx, signer, senderKey)
+	if err != nil {
+		return nil, err
+	}
+	return signed, nil
+}
+
+// Since the node config is not marshalable by default we construct a
+// marshalable struct which we marshal and unmarshal and then unpack into the
+// original struct type.
+func copyNodeConfig(source, dest *node.Config) error {
+	s := &MarshalableNodeConfig{}
+	s.Config = *source
+	p := MarshalableP2PConfig{}
+	p.Config = source.P2P
+
+	p.PrivateKey = (*MarshalableECDSAPrivateKey)(source.P2P.PrivateKey)
+	s.P2P = p
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	u := new(MarshalableNodeConfig)
+	err = json.Unmarshal(data, u)
+	if err != nil {
+		return err
+	}
+	*dest = u.Config
+	dest.P2P = u.P2P.Config
+	dest.P2P.PrivateKey = (*ecdsa.PrivateKey)(u.P2P.PrivateKey)
+	return nil
+}
+
+type MarshalableNodeConfig struct {
+	node.Config
+	P2P MarshalableP2PConfig
+}
+
+type MarshalableP2PConfig struct {
+	p2p.Config
+	PrivateKey *MarshalableECDSAPrivateKey
+}
+
+type MarshalableECDSAPrivateKey ecdsa.PrivateKey
+
+func (k *MarshalableECDSAPrivateKey) UnmarshalJSON(b []byte) error {
+	key, err := crypto.PrivECDSAFromHex(b[1 : len(b)-1])
+	if err != nil {
+		return err
+	}
+	*k = MarshalableECDSAPrivateKey(*key)
+	return nil
+}
+
+func (k *MarshalableECDSAPrivateKey) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + hex.EncodeToString(crypto.FromECDSA((*ecdsa.PrivateKey)(k))) + `"`), nil
+}
+
+// copyObject copies an object so that the copy shares no memory with the
+// original.
+func copyObject(source, dest interface{}) error {
+	data, err := json.Marshal(source)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, dest)
+}

--- a/test/node.go
+++ b/test/node.go
@@ -58,6 +58,9 @@ var (
 		DatabaseCache:   256,
 		DatabaseHandles: 256,
 		TxPool:          core.DefaultTxPoolConfig,
+		Istanbul: istanbul.Config{
+			Validator: true,
+		},
 	}
 )
 
@@ -102,6 +105,8 @@ func NewNode(c *NodeConfig, genesis *core.Genesis) (*Node, error) {
 	}
 	ec.Genesis = genesis
 	ec.NetworkId = genesis.Config.ChainID.Uint64()
+	ec.Miner.Validator = c.ValidatorAccount.Address
+	ec.TxFeeRecipient = c.ValidatorAccount.Address
 
 	node := &Node{
 		Config:     c.Config,
@@ -152,17 +157,6 @@ func (n *Node) Start() error {
 	if err != nil {
 		return err
 	}
-	ethConfigCopy.Miner.Validator = n.Address
-	ethConfigCopy.TxFeeRecipient = n.Address
-	ethConfigCopy.Istanbul.AnnounceQueryEnodeGossipPeriod = 60
-	ethConfigCopy.Istanbul.Validator = true
-	// ethConfigCopy.Istanbul.BlockPeriod = 0
-	// Somehow this is not being honored, its being set to 3000
-	// ethConfigCopy.Istanbul.RequestTimeout = 100
-	ethConfigCopy.Istanbul.TimeoutBackoffFactor = 10
-	ethConfigCopy.Istanbul.MinResendRoundChangeTimeout = 15 * 1000
-	ethConfigCopy.Istanbul.MaxResendRoundChangeTimeout = 2 * 60 * 1000
-	// ethConfigCopy.Istanbul.Epoch = 100
 
 	// Register eth service
 	err = n.Register(func(ctx *node.ServiceContext) (node.Service, error) {

--- a/test/transaction_tracker.go
+++ b/test/transaction_tracker.go
@@ -1,0 +1,193 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	ethereum "github.com/celo-org/celo-blockchain"
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/ethclient"
+)
+
+var (
+	errStopped = errors.New("transaction tracker closed")
+)
+
+// TransactionTracker tracks processed transactions through a subscription with
+// an ethclient. It provides the ability to check whether transactions have
+// been processed and to wait till those transactions have been processed.
+type TransactionTracker struct {
+	client *ethclient.Client
+	heads  chan *types.Header
+	sub    ethereum.Subscription
+	wg     sync.WaitGroup
+	// processed maps transaction hashes to the block they were processed in.
+	processed map[common.Hash]*types.Block
+	newTxs    *sync.Cond
+	stopCh    chan struct{}
+}
+
+// NewTransactionTracker creates a new transaction tracker, it subscribes to
+// new head events on the client and starts processing the events in a
+// goroutine.
+func NewTransactionTracker() *TransactionTracker {
+	return &TransactionTracker{
+		heads:     make(chan *types.Header),
+		processed: make(map[common.Hash]*types.Block),
+		newTxs:    sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+// GetProcessedTx returns the processed transaction with the given hash or nil
+// if the tracker has not seen a processed transaction with the given hash.
+func (tr *TransactionTracker) GetProcessedTx(hash common.Hash) *types.Transaction {
+	tr.newTxs.L.Lock()
+	defer tr.newTxs.L.Unlock()
+	return tr.processed[hash].Transaction(hash)
+}
+
+// GetProcessedTx returns the block that a transaction with the given hash was
+// processed in or nil if the tracker has not seen a processed transaction with
+// the given hash.
+func (tr *TransactionTracker) GetProcessedBlock(hash common.Hash) *types.Block {
+	tr.newTxs.L.Lock()
+	defer tr.newTxs.L.Unlock()
+	return tr.processed[hash]
+}
+
+func (tr *TransactionTracker) StartTracking(client *ethclient.Client) error {
+	if tr.sub != nil {
+		return errors.New("attempted to start already started tracker")
+	}
+	// The subscription client will buffer 20000 notifications before closing
+	// the subscription, if that happens the Err() chan will return
+	// ErrSubscriptionQueueOverflow
+	sub, err := client.SubscribeNewHead(context.Background(), tr.heads)
+	if err != nil {
+		return err
+	}
+	tr.client = client
+	tr.sub = sub
+	tr.stopCh = make(chan struct{})
+
+	tr.wg.Add(1)
+	go func() {
+		defer tr.wg.Done()
+		err := tr.trackTransactions()
+		if err != nil {
+			fmt.Printf("trackTransactions failed with error: %v\n", err)
+		}
+	}()
+	return nil
+}
+
+// trackTransactions reads new heads from the heads channel and for each head
+// retrieves the block and places the transactions into the processed map. It
+// signals the newTxs condition for every block that contained transactions.
+func (tr *TransactionTracker) trackTransactions() error {
+	for {
+		select {
+		case h := <-tr.heads:
+			b, err := tr.client.BlockByHash(context.Background(), h.Hash())
+			if err != nil {
+				return err
+			}
+			// If we have transactions then process them
+			if len(b.Transactions()) > 0 {
+				tr.newTxs.L.Lock()
+				for _, t := range b.Transactions() {
+					tr.processed[t.Hash()] = b
+				}
+				// signal
+				tr.newTxs.Signal()
+				tr.newTxs.L.Unlock()
+			}
+		case err := <-tr.sub.Err():
+			// Will be nil if closed by calling Unsubscribe()
+			return err
+		case <-tr.stopCh:
+			return nil
+		}
+	}
+}
+
+// AwaitTransactions waits for the transactions listed in hashes to be
+// processed, it will return the ctx.Err() if ctx expires before all the
+// transactions in hashes were processed or ErrStopped if StopTracking is
+// called before all the transactions in hashes were processed.
+func (tr *TransactionTracker) AwaitTransactions(ctx context.Context, hashes []common.Hash) error {
+	hashmap := make(map[common.Hash]struct{}, len(hashes))
+	for i := range hashes {
+		hashmap[hashes[i]] = struct{}{}
+	}
+	tr.newTxs.L.Lock()
+	defer tr.newTxs.L.Unlock()
+	txsFound := make(chan struct{})
+	var exitErr error
+	// This go-routine will either call Signal when the context expires or the
+	// tracker is closed, allowing us to wake from waiting on these events, or
+	// simply exit if the awaited transactions are processed before the context
+	// expires or the tracker is closed.
+	tr.wg.Add(1)
+	go func() {
+		defer tr.wg.Done()
+		// Note that we have already locked tr.newTxs.L in the creating
+		// go-routine and it will only be unlocked when Wait is called from the
+		// creating go-routine, this means Wait must have been called before we
+		// are able to send our signal.
+		select {
+		case <-ctx.Done():
+			tr.newTxs.L.Lock()
+			defer tr.newTxs.L.Unlock()
+			exitErr = ctx.Err()
+			tr.newTxs.Signal()
+		case <-tr.stopCh:
+			tr.newTxs.L.Lock()
+			defer tr.newTxs.L.Unlock()
+			exitErr = errStopped
+			tr.newTxs.Signal()
+		case <-txsFound:
+			return
+		}
+	}()
+
+	for {
+		// Delete processed transactions from hashmap
+		for hash := range hashmap {
+			_, ok := tr.processed[hash]
+			if ok {
+				delete(hashmap, hash)
+			}
+		}
+		// If there are no transactions left then they have all been processed.
+		if len(hashmap) == 0 {
+			close(txsFound) // Signal to the go routine that it can exit
+			return nil
+		}
+		tr.newTxs.Wait()
+		// Check the exit error to see if the context expired.
+		if exitErr != nil {
+			return exitErr
+		}
+	}
+}
+
+// StopTracking shuts down all the goroutines in the tracker.
+func (tr *TransactionTracker) StopTracking() error {
+	if tr.sub == nil {
+		return errors.New("attempted to stop already stopped tracker")
+	}
+	tr.sub.Unsubscribe()
+	close(tr.stopCh)
+	tr.wg.Wait()
+	tr.wg = sync.WaitGroup{}
+
+	// Free fields
+	tr.client = nil
+	tr.sub = nil
+	tr.stopCh = nil
+	return nil
+}

--- a/test/transaction_tracker.go
+++ b/test/transaction_tracker.go
@@ -184,10 +184,5 @@ func (tr *TransactionTracker) StopTracking() error {
 	close(tr.stopCh)
 	tr.wg.Wait()
 	tr.wg = sync.WaitGroup{}
-
-	// Free fields
-	tr.client = nil
-	tr.sub = nil
-	tr.stopCh = nil
 	return nil
 }

--- a/test/transaction_tracker.go
+++ b/test/transaction_tracker.go
@@ -104,7 +104,6 @@ func (tr *TransactionTracker) trackTransactions() error {
 					tr.processed[t.Hash()] = b
 				}
 				// signal
-				// tr.newTxs.Signal()
 				tr.processedMu.Unlock()
 				tr.newTxs.Send(struct{}{})
 			}

--- a/test/transaction_tracker.go
+++ b/test/transaction_tracker.go
@@ -37,7 +37,7 @@ type TransactionTracker struct {
 // goroutine.
 func NewTransactionTracker() *TransactionTracker {
 	return &TransactionTracker{
-		heads:     make(chan *types.Header),
+		heads:     make(chan *types.Header, 10),
 		processed: make(map[common.Hash]*types.Block),
 	}
 }
@@ -124,7 +124,7 @@ func (tr *TransactionTracker) AwaitTransactions(ctx context.Context, hashes []co
 	for i := range hashes {
 		hashmap[hashes[i]] = struct{}{}
 	}
-	ch := make(chan struct{})
+	ch := make(chan struct{}, 10)
 	sub := tr.newTxs.Subscribe(ch)
 	defer sub.Unsubscribe()
 	for {

--- a/test/transaction_tracker.go
+++ b/test/transaction_tracker.go
@@ -27,7 +27,7 @@ type TransactionTracker struct {
 	wg     sync.WaitGroup
 	// processed maps transaction hashes to the block they were processed in.
 	processed   map[common.Hash]*types.Block
-	processedMu *sync.Mutex
+	processedMu sync.Mutex
 	stopCh      chan struct{}
 	newTxs      event.Feed
 }
@@ -37,9 +37,8 @@ type TransactionTracker struct {
 // goroutine.
 func NewTransactionTracker() *TransactionTracker {
 	return &TransactionTracker{
-		heads:       make(chan *types.Header),
-		processed:   make(map[common.Hash]*types.Block),
-		processedMu: &sync.Mutex{},
+		heads:     make(chan *types.Header),
+		processed: make(map[common.Hash]*types.Block),
 	}
 }
 


### PR DESCRIPTION
### Description

This PR adds a package that enables writing tests of full networks within a singe go test process. It also adds an example test.

To try this out you will first need to run `make prepare-system-contracts` and then you can run the test (note you will need node v10 for the make command to succeed)

The commits for this PR are well separated and I think it would be easier to review commit by commit.

### Tested

The test works most of the time on my machine and seems to work most of the time on CI, sometimes the network hangs, I believe this is a problem with the blockchain code not the test code. I'm wondering whether it would be better to skip the test, but at least for now it's useful to know that the test is able to be run in CI.

You can run the e2e test with `go test ./e2e_test -count 1` it should take roughly a second to run.

I also noticed that having the monorepo checked out under the celo-blockchain folder seems to make `gopls` operate very slowly so I'm considering making the monorepo be checked out alongside the celo-blockchain project dir as opposed to under it, but before doing that I'd like to know if this is affecting anyone else?

### Related issues

- Fixes #1476

### Backwards compatibility

I believe so, no major changes were made to any core code.