### PR TITLE
Remove support for celo/64 and celo/65 protocols.

### DIFF
--- a/consensus/istanbul/protocol.go
+++ b/consensus/istanbul/protocol.go
@@ -22,8 +22,12 @@ import (
 
 // Constants to match up protocol versions and messages
 const (
+	// No longer supported, can be removed.
+	// The corresponding version upstream (eth/65) is removed in upstream PR #22636.
 	Celo64 = 64 // eth/63 + the istanbul messages
 	Celo65 = 65 // incorporates changes from eth/64 (EIP)
+
+	// Supported versions
 	Celo66 = 66 // incorporates changes from eth/65 (EIP-2464)
 )
 
@@ -31,16 +35,8 @@ const (
 const ProtocolName = "istanbul"
 
 // ProtocolVersions are the supported versions of the istanbul protocol (first is primary).
-// (First is primary in the sense that it's the most current one supported, not in the sense of IsPrimary() below)
-var ProtocolVersions = []uint{Celo66, Celo65, Celo64}
-
-// Returns whether this version of Istanbul should have Primary: true (a legacy property that was needed to work
-// around an upstream bug in the LES protocol which prevented two LES servers from connecting to each other).
-// Versions up to Celo65 need to have it, for backwards compatibility. Newer versions don't need it, since the
-// upstream LES bug has now been fixed.
-func IsPrimary(version uint) bool {
-	return version <= Celo65
-}
+// (First is primary in the sense that it's the most current one supported)
+var ProtocolVersions = []uint{Celo66}
 
 // protocolLengths are the number of implemented message corresponding to different protocol versions.
 var ProtocolLengths = map[uint]uint64{Celo64: 22, Celo65: 27, Celo66: 27}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -231,7 +231,6 @@ func (pm *ProtocolManager) makeProtocol(version uint) p2p.Protocol {
 		Name:    istanbul.ProtocolName,
 		Version: version,
 		Length:  length,
-		Primary: istanbul.IsPrimary(version),
 		Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
 			return pm.runPeer(pm.newPeer(int(version), p, rw, pm.txpool.Get))
 		},

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -419,16 +419,6 @@ outer:
 		}
 	}
 
-	// If a primary protocol matched, return only that protocol.
-	for _, proto := range protocols {
-		if proto.Primary {
-			if match, ok := result[proto.Name]; ok && match.Version == proto.Version {
-				primary := make(map[string]*protoRW)
-				primary[proto.Name] = result[proto.Name]
-				return primary
-			}
-		}
-	}
 	return result
 }
 

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -36,9 +36,6 @@ type Protocol struct {
 	// by the protocol.
 	Length uint64
 
-	// Whether this should be the primary form of communication between nodes that support this protocol.
-	Primary bool
-
 	// Run is called in a new goroutine when the protocol has been
 	// negotiated with a peer. It should read and write messages from
 	// rw. The Payload for each message must be fully consumed.

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -594,20 +594,10 @@ func (srv *Server) setupLocalNode() error {
 	srv.localnode.SetFallbackIP(net.IP{127, 0, 0, 1})
 
 	// TODO: check conflicts
-	primaries := make(map[string]bool)
 	for _, p := range srv.Protocols {
-		if p.Primary {
-			primaries[p.Name] = true
-		}
 		for _, e := range p.Attributes {
 			srv.localnode.Set(e)
 		}
-	}
-	if len(primaries) > 1 {
-		// It's ok for multiple versions of Istanbul to be marked as primary, since for a given peer
-		// connection only the latest version they both support will be used. But it's not ok if another
-		// protocol besides Istanbul is marked a primary, since then it's unclear which should be run.
-		srv.log.Crit("Multiple primary protocols specified", "names", primaries)
 	}
 	switch srv.NAT.(type) {
 	case nil:


### PR DESCRIPTION
### Description

Now that Donut has been activated on Alfajores, Baklava, and mainnet, all nodes which are still able to connect and sync are running v1.3.x and thus support celo/66.  Therefore, it is possible to remove support for celo/64 and celo/65 and with them the notion of a "primary" protocol.

See #1213 for more context.

### Tested

* Automated testing
* A full node successfully starts syncing to mainnet.

### Related issues

- Closes #1213

### Backwards compatibility

This breaks compatibility with nodes running v1.2.x or older.

On Alfajores, Baklava, and mainnet we have already broken compatibility with such nodes when the Donut hard fork was activated, so this PR doesn't add any additional incompatibility.

However, on private testnets that might not be the case, and so for them this PR would constitute a breaking change requiring nodes to upgrade to v1.3.0 or higher in order to be able to communicate with each other.