### PR TITLE
Fix RunTaskRepeteadly flakyness

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -350,7 +350,7 @@ func doTest(cmdline []string) {
 	// Test a single package at a time. CI builders are slow
 	// and some tests run into timeouts under load.
 	gotest := goTool("test", buildFlags(env)...)
-	// gotest.Args = append(gotest.Args, "-p", "1")
+	gotest.Args = append(gotest.Args, "-p", "1")
 	if *coverage {
 		gotest.Args = append(gotest.Args, "-covermode=atomic", "-cover", "-coverprofile=coverage.out")
 	}

--- a/common/task/task_test.go
+++ b/common/task/task_test.go
@@ -6,13 +6,15 @@ import (
 )
 
 func TestRunTaskRepeateadly(t *testing.T) {
+	t.Parallel()
+
 	counter := 0
 	ping := func() { counter++ }
 
-	stopTask := RunTaskRepeateadly(ping, 7*time.Millisecond)
-	time.Sleep(25 * time.Millisecond)
+	stopTask := RunTaskRepeateadly(ping, 50*time.Millisecond)
+	time.Sleep((3*50 + 30) * time.Millisecond)
 	stopTask()
-	time.Sleep(25 * time.Millisecond)
+	time.Sleep(30 * time.Millisecond)
 
 	if counter != 3 {
 		t.Errorf("Expect task to run 3 times but got %d", counter)


### PR DESCRIPTION
### Description

Increase internal, to cope for resource contention when running tests

