### PR TITLE
Update mycelo config values to work with monorepo e2e tests

### DIFF
--- a/cmd/mycelo/templates.go
+++ b/cmd/mycelo/templates.go
@@ -164,7 +164,7 @@ func (e monorepoEnv) createEnv(workdir string) (*env.Environment, error) {
 		Accounts: env.AccountsConfig{
 			Mnemonic:             env.MustNewMnemonic(),
 			NumValidators:        3,
-			ValidatorsPerGroup:   1,
+			ValidatorsPerGroup:   5, // monorepo uses a single validator group, max group size is 5
 			NumDeveloperAccounts: 0,
 			UseValidatorAsAdmin:  true, // monorepo doesn't use the admin account type, uses first validator instead
 		},

--- a/cmd/mycelo/templates.go
+++ b/cmd/mycelo/templates.go
@@ -186,6 +186,11 @@ func (e monorepoEnv) createGenesisConfig(env *env.Environment) (*genesis.Config,
 		BlockPeriod:    1,
 		RequestTimeout: 3000,
 	})
+	// To match the 'testing' config in monorepo
+	genesisConfig.EpochRewards.TargetVotingYieldInitial = fixed.MustNew("0.00016")
+	genesisConfig.EpochRewards.TargetVotingYieldMax = fixed.MustNew("0.0005")
+	genesisConfig.EpochRewards.TargetVotingYieldAdjustmentFactor = fixed.MustNew("0.1")
+	genesisConfig.Reserve.InitialBalance = common.MustBigInt("100000000000000000000000000") // 100M CELO
 
 	// Add balances to validator accounts instead of developer accounts
 	fundAccounts(genesisConfig, env.Accounts().ValidatorAccounts())

--- a/cmd/mycelo/templates.go
+++ b/cmd/mycelo/templates.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"math/rand"
 
+	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/common/decimal/fixed"
 	"github.com/celo-org/celo-blockchain/mycelo/env"
 	"github.com/celo-org/celo-blockchain/mycelo/genesis"

--- a/mycelo/genesis/base_config.go
+++ b/mycelo/genesis/base_config.go
@@ -147,7 +147,7 @@ func BaseConfig() *Config {
 		DowntimeSlasher: DowntimeSlasherParameters{
 			Reward:            bigIntStr("10000000000000000000"),  // 10 cGLD
 			Penalty:           bigIntStr("100000000000000000000"), // 100 cGLD
-			SlashableDowntime: 60,                                 // Should be overridden on public testnets
+			SlashableDowntime: 4,                                  // make it small so it works with small epoch sizes, e.g. 10
 		},
 		Governance: GovernanceParameters{
 			UseMultiSig:             true,


### PR DESCRIPTION
### Description

This is a companion PR to https://github.com/celo-org/celo-monorepo/pull/8086, with some changes which are needed to make the tests work:

1. Monorepo uses a single validator group, so we update the mycelo monorepo template to do so as well.
2. Make the DowntimeSlasher's slashable downtime small so it works with the small epoch sizes we use (if the slashable downtime is larger than the epoch size, you can't test out slashing)
3. Modify the monorepo template's config values for epoch rewards and initial reserve balance to match what is done in the monorepo for the 'testing' context (which is what the e2e tests use).  See https://github.com/celo-org/celo-monorepo/blob/c90edf1c938363e24746c90153d36263bb668aef/packages/protocol/migrationsConfig.js#L244-L281 .

### Tested

* Tested in conjunction with the monorepo tests PR above, locally and multiple times in CI.  Did not witness flakiness in the e2e tests.

### Related issues

- Necessary for #1384

### Backwards compatibility

No incompatibility