### PR TITLE
Extract GossipCache from the istanbul.Backend

### DIFF
--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -646,11 +646,11 @@ func (sb *Backend) handleQueryEnodeMsg(addr common.Address, peer consensus.Peer,
 	msg := new(istanbul.Message)
 
 	// Since this is a gossiped messaged, mark that the peer gossiped it (and presumably processed it) and check to see if this node already processed it
-	sb.markMessageProcessedByPeer(addr, payload)
-	if sb.checkIfMessageProcessedBySelf(payload) {
+	sb.gossipCache.MarkMessageProcessedByPeer(addr, payload)
+	if sb.gossipCache.CheckIfMessageProcessedBySelf(payload) {
 		return nil
 	}
-	defer sb.markMessageProcessedBySelf(payload)
+	defer sb.gossipCache.MarkMessageProcessedBySelf(payload)
 
 	// Decode message
 	err := msg.FromPayload(payload, istanbul.GetSignatureAddress)
@@ -1009,11 +1009,11 @@ func (sb *Backend) handleVersionCertificatesMsg(addr common.Address, peer consen
 	logger.Trace("Handling version certificates msg")
 
 	// Since this is a gossiped messaged, mark that the peer gossiped it (and presumably processed it) and check to see if this node already processed it
-	sb.markMessageProcessedByPeer(addr, payload)
-	if sb.checkIfMessageProcessedBySelf(payload) {
+	sb.gossipCache.MarkMessageProcessedByPeer(addr, payload)
+	if sb.gossipCache.CheckIfMessageProcessedBySelf(payload) {
 		return nil
 	}
-	defer sb.markMessageProcessedBySelf(payload)
+	defer sb.gossipCache.MarkMessageProcessedBySelf(payload)
 
 	var msg istanbul.Message
 	if err := msg.FromPayload(payload, nil); err != nil {

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -65,14 +65,6 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 	if err != nil {
 		logger.Crit("Failed to create recent snapshots cache", "err", err)
 	}
-	peerRecentMessages, err := lru.NewARC(inmemoryPeers)
-	if err != nil {
-		logger.Crit("Failed to create recent messages cache", "err", err)
-	}
-	selfRecentMessages, err := lru.NewARC(inmemoryMessages)
-	if err != nil {
-		logger.Crit("Failed to create known messages cache", "err", err)
-	}
 	backend := &Backend{
 		config:                             config,
 		istanbulEventMux:                   new(event.TypeMux),
@@ -81,8 +73,7 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 		recentSnapshots:                    recentSnapshots,
 		coreStarted:                        false,
 		announceRunning:                    false,
-		peerRecentMessages:                 peerRecentMessages,
-		selfRecentMessages:                 selfRecentMessages,
+		gossipCache:                        NewLRUGossipCache(inmemoryPeers, inmemoryMessages),
 		announceThreadWg:                   new(sync.WaitGroup),
 		generateAndGossipQueryEnodeCh:      make(chan struct{}, 1),
 		updateAnnounceVersionCh:            make(chan struct{}, 1),
@@ -205,8 +196,7 @@ type Backend struct {
 	// interface to the p2p server
 	p2pserver consensus.P2PServer
 
-	peerRecentMessages *lru.ARCCache // the cache of peer's recent messages
-	selfRecentMessages *lru.ARCCache // the cache of self recent messages
+	gossipCache GossipCache
 
 	lastQueryEnodeGossiped   map[common.Address]time.Time
 	lastQueryEnodeGossipedMu sync.RWMutex

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/celo-org/celo-blockchain/p2p"
 	"github.com/celo-org/celo-blockchain/p2p/enode"
 	"github.com/celo-org/celo-blockchain/rlp"
-	lru "github.com/hashicorp/golang-lru"
 )
 
 type MockPeer struct {
@@ -121,18 +120,17 @@ func TestRecentMessageCaches(t *testing.T) {
 
 		// generate a msg that is not an Announce
 		data := []byte("data1")
-		hash := istanbul.RLPHash(data)
 		msg := makeMsg(tt.ethMsgCode, data)
 		addr := common.BytesToAddress([]byte("address"))
 
 		// 1. this message should not be in cache
 		// for peers
-		if _, ok := backend.peerRecentMessages.Get(addr); ok {
+		if backend.gossipCache.CheckIfMessageProcessedByPeer(addr, data) {
 			t.Fatalf("the cache of messages for this peer should be nil")
 		}
 
 		// for self
-		if _, ok := backend.selfRecentMessages.Get(hash); ok {
+		if backend.gossipCache.CheckIfMessageProcessedBySelf(data) {
 			t.Fatalf("the cache of messages should be nil")
 		}
 
@@ -146,17 +144,11 @@ func TestRecentMessageCaches(t *testing.T) {
 		time.Sleep(10 * time.Second)
 
 		// for peers
-		if ms, ok := backend.peerRecentMessages.Get(addr); tt.shouldCache != ok {
+		if ok := backend.gossipCache.CheckIfMessageProcessedByPeer(addr, data); tt.shouldCache != ok {
 			t.Fatalf("the cache of messages for this peer should be nil")
-		} else if tt.shouldCache {
-			if m, ok := ms.(*lru.ARCCache); !ok {
-				t.Fatalf("the cache of messages for this peer cannot be casted")
-			} else if _, ok := m.Get(hash); !ok {
-				t.Fatalf("the cache of messages for this peer cannot be found")
-			}
 		}
 		// for self
-		if _, ok := backend.selfRecentMessages.Get(hash); tt.shouldCache != ok {
+		if ok := backend.gossipCache.CheckIfMessageProcessedBySelf(data); tt.shouldCache != ok {
 			t.Fatalf("the cache of messages must be nil")
 		}
 

--- a/consensus/istanbul/backend/message_senders.go
+++ b/consensus/istanbul/backend/message_senders.go
@@ -88,18 +88,18 @@ func (sb *Backend) Gossip(payload []byte, ethMsgCode uint64) error {
 
 	// Mark that this node gossiped/processed this message, so that it will ignore it if
 	// one of it's peers sends the message to it.
-	sb.markMessageProcessedBySelf(payload)
+	sb.gossipCache.MarkMessageProcessedBySelf(payload)
 
 	// Filter out peers that already sent us this gossip message
 	for nodeID, peer := range peersToSendMsg {
 		nodePubKey := peer.Node().Pubkey()
 		nodeAddr := crypto.PubkeyToAddress(*nodePubKey)
-		if sb.checkIfMessageProcessedByPeer(nodeAddr, payload) {
+		if sb.gossipCache.CheckIfMessageProcessedByPeer(nodeAddr, payload) {
 			delete(peersToSendMsg, nodeID)
 			logger.Trace("Peer already gossiped this message.  Not sending message to it", "peer", peer)
 			continue
 		} else {
-			sb.markMessageProcessedByPeer(nodeAddr, payload)
+			sb.gossipCache.MarkMessageProcessedByPeer(nodeAddr, payload)
 		}
 	}
 


### PR DESCRIPTION
Small needed change which is a part of a work in progress to tidy & modularize the announce protocol.

The Istanbul Backend has a cache of processed messages to avoid re-processing them. It's implemented using two different cache instances for self & peer messages. This commit extracts them to a single type `GossipCache`.