### PR TITLE
Consolidate istanbul.Message encoding/decoding

### DIFF
--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -508,7 +508,7 @@ func (sb *Backend) generateQueryEnodeMsg(version uint, enodeQueries []*enodeQuer
 		return nil, nil
 	}
 
-	msg := istanbul.NewMessage(&istanbul.QueryEnodeData{
+	msg := istanbul.NewQueryEnodeMessage(&istanbul.QueryEnodeData{
 		EncryptedEnodeURLs: encryptedEnodeURLs,
 		Version:            version,
 		Timestamp:          getTimestamp(),
@@ -751,7 +751,7 @@ func (sb *Backend) regossipQueryEnode(msg *istanbul.Message, msgTimestamp uint, 
 func (sb *Backend) gossipVersionCertificatesMsg(versionCertificates []*istanbul.VersionCertificate) error {
 	logger := sb.logger.New("func", "gossipVersionCertificatesMsg")
 
-	payload, err := istanbul.NewMessage(versionCertificates, sb.address).Payload()
+	payload, err := istanbul.NewVersionCeritifcatesMessage(versionCertificates, sb.address).Payload()
 	if err != nil {
 		logger.Warn("Error encoding version certificate msg", "err", err)
 		return err
@@ -772,7 +772,7 @@ func (sb *Backend) sendVersionCertificateTable(peer consensus.Peer) error {
 		logger.Warn("Error getting all version certificates", "err", err)
 		return err
 	}
-	payload, err := istanbul.NewMessage(allVersionCertificates, sb.address).Payload()
+	payload, err := istanbul.NewVersionCeritifcatesMessage(allVersionCertificates, sb.address).Payload()
 	if err != nil {
 		logger.Warn("Error encoding version certificate msg", "err", err)
 		return err
@@ -1035,7 +1035,7 @@ func (sb *Backend) generateEnodeCertificateMsgs(version uint) (map[enode.ID]*ist
 	}
 
 	for _, externalNode := range externalEnodes {
-		msg := istanbul.NewMessage(
+		msg := istanbul.NewEnodeCeritifcateMessage(
 			&istanbul.EnodeCertificate{EnodeURL: externalNode.URLv4(), Version: version},
 			sb.Address(),
 		)

--- a/consensus/istanbul/backend/announce_test.go
+++ b/consensus/istanbul/backend/announce_test.go
@@ -49,7 +49,7 @@ func TestAnnounceGossipQueryMsg(t *testing.T) {
 
 	// Have engine0 handle vCert messages from engine1 and engine2
 
-	vCert1MsgPayload, err := istanbul.NewMessage([]*istanbul.VersionCertificate{vCert1}, engine1Address).Payload()
+	vCert1MsgPayload, err := istanbul.NewVersionCeritifcatesMessage([]*istanbul.VersionCertificate{vCert1}, engine1Address).Payload()
 	if err != nil {
 		t.Errorf("Error in encoding vCert1.  Error: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestAnnounceGossipQueryMsg(t *testing.T) {
 		t.Errorf("Error in handling vCert1.  Error: %v", err)
 	}
 
-	vCert2MsgPayload, err := istanbul.NewMessage([]*istanbul.VersionCertificate{vCert2}, engine2Address).Payload()
+	vCert2MsgPayload, err := istanbul.NewVersionCeritifcatesMessage([]*istanbul.VersionCertificate{vCert2}, engine2Address).Payload()
 	if err != nil {
 		t.Errorf("Error in encoding vCert2.  Error: %v", err)
 	}

--- a/consensus/istanbul/backend/announce_test.go
+++ b/consensus/istanbul/backend/announce_test.go
@@ -37,18 +37,19 @@ func TestAnnounceGossipQueryMsg(t *testing.T) {
 	engine0Enode := engine0.SelfNode()
 
 	// Create version certificate messages for engine1 and engine2, so that engine0 will send a queryEnodeMessage to them
-	vCert1, err := engine1.generateVersionCertificate(engine1AnnounceVersion)
+	vCert1, err := istanbul.NewVersionCertificate(engine1AnnounceVersion, engine1.Sign)
 	if err != nil {
 		t.Errorf("Error in generating version certificate for engine1.  Error: %v", err)
 	}
 
-	vCert2, err := engine2.generateVersionCertificate(engine2AnnounceVersion)
+	vCert2, err := istanbul.NewVersionCertificate(engine1AnnounceVersion, engine2.Sign)
 	if err != nil {
 		t.Errorf("Error in generating version certificate for engine2.  Error: %v", err)
 	}
 
 	// Have engine0 handle vCert messages from engine1 and engine2
-	vCert1MsgPayload, err := engine1.encodeVersionCertificatesMsg([]*versionCertificate{vCert1})
+
+	vCert1MsgPayload, err := istanbul.NewMessage([]*istanbul.VersionCertificate{vCert1}, engine1Address).Payload()
 	if err != nil {
 		t.Errorf("Error in encoding vCert1.  Error: %v", err)
 	}
@@ -57,7 +58,7 @@ func TestAnnounceGossipQueryMsg(t *testing.T) {
 		t.Errorf("Error in handling vCert1.  Error: %v", err)
 	}
 
-	vCert2MsgPayload, err := engine2.encodeVersionCertificatesMsg([]*versionCertificate{vCert2})
+	vCert2MsgPayload, err := istanbul.NewMessage([]*istanbul.VersionCertificate{vCert2}, engine2Address).Payload()
 	if err != nil {
 		t.Errorf("Error in encoding vCert2.  Error: %v", err)
 	}

--- a/consensus/istanbul/core/backlog_test.go
+++ b/consensus/istanbul/core/backlog_test.go
@@ -231,19 +231,10 @@ func TestStoreBacklog(t *testing.T) {
 	p1 := validator.New(common.BytesToAddress([]byte("12345667890")), blscrypto.SerializedPublicKey{})
 	p2 := validator.New(common.BytesToAddress([]byte("47324349949")), blscrypto.SerializedPublicKey{})
 
-	// push messages
-	preprepare := &istanbul.Preprepare{
-		View:     v10,
-		Proposal: makeBlock(10),
-	}
-
-	prepreparePayload, _ := Encode(preprepare)
-	mPreprepare := &istanbul.Message{
-		Code:    istanbul.MsgPreprepare,
-		Msg:     prepreparePayload,
-		Address: p1.Address(),
-	}
-
+	mPreprepare := istanbul.NewMessage(
+		&istanbul.Preprepare{View: v10, Proposal: makeBlock(10)},
+		p1.Address(),
+	)
 	backlog.store(mPreprepare)
 
 	msg := backlog.backlogBySeq[v10.Sequence.Uint64()].PopItem()
@@ -251,27 +242,14 @@ func TestStoreBacklog(t *testing.T) {
 		t.Errorf("message mismatch: have %v, want %v", msg, mPreprepare)
 	}
 
-	subject := &istanbul.Subject{
-		View:   v10,
-		Digest: common.BytesToHash([]byte("1234567890")),
-	}
-	subjectPayload, _ := Encode(subject)
-	mPrepare := &istanbul.Message{
-		Code:    istanbul.MsgPrepare,
-		Msg:     subjectPayload,
-		Address: p1.Address(),
-	}
-
-	preprepare2 := &istanbul.Preprepare{
-		View:     v11,
-		Proposal: makeBlock(11),
-	}
-	preprepare2Payload, _ := Encode(preprepare2)
-	mPreprepare2 := &istanbul.Message{
-		Code:    istanbul.MsgPreprepare,
-		Msg:     preprepare2Payload,
-		Address: p2.Address(),
-	}
+	mPrepare := istanbul.NewMessage(
+		&istanbul.Subject{View: v10, Digest: common.BytesToHash([]byte("1234567890"))},
+		p1.Address(),
+	)
+	mPreprepare2 := istanbul.NewMessage(
+		&istanbul.Preprepare{View: v11, Proposal: makeBlock(11)},
+		p2.Address(),
+	)
 
 	backlog.store(mPreprepare)
 	backlog.store(mPrepare)
@@ -280,19 +258,11 @@ func TestStoreBacklog(t *testing.T) {
 	if backlog.msgCountBySrc[p1.Address()] != 3 {
 		t.Errorf("msgCountBySrc mismatch: have %v, want 3", backlog.msgCountBySrc[p1.Address()])
 	}
-	// push commit msg
-	committedSubject := &istanbul.CommittedSubject{
-		Subject:       subject,
-		CommittedSeal: []byte{0x63, 0x65, 0x6C, 0x6F}, // celo in hex!
-	}
 
-	committedSubjectPayload, _ := Encode(committedSubject)
-
-	mCommit := &istanbul.Message{
-		Code:    istanbul.MsgCommit,
-		Msg:     committedSubjectPayload,
-		Address: p1.Address(),
-	}
+	mCommit := istanbul.NewMessage(
+		&istanbul.CommittedSubject{Subject: mPrepare.Prepare(), CommittedSeal: []byte{0x63, 0x65, 0x6C, 0x6F}}, // celo in hex!},
+		p1.Address(),
+	)
 
 	backlog.store(mCommit)
 	if backlog.msgCountBySrc[p2.Address()] != 1 {
@@ -328,21 +298,16 @@ func TestClearBacklogForSequence(t *testing.T) {
 	).(*msgBacklogImpl)
 
 	// The backlog's state is sequence number 1, round 0.  Store future messages with sequence number 2
-	v := &istanbul.View{
-		Round:    big.NewInt(0),
-		Sequence: big.NewInt(2),
-	}
 	p1 := validator.New(common.BytesToAddress([]byte("12345667890")), blscrypto.SerializedPublicKey{})
-	preprepare := &istanbul.Preprepare{
-		View:     v,
-		Proposal: makeBlock(2),
-	}
-	prepreparePayload, _ := Encode(preprepare)
-	mPreprepare := &istanbul.Message{
-		Code:    istanbul.MsgPreprepare,
-		Msg:     prepreparePayload,
-		Address: p1.Address(),
-	}
+
+	mPreprepare := istanbul.NewMessage(
+		&istanbul.Preprepare{
+			View:     &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(2)},
+			Proposal: makeBlock(2),
+		},
+		p1.Address(),
+	)
+
 	numMsgs := 20
 	for i := 0; i < numMsgs; i++ {
 		backlog.store(mPreprepare)
@@ -377,49 +342,41 @@ func TestProcessFutureBacklog(t *testing.T) {
 	).(*msgBacklogImpl)
 	defer backlog.clearBacklogForSeq(12)
 
-	// push a future msg
-	v := &istanbul.View{
-		Round:    big.NewInt(10),
-		Sequence: big.NewInt(10),
-	}
+	futureSequence := big.NewInt(10)
+	oldSequence := big.NewInt(0)
 
-	committedSubject := &istanbul.CommittedSubject{
-		Subject: &istanbul.Subject{
-			View:   v,
-			Digest: common.BytesToHash([]byte("1234567890")),
-		},
-		CommittedSeal: []byte{0x63, 0x65, 0x6C, 0x6F},
-	}
-
-	committedSubjectPayload, _ := Encode(committedSubject)
 	// push a future msg
 	valSet := newTestValidatorSet(4)
-	mFuture := &istanbul.Message{
-		Code:    istanbul.MsgCommit,
-		Msg:     committedSubjectPayload,
-		Address: valSet.GetByIndex(0).Address(),
-	}
+	mFuture := istanbul.NewMessage(
+		&istanbul.CommittedSubject{
+			Subject: &istanbul.Subject{
+				View:   &istanbul.View{Round: big.NewInt(10), Sequence: futureSequence},
+				Digest: common.BytesToHash([]byte("1234567890")),
+			},
+			CommittedSeal: []byte{0x63, 0x65, 0x6C, 0x6F},
+		},
+		valSet.GetByIndex(0).Address())
+
 	backlog.store(mFuture)
 
 	// push a message from the past and check we expire it
-	v0 := &istanbul.View{
-		Round:    big.NewInt(0),
-		Sequence: big.NewInt(0),
-	}
-	subject0 := &istanbul.Subject{
-		View:   v0,
-		Digest: common.BytesToHash([]byte("1234567890")),
-	}
-	subjectPayload0, _ := Encode(subject0)
-	mPast := &istanbul.Message{
-		Code:    istanbul.MsgRoundChange,
-		Msg:     subjectPayload0,
-		Address: valSet.GetByIndex(1).Address(),
-	}
+	mPast := istanbul.NewMessage(&istanbul.RoundChange{
+		View: &istanbul.View{
+			Round:    big.NewInt(0),
+			Sequence: oldSequence,
+		},
+		PreparedCertificate: istanbul.PreparedCertificate{
+			Proposal: makeBlock(0),
+		},
+	}, valSet.GetByIndex(1).Address())
+
 	backlog.store(mPast)
 
+	// Should prune old messages
+	backlog.processBacklog()
+
 	backlogSeqs := backlog.getSortedBacklogSeqs()
-	if len(backlogSeqs) != 1 || backlogSeqs[0] != v.Sequence.Uint64() {
+	if len(backlogSeqs) != 1 || backlogSeqs[0] != futureSequence.Uint64() {
 		t.Errorf("getSortedBacklogSeqs mismatch: have %v", backlogSeqs)
 	}
 
@@ -439,53 +396,27 @@ func TestProcessBacklog(t *testing.T) {
 		Round:    big.NewInt(0),
 		Sequence: big.NewInt(1),
 	}
-	preprepare := &istanbul.Preprepare{
-		View:     v,
-		Proposal: makeBlock(1),
-	}
-	prepreparePayload, _ := Encode(preprepare)
 
 	subject := &istanbul.Subject{
 		View:   v,
 		Digest: common.BytesToHash([]byte("1234567890")),
 	}
-	subjectPayload, _ := Encode(subject)
-
-	committedSubject := &istanbul.CommittedSubject{
-		Subject:       subject,
-		CommittedSeal: []byte{0x63, 0x65, 0x6C, 0x6F},
-	}
-	committedSubjectPayload, _ := Encode(committedSubject)
-
-	rc := &istanbul.RoundChange{
-		View:                v,
-		PreparedCertificate: istanbul.EmptyPreparedCertificate(),
-	}
-	rcPayload, _ := Encode(rc)
-
 	address := common.BytesToAddress([]byte("0xce10ce10"))
 
 	msgs := []*istanbul.Message{
-		{
-			Code:    istanbul.MsgPreprepare,
-			Msg:     prepreparePayload,
-			Address: address,
-		},
-		{
-			Code:    istanbul.MsgPrepare,
-			Msg:     subjectPayload,
-			Address: address,
-		},
-		{
-			Code:    istanbul.MsgCommit,
-			Msg:     committedSubjectPayload,
-			Address: address,
-		},
-		{
-			Code:    istanbul.MsgRoundChange,
-			Msg:     rcPayload,
-			Address: address,
-		},
+		istanbul.NewMessage(
+			&istanbul.Preprepare{View: v, Proposal: makeBlock(1)},
+			address,
+		),
+		istanbul.NewMessage(subject, address),
+		istanbul.NewMessage(
+			&istanbul.CommittedSubject{Subject: subject, CommittedSeal: []byte{0x63, 0x65, 0x6C, 0x6F}},
+			address,
+		),
+		istanbul.NewMessage(
+			&istanbul.RoundChange{View: v, PreparedCertificate: istanbul.EmptyPreparedCertificate()},
+			address,
+		),
 	}
 	for i := 0; i < len(msgs); i++ {
 		t.Run(fmt.Sprintf("Msg with code %d", msgs[i].Code), func(t *testing.T) {

--- a/consensus/istanbul/core/backlog_test.go
+++ b/consensus/istanbul/core/backlog_test.go
@@ -260,7 +260,7 @@ func TestStoreBacklog(t *testing.T) {
 	}
 
 	mCommit := istanbul.NewCommitMessage(
-		&istanbul.CommittedSubject{Subject: mPrepare.Prepare(), CommittedSeal: []byte{0x63, 0x65, 0x6C, 0x6F}}, // celo in hex!},
+		&istanbul.CommittedSubject{Subject: mPrepare.Prepare(), CommittedSeal: []byte{0x63, 0x65, 0x6C, 0x6F}}, // celo in hex!
 		p1.Address(),
 	)
 

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -119,7 +119,7 @@ func (c *core) broadcastCommit(sub *istanbul.Subject) {
 			return
 		}
 	}
-	istMsg := istanbul.NewMessage(&istanbul.CommittedSubject{
+	istMsg := istanbul.NewCommitMessage(&istanbul.CommittedSubject{
 		Subject:               sub,
 		CommittedSeal:         committedSeal[:],
 		EpochValidatorSetSeal: epochValidatorSetSeal[:],

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -119,35 +119,18 @@ func (c *core) broadcastCommit(sub *istanbul.Subject) {
 			return
 		}
 	}
-
-	committedSub := &istanbul.CommittedSubject{
+	istMsg := istanbul.NewMessage(&istanbul.CommittedSubject{
 		Subject:               sub,
 		CommittedSeal:         committedSeal[:],
 		EpochValidatorSetSeal: epochValidatorSetSeal[:],
-	}
-	encodedCommittedSubject, err := Encode(committedSub)
-	if err != nil {
-		logger.Error("Failed to encode committedSubject", committedSub)
-	}
-
-	istMsg := istanbul.Message{
-		Code: istanbul.MsgCommit,
-		Msg:  encodedCommittedSubject,
-	}
-	c.broadcast(&istMsg)
+	}, c.address)
+	c.broadcast(istMsg)
 }
 
 func (c *core) handleCommit(msg *istanbul.Message) error {
 	defer c.handleCommitTimer.UpdateSince(time.Now())
-	// Decode COMMIT message
-	var commit *istanbul.CommittedSubject
-	err := msg.Decode(&commit)
-	if err != nil {
-		return errFailedDecodeCommit
-	}
-
-	err = c.checkMessage(istanbul.MsgCommit, commit.Subject.View)
-
+	commit := msg.Commit()
+	err := c.checkMessage(istanbul.MsgCommit, commit.Subject.View)
 	if err == errOldMessage {
 		// Discard messages from previous views, unless they are commits from the previous sequence,
 		// with the same round as what we wound up finalizing, as we would be able to include those

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -214,7 +214,7 @@ OUTER:
 			defer signature.Destroy()
 			signatureBytes, _ := signature.Serialize()
 
-			msg := istanbul.NewMessage(
+			msg := istanbul.NewCommitMessage(
 				&istanbul.CommittedSubject{Subject: v.engine.(*core).current.Subject(), CommittedSeal: signatureBytes},
 				validator.Address(),
 			)
@@ -430,7 +430,7 @@ func BenchmarkHandleCommit(b *testing.B) {
 		signature, _ := privateKey.SignMessage(hash, []byte{}, false, false)
 		defer signature.Destroy()
 		signatureBytes, _ := signature.Serialize()
-		im = istanbul.NewMessage(&istanbul.CommittedSubject{
+		im = istanbul.NewCommitMessage(&istanbul.CommittedSubject{
 			Subject:       v.engine.(*core).current.Subject(),
 			CommittedSeal: signatureBytes,
 		}, validator.Address())

--- a/consensus/istanbul/core/commit_test.go
+++ b/consensus/istanbul/core/commit_test.go
@@ -213,17 +213,13 @@ OUTER:
 			signature, _ := privateKey.SignMessage(hash, []byte{}, false, false)
 			defer signature.Destroy()
 			signatureBytes, _ := signature.Serialize()
-			committedSubject := &istanbul.CommittedSubject{
-				Subject:       v.engine.(*core).current.Subject(),
-				CommittedSeal: signatureBytes,
-			}
-			m, _ := Encode(committedSubject)
-			if err := r0.handleCommit(&istanbul.Message{
-				Code:      istanbul.MsgCommit,
-				Msg:       m,
-				Address:   validator.Address(),
-				Signature: []byte{},
-			}); err != nil {
+
+			msg := istanbul.NewMessage(
+				&istanbul.CommittedSubject{Subject: v.engine.(*core).current.Subject(), CommittedSeal: signatureBytes},
+				validator.Address(),
+			)
+
+			if err := r0.handleCommit(msg); err != nil {
 				if err != test.expectedErr {
 					t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
 				}
@@ -434,17 +430,10 @@ func BenchmarkHandleCommit(b *testing.B) {
 		signature, _ := privateKey.SignMessage(hash, []byte{}, false, false)
 		defer signature.Destroy()
 		signatureBytes, _ := signature.Serialize()
-		committedSubject := &istanbul.CommittedSubject{
+		im = istanbul.NewMessage(&istanbul.CommittedSubject{
 			Subject:       v.engine.(*core).current.Subject(),
 			CommittedSeal: signatureBytes,
-		}
-		m, _ := Encode(committedSubject)
-		im = &istanbul.Message{
-			Code:      istanbul.MsgCommit,
-			Msg:       m,
-			Address:   validator.Address(),
-			Signature: []byte{},
-		}
+		}, validator.Address())
 	}
 	// benchmarked portion
 	b.ResetTimer()

--- a/consensus/istanbul/core/errors.go
+++ b/consensus/istanbul/core/errors.go
@@ -33,12 +33,6 @@ var (
 	errOldMessage = errors.New("old message")
 	// errInvalidMessage is returned when the message is malformed.
 	errInvalidMessage = errors.New("invalid message")
-	// errFailedDecodePreprepare is returned when the PREPREPARE message is malformed.
-	errFailedDecodePreprepare = errors.New("failed to decode PREPREPARE")
-	// errFailedDecodePrepare is returned when the PREPARE message is malformed.
-	errFailedDecodePrepare = errors.New("failed to decode PREPARE")
-	// errFailedDecodeCommit is returned when the COMMIT message is malformed.
-	errFailedDecodeCommit = errors.New("failed to decode COMMIT")
 	// errInvalidPreparedCertificateProposal is returned when the PREPARED certificate has an invalid proposal.
 	errInvalidPreparedCertificateProposal = errors.New("invalid proposal in PREPARED certificate")
 	// errInvalidPreparedCertificateNumMsgs is returned when the PREPARED certificate has an incorrect number of messages.

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -64,7 +64,7 @@ func TestMalformedMessageDecoding(t *testing.T) {
 		Proposal: makeBlock(1),
 	}, v0.Address())
 
-	// Prepprepare message but prepare message code
+	// Preprepare message but prepare message code
 	m.Code = istanbul.MsgPrepare
 
 	payload, err = m.Payload()

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // notice: the normal case have been tested in integration tests.
@@ -36,90 +38,77 @@ func TestHandleMsg(t *testing.T) {
 	v0 := sys.backends[0]
 	r0 := v0.engine.(*core)
 
-	m, _ := Encode(&istanbul.Subject{
+	m := istanbul.NewMessage(&istanbul.Subject{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
 		},
 		Digest: common.BytesToHash([]byte("1234567890")),
-	})
+	}, v0.Address())
+
 	// with a matched payload. istanbul.MsgPreprepare should match with *istanbul.Preprepare in normal case.
-	msg := &istanbul.Message{
-		Code:      istanbul.MsgPreprepare,
-		Msg:       m,
-		Address:   v0.Address(),
-		Signature: []byte{},
-	}
+	m.Code = istanbul.MsgPreprepare
 
-	_, val := v0.Validators(nil).GetByAddress(v0.Address())
-	if err := r0.handleCheckedMsg(msg, val); err != errFailedDecodePreprepare {
-		t.Errorf("error mismatch: have %v, want %v", err, errFailedDecodePreprepare)
-	}
+	payload, err := m.Payload()
+	require.NoError(t, err)
 
-	m, _ = Encode(&istanbul.Preprepare{
+	err = r0.handleMsg(payload)
+	assert.Error(t, err)
+
+	m = istanbul.NewMessage(&istanbul.Preprepare{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
 		},
 		Proposal: makeBlock(1),
-	})
+	}, v0.Address())
+
 	// with a unmatched payload. istanbul.MsgPrepare should match with *istanbul.Subject in normal case.
-	msg = &istanbul.Message{
-		Code:      istanbul.MsgPrepare,
-		Msg:       m,
-		Address:   v0.Address(),
-		Signature: []byte{},
-	}
+	m.Code = istanbul.MsgPrepare
 
-	_, val = v0.Validators(nil).GetByAddress(v0.Address())
-	if err := r0.handleCheckedMsg(msg, val); err != errFailedDecodePrepare {
-		t.Errorf("error mismatch: have %v, want %v", err, errFailedDecodePreprepare)
-	}
+	payload, err = m.Payload()
+	require.NoError(t, err)
 
-	m, _ = Encode(&istanbul.Preprepare{
+	err = r0.handleMsg(payload)
+	assert.Error(t, err)
+
+	m = istanbul.NewMessage(&istanbul.Preprepare{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
 		},
 		Proposal: makeBlock(2),
-	})
+	}, v0.Address())
+
 	// with a unmatched payload. istanbul.MsgCommit should match with *istanbul.Subject in normal case.
-	msg = &istanbul.Message{
-		Code:      istanbul.MsgCommit,
-		Msg:       m,
-		Address:   v0.Address(),
-		Signature: []byte{},
-	}
+	m.Code = istanbul.MsgCommit
 
-	_, val = v0.Validators(nil).GetByAddress(v0.Address())
-	if err := r0.handleCheckedMsg(msg, val); err != errFailedDecodeCommit {
-		t.Errorf("error mismatch: have %v, want %v", err, errFailedDecodeCommit)
-	}
+	payload, err = m.Payload()
+	require.NoError(t, err)
 
-	m, _ = Encode(&istanbul.Preprepare{
+	err = r0.handleMsg(payload)
+	assert.Error(t, err)
+
+	m = istanbul.NewMessage(&istanbul.Preprepare{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
 		},
 		Proposal: makeBlock(3),
-	})
-	// invalid message code. message code is not exists in list
-	msg = &istanbul.Message{
-		Code:      uint64(99),
-		Msg:       m,
-		Address:   v0.Address(),
-		Signature: []byte{},
-	}
+	}, v0.Address())
 
-	_, val = v0.Validators(nil).GetByAddress(v0.Address())
-	if err := r0.handleCheckedMsg(msg, val); err == nil {
-		t.Errorf("error mismatch: have %v, want nil", err)
-	}
+	// invalid message code. message code is not exists in list
+	m.Code = uint64(99)
+
+	payload, err = m.Payload()
+	require.NoError(t, err)
+
+	err = r0.handleMsg(payload)
+	assert.Error(t, err)
 
 	// with malicious payload
-	if err := r0.handleMsg([]byte{1}); err == nil {
-		t.Errorf("error mismatch: have %v, want nil", err)
-	}
+	err = r0.handleMsg([]byte{1})
+	assert.Error(t, err)
 }
 
 func BenchmarkHandleMsg(b *testing.B) {

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -38,7 +38,7 @@ func TestHandleMsg(t *testing.T) {
 	v0 := sys.backends[0]
 	r0 := v0.engine.(*core)
 
-	m := istanbul.NewMessage(&istanbul.Subject{
+	m := istanbul.NewPrepareMessage(&istanbul.Subject{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
@@ -55,7 +55,7 @@ func TestHandleMsg(t *testing.T) {
 	err = r0.handleMsg(payload)
 	assert.Error(t, err)
 
-	m = istanbul.NewMessage(&istanbul.Preprepare{
+	m = istanbul.NewPreprepareMessage(&istanbul.Preprepare{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
@@ -72,7 +72,7 @@ func TestHandleMsg(t *testing.T) {
 	err = r0.handleMsg(payload)
 	assert.Error(t, err)
 
-	m = istanbul.NewMessage(&istanbul.Preprepare{
+	m = istanbul.NewPreprepareMessage(&istanbul.Preprepare{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),
@@ -89,7 +89,7 @@ func TestHandleMsg(t *testing.T) {
 	err = r0.handleMsg(payload)
 	assert.Error(t, err)
 
-	m = istanbul.NewMessage(&istanbul.Preprepare{
+	m = istanbul.NewPreprepareMessage(&istanbul.Preprepare{
 		View: &istanbul.View{
 			Sequence: big.NewInt(0),
 			Round:    big.NewInt(0),

--- a/consensus/istanbul/core/handler_test.go
+++ b/consensus/istanbul/core/handler_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 // notice: the normal case have been tested in integration tests.
-func TestHandleMsg(t *testing.T) {
+func TestMalformedMessageDecoding(t *testing.T) {
 	N := uint64(4)
 	F := uint64(1)
 	sys := NewTestSystemWithBackend(N, F)
@@ -46,13 +46,14 @@ func TestHandleMsg(t *testing.T) {
 		Digest: common.BytesToHash([]byte("1234567890")),
 	}, v0.Address())
 
-	// with a matched payload. istanbul.MsgPreprepare should match with *istanbul.Preprepare in normal case.
+	// Prepare message but preprepare message code
 	m.Code = istanbul.MsgPreprepare
 
 	payload, err := m.Payload()
 	require.NoError(t, err)
 
-	err = r0.handleMsg(payload)
+	msg := &istanbul.Message{}
+	err = msg.FromPayload(payload, r0.validateFn)
 	assert.Error(t, err)
 
 	m = istanbul.NewPreprepareMessage(&istanbul.Preprepare{
@@ -63,13 +64,14 @@ func TestHandleMsg(t *testing.T) {
 		Proposal: makeBlock(1),
 	}, v0.Address())
 
-	// with a unmatched payload. istanbul.MsgPrepare should match with *istanbul.Subject in normal case.
+	// Prepprepare message but prepare message code
 	m.Code = istanbul.MsgPrepare
 
 	payload, err = m.Payload()
 	require.NoError(t, err)
 
-	err = r0.handleMsg(payload)
+	msg = &istanbul.Message{}
+	err = msg.FromPayload(payload, r0.validateFn)
 	assert.Error(t, err)
 
 	m = istanbul.NewPreprepareMessage(&istanbul.Preprepare{
@@ -80,13 +82,14 @@ func TestHandleMsg(t *testing.T) {
 		Proposal: makeBlock(2),
 	}, v0.Address())
 
-	// with a unmatched payload. istanbul.MsgCommit should match with *istanbul.Subject in normal case.
+	// Preprepare message but commit message code
 	m.Code = istanbul.MsgCommit
 
 	payload, err = m.Payload()
 	require.NoError(t, err)
 
-	err = r0.handleMsg(payload)
+	msg = &istanbul.Message{}
+	err = msg.FromPayload(payload, r0.validateFn)
 	assert.Error(t, err)
 
 	m = istanbul.NewPreprepareMessage(&istanbul.Preprepare{
@@ -103,10 +106,11 @@ func TestHandleMsg(t *testing.T) {
 	payload, err = m.Payload()
 	require.NoError(t, err)
 
-	err = r0.handleMsg(payload)
+	msg = &istanbul.Message{}
+	err = msg.FromPayload(payload, r0.validateFn)
 	assert.Error(t, err)
 
-	// with malicious payload
+	// check fails with garbage message
 	err = r0.handleMsg([]byte{1})
 	assert.Error(t, err)
 }

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -27,7 +27,7 @@ import (
 func (c *core) sendPrepare() {
 	logger := c.newLogger("func", "sendPrepare")
 	logger.Debug("Sending prepare")
-	c.broadcast(istanbul.NewMessage(c.current.Subject(), c.address))
+	c.broadcast(istanbul.NewPrepareMessage(c.current.Subject(), c.address))
 }
 
 // Verify a prepared certificate and return the view that all of its messages pertain to.

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -26,18 +26,8 @@ import (
 
 func (c *core) sendPrepare() {
 	logger := c.newLogger("func", "sendPrepare")
-
-	sub := c.current.Subject()
-	encodedSubject, err := Encode(sub)
-	if err != nil {
-		logger.Error("Failed to encode", "subject", sub)
-		return
-	}
 	logger.Debug("Sending prepare")
-	c.broadcast(&istanbul.Message{
-		Code: istanbul.MsgPrepare,
-		Msg:  encodedSubject,
-	})
+	c.broadcast(istanbul.NewMessage(c.current.Subject(), c.address))
 }
 
 // Verify a prepared certificate and return the view that all of its messages pertain to.
@@ -82,19 +72,13 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 			return nil, errInvalidPreparedCertificateMsgCode
 		}
 
-		var subject *istanbul.Subject
-
+		// Assume prepare but overwrite if commit
+		subject := message.Prepare()
 		if message.Code == istanbul.MsgCommit {
-			var committedSubject *istanbul.CommittedSubject
-			err := message.Decode(&committedSubject)
-			if err != nil {
-				logger.Error("Failed to decode committedSubject in PREPARED certificate", "err", err)
-				return nil, err
-			}
-
+			commit := message.Commit()
 			// Verify the committedSeal
 			src := c.current.GetValidatorByAddress(signer)
-			err = c.verifyCommittedSeal(committedSubject, src)
+			err = c.verifyCommittedSeal(commit, src)
 			if err != nil {
 				logger.Error("Commit seal did not contain signature from message signer.", "err", err)
 				return nil, err
@@ -104,18 +88,13 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 			if err != nil {
 				return nil, err
 			}
-			err = c.verifyEpochValidatorSetSeal(committedSubject, preparedCertificate.Proposal.Number().Uint64(), newValSet, src)
+			err = c.verifyEpochValidatorSetSeal(commit, preparedCertificate.Proposal.Number().Uint64(), newValSet, src)
 			if err != nil {
 				logger.Error("Epoch validator set seal seal did not contain signature from message signer.", "err", err)
 				return nil, err
 			}
 
-			subject = committedSubject.Subject
-		} else {
-			if err := message.Decode(&subject); err != nil {
-				logger.Error("Failed to decode message in PREPARED certificate", "err", err)
-				return nil, err
-			}
+			subject = commit.Subject
 		}
 
 		msgLogger := logger.New("msg_round", subject.View.Round, "msg_seq", subject.View.Sequence, "msg_digest", subject.Digest.String())
@@ -145,42 +124,24 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 
 // Extract the view from a PreparedCertificate that has already been verified.
 func (c *core) getViewFromVerifiedPreparedCertificate(preparedCertificate istanbul.PreparedCertificate) (*istanbul.View, error) {
-	logger := c.newLogger("func", "getViewFromVerifiedPreparedCertificate", "proposal_number", preparedCertificate.Proposal.Number(), "proposal_hash", preparedCertificate.Proposal.Hash().String())
-
 	if len(preparedCertificate.PrepareOrCommitMessages) < c.current.ValidatorSet().MinQuorumSize() {
 		return nil, errInvalidPreparedCertificateNumMsgs
 	}
 
 	message := preparedCertificate.PrepareOrCommitMessages[0]
 
-	var subject *istanbul.Subject
-
+	// Assume prepare but overwrite if commit
+	subject := message.Prepare()
 	if message.Code == istanbul.MsgCommit {
-		var committedSubject *istanbul.CommittedSubject
-		err := message.Decode(&committedSubject)
-		if err != nil {
-			logger.Error("Failed to decode committedSubject in PREPARED certificate", "err", err)
-			return nil, err
-		}
-		subject = committedSubject.Subject
-	} else {
-		if err := message.Decode(&subject); err != nil {
-			logger.Error("Failed to decode message in PREPARED certificate", "err", err)
-			return nil, err
-		}
+		subject = message.Commit().Subject
 	}
-
 	return subject.View, nil
 }
 
 func (c *core) handlePrepare(msg *istanbul.Message) error {
 	defer c.handlePrepareTimer.UpdateSince(time.Now())
 	// Decode PREPARE message
-	var prepare *istanbul.Subject
-	err := msg.Decode(&prepare)
-	if err != nil {
-		return errFailedDecodePrepare
-	}
+	prepare := msg.Prepare()
 	logger := c.newLogger("func", "handlePrepare", "tag", "handleMsg", "msg_round", prepare.View.Round, "msg_seq", prepare.View.Sequence, "msg_digest", prepare.Digest.String())
 
 	if err := c.checkMessage(istanbul.MsgPrepare, prepare.View); err != nil {

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -374,12 +374,8 @@ func TestHandlePrepare(t *testing.T) {
 
 			for i, v := range test.system.backends {
 				validator := r0.current.ValidatorSet().GetByIndex(uint64(i))
-				m, _ := Encode(v.engine.(*core).current.Subject())
-				err := r0.handlePrepare(&istanbul.Message{
-					Code:    istanbul.MsgPrepare,
-					Msg:     m,
-					Address: validator.Address(),
-				})
+				msg := istanbul.NewMessage(v.engine.(*core).current.Subject(), validator.Address())
+				err := r0.handlePrepare(msg)
 				if err != nil {
 					if err != test.expectedErr {
 						t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
@@ -421,13 +417,9 @@ func TestHandlePrepare(t *testing.T) {
 			if decodedMsg.Code != istanbul.MsgCommit {
 				t.Errorf("message code mismatch: have %v, want %v", decodedMsg.Code, istanbul.MsgCommit)
 			}
-			var m *istanbul.CommittedSubject
-			err = decodedMsg.Decode(&m)
-			if err != nil {
-				t.Errorf("error mismatch: have %v, want nil", err)
-			}
-			if !reflect.DeepEqual(m.Subject, expectedSubject) {
-				t.Errorf("subject mismatch: have %v, want %v", m, expectedSubject)
+			subject := decodedMsg.Commit().Subject
+			if !reflect.DeepEqual(subject, expectedSubject) {
+				t.Errorf("subject mismatch: have %v, want %v", subject, expectedSubject)
 			}
 		})
 	}

--- a/consensus/istanbul/core/prepare_test.go
+++ b/consensus/istanbul/core/prepare_test.go
@@ -374,7 +374,7 @@ func TestHandlePrepare(t *testing.T) {
 
 			for i, v := range test.system.backends {
 				validator := r0.current.ValidatorSet().GetByIndex(uint64(i))
-				msg := istanbul.NewMessage(v.engine.(*core).current.Subject(), validator.Address())
+				msg := istanbul.NewPrepareMessage(v.engine.(*core).current.Subject(), validator.Address())
 				err := r0.handlePrepare(msg)
 				if err != nil {
 					if err != test.expectedErr {

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -29,7 +29,7 @@ func (c *core) sendPreprepare(request *istanbul.Request, roundChangeCertificate 
 
 	// If I'm the proposer and I have the same sequence with the proposal
 	if c.current.Sequence().Cmp(request.Proposal.Number()) == 0 && c.isProposer() {
-		m := istanbul.NewMessage(&istanbul.Preprepare{
+		m := istanbul.NewPreprepareMessage(&istanbul.Preprepare{
 			View:                   c.current.View(),
 			Proposal:               request.Proposal,
 			RoundChangeCertificate: roundChangeCertificate,

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -368,11 +368,14 @@ func TestHandlePreprepare(t *testing.T) {
 				preprepareView = &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(5)}
 			}
 
-			preprepare := &istanbul.Preprepare{
-				View:                   preprepareView,
-				Proposal:               test.expectedRequest,
-				RoundChangeCertificate: test.getCert(sys),
-			}
+			msg := istanbul.NewMessage(
+				&istanbul.Preprepare{
+					View:                   preprepareView,
+					Proposal:               test.expectedRequest,
+					RoundChangeCertificate: test.getCert(sys),
+				},
+				v0.Address(),
+			)
 
 			for i, v := range sys.backends {
 				// i == 0 is primary backend, it is responsible for send PRE-PREPARE messages to others.
@@ -382,13 +385,8 @@ func TestHandlePreprepare(t *testing.T) {
 
 				c := v.engine.(*core)
 
-				m, _ := Encode(preprepare)
 				// run each backends and verify handlePreprepare function.
-				if err := c.handlePreprepare(&istanbul.Message{
-					Code:    istanbul.MsgPreprepare,
-					Msg:     m,
-					Address: v0.Address(),
-				}); err != nil {
+				if err := c.handlePreprepare(msg); err != nil {
 					if err != test.expectedErr {
 						t.Errorf("error mismatch: have %v, want %v", err, test.expectedErr)
 					}
@@ -424,14 +422,9 @@ func TestHandlePreprepare(t *testing.T) {
 					t.Errorf("message code mismatch: have %v, want %v", decodedMsg.Code, expectedCode)
 				}
 
-				var subject *istanbul.Subject
-				var committedSubject *istanbul.CommittedSubject
-
-				if decodedMsg.Code == istanbul.MsgPrepare {
-					err = decodedMsg.Decode(&subject)
-				} else if decodedMsg.Code == istanbul.MsgCommit {
-					err = decodedMsg.Decode(&committedSubject)
-					subject = committedSubject.Subject
+				subject := decodedMsg.Prepare()
+				if decodedMsg.Code == istanbul.MsgCommit {
+					subject = decodedMsg.Commit().Subject
 				}
 
 				if err != nil {
@@ -451,8 +444,8 @@ func TestHandlePreprepare(t *testing.T) {
 				if expectedCode == istanbul.MsgCommit {
 					srcValidator := c.current.GetValidatorByAddress(v.address)
 
-					if err := c.verifyCommittedSeal(committedSubject, srcValidator); err != nil {
-						t.Errorf("invalid seal.  verify commmited seal error: %v, subject: %v, committedSeal: %v", err, expectedSubject, committedSubject.CommittedSeal)
+					if err := c.verifyCommittedSeal(decodedMsg.Commit(), srcValidator); err != nil {
+						t.Errorf("invalid seal.  verify commmited seal error: %v, subject: %v, committedSeal: %v", err, expectedSubject, decodedMsg.Commit().CommittedSeal)
 					}
 				}
 			}

--- a/consensus/istanbul/core/preprepare_test.go
+++ b/consensus/istanbul/core/preprepare_test.go
@@ -368,7 +368,7 @@ func TestHandlePreprepare(t *testing.T) {
 				preprepareView = &istanbul.View{Round: big.NewInt(0), Sequence: big.NewInt(5)}
 			}
 
-			msg := istanbul.NewMessage(
+			msg := istanbul.NewPreprepareMessage(
 				&istanbul.Preprepare{
 					View:                   preprepareView,
 					Proposal:               test.expectedRequest,

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -43,7 +43,7 @@ func (c *core) buildRoundChangeMsg(round *big.Int) *istanbul.Message {
 		Round:    new(big.Int).Set(round),
 		Sequence: new(big.Int).Set(c.current.View().Sequence),
 	}
-	return istanbul.NewMessage(&istanbul.RoundChange{
+	return istanbul.NewRoundChangeMessage(&istanbul.RoundChange{
 		View:                nextView,
 		PreparedCertificate: c.current.PreparedCertificate(),
 	}, c.address)

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -29,51 +29,24 @@ import (
 
 // sendRoundChange broadcasts a ROUND CHANGE message with the current desired round.
 func (c *core) sendRoundChange() {
-	logger := c.newLogger("func", "sendRoundChange")
-
-	msg, err := c.buildRoundChangeMsg(c.current.DesiredRound())
-	if err != nil {
-		logger.Error("Could not build round change message", "err", msg)
-		return
-	}
-
-	c.broadcast(msg)
+	c.broadcast(c.buildRoundChangeMsg(c.current.DesiredRound()))
 }
 
 // sendRoundChange sends a ROUND CHANGE message for the current desired round back to a single address
 func (c *core) sendRoundChangeAgain(addr common.Address) {
-	logger := c.newLogger("func", "sendRoundChangeAgain", "to", addr)
-
-	msg, err := c.buildRoundChangeMsg(c.current.DesiredRound())
-	if err != nil {
-		logger.Error("Could not build round change message", "err", err)
-		return
-	}
-
-	c.unicast(msg, addr)
+	c.unicast(c.buildRoundChangeMsg(c.current.DesiredRound()), addr)
 }
 
 // buildRoundChangeMsg creates a round change msg for the given round
-func (c *core) buildRoundChangeMsg(round *big.Int) (*istanbul.Message, error) {
+func (c *core) buildRoundChangeMsg(round *big.Int) *istanbul.Message {
 	nextView := &istanbul.View{
 		Round:    new(big.Int).Set(round),
 		Sequence: new(big.Int).Set(c.current.View().Sequence),
 	}
-
-	rc := &istanbul.RoundChange{
+	return istanbul.NewMessage(&istanbul.RoundChange{
 		View:                nextView,
 		PreparedCertificate: c.current.PreparedCertificate(),
-	}
-
-	payload, err := Encode(rc)
-	if err != nil {
-		return nil, err
-	}
-
-	return &istanbul.Message{
-		Code: istanbul.MsgRoundChange,
-		Msg:  payload,
-	}, nil
+	}, c.address)
 }
 
 func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChangeCertificate istanbul.RoundChangeCertificate) error {
@@ -117,11 +90,8 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 			return errInvalidRoundChangeCertificateMsgCode
 		}
 
-		var roundChange *istanbul.RoundChange
-		if err := message.Decode(&roundChange); err != nil {
-			logger.Warn("Failed to decode ROUND CHANGE in certificate", "err", err)
-			return err
-		} else if roundChange.View == nil || roundChange.View.Sequence == nil || roundChange.View.Round == nil {
+		roundChange := message.RoundChange()
+		if roundChange.View == nil || roundChange.View.Sequence == nil || roundChange.View.Round == nil {
 			return errInvalidRoundChangeCertificateMsgView
 		}
 
@@ -175,12 +145,7 @@ func (c *core) handleRoundChangeCertificate(proposal istanbul.Subject, roundChan
 func (c *core) handleRoundChange(msg *istanbul.Message) error {
 	logger := c.newLogger("func", "handleRoundChange", "tag", "handleMsg", "from", msg.Address)
 
-	// Decode ROUND CHANGE message
-	var rc *istanbul.RoundChange
-	if err := msg.Decode(&rc); err != nil {
-		logger.Info("Failed to decode ROUND CHANGE", "err", err)
-		return errInvalidMessage
-	}
+	rc := msg.RoundChange()
 	logger = logger.New("msg_round", rc.View.Round, "msg_seq", rc.View.Sequence)
 
 	// Must be same sequence and future round.

--- a/consensus/istanbul/core/roundchange_test.go
+++ b/consensus/istanbul/core/roundchange_test.go
@@ -43,7 +43,7 @@ func TestRoundChangeSet(t *testing.T) {
 	// Test Add()
 	// Add message from all validators
 	for i, v := range vset.List() {
-		rc.Add(view.Round, istanbul.NewMessage(r, v.Address()))
+		rc.Add(view.Round, istanbul.NewPrepareMessage(r, v.Address()))
 		if rc.msgsForRound[view.Round.Uint64()].Size() != i+1 {
 			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.msgsForRound[view.Round.Uint64()].Size(), i+1)
 		}
@@ -51,7 +51,7 @@ func TestRoundChangeSet(t *testing.T) {
 
 	// Add message again from all validators, but the size should be the same
 	for _, v := range vset.List() {
-		rc.Add(view.Round, istanbul.NewMessage(r, v.Address()))
+		rc.Add(view.Round, istanbul.NewPrepareMessage(r, v.Address()))
 		if rc.msgsForRound[view.Round.Uint64()].Size() != vset.Size() {
 			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.msgsForRound[view.Round.Uint64()].Size(), vset.Size())
 		}
@@ -84,7 +84,7 @@ func TestRoundChangeSet(t *testing.T) {
 	// Test Add()
 	// Add message from all validators
 	for i, v := range vset.List() {
-		rc.Add(view.Round, istanbul.NewMessage(r, v.Address()))
+		rc.Add(view.Round, istanbul.NewPrepareMessage(r, v.Address()))
 		if rc.msgsForRound[view.Round.Uint64()].Size() != i+1 {
 			t.Errorf("the size of round change messages mismatch: have %v, want %v", rc.msgsForRound[view.Round.Uint64()].Size(), i+1)
 		}
@@ -320,7 +320,7 @@ func TestHandleRoundChange(t *testing.T) {
 				Sequence: curView.Sequence,
 			}
 
-			msg := istanbul.NewMessage(&istanbul.RoundChange{
+			msg := istanbul.NewRoundChangeMessage(&istanbul.RoundChange{
 				View:                nextView,
 				PreparedCertificate: test.getCert(t, sys),
 			}, v0.Address())

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -275,41 +275,20 @@ func (self *testSystemBackend) finalizeAndReturnMessage(msg *istanbul.Message) (
 }
 
 func (self *testSystemBackend) getPreprepareMessage(view istanbul.View, roundChangeCertificate istanbul.RoundChangeCertificate, proposal istanbul.Proposal) (istanbul.Message, error) {
-	preprepare := &istanbul.Preprepare{
+	msg := istanbul.NewMessage(&istanbul.Preprepare{
 		View:                   &view,
 		RoundChangeCertificate: roundChangeCertificate,
 		Proposal:               proposal,
-	}
-
-	payload, err := Encode(preprepare)
-	if err != nil {
-		return istanbul.Message{}, err
-	}
-
-	msg := &istanbul.Message{
-		Code: istanbul.MsgPreprepare,
-		Msg:  payload,
-	}
+	}, self.address)
 
 	return self.finalizeAndReturnMessage(msg)
 }
 
 func (self *testSystemBackend) getPrepareMessage(view istanbul.View, digest common.Hash) (istanbul.Message, error) {
-	prepare := &istanbul.Subject{
+	msg := istanbul.NewMessage(&istanbul.Subject{
 		View:   &view,
 		Digest: digest,
-	}
-
-	payload, err := Encode(prepare)
-	if err != nil {
-		return istanbul.Message{}, err
-	}
-
-	msg := &istanbul.Message{
-		Code: istanbul.MsgPrepare,
-		Msg:  payload,
-	}
-
+	}, self.address)
 	return self.finalizeAndReturnMessage(msg)
 }
 
@@ -324,20 +303,10 @@ func (self *testSystemBackend) getCommitMessage(view istanbul.View, proposal ist
 		return istanbul.Message{}, err
 	}
 
-	committedSubject := &istanbul.CommittedSubject{
+	msg := istanbul.NewMessage(&istanbul.CommittedSubject{
 		Subject:       subject,
 		CommittedSeal: committedSeal[:],
-	}
-
-	payload, err := Encode(committedSubject)
-	if err != nil {
-		return istanbul.Message{}, err
-	}
-
-	msg := &istanbul.Message{
-		Code: istanbul.MsgCommit,
-		Msg:  payload,
-	}
+	}, self.address)
 
 	// // We swap in the provided proposal so that the message is finalized for the provided proposal
 	// // and not for the current preprepare.
@@ -353,20 +322,10 @@ func (self *testSystemBackend) getCommitMessage(view istanbul.View, proposal ist
 }
 
 func (self *testSystemBackend) getRoundChangeMessage(view istanbul.View, preparedCert istanbul.PreparedCertificate) (istanbul.Message, error) {
-	rc := &istanbul.RoundChange{
+	msg := istanbul.NewMessage(&istanbul.RoundChange{
 		View:                &view,
 		PreparedCertificate: preparedCert,
-	}
-
-	payload, err := Encode(rc)
-	if err != nil {
-		return istanbul.Message{}, err
-	}
-
-	msg := &istanbul.Message{
-		Code: istanbul.MsgRoundChange,
-		Msg:  payload,
-	}
+	}, common.Address{})
 
 	return self.finalizeAndReturnMessage(msg)
 }

--- a/consensus/istanbul/core/testbackend_test.go
+++ b/consensus/istanbul/core/testbackend_test.go
@@ -275,7 +275,7 @@ func (self *testSystemBackend) finalizeAndReturnMessage(msg *istanbul.Message) (
 }
 
 func (self *testSystemBackend) getPreprepareMessage(view istanbul.View, roundChangeCertificate istanbul.RoundChangeCertificate, proposal istanbul.Proposal) (istanbul.Message, error) {
-	msg := istanbul.NewMessage(&istanbul.Preprepare{
+	msg := istanbul.NewPreprepareMessage(&istanbul.Preprepare{
 		View:                   &view,
 		RoundChangeCertificate: roundChangeCertificate,
 		Proposal:               proposal,
@@ -285,7 +285,7 @@ func (self *testSystemBackend) getPreprepareMessage(view istanbul.View, roundCha
 }
 
 func (self *testSystemBackend) getPrepareMessage(view istanbul.View, digest common.Hash) (istanbul.Message, error) {
-	msg := istanbul.NewMessage(&istanbul.Subject{
+	msg := istanbul.NewPrepareMessage(&istanbul.Subject{
 		View:   &view,
 		Digest: digest,
 	}, self.address)
@@ -303,7 +303,7 @@ func (self *testSystemBackend) getCommitMessage(view istanbul.View, proposal ist
 		return istanbul.Message{}, err
 	}
 
-	msg := istanbul.NewMessage(&istanbul.CommittedSubject{
+	msg := istanbul.NewCommitMessage(&istanbul.CommittedSubject{
 		Subject:       subject,
 		CommittedSeal: committedSeal[:],
 	}, self.address)
@@ -322,7 +322,7 @@ func (self *testSystemBackend) getCommitMessage(view istanbul.View, proposal ist
 }
 
 func (self *testSystemBackend) getRoundChangeMessage(view istanbul.View, preparedCert istanbul.PreparedCertificate) (istanbul.Message, error) {
-	msg := istanbul.NewMessage(&istanbul.RoundChange{
+	msg := istanbul.NewRoundChangeMessage(&istanbul.RoundChange{
 		View:                &view,
 		PreparedCertificate: preparedCert,
 	}, common.Address{})

--- a/consensus/istanbul/core/types_test.go
+++ b/consensus/istanbul/core/types_test.go
@@ -35,7 +35,7 @@ func testPreprepare(t *testing.T) {
 		},
 		Proposal: makeBlock(1),
 	}
-	m := istanbul.NewMessage(pp, common.HexToAddress("0x1234567890"))
+	m := istanbul.NewPreprepareMessage(pp, common.HexToAddress("0x1234567890"))
 	msgPayload, err := m.Payload()
 	if err != nil {
 		t.Errorf("error mismatch: have %v, want nil", err)
@@ -72,7 +72,7 @@ func testSubject(t *testing.T) {
 		Digest: common.BytesToHash([]byte("1234567890")),
 	}
 
-	m := istanbul.NewMessage(s, common.HexToAddress("0x1234567890"))
+	m := istanbul.NewPrepareMessage(s, common.HexToAddress("0x1234567890"))
 
 	msgPayload, err := m.Payload()
 	if err != nil {
@@ -108,7 +108,7 @@ func testSubjectWithSignature(t *testing.T) {
 	spooferAddress := common.HexToAddress("0x2")
 
 	// 1. Encode test
-	m := istanbul.NewMessage(s, correctAddress)
+	m := istanbul.NewPrepareMessage(s, correctAddress)
 
 	err = m.Sign(signCorrect)
 	require.NoError(t, err)

--- a/consensus/istanbul/core/types_test.go
+++ b/consensus/istanbul/core/types_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
+	"github.com/celo-org/celo-blockchain/crypto"
+	"github.com/stretchr/testify/require"
 )
 
 func testPreprepare(t *testing.T) {
@@ -33,14 +35,7 @@ func testPreprepare(t *testing.T) {
 		},
 		Proposal: makeBlock(1),
 	}
-	prepreparePayload, _ := Encode(pp)
-
-	m := &istanbul.Message{
-		Code:    istanbul.MsgPreprepare,
-		Msg:     prepreparePayload,
-		Address: common.HexToAddress("0x1234567890"),
-	}
-
+	m := istanbul.NewMessage(pp, common.HexToAddress("0x1234567890"))
 	msgPayload, err := m.Payload()
 	if err != nil {
 		t.Errorf("error mismatch: have %v, want nil", err)
@@ -52,12 +47,7 @@ func testPreprepare(t *testing.T) {
 		t.Errorf("error mismatch: have %v, want nil", err)
 	}
 
-	var decodedPP *istanbul.Preprepare
-	err = decodedMsg.Decode(&decodedPP)
-	if err != nil {
-		t.Errorf("error mismatch: have %v, want nil", err)
-	}
-
+	decodedPP := decodedMsg.Preprepare()
 	// if block is encoded/decoded by rlp, we cannot to compare interface data type using reflect.DeepEqual. (like istanbul.Proposal)
 	// so individual comparison here.
 	if !reflect.DeepEqual(pp.Proposal.Hash(), decodedPP.Proposal.Hash()) {
@@ -82,13 +72,7 @@ func testSubject(t *testing.T) {
 		Digest: common.BytesToHash([]byte("1234567890")),
 	}
 
-	subjectPayload, _ := Encode(s)
-
-	m := &istanbul.Message{
-		Code:    istanbul.MsgPreprepare,
-		Msg:     subjectPayload,
-		Address: common.HexToAddress("0x1234567890"),
-	}
+	m := istanbul.NewMessage(s, common.HexToAddress("0x1234567890"))
 
 	msgPayload, err := m.Payload()
 	if err != nil {
@@ -101,14 +85,8 @@ func testSubject(t *testing.T) {
 		t.Errorf("error mismatch: have %v, want nil", err)
 	}
 
-	var decodedSub *istanbul.Subject
-	err = decodedMsg.Decode(&decodedSub)
-	if err != nil {
-		t.Errorf("error mismatch: have %v, want nil", err)
-	}
-
-	if !reflect.DeepEqual(s, decodedSub) {
-		t.Errorf("subject mismatch: have %v, want %v", decodedSub, s)
+	if !reflect.DeepEqual(s, decodedMsg.Prepare()) {
+		t.Errorf("subject mismatch: have %v, want %v", decodedMsg.Prepare(), s)
 	}
 }
 
@@ -120,20 +98,20 @@ func testSubjectWithSignature(t *testing.T) {
 		},
 		Digest: common.BytesToHash([]byte("1234567890")),
 	}
-	expectedSig := []byte{0x01}
-
-	correctAddress := common.HexToAddress("0x1")
-	spooferAddress := common.HexToAddress("0x2")
-
-	subjectPayload, _ := Encode(s)
-	// 1. Encode test
-	m := &istanbul.Message{
-		Code:      istanbul.MsgPreprepare,
-		Msg:       subjectPayload,
-		Address:   correctAddress,
-		Signature: expectedSig,
+	correctKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	correctAddress := crypto.PubkeyToAddress(correctKey.PublicKey)
+	signCorrect := func(data []byte) ([]byte, error) {
+		return crypto.Sign(crypto.Keccak256(data), correctKey)
 	}
 
+	spooferAddress := common.HexToAddress("0x2")
+
+	// 1. Encode test
+	m := istanbul.NewMessage(s, correctAddress)
+
+	err = m.Sign(signCorrect)
+	require.NoError(t, err)
 	msgPayload, err := m.Payload()
 	if err != nil {
 		t.Errorf("error mismatch: have %v, want nil", err)

--- a/consensus/istanbul/proxy/forward_message.go
+++ b/consensus/istanbul/proxy/forward_message.go
@@ -32,7 +32,7 @@ func (pv *proxiedValidatorEngine) sendForwardMsg(ps *proxySet, destAddresses []c
 		if proxy.IsPeered() {
 
 			// Convert the message to a fwdMessage
-			msg := istanbul.NewMessage(&istanbul.ForwardMessage{
+			msg := istanbul.NewForwardMessage(&istanbul.ForwardMessage{
 				Code:          ethMsgCode,
 				DestAddresses: destAddresses,
 				Msg:           payload,

--- a/consensus/istanbul/proxy/proxy_engine_test.go
+++ b/consensus/istanbul/proxy/proxy_engine_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/celo-org/celo-blockchain/consensus/istanbul/backend/backendtest"
 	"github.com/celo-org/celo-blockchain/crypto"
 	"github.com/celo-org/celo-blockchain/p2p"
-	"github.com/celo-org/celo-blockchain/rlp"
+	"github.com/davecgh/go-spew/spew"
 )
 
 func TestHandleValEnodeShare(t *testing.T) {
@@ -109,6 +109,9 @@ func TestHandleValEnodeShare(t *testing.T) {
 	}
 
 	expectedVetEntry := istanbul.AddressEntry{Address: val1BE.Address(), Node: val1BE.SelfNode()}
+	spew.Dump(expectedVetEntry)
+	spew.Dump(vetEntries)
+	spew.Dump(val1BE.Address())
 	if vetEntries[val1BE.Address()].Address != expectedVetEntry.Address || vetEntries[val1BE.Address()].Node.URLv4() != expectedVetEntry.Node.URLv4() {
 		t.Errorf("Proxy has incorrect val enode table entry.  Want: %v, Have: %v", expectedVetEntry, vetEntries[val1BE.Address()])
 	}
@@ -184,19 +187,10 @@ func testEnodeCertFromRemoteVal(t *testing.T, valBE BackendForProxiedValidatorEn
 }
 
 func testEnodeCertFromUnelectedRemoteVal(t *testing.T, unelectedValBE BackendForProxiedValidatorEngine, unelectedValKey *ecdsa.PrivateKey, unelectedValPeer consensus.Peer, proxyBEi backendtest.TestBackendInterface) {
-	unelectedValEC := &istanbul.EnodeCertificate{
+	ecMsg := istanbul.NewMessage(&istanbul.EnodeCertificate{
 		EnodeURL: unelectedValBE.SelfNode().URLv4(),
 		Version:  1,
-	}
-	ecBytes, err := rlp.EncodeToBytes(unelectedValEC)
-	if err != nil {
-		t.Errorf("Error in encoding enode certificate.  Error: %v", err)
-	}
-	ecMsg := &istanbul.Message{
-		Code:    istanbul.EnodeCertificateMsg,
-		Address: unelectedValBE.Address(),
-		Msg:     ecBytes,
-	}
+	}, unelectedValBE.Address())
 	// Sign the message
 	if err := ecMsg.Sign(func(data []byte) ([]byte, error) {
 		return crypto.Sign(crypto.Keccak256(data), unelectedValKey)
@@ -290,23 +284,25 @@ func TestHandleConsensusMsg(t *testing.T) {
 	// Sleep for 5 seconds so that val1BE will generate it's enode certificate.
 	time.Sleep(5 * time.Second)
 
+	subject := &istanbul.Subject{
+		View: &istanbul.View{
+			Round:    common.Big0,
+			Sequence: common.Big0,
+		},
+		Digest: common.Hash{},
+	}
+
 	// Test that the node will forward a consensus message from val within val connection set
-	testConsensusMsgFromRemoteVal(t, val1BE, nodeKeys[1], val1Peer, proxyBEi)
+	testConsensusMsgFromRemoteVal(t, istanbul.NewMessage(subject, val1BE.Address()), val1BE, nodeKeys[1], val1Peer, proxyBEi)
 
 	// Test that the node will not forward a consensus message not within val connetion set
-	testConsensusMsgFromUnelectedRemoteVal(t, unelectedValBE, unelectedValKey, unelectedValPeer, proxyBEi)
+	testConsensusMsgFromUnelectedRemoteVal(t, istanbul.NewMessage(subject, unelectedValBE.Address()), unelectedValBE, unelectedValKey, unelectedValPeer, proxyBEi)
 
 	// Test that the proxy will not handle a consensus message from the proxied validator
-	testConsensusMsgFromProxiedVal(t, val0BE, nodeKeys[0], val0Peer, proxyBEi)
+	testConsensusMsgFromProxiedVal(t, istanbul.NewMessage(subject, val0BE.Address()), val0BE, nodeKeys[0], val0Peer, proxyBEi)
 }
 
-func testConsensusMsgFromRemoteVal(t *testing.T, valBE BackendForProxiedValidatorEngine, valKey *ecdsa.PrivateKey, valPeer consensus.Peer, proxyBEi backendtest.TestBackendInterface) {
-	consMsg := &istanbul.Message{
-		Code:    istanbul.MsgPreprepare,
-		Address: valBE.Address(),
-		Msg:     []byte{},
-	}
-	// Sign the message
+func testConsensusMsgFromRemoteVal(t *testing.T, consMsg *istanbul.Message, valBE BackendForProxiedValidatorEngine, valKey *ecdsa.PrivateKey, valPeer consensus.Peer, proxyBEi backendtest.TestBackendInterface) {
 	if err := consMsg.Sign(func(data []byte) ([]byte, error) {
 		return crypto.Sign(crypto.Keccak256(data), valKey)
 	}); err != nil {
@@ -327,12 +323,7 @@ func testConsensusMsgFromRemoteVal(t *testing.T, valBE BackendForProxiedValidato
 	}
 }
 
-func testConsensusMsgFromUnelectedRemoteVal(t *testing.T, unelectedValBE BackendForProxiedValidatorEngine, unelectedValKey *ecdsa.PrivateKey, unelectedValPeer consensus.Peer, proxyBEi backendtest.TestBackendInterface) {
-	consMsg := &istanbul.Message{
-		Code:    istanbul.MsgPreprepare,
-		Address: unelectedValBE.Address(),
-		Msg:     []byte{},
-	}
+func testConsensusMsgFromUnelectedRemoteVal(t *testing.T, consMsg *istanbul.Message, unelectedValBE BackendForProxiedValidatorEngine, unelectedValKey *ecdsa.PrivateKey, unelectedValPeer consensus.Peer, proxyBEi backendtest.TestBackendInterface) {
 	// Sign the message
 	if err := consMsg.Sign(func(data []byte) ([]byte, error) {
 		return crypto.Sign(crypto.Keccak256(data), unelectedValKey)
@@ -354,12 +345,7 @@ func testConsensusMsgFromUnelectedRemoteVal(t *testing.T, unelectedValBE Backend
 	}
 }
 
-func testConsensusMsgFromProxiedVal(t *testing.T, proxiedValBE BackendForProxiedValidatorEngine, proxiedValKey *ecdsa.PrivateKey, proxiedValPeer consensus.Peer, proxyBEi backendtest.TestBackendInterface) {
-	consMsg := &istanbul.Message{
-		Code:    istanbul.MsgPreprepare,
-		Address: proxiedValBE.Address(),
-		Msg:     []byte{},
-	}
+func testConsensusMsgFromProxiedVal(t *testing.T, consMsg *istanbul.Message, proxiedValBE BackendForProxiedValidatorEngine, proxiedValKey *ecdsa.PrivateKey, proxiedValPeer consensus.Peer, proxyBEi backendtest.TestBackendInterface) {
 	// Sign the message
 	if err := consMsg.Sign(func(data []byte) ([]byte, error) {
 		return crypto.Sign(crypto.Keccak256(data), proxiedValKey)

--- a/consensus/istanbul/proxy/proxy_engine_test.go
+++ b/consensus/istanbul/proxy/proxy_engine_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/celo-org/celo-blockchain/consensus/istanbul/backend/backendtest"
 	"github.com/celo-org/celo-blockchain/crypto"
 	"github.com/celo-org/celo-blockchain/p2p"
-	"github.com/davecgh/go-spew/spew"
 )
 
 func TestHandleValEnodeShare(t *testing.T) {
@@ -109,9 +108,6 @@ func TestHandleValEnodeShare(t *testing.T) {
 	}
 
 	expectedVetEntry := istanbul.AddressEntry{Address: val1BE.Address(), Node: val1BE.SelfNode()}
-	spew.Dump(expectedVetEntry)
-	spew.Dump(vetEntries)
-	spew.Dump(val1BE.Address())
 	if vetEntries[val1BE.Address()].Address != expectedVetEntry.Address || vetEntries[val1BE.Address()].Node.URLv4() != expectedVetEntry.Node.URLv4() {
 		t.Errorf("Proxy has incorrect val enode table entry.  Want: %v, Have: %v", expectedVetEntry, vetEntries[val1BE.Address()])
 	}

--- a/consensus/istanbul/proxy/proxy_engine_test.go
+++ b/consensus/istanbul/proxy/proxy_engine_test.go
@@ -187,7 +187,7 @@ func testEnodeCertFromRemoteVal(t *testing.T, valBE BackendForProxiedValidatorEn
 }
 
 func testEnodeCertFromUnelectedRemoteVal(t *testing.T, unelectedValBE BackendForProxiedValidatorEngine, unelectedValKey *ecdsa.PrivateKey, unelectedValPeer consensus.Peer, proxyBEi backendtest.TestBackendInterface) {
-	ecMsg := istanbul.NewMessage(&istanbul.EnodeCertificate{
+	ecMsg := istanbul.NewEnodeCeritifcateMessage(&istanbul.EnodeCertificate{
 		EnodeURL: unelectedValBE.SelfNode().URLv4(),
 		Version:  1,
 	}, unelectedValBE.Address())
@@ -293,13 +293,13 @@ func TestHandleConsensusMsg(t *testing.T) {
 	}
 
 	// Test that the node will forward a consensus message from val within val connection set
-	testConsensusMsgFromRemoteVal(t, istanbul.NewMessage(subject, val1BE.Address()), val1BE, nodeKeys[1], val1Peer, proxyBEi)
+	testConsensusMsgFromRemoteVal(t, istanbul.NewPrepareMessage(subject, val1BE.Address()), val1BE, nodeKeys[1], val1Peer, proxyBEi)
 
 	// Test that the node will not forward a consensus message not within val connetion set
-	testConsensusMsgFromUnelectedRemoteVal(t, istanbul.NewMessage(subject, unelectedValBE.Address()), unelectedValBE, unelectedValKey, unelectedValPeer, proxyBEi)
+	testConsensusMsgFromUnelectedRemoteVal(t, istanbul.NewPrepareMessage(subject, unelectedValBE.Address()), unelectedValBE, unelectedValKey, unelectedValPeer, proxyBEi)
 
 	// Test that the proxy will not handle a consensus message from the proxied validator
-	testConsensusMsgFromProxiedVal(t, istanbul.NewMessage(subject, val0BE.Address()), val0BE, nodeKeys[0], val0Peer, proxyBEi)
+	testConsensusMsgFromProxiedVal(t, istanbul.NewPrepareMessage(subject, val0BE.Address()), val0BE, nodeKeys[0], val0Peer, proxyBEi)
 }
 
 func testConsensusMsgFromRemoteVal(t *testing.T, consMsg *istanbul.Message, valBE BackendForProxiedValidatorEngine, valKey *ecdsa.PrivateKey, valPeer consensus.Peer, proxyBEi backendtest.TestBackendInterface) {

--- a/consensus/istanbul/proxy/types.go
+++ b/consensus/istanbul/proxy/types.go
@@ -19,14 +19,12 @@ package proxy
 import (
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/consensus"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/p2p/enode"
-	"github.com/celo-org/celo-blockchain/rlp"
 )
 
 var (
@@ -182,52 +180,4 @@ type ProxiedValidatorInfo struct {
 	Address  common.Address `json:"address"`
 	IsPeered bool           `json:"isPeered"`
 	Node     *enode.Node    `json:"enodeURL"`
-}
-
-// ==============================================
-//
-// define the validator enode share message
-
-type sharedValidatorEnode struct {
-	Address  common.Address
-	EnodeURL string
-	Version  uint
-}
-
-type valEnodesShareData struct {
-	ValEnodes []sharedValidatorEnode
-}
-
-func (sve *sharedValidatorEnode) String() string {
-	return fmt.Sprintf("{Address: %s, EnodeURL: %v, Version: %v}", sve.Address.Hex(), sve.EnodeURL, sve.Version)
-}
-
-func (sd *valEnodesShareData) String() string {
-	outputStr := "{ValEnodes:"
-	for _, valEnode := range sd.ValEnodes {
-		outputStr = fmt.Sprintf("%s %s", outputStr, valEnode.String())
-	}
-	return fmt.Sprintf("%s}", outputStr)
-}
-
-// ==============================================
-//
-// define the functions that needs to be provided for rlp Encoder/Decoder.
-
-// EncodeRLP serializes sd into the Ethereum RLP format.
-func (sd *valEnodesShareData) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, []interface{}{sd.ValEnodes})
-}
-
-// DecodeRLP implements rlp.Decoder, and load the sd fields from a RLP stream.
-func (sd *valEnodesShareData) DecodeRLP(s *rlp.Stream) error {
-	var msg struct {
-		ValEnodes []sharedValidatorEnode
-	}
-
-	if err := s.Decode(&msg); err != nil {
-		return err
-	}
-	sd.ValEnodes = msg.ValEnodes
-	return nil
 }

--- a/consensus/istanbul/proxy/val_enodes_share.go
+++ b/consensus/istanbul/proxy/val_enodes_share.go
@@ -51,7 +51,7 @@ func (pv *proxiedValidatorEngine) generateValEnodesShareMsg(remoteValidators []c
 		})
 	}
 
-	msg := istanbul.NewMessage(&istanbul.ValEnodesShareData{
+	msg := istanbul.NewValEnodesShareMessage(&istanbul.ValEnodesShareData{
 		ValEnodes: sharedValidatorEnodes,
 	}, pv.backend.Address())
 

--- a/consensus/istanbul/proxy/val_enodes_share.go
+++ b/consensus/istanbul/proxy/val_enodes_share.go
@@ -39,34 +39,21 @@ func (pv *proxiedValidatorEngine) generateValEnodesShareMsg(remoteValidators []c
 		return nil, err
 	}
 
-	sharedValidatorEnodes := make([]sharedValidatorEnode, 0, len(vetEntries))
+	sharedValidatorEnodes := make([]istanbul.SharedValidatorEnode, 0, len(vetEntries))
 	for address, vetEntry := range vetEntries {
 		if vetEntry.GetNode() == nil {
 			continue
 		}
-		sharedValidatorEnodes = append(sharedValidatorEnodes, sharedValidatorEnode{
+		sharedValidatorEnodes = append(sharedValidatorEnodes, istanbul.SharedValidatorEnode{
 			Address:  address,
 			EnodeURL: vetEntry.GetNode().String(),
 			Version:  vetEntry.GetVersion(),
 		})
 	}
 
-	valEnodesShareData := &valEnodesShareData{
+	msg := istanbul.NewMessage(&istanbul.ValEnodesShareData{
 		ValEnodes: sharedValidatorEnodes,
-	}
-
-	valEnodesShareBytes, err := rlp.EncodeToBytes(valEnodesShareData)
-	if err != nil {
-		logger.Error("Error encoding Istanbul Validator Enodes Share message content", "ValEnodesShareData", valEnodesShareData.String(), "err", err)
-		return nil, err
-	}
-
-	msg := &istanbul.Message{
-		Code:      istanbul.ValEnodesShareMsg,
-		Msg:       valEnodesShareBytes,
-		Address:   pv.backend.Address(),
-		Signature: []byte{},
-	}
+	}, pv.backend.Address())
 
 	// Sign the validator enode share message
 	if err := msg.Sign(pv.backend.Sign); err != nil {
@@ -74,7 +61,7 @@ func (pv *proxiedValidatorEngine) generateValEnodesShareMsg(remoteValidators []c
 		return nil, err
 	}
 
-	logger.Trace("Generated a Istanbul Validator Enodes Share message", "IstanbulMsg", msg.String(), "ValEnodesShareData", valEnodesShareData.String())
+	logger.Trace("Generated a Istanbul Validator Enodes Share message", "IstanbulMsg", msg.String(), "istanbul.ValEnodesShareData", msg.ValEnodesShareData().String())
 
 	return msg, nil
 }
@@ -140,7 +127,7 @@ func (p *proxyEngine) handleValEnodesShareMsg(peer consensus.Peer, payload []byt
 		return true, errUnauthorizedMessageFromProxiedValidator
 	}
 
-	var valEnodesShareData valEnodesShareData
+	var valEnodesShareData istanbul.ValEnodesShareData
 	err = rlp.DecodeBytes(msg.Msg, &valEnodesShareData)
 	if err != nil {
 		logger.Error("Error in decoding received Istanbul Validator Enodes Share message content", "err", err, "IstanbulMsg", msg.String())

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -101,7 +101,7 @@ func dummyBlock(number int64) *types.Block {
 	return types.NewBlock(header, []*types.Transaction{tx}, nil, nil)
 }
 func dummyMessage(code uint64) *Message {
-	msg := NewMessage(dummySubject(), common.HexToAddress("AABB"))
+	msg := NewPrepareMessage(dummySubject(), common.HexToAddress("AABB"))
 	// Set empty rather than nil signature since this is how rlp decodes non
 	// existent slices.
 	msg.Signature = []byte{}

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -101,13 +101,13 @@ func dummyBlock(number int64) *types.Block {
 	return types.NewBlock(header, []*types.Transaction{tx}, nil, nil)
 }
 func dummyMessage(code uint64) *Message {
-	return &Message{
-		Code:      code,
-		Address:   common.HexToAddress("AABB"),
-		Msg:       []byte{10, 20, 42},
-		Signature: []byte{30, 40, 52},
-	}
+	msg := NewMessage(dummySubject(), common.HexToAddress("AABB"))
+	// Set empty rather than nil signature since this is how rlp decodes non
+	// existent slices.
+	msg.Signature = []byte{}
+	return msg
 }
+
 func dummyRoundChangeCertificate() *RoundChangeCertificate {
 	return &RoundChangeCertificate{
 		RoundChangeMessages: []Message{*dummyMessage(42), *dummyMessage(32), *dummyMessage(15)},


### PR DESCRIPTION
### Description

Message decoding and encoding, previously happened in 2 steps. This commit
makes decoding and encoding a message an atomic operation, either it
succeeds or it fails and the full result of decoding is now stored in the message.
It also enforces the mapping between message code and message type, reducing
burden on users who previously had to manage these mappings in multiple places.

This allows us to decode in just one place in the code, allowing us to
have a consistent approach to decode errors. By being able to respond to
decode errors at a higher level in the stack, we remove the need to pass
errors back up the stack to indicate invalid messages. It also helps
separate encoding and decoding logic from our domain logic. By storing
the result of the decoding we avoid repeating the decode operation. Previously
messages going to the backlog would be decoded 3 times, the initial decoding,
then when being stored in the backlog, then again when being processed from
the backlog. Also commit messages would be decoded up to 3 times, the initial
decoding, then once for the bls signature generation then once for the epoch
signature generation.


### Tested

CI is passing

Codecov is failing and I don't understand why, I seem to be rate-limited now,
but when I last checked to report it looked like coverage had dropped in the
eth core package and I haven't touched that. So I would appreciate any help
understanding that.

### Related issues

This PR lays the groundwork for #1434, we needed a way to mark commit messages as verified and this change allows us to cache this information on the commit message.

### Backwards compatibility

This is a mechanical change substituting a 2 step process for a single step process, so backwards compatibility should not have been changed.
