### PR TITLE
Set master version to be ahead of latest release, and add comment about versioning

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -20,9 +20,13 @@ import (
 	"fmt"
 )
 
+// On master, the version should be the UPCOMING one and "unstable"
+// e.g. if the latest release was v1.3.2, master should be 1.4.0-unstable
+// On release branches, it should be a beta or stable.  For example:
+// "1.3.0-beta", "1.3.0-beta.2", etc. and then "1.3.0-stable", "1.3.1-stable", etc.
 const (
 	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 0          // Minor version component of the current release
+	VersionMinor = 4          // Minor version component of the current release
 	VersionPatch = 0          // Patch version component of the current release
 	VersionMeta  = "unstable" // Version metadata to append to the version string
 )


### PR DESCRIPTION
### Description

We have previously been setting versions only on release branches, leaving master permanently at v1.0.0-unstable.  Besides being confusing, this wouldn't work properly if we ever increase the minimum client version on the `BlockchainParameters` contract.

Instead, this PR sets it to v1.4.0-unstable, since the latest stable release was v1.3.2, so the next release branch will be v1.4.x.  It also adds a comment describing how the versioning should go.

### Tested

Verified with `geth version`:

```
❯ geth version
Celo
Version: 1.4.0-unstable
Git Commit: 538d2f885984db4e0aff0bdaab22a562a8ad2d39
Git Commit Date: 20210616
[...]
```

### Related issues

- Fixes #1580

### Backwards compatibility

No incompatibility.