### PR TITLE
Move several sign&address properties from istanbul.Backend to its own type

### DIFF
--- a/cmd/geth/les_test.go
+++ b/cmd/geth/les_test.go
@@ -66,7 +66,7 @@ func startGethWithRpc(t *testing.T, name string, args ...string) *gethrpc {
 	t.Logf("Starting %v with rpc: %v", name, args)
 	g.geth = runGeth(t, args...)
 	// wait before we can attach to it. TODO: probe for it properly
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 	var err error
 	ipcpath := filepath.Join(g.geth.Datadir, "geth.ipc")
 	g.rpc, err = rpc.Dial(ipcpath)

--- a/cmd/geth/les_test.go
+++ b/cmd/geth/les_test.go
@@ -66,7 +66,7 @@ func startGethWithRpc(t *testing.T, name string, args ...string) *gethrpc {
 	t.Logf("Starting %v with rpc: %v", name, args)
 	g.geth = runGeth(t, args...)
 	// wait before we can attach to it. TODO: probe for it properly
-	time.Sleep(2 * time.Second)
+	time.Sleep(1 * time.Second)
 	var err error
 	ipcpath := filepath.Join(g.geth.Datadir, "geth.ipc")
 	g.rpc, err = rpc.Dial(ipcpath)

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -591,16 +591,16 @@ func (sb *Backend) generateQueryEnodeMsg(version uint, enodeQueries []*enodeQuer
 		logger.Error("Error encoding queryEnode content", "QueryEnodeData", queryEnodeData.String(), "err", err)
 		return nil, err
 	}
-	ai := sb.wallets()
+	w := sb.wallets()
 	msg := &istanbul.Message{
 		Code:      istanbul.QueryEnodeMsg,
 		Msg:       queryEnodeBytes,
-		Address:   ai.Ecdsa.Address,
+		Address:   w.Ecdsa.Address,
 		Signature: []byte{},
 	}
 
 	// Sign the announce message
-	if err := msg.Sign(ai.Ecdsa.Sign); err != nil {
+	if err := msg.Sign(w.Ecdsa.Sign); err != nil {
 		logger.Error("Error in signing a QueryEnode Message", "QueryEnodeMsg", msg.String(), "err", err)
 		return nil, err
 	}
@@ -935,13 +935,13 @@ func (vc *versionCertificate) payloadToSign() ([]byte, error) {
 }
 
 func (sb *Backend) generateVersionCertificate(version uint) (*versionCertificate, error) {
-	ai := sb.wallets()
+	w := sb.wallets()
 	vc := &versionCertificate{
-		Address:   ai.Ecdsa.Address,
-		PublicKey: ai.Ecdsa.PublicKey,
+		Address:   w.Ecdsa.Address,
+		PublicKey: w.Ecdsa.PublicKey,
 		Version:   version,
 	}
-	err := vc.Sign(ai.Ecdsa.Sign)
+	err := vc.Sign(w.Ecdsa.Sign)
 	if err != nil {
 		return nil, err
 	}
@@ -1266,7 +1266,7 @@ func (sb *Backend) generateEnodeCertificateMsgs(version uint) (map[enode.ID]*ist
 	if err != nil {
 		return nil, err
 	}
-	ai := sb.wallets()
+	w := sb.wallets()
 	for _, externalNode := range externalEnodes {
 		enodeCertificate := &istanbul.EnodeCertificate{
 			EnodeURL: externalNode.URLv4(),
@@ -1278,11 +1278,11 @@ func (sb *Backend) generateEnodeCertificateMsgs(version uint) (map[enode.ID]*ist
 		}
 		msg := &istanbul.Message{
 			Code:    istanbul.EnodeCertificateMsg,
-			Address: ai.Ecdsa.Address,
+			Address: w.Ecdsa.Address,
 			Msg:     enodeCertificateBytes,
 		}
 		// Sign the message
-		if err := msg.Sign(ai.Ecdsa.Sign); err != nil {
+		if err := msg.Sign(w.Ecdsa.Sign); err != nil {
 			return nil, err
 		}
 

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -591,7 +591,7 @@ func (sb *Backend) generateQueryEnodeMsg(version uint, enodeQueries []*enodeQuer
 		logger.Error("Error encoding queryEnode content", "QueryEnodeData", queryEnodeData.String(), "err", err)
 		return nil, err
 	}
-	ai := sb.auth()
+	ai := sb.wallets()
 	msg := &istanbul.Message{
 		Code:      istanbul.QueryEnodeMsg,
 		Msg:       queryEnodeBytes,
@@ -700,7 +700,7 @@ func (sb *Backend) handleQueryEnodeMsg(addr common.Address, peer consensus.Peer,
 			if encEnodeURL.DestAddress != sb.Address() {
 				continue
 			}
-			enodeBytes, err := sb.auth().Ecdsa.Decrypt(accounts.Account{Address: sb.Address()}, encEnodeURL.EncryptedEnodeURL, nil, nil)
+			enodeBytes, err := sb.wallets().Ecdsa.Decrypt(accounts.Account{Address: sb.Address()}, encEnodeURL.EncryptedEnodeURL, nil, nil)
 			if err != nil {
 				sb.logger.Warn("Error decrypting endpoint", "err", err, "encEnodeURL.EncryptedEnodeURL", encEnodeURL.EncryptedEnodeURL)
 				return err
@@ -935,7 +935,7 @@ func (vc *versionCertificate) payloadToSign() ([]byte, error) {
 }
 
 func (sb *Backend) generateVersionCertificate(version uint) (*versionCertificate, error) {
-	ai := sb.auth()
+	ai := sb.wallets()
 	vc := &versionCertificate{
 		Address:   ai.Ecdsa.Address,
 		PublicKey: ai.Ecdsa.PublicKey,
@@ -1266,7 +1266,7 @@ func (sb *Backend) generateEnodeCertificateMsgs(version uint) (map[enode.ID]*ist
 	if err != nil {
 		return nil, err
 	}
-	ai := sb.auth()
+	ai := sb.wallets()
 	for _, externalNode := range externalEnodes {
 		enodeCertificate := &istanbul.EnodeCertificate{
 			EnodeURL: externalNode.URLv4(),

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -595,7 +595,7 @@ func (sb *Backend) generateQueryEnodeMsg(version uint, enodeQueries []*enodeQuer
 	msg := &istanbul.Message{
 		Code:      istanbul.QueryEnodeMsg,
 		Msg:       queryEnodeBytes,
-		Address:   ai.Address,
+		Address:   ai.Ecdsa.Address,
 		Signature: []byte{},
 	}
 
@@ -700,7 +700,7 @@ func (sb *Backend) handleQueryEnodeMsg(addr common.Address, peer consensus.Peer,
 			if encEnodeURL.DestAddress != sb.Address() {
 				continue
 			}
-			enodeBytes, err := sb.auth().DecryptFn(accounts.Account{Address: sb.Address()}, encEnodeURL.EncryptedEnodeURL, nil, nil)
+			enodeBytes, err := sb.auth().Ecdsa.Decrypt(accounts.Account{Address: sb.Address()}, encEnodeURL.EncryptedEnodeURL, nil, nil)
 			if err != nil {
 				sb.logger.Warn("Error decrypting endpoint", "err", err, "encEnodeURL.EncryptedEnodeURL", encEnodeURL.EncryptedEnodeURL)
 				return err
@@ -937,8 +937,8 @@ func (vc *versionCertificate) payloadToSign() ([]byte, error) {
 func (sb *Backend) generateVersionCertificate(version uint) (*versionCertificate, error) {
 	ai := sb.auth()
 	vc := &versionCertificate{
-		Address:   ai.Address,
-		PublicKey: ai.PublicKey,
+		Address:   ai.Ecdsa.Address,
+		PublicKey: ai.Ecdsa.PublicKey,
 		Version:   version,
 	}
 	err := vc.Sign(nilCheckSignFn(ai))
@@ -1278,7 +1278,7 @@ func (sb *Backend) generateEnodeCertificateMsgs(version uint) (map[enode.ID]*ist
 		}
 		msg := &istanbul.Message{
 			Code:    istanbul.EnodeCertificateMsg,
-			Address: ai.Address,
+			Address: ai.Ecdsa.Address,
 			Msg:     enodeCertificateBytes,
 		}
 		// Sign the message

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -600,7 +600,7 @@ func (sb *Backend) generateQueryEnodeMsg(version uint, enodeQueries []*enodeQuer
 	}
 
 	// Sign the announce message
-	if err := msg.Sign(nilCheckSignFn(ai)); err != nil {
+	if err := msg.Sign(ai.Ecdsa.Sign); err != nil {
 		logger.Error("Error in signing a QueryEnode Message", "QueryEnodeMsg", msg.String(), "err", err)
 		return nil, err
 	}
@@ -941,7 +941,7 @@ func (sb *Backend) generateVersionCertificate(version uint) (*versionCertificate
 		PublicKey: ai.Ecdsa.PublicKey,
 		Version:   version,
 	}
-	err := vc.Sign(nilCheckSignFn(ai))
+	err := vc.Sign(ai.Ecdsa.Sign)
 	if err != nil {
 		return nil, err
 	}
@@ -1282,7 +1282,7 @@ func (sb *Backend) generateEnodeCertificateMsgs(version uint) (map[enode.ID]*ist
 			Msg:     enodeCertificateBytes,
 		}
 		// Sign the message
-		if err := msg.Sign(nilCheckSignFn(ai)); err != nil {
+		if err := msg.Sign(ai.Ecdsa.Sign); err != nil {
 			return nil, err
 		}
 

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -700,7 +700,7 @@ func (sb *Backend) handleQueryEnodeMsg(addr common.Address, peer consensus.Peer,
 			if encEnodeURL.DestAddress != sb.Address() {
 				continue
 			}
-			enodeBytes, err := sb.decryptFn(accounts.Account{Address: sb.Address()}, encEnodeURL.EncryptedEnodeURL, nil, nil)
+			enodeBytes, err := sb.authorizeInfo.Load().(*AuthorizeInfo).DecryptFn(accounts.Account{Address: sb.Address()}, encEnodeURL.EncryptedEnodeURL, nil, nil)
 			if err != nil {
 				sb.logger.Warn("Error decrypting endpoint", "err", err, "encEnodeURL.EncryptedEnodeURL", encEnodeURL.EncryptedEnodeURL)
 				return err
@@ -937,7 +937,7 @@ func (vc *versionCertificate) payloadToSign() ([]byte, error) {
 func (sb *Backend) generateVersionCertificate(version uint) (*versionCertificate, error) {
 	vc := &versionCertificate{
 		Address:   sb.Address(),
-		PublicKey: sb.publicKey,
+		PublicKey: sb.authorizeInfo.Load().(*AuthorizeInfo).PublicKey,
 		Version:   version,
 	}
 	err := vc.Sign(sb.Sign)

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -591,16 +591,16 @@ func (sb *Backend) generateQueryEnodeMsg(version uint, enodeQueries []*enodeQuer
 		logger.Error("Error encoding queryEnode content", "QueryEnodeData", queryEnodeData.String(), "err", err)
 		return nil, err
 	}
-
+	ai := sb.auth()
 	msg := &istanbul.Message{
 		Code:      istanbul.QueryEnodeMsg,
 		Msg:       queryEnodeBytes,
-		Address:   sb.Address(),
+		Address:   ai.Address,
 		Signature: []byte{},
 	}
 
 	// Sign the announce message
-	if err := msg.Sign(sb.Sign); err != nil {
+	if err := msg.Sign(nilCheckSignFn(ai)); err != nil {
 		logger.Error("Error in signing a QueryEnode Message", "QueryEnodeMsg", msg.String(), "err", err)
 		return nil, err
 	}
@@ -941,7 +941,7 @@ func (sb *Backend) generateVersionCertificate(version uint) (*versionCertificate
 		PublicKey: ai.PublicKey,
 		Version:   version,
 	}
-	err := vc.Sign(sb.Sign)
+	err := vc.Sign(nilCheckSignFn(ai))
 	if err != nil {
 		return nil, err
 	}
@@ -1266,7 +1266,7 @@ func (sb *Backend) generateEnodeCertificateMsgs(version uint) (map[enode.ID]*ist
 	if err != nil {
 		return nil, err
 	}
-
+	ai := sb.auth()
 	for _, externalNode := range externalEnodes {
 		enodeCertificate := &istanbul.EnodeCertificate{
 			EnodeURL: externalNode.URLv4(),
@@ -1278,11 +1278,11 @@ func (sb *Backend) generateEnodeCertificateMsgs(version uint) (map[enode.ID]*ist
 		}
 		msg := &istanbul.Message{
 			Code:    istanbul.EnodeCertificateMsg,
-			Address: sb.Address(),
+			Address: ai.Address,
 			Msg:     enodeCertificateBytes,
 		}
 		// Sign the message
-		if err := msg.Sign(sb.Sign); err != nil {
+		if err := msg.Sign(nilCheckSignFn(ai)); err != nil {
 			return nil, err
 		}
 

--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -700,7 +700,7 @@ func (sb *Backend) handleQueryEnodeMsg(addr common.Address, peer consensus.Peer,
 			if encEnodeURL.DestAddress != sb.Address() {
 				continue
 			}
-			enodeBytes, err := sb.authorizeInfo.Load().(*AuthorizeInfo).DecryptFn(accounts.Account{Address: sb.Address()}, encEnodeURL.EncryptedEnodeURL, nil, nil)
+			enodeBytes, err := sb.auth().DecryptFn(accounts.Account{Address: sb.Address()}, encEnodeURL.EncryptedEnodeURL, nil, nil)
 			if err != nil {
 				sb.logger.Warn("Error decrypting endpoint", "err", err, "encEnodeURL.EncryptedEnodeURL", encEnodeURL.EncryptedEnodeURL)
 				return err
@@ -935,9 +935,10 @@ func (vc *versionCertificate) payloadToSign() ([]byte, error) {
 }
 
 func (sb *Backend) generateVersionCertificate(version uint) (*versionCertificate, error) {
+	ai := sb.auth()
 	vc := &versionCertificate{
-		Address:   sb.Address(),
-		PublicKey: sb.authorizeInfo.Load().(*AuthorizeInfo).PublicKey,
+		Address:   ai.Address,
+		PublicKey: ai.PublicKey,
 		Version:   version,
 	}
 	err := vc.Sign(sb.Sign)

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -385,9 +385,13 @@ func (sb *Backend) Authorize(ecdsaAddress, blsAddress common.Address, publicKey 
 	sb.core.SetAddress(ecdsaAddress)
 }
 
+func (sb *Backend) auth() *AuthorizeInfo {
+	return sb.authorizeInfo.Load().(*AuthorizeInfo)
+}
+
 // Address implements istanbul.Backend.Address
 func (sb *Backend) Address() common.Address {
-	return sb.authorizeInfo.Load().(*AuthorizeInfo).Address
+	return sb.auth().Address
 }
 
 // SelfNode returns the owner's node (if this is a proxy, it will return the external node)
@@ -656,7 +660,7 @@ func (sb *Backend) verifyValSetDiff(proposal istanbul.Proposal, block *types.Blo
 
 // Sign implements istanbul.Backend.Sign
 func (sb *Backend) Sign(data []byte) ([]byte, error) {
-	ai := sb.authorizeInfo.Load().(*AuthorizeInfo)
+	ai := sb.auth()
 	if ai.SignFn == nil {
 		return nil, errInvalidSigningFn
 	}
@@ -665,7 +669,7 @@ func (sb *Backend) Sign(data []byte) ([]byte, error) {
 
 // Sign implements istanbul.Backend.SignBLS
 func (sb *Backend) SignBLS(data []byte, extra []byte, useComposite, cip22 bool) (blscrypto.SerializedSignature, error) {
-	ai := sb.authorizeInfo.Load().(*AuthorizeInfo)
+	ai := sb.auth()
 	if ai.SignBLSFn == nil {
 		return blscrypto.SerializedSignature{}, errInvalidSigningFn
 	}

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -660,11 +660,18 @@ func (sb *Backend) verifyValSetDiff(proposal istanbul.Proposal, block *types.Blo
 
 // Sign implements istanbul.Backend.Sign
 func (sb *Backend) Sign(data []byte) ([]byte, error) {
-	ai := sb.auth()
-	if ai.SignFn == nil {
-		return nil, errInvalidSigningFn
+	fn := nilCheckSignFn(sb.auth())
+	return fn(data)
+}
+
+// nilCheckSignFn wraps the AuthorizeInfo.SignFn with a nil check
+func nilCheckSignFn(ai *AuthorizeInfo) func(data []byte) ([]byte, error) {
+	return func(data []byte) ([]byte, error) {
+		if ai.SignFn == nil {
+			return nil, errInvalidSigningFn
+		}
+		return ai.SignFn(accounts.Account{Address: ai.Address}, accounts.MimetypeIstanbul, data)
 	}
-	return ai.SignFn(accounts.Account{Address: ai.Address}, accounts.MimetypeIstanbul, data)
 }
 
 // Sign implements istanbul.Backend.SignBLS

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -413,11 +413,11 @@ func (sb *Backend) Authorize(ecdsaAddress, blsAddress common.Address, publicKey 
 		sign:      signFn,
 		signHash:  signHashFn,
 	}
-	ai := &Wallets{
+	w := &Wallets{
 		Ecdsa: ecdsa,
 		Bls:   bls,
 	}
-	sb.aWallets.Store(ai)
+	sb.aWallets.Store(w)
 	sb.core.SetAddress(ecdsaAddress)
 }
 
@@ -701,8 +701,8 @@ func (sb *Backend) Sign(data []byte) ([]byte, error) {
 
 // Sign implements istanbul.Backend.SignBLS
 func (sb *Backend) SignBLS(data []byte, extra []byte, useComposite, cip22 bool) (blscrypto.SerializedSignature, error) {
-	ai := sb.wallets()
-	return ai.Bls.Sign(data, extra, useComposite, cip22)
+	w := sb.wallets()
+	return w.Bls.Sign(data, extra, useComposite, cip22)
 }
 
 // CheckSignature implements istanbul.Backend.CheckSignature

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -524,7 +524,7 @@ func (sb *Backend) checkIsValidSigner(chain consensus.ChainHeaderReader, header 
 		return err
 	}
 
-	_, v := snap.ValSet.GetByAddress(sb.address)
+	_, v := snap.ValSet.GetByAddress(sb.authorizeInfo.Load().(*AuthorizeInfo).Address)
 	if v == nil {
 		return errUnauthorized
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -524,7 +524,7 @@ func (sb *Backend) checkIsValidSigner(chain consensus.ChainHeaderReader, header 
 		return err
 	}
 
-	_, v := snap.ValSet.GetByAddress(sb.auth().Address)
+	_, v := snap.ValSet.GetByAddress(sb.auth().Ecdsa.Address)
 	if v == nil {
 		return errUnauthorized
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -524,7 +524,7 @@ func (sb *Backend) checkIsValidSigner(chain consensus.ChainHeaderReader, header 
 		return err
 	}
 
-	_, v := snap.ValSet.GetByAddress(sb.auth().Ecdsa.Address)
+	_, v := snap.ValSet.GetByAddress(sb.wallets().Ecdsa.Address)
 	if v == nil {
 		return errUnauthorized
 	}

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -524,7 +524,7 @@ func (sb *Backend) checkIsValidSigner(chain consensus.ChainHeaderReader, header 
 		return err
 	}
 
-	_, v := snap.ValSet.GetByAddress(sb.authorizeInfo.Load().(*AuthorizeInfo).Address)
+	_, v := snap.ValSet.GetByAddress(sb.auth().Address)
 	if v == nil {
 		return errUnauthorized
 	}

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -207,7 +207,7 @@ func TestReadValidatorHandshakeMessage(t *testing.T) {
 	block := backend.currentBlock()
 	valSet := backend.getValidators(block.Number().Uint64(), block.Hash())
 	// set backend to a different validator
-	backend.address = valSet.GetByIndex(1).Address()
+	backend.authorizeInfo.Load().(*AuthorizeInfo).Address = valSet.GetByIndex(1).Address()
 
 	isValidator, err = backend.readValidatorHandshakeMessage(peer)
 	if err != nil {

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -207,7 +207,7 @@ func TestReadValidatorHandshakeMessage(t *testing.T) {
 	block := backend.currentBlock()
 	valSet := backend.getValidators(block.Number().Uint64(), block.Hash())
 	// set backend to a different validator
-	backend.auth().Ecdsa.Address = valSet.GetByIndex(1).Address()
+	backend.wallets().Ecdsa.Address = valSet.GetByIndex(1).Address()
 
 	isValidator, err = backend.readValidatorHandshakeMessage(peer)
 	if err != nil {

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -207,7 +207,7 @@ func TestReadValidatorHandshakeMessage(t *testing.T) {
 	block := backend.currentBlock()
 	valSet := backend.getValidators(block.Number().Uint64(), block.Hash())
 	// set backend to a different validator
-	backend.authorizeInfo.Load().(*AuthorizeInfo).Address = valSet.GetByIndex(1).Address()
+	backend.auth().Address = valSet.GetByIndex(1).Address()
 
 	isValidator, err = backend.readValidatorHandshakeMessage(peer)
 	if err != nil {

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -207,7 +207,7 @@ func TestReadValidatorHandshakeMessage(t *testing.T) {
 	block := backend.currentBlock()
 	valSet := backend.getValidators(block.Number().Uint64(), block.Hash())
 	// set backend to a different validator
-	backend.auth().Address = valSet.GetByIndex(1).Address()
+	backend.auth().Ecdsa.Address = valSet.GetByIndex(1).Address()
 
 	isValidator, err = backend.readValidatorHandshakeMessage(peer)
 	if err != nil {

--- a/consensus/istanbul/backend/random.go
+++ b/consensus/istanbul/backend/random.go
@@ -43,7 +43,7 @@ func (sb *Backend) GenerateRandomness(parentHash common.Hash) (common.Hash, comm
 	sb.randomSeedMu.Lock()
 	if sb.randomSeed == nil {
 		var err error
-		ai := sb.authorizeInfo.Load().(*AuthorizeInfo)
+		ai := sb.auth()
 		sb.randomSeed, err = ai.SignHashFn(accounts.Account{Address: ai.Address}, common.BytesToHash(randomSeedString).Bytes())
 		if err != nil {
 			logger.Error("Failed to create randomSeed", "err", err)

--- a/consensus/istanbul/backend/random.go
+++ b/consensus/istanbul/backend/random.go
@@ -42,7 +42,7 @@ func (sb *Backend) GenerateRandomness(parentHash common.Hash) (common.Hash, comm
 	sb.randomSeedMu.Lock()
 	if sb.randomSeed == nil {
 		var err error
-		ai := sb.auth()
+		ai := sb.wallets()
 		sb.randomSeed, err = ai.Ecdsa.SignHash(common.BytesToHash(randomSeedString))
 		if err != nil {
 			logger.Error("Failed to create randomSeed", "err", err)

--- a/consensus/istanbul/backend/random.go
+++ b/consensus/istanbul/backend/random.go
@@ -42,8 +42,8 @@ func (sb *Backend) GenerateRandomness(parentHash common.Hash) (common.Hash, comm
 	sb.randomSeedMu.Lock()
 	if sb.randomSeed == nil {
 		var err error
-		ai := sb.wallets()
-		sb.randomSeed, err = ai.Ecdsa.SignHash(common.BytesToHash(randomSeedString))
+		w := sb.wallets()
+		sb.randomSeed, err = w.Ecdsa.SignHash(common.BytesToHash(randomSeedString))
 		if err != nil {
 			logger.Error("Failed to create randomSeed", "err", err)
 			sb.randomSeedMu.Unlock()

--- a/consensus/istanbul/backend/random.go
+++ b/consensus/istanbul/backend/random.go
@@ -17,7 +17,6 @@
 package backend
 
 import (
-	"github.com/celo-org/celo-blockchain/accounts"
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/contracts/random"
 	"github.com/celo-org/celo-blockchain/crypto"
@@ -44,7 +43,7 @@ func (sb *Backend) GenerateRandomness(parentHash common.Hash) (common.Hash, comm
 	if sb.randomSeed == nil {
 		var err error
 		ai := sb.auth()
-		sb.randomSeed, err = ai.Ecdsa.SignHash(accounts.Account{Address: ai.Ecdsa.Address}, common.BytesToHash(randomSeedString).Bytes())
+		sb.randomSeed, err = ai.Ecdsa.SignHash(common.BytesToHash(randomSeedString))
 		if err != nil {
 			logger.Error("Failed to create randomSeed", "err", err)
 			sb.randomSeedMu.Unlock()

--- a/consensus/istanbul/backend/random.go
+++ b/consensus/istanbul/backend/random.go
@@ -44,7 +44,7 @@ func (sb *Backend) GenerateRandomness(parentHash common.Hash) (common.Hash, comm
 	if sb.randomSeed == nil {
 		var err error
 		ai := sb.auth()
-		sb.randomSeed, err = ai.SignHashFn(accounts.Account{Address: ai.Address}, common.BytesToHash(randomSeedString).Bytes())
+		sb.randomSeed, err = ai.Ecdsa.SignHash(accounts.Account{Address: ai.Ecdsa.Address}, common.BytesToHash(randomSeedString).Bytes())
 		if err != nil {
 			logger.Error("Failed to create randomSeed", "err", err)
 			sb.randomSeedMu.Unlock()

--- a/consensus/istanbul/backend/random.go
+++ b/consensus/istanbul/backend/random.go
@@ -43,7 +43,8 @@ func (sb *Backend) GenerateRandomness(parentHash common.Hash) (common.Hash, comm
 	sb.randomSeedMu.Lock()
 	if sb.randomSeed == nil {
 		var err error
-		sb.randomSeed, err = sb.signHashFn(accounts.Account{Address: sb.address}, common.BytesToHash(randomSeedString).Bytes())
+		ai := sb.authorizeInfo.Load().(*AuthorizeInfo)
+		sb.randomSeed, err = ai.SignHashFn(accounts.Account{Address: ai.Address}, common.BytesToHash(randomSeedString).Bytes())
 		if err != nil {
 			logger.Error("Failed to create randomSeed", "err", err)
 			sb.randomSeedMu.Unlock()

--- a/consensus/istanbul/backend/test_utils.go
+++ b/consensus/istanbul/backend/test_utils.go
@@ -217,7 +217,7 @@ func makeBlock(keys []*ecdsa.PrivateKey, chain *core.BlockChain, engine *Backend
 func makeBlockWithoutSeal(chain *core.BlockChain, engine *Backend, parent *types.Block) *types.Block {
 	header := makeHeader(parent, engine.config)
 	// The worker that calls Prepare is the one filling the Coinbase
-	header.Coinbase = engine.address
+	header.Coinbase = engine.authorizeInfo.Load().(*AuthorizeInfo).Address
 	engine.Prepare(chain, header)
 	time.Sleep(time.Until(time.Unix(int64(header.Time), 0)))
 

--- a/consensus/istanbul/backend/test_utils.go
+++ b/consensus/istanbul/backend/test_utils.go
@@ -217,7 +217,7 @@ func makeBlock(keys []*ecdsa.PrivateKey, chain *core.BlockChain, engine *Backend
 func makeBlockWithoutSeal(chain *core.BlockChain, engine *Backend, parent *types.Block) *types.Block {
 	header := makeHeader(parent, engine.config)
 	// The worker that calls Prepare is the one filling the Coinbase
-	header.Coinbase = engine.auth().Ecdsa.Address
+	header.Coinbase = engine.wallets().Ecdsa.Address
 	engine.Prepare(chain, header)
 	time.Sleep(time.Until(time.Unix(int64(header.Time), 0)))
 

--- a/consensus/istanbul/backend/test_utils.go
+++ b/consensus/istanbul/backend/test_utils.go
@@ -217,7 +217,7 @@ func makeBlock(keys []*ecdsa.PrivateKey, chain *core.BlockChain, engine *Backend
 func makeBlockWithoutSeal(chain *core.BlockChain, engine *Backend, parent *types.Block) *types.Block {
 	header := makeHeader(parent, engine.config)
 	// The worker that calls Prepare is the one filling the Coinbase
-	header.Coinbase = engine.auth().Address
+	header.Coinbase = engine.auth().Ecdsa.Address
 	engine.Prepare(chain, header)
 	time.Sleep(time.Until(time.Unix(int64(header.Time), 0)))
 

--- a/consensus/istanbul/backend/test_utils.go
+++ b/consensus/istanbul/backend/test_utils.go
@@ -217,7 +217,7 @@ func makeBlock(keys []*ecdsa.PrivateKey, chain *core.BlockChain, engine *Backend
 func makeBlockWithoutSeal(chain *core.BlockChain, engine *Backend, parent *types.Block) *types.Block {
 	header := makeHeader(parent, engine.config)
 	// The worker that calls Prepare is the one filling the Coinbase
-	header.Coinbase = engine.authorizeInfo.Load().(*AuthorizeInfo).Address
+	header.Coinbase = engine.auth().Address
 	engine.Prepare(chain, header)
 	time.Sleep(time.Until(time.Unix(int64(header.Time), 0)))
 


### PR DESCRIPTION
Properties received in the `Authorize(...)` method of `istanbul.Backend` are guarded by a lock to avoid race conditions during  the setting of the values (golang reference assigmnent is not guaranteed to be atomic I believe).

I moved all of those into a type `AuthorizeInfo` and used an `atomic.Value` to be able to remove the lock. The `decryptFn` was not being guarded by the lock, as many other `address` fields, in what I believe it was a possible race condition bug during assignment and check. It's probably the case that it would have never been triggered in real world use though.

I also incremented a sleep in an unrelated test since the wait period for a geth instance to start was too low and it was making the test a bit flaky.