### PR TITLE
Fix race

### DIFF
--- a/consensus/istanbul/backend/backend_test.go
+++ b/consensus/istanbul/backend/backend_test.go
@@ -161,7 +161,7 @@ func TestGetProposer(t *testing.T) {
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)
 	chain, engine, _ := newBlockChainWithKeys(false, common.Address{}, false, genesisCfg, nodeKeys[0])
 	defer chain.Stop()
-	if _, err := makeBlock(nodeKeys, chain, engine, chain.Genesis()); err != nil {
+	if _, err := makeBlock(chain, engine, chain.Genesis()); err != nil {
 		t.Errorf("Failed to make a block: %v", err)
 	}
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -716,10 +716,10 @@ func (sb *Backend) StartAnnouncing() error {
 		return istanbul.ErrStartedAnnounce
 	}
 
-	go sb.announceThread()
-
 	sb.announceThreadQuit = make(chan struct{})
 	sb.announceRunning = true
+
+	go sb.announceThread()
 
 	if err := sb.vph.startThread(); err != nil {
 		sb.StopAnnouncing()

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -61,7 +61,6 @@ func TestMakeBlockWithSignature(t *testing.T) {
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)
 	chain, engine, _ := newBlockChainWithKeys(false, common.Address{}, false, genesisCfg, nodeKeys[0])
 
-	//defer stopEngine(engine)
 	defer chain.Stop()
 	genesis := chain.Genesis()
 

--- a/consensus/istanbul/backend/engine_test.go
+++ b/consensus/istanbul/backend/engine_test.go
@@ -61,18 +61,22 @@ func TestMakeBlockWithSignature(t *testing.T) {
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)
 	chain, engine, _ := newBlockChainWithKeys(false, common.Address{}, false, genesisCfg, nodeKeys[0])
 
-	defer stopEngine(engine)
+	//defer stopEngine(engine)
 	defer chain.Stop()
 	genesis := chain.Genesis()
 
-	block, err := makeBlock(nodeKeys, chain, engine, genesis)
+	block, err := makeBlock(chain, engine, genesis)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	block2, err := makeBlock(nodeKeys, chain, engine, block)
+	block2, err := makeBlock(chain, engine, block)
 	g.Expect(err).ToNot(HaveOccurred())
 
-	_, err = makeBlock(nodeKeys, chain, engine, block2)
+	_, err = makeBlock(chain, engine, block2)
 	g.Expect(err).ToNot(HaveOccurred())
+
+	if err != nil {
+		stopEngine(engine)
+	}
 }
 
 func TestSealCommitted(t *testing.T) {
@@ -158,7 +162,7 @@ func TestVerifySeal(t *testing.T) {
 	g.Expect(err).Should(BeIdenticalTo(errUnknownBlock))
 
 	// should verify
-	block, err := makeBlock(nodeKeys, chain, engine, genesis)
+	block, err := makeBlock(chain, engine, genesis)
 	g.Expect(err).ToNot(HaveOccurred())
 	header := block.Header()
 	err = engine.VerifySeal(header)
@@ -208,9 +212,9 @@ func TestVerifyHeaders(t *testing.T) {
 	for i := 0; i < size; i++ {
 		var b *types.Block
 		if i == 0 {
-			b, _ = makeBlock(nodeKeys, chain, engine, genesis)
+			b, _ = makeBlock(chain, engine, genesis)
 		} else {
-			b, _ = makeBlock(nodeKeys, chain, engine, blocks[i-1])
+			b, _ = makeBlock(chain, engine, blocks[i-1])
 		}
 
 		blocks = append(blocks, b)

--- a/consensus/istanbul/backend/test_utils.go
+++ b/consensus/istanbul/backend/test_utils.go
@@ -186,7 +186,7 @@ func makeHeader(parent *types.Block, config *istanbul.Config) *types.Header {
 	return header
 }
 
-func makeBlock(keys []*ecdsa.PrivateKey, chain *core.BlockChain, engine *Backend, parent *types.Block) (*types.Block, error) {
+func makeBlock(chain *core.BlockChain, engine *Backend, parent *types.Block) (*types.Block, error) {
 	block := makeBlockWithoutSeal(chain, engine, parent)
 
 	// Set up block subscription

--- a/consensus/istanbul/backend/test_utils.go
+++ b/consensus/istanbul/backend/test_utils.go
@@ -83,7 +83,6 @@ func newBlockChainWithKeys(isProxy bool, proxiedValAddress common.Address, isPro
 	)
 	b.SetBroadcaster(&consensustest.MockBroadcaster{})
 	b.SetP2PServer(consensustest.NewMockP2PServer(&publicKey))
-	b.StartAnnouncing()
 
 	if !isProxy {
 		b.SetCallBacks(blockchain.HasBadBlock,
@@ -101,6 +100,7 @@ func newBlockChainWithKeys(isProxy bool, proxiedValAddress common.Address, isPro
 		}
 		b.StartValidating()
 	}
+	b.StartAnnouncing()
 
 	return blockchain, b, &config
 }

--- a/les/lespay/client/valuetracker.go
+++ b/les/lespay/client/valuetracker.go
@@ -481,9 +481,13 @@ func (vt *ValueTracker) Served(nv *NodeValueTracker, reqs []ServedRequest, respT
 	var value float64
 	for _, r := range reqs {
 		nv.basket.add(r.ReqType, r.Amount, nv.reqCosts[r.ReqType]*uint64(r.Amount), expFactor)
+		vt.refBasket.reqValuesLock.RLock()
 		value += (*nv.reqValues)[r.ReqType] * float64(r.Amount)
+		vt.refBasket.reqValuesLock.RUnlock()
 	}
+	vt.statsExpLock.RLock()
 	nv.rtStats.Add(respTime, value, vt.statsExpFactor)
+	vt.statsExpLock.RUnlock()
 }
 
 type RequestStatsItem struct {

--- a/p2p/enode/iter_test.go
+++ b/p2p/enode/iter_test.go
@@ -268,7 +268,7 @@ func (s *genIter) Node() *Node {
 }
 
 func (s *genIter) Close() {
-	s.index = ^uint32(0)
+	atomic.StoreUint32(&s.index, ^uint32(0))
 }
 
 func testNode(id, seq uint64) *Node {

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -559,7 +559,9 @@ func (p *Peer) Info() *PeerInfo {
 		info.Protocols[proto.Name] = protoInfo
 	}
 
+	p.purposesMu.Lock()
 	info.Purposes = p.purposes.String()
+	p.purposesMu.Unlock()
 
 	return info
 }


### PR DESCRIPTION
### Description

Fix races from `go test -race`

consensus/istanbul/backend:
- [x] TestMakeBlockWithSignature

    - [x] announceThreadQuit is read before it's initialized
    - [x] StartAnnouncing should happen after StartValidating
    - [x] Only stopEngine when no err  & signature
- [ ] TestSign
- [ ] TestCheckSignature

-----
- [x] TestFairMixNextFromAll / TestFairMix: Use atomic
- [x] TestServerDial: use mu
- [x] TestValueTracker: add reqValuesLock / add vt.statsExpLock.RLock/RUnlock



### Tested

CI

### Other changes

* removed an unused param from `makeBlock` signature

### Related issues

- Fixes #585 

### Backwards compatibility

Yes, only changed tests
