### PR TITLE
Piersy/update prepare-system-contracts make rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ MONOREPO_COMMIT=celo-core-contracts-v3.rc0
 # We checkout the monorepo as a sibling to the celo-blockchain dir because the
 # huge amount of files in the monorepo interferes with tooling such as gopls,
 # which becomes very slow.
-MONOREPO_PATH=../monorepo
+MONOREPO_PATH=../.celo-blockchain-monorepo-checkout
 
 # This either evaluates to the contract source files if they exist or NOT_FOUND
 # if celo-monorepo has not been checked out yet.

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ MONOREPO_COMMIT=celo-core-contracts-v3.rc0
 export NDK_VERSION ?= android-ndk-r19c
 export ANDROID_NDK ?= $(PWD)/ndk_bundle/$(NDK_VERSION)
 
+geth:
+	$(GORUN) build/ci.go install ./cmd/geth
+	@echo "Done building."
+	@echo "Run \"$(GOBIN)/geth\" to launch geth."
+
 prepare-system-contracts: ./monorepo ./monorepo/packages/protocol/build
 
 # Clone the monorepo
@@ -42,10 +47,6 @@ prepare-system-contracts: ./monorepo ./monorepo/packages/protocol/build
 	@echo Running yarn install and compiling contracts
 	@cd ./monorepo && rm -rf packages/protocol/build && yarn && cd packages/protocol && yarn run build:sol
 
-geth:
-	$(GORUN) build/ci.go install ./cmd/geth
-	@echo "Done building."
-	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
 geth-musl:
 	$(GORUN) build/ci.go install -musl ./cmd/geth

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 .PHONY: geth-linux-arm geth-linux-arm-5 geth-linux-arm-6 geth-linux-arm-7 geth-linux-arm64
 .PHONY: geth-darwin geth-darwin-amd64
 .PHONY: geth-windows geth-windows-386 geth-windows-amd64
-.PHONY: prepare-system-contracts
+.PHONY: prepare-system-contracts ./monorepo
 
 GOBIN = ./build/bin
 GO ?= latest
@@ -29,6 +29,15 @@ MONOREPO_COMMIT=celo-core-contracts-v3.rc0
 # which becomes very slow.
 MONOREPO_PATH=../monorepo
 
+# This either evaluates to the contract source files if they exist or NOT_FOUND
+# if celo-monorepo has not been checked out yet.
+CONTRACT_SOURCE_FILES=$(shell 2>/dev/null find ./monorepo/packages/protocol \
+						   -not -path "*/node_modules*" \
+						   -not -path "./monorepo/packages/protocol/test*" \
+						   -not -path "./monorepo/packages/protocol/build*" \
+						   -not -path "./monorepo/packages/protocol/types*" \
+						   || echo "NOT_FOUND")
+
 # example NDK values
 export NDK_VERSION ?= android-ndk-r19c
 export ANDROID_NDK ?= $(PWD)/ndk_bundle/$(NDK_VERSION)
@@ -42,20 +51,46 @@ geth:
 # MONOREPO_COMMIT and compiles the system solidty contracts. A softlink is
 # created at ./monorepo so that code in this repo can always access the system
 # contracts with a consistent path.
-prepare-system-contracts: ./monorepo ./monorepo/packages/protocol/build
-
-# Clone the monorepo and setup softlink.
-./monorepo: 
-	@echo "Cloning monorepo at $(MONOREPO_COMMIT)"
-	@git clone --depth 1 --branch $(MONOREPO_COMMIT) https://github.com/celo-org/celo-monorepo.git $(MONOREPO_PATH)
-	@ln -s $(MONOREPO_PATH) ./monorepo
+prepare-system-contracts: ./monorepo/packages/protocol/build
 
 # If any of the source files found by the find command are more recent than the
-# build dir then we remove the build dir, yarn install and rebuild the contracts.
-./monorepo/packages/protocol/build: $(shell 2>/dev/null find ./monorepo/packages/protocol -not -path "*/node_modules*" -not -path "./monorepo/packages/protocol/test*" -not -path "./monorepo/packages/protocol/build*" -not -path "./monorepo/packages/protocol/types*")
+# build dir or the build dir does not exist then we remove the build dir, yarn
+# install and rebuild the contracts.
+./monorepo/packages/protocol/build: $(CONTRACT_SOURCE_FILES)
 	@node --version | grep "^v10" || (echo "node v10 is required to build the monorepo (nvm use 10)" && exit 1)
 	@echo Running yarn install and compiling contracts
 	@cd ./monorepo && rm -rf packages/protocol/build && yarn && cd packages/protocol && yarn run build:sol
+
+# The source files depend on the ./monorepo rule to ensure that the monorepo is
+# checked out before we try to build.
+$(CONTRACT_SOURCE_FILES): ./monorepo
+
+# Clone the monorepo and setup softlink.
+#
+# If the repo has not been cloned then clone it at the MONOREPO_COMMIT store
+# that commit in a file and then add a symlink from ./monorepo to the checkout
+# location.
+#
+# Otherwise if the repo has been cloned and MONOREPO_COMMIT doesn't match the
+# contents of current_commit then checkout the new commit, and update the file
+# that stores the current commit.  This will fail if there are local changes.
+./monorepo:
+	@set -e; \
+	if  [ ! -e ./monorepo ]; \
+	then \
+		echo "Cloning monorepo at $(MONOREPO_COMMIT)"; \
+		git clone --quiet --depth 1 --branch $(MONOREPO_COMMIT) https://github.com/celo-org/celo-monorepo.git $(MONOREPO_PATH); \
+		ln -s $(MONOREPO_PATH) ./monorepo; \
+		echo $(MONOREPO_COMMIT) > ./monorepo/current_commit; \
+	elif [ $(MONOREPO_COMMIT) != $(shell cat ./monorepo/current_commit || echo "") ]; \
+	then \
+		echo "Cheking out monorepo at $(MONOREPO_COMMIT)"; \
+		cd ./monorepo; \
+		git fetch --quiet --depth 1 origin $(MONOREPO_COMMIT); \
+		git checkout FETCH_HEAD; \
+		sleep 0.5; \
+		echo $(MONOREPO_COMMIT) > current_commit; \
+	fi
 
 
 geth-musl:

--- a/README.md
+++ b/README.md
@@ -57,8 +57,20 @@ The Celo blockchain client comes with several wrappers/executables found in the 
 ## Running tests
 
 Prior to running tests you will need to run `make prepare-system-contracts`.
-This will checkout the celo-monorepo and compile the system contracts for use in
-full network tests.
+This will checkout the celo-monorepo and compile the system contracts for use
+in full network tests. If you subsequently edit the system contracts source,
+running the make rule again will re-compile them.
+
+This make rule will shallow checkout
+[celo-monorepo](https://github.com/celo-org/celo-monorepo) under `../monorepo`
+relative to this project's root and it will checkout the commit defined in the
+variable MONOREPO_COMMIT in the Makefile. 
+
+These values can be overridden if required by setting those variables in the
+make command, for example:
+```
+make prepare-system-contracts MONOREPO_COMMIT=master MONOREPO_PATH=../alt-monorepo
+```
 
 Without first running this certain tests will fail with errors such as:
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,14 @@ This make rule will shallow checkout
 relative to this project's root and it will checkout the commit defined in the
 variable MONOREPO_COMMIT in the Makefile. 
 
-These values can be overridden if required by setting those variables in the
+These values can be overridden if required, by setting those variables in the
 make command, for example:
 ```
 make prepare-system-contracts MONOREPO_COMMIT=master MONOREPO_PATH=../alt-monorepo
 ```
+
+This is only required on the first invocation, as both the path and commit
+are then stored on disk.
 
 Without first running this certain tests will fail with errors such as:
 

--- a/scripts/check_imports.sh
+++ b/scripts/check_imports.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-grep --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
+grep --exclude-dir=monorepo --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
 if [ "$?" -gt "0" ]; then
     exit 0
 else

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -46,7 +46,7 @@ EOF
 fi
 
 # Check imports
-grep --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
+grep --exclude-dir=monorepo --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
 if [ "$?" -gt "0" ]; then
     exit 0
 else

--- a/scripts/rename_imports.sh
+++ b/scripts/rename_imports.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 find . \
+     -not -path "./monorepo/*" \
      -type f \
      -name '*.go' \
      -exec sed -i "" "s|github.com/ethereum/go-ethereum|github.com/celo-org/celo-blockchain|" {} \;


### PR DESCRIPTION
### Description

 This PR fixes a couple of problems with the prepare-system-contracts make rule.

* The rule previously appeared first in the Makefile, which meant that running just `make` would now run `prepare-system-contracts` instead of `geth`.
* The rule also checked out celo-monorepo under the celo-blockchain dir and this slowed down gopls massively, because of the huge amount of files in celo-monorepo.
* The rule did not handle celo-monorepo commit version changes gracefully, now when updating the version the new version will be fetched, checked out and then built.
* The default checkout path clashed with some people's setup so that has been changed to be something less likely to clash.
* Some scripts were updated to ignore the monorepo symlink at the repo root.

### Tested

I've tested it locally and it seems to work.

### Backwards compatibility

Yes, no node code was changed.