### PR TITLE
Exclude the monorepo from recursive operations

### DIFF
--- a/scripts/check_imports.sh
+++ b/scripts/check_imports.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-grep --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
+grep --exclude-dir=monorepo --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
 if [ "$?" -gt "0" ]; then
     exit 0
 else

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -46,7 +46,7 @@ EOF
 fi
 
 # Check imports
-grep --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
+grep --exclude-dir=monorepo --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
 if [ "$?" -gt "0" ]; then
     exit 0
 else

--- a/scripts/rename_imports.sh
+++ b/scripts/rename_imports.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 find . \
+     -not -path "./monorepo/*" \
      -type f \
      -name '*.go' \
      -exec sed -i "" "s|github.com/ethereum/go-ethereum|github.com/celo-org/celo-blockchain|" {} \;


### PR DESCRIPTION
### Description

With #1564 we vendor the monorepo to use the contracts for network testing.
In #1606 the monorepo is symlinked which helps with gopls, but not these scripts.
This commit exclude the monorepo from recursive operations performed in the
modified scripts.


