### PR TITLE
Fix race condition in p2p/enode

### DIFF
--- a/p2p/enode/iter_test.go
+++ b/p2p/enode/iter_test.go
@@ -268,7 +268,7 @@ func (s *genIter) Node() *Node {
 }
 
 func (s *genIter) Close() {
-	s.index = ^uint32(0)
+	atomic.StoreUint32(&s.index, ^uint32(0))
 }
 
 func testNode(id, seq uint64) *Node {


### PR DESCRIPTION
### Description
Run `go test -race ./p2p/enode`
Get:
```
==================
WARNING: DATA RACE
Write at 0x00c0001c6b18 by goroutine 13:
  github.com/celo-org/celo-blockchain/p2p/enode.(*genIter).Close()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter_test.go:271 +0x3e
  github.com/celo-org/celo-blockchain/p2p/enode.(*FairMix).Close()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter.go:193 +0x141
  github.com/celo-org/celo-blockchain/p2p/enode.testMixerFairness()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter_test.go:118 +0x585
  github.com/celo-org/celo-blockchain/p2p/enode.TestFairMix()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter_test.go:96 +0x44
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202

Previous read at 0x00c0001c6b18 by goroutine 14:
  sync/atomic.LoadInt32()
      /usr/local/go/src/runtime/race_amd64.s:213 +0xb
  github.com/celo-org/celo-blockchain/p2p/enode.(*genIter).Next()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter_test.go:256 +0x44
  github.com/celo-org/celo-blockchain/p2p/enode.(*FairMix).runSource()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter.go:279 +0x116

Goroutine 13 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1238 +0x5d7
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1511 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1509 +0x612
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1417 +0x3b3
  main.main()
      _testmain.go:103 +0x236

Goroutine 14 (running) created at:
  github.com/celo-org/celo-blockchain/p2p/enode.(*FairMix).AddSource()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter.go:180 +0x305
  github.com/celo-org/celo-blockchain/p2p/enode.testMixerFairness()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter_test.go:102 +0x21d
  github.com/celo-org/celo-blockchain/p2p/enode.TestFairMix()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter_test.go:96 +0x44
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202
==================
--- FAIL: TestFairMix (3.26s)
    testing.go:1092: race detected during execution of test
==================
WARNING: DATA RACE
Write at 0x00c0001e8378 by goroutine 56:
  github.com/celo-org/celo-blockchain/p2p/enode.(*genIter).Close()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter_test.go:271 +0x3e
  github.com/celo-org/celo-blockchain/p2p/enode.(*FairMix).Close()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter.go:193 +0x141
  github.com/celo-org/celo-blockchain/p2p/enode.TestFairMixNextFromAll()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter_test.go:135 +0x41f
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202

Previous read at 0x00c0001e8378 by goroutine 69:
  sync/atomic.LoadInt32()
      /usr/local/go/src/runtime/race_amd64.s:213 +0xb
  github.com/celo-org/celo-blockchain/p2p/enode.(*genIter).Next()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter_test.go:256 +0x44
  github.com/celo-org/celo-blockchain/p2p/enode.(*FairMix).runSource()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter.go:279 +0x116

Goroutine 56 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1238 +0x5d7
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1511 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1509 +0x612
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1417 +0x3b3
  main.main()
      _testmain.go:103 +0x236

Goroutine 69 (running) created at:
  github.com/celo-org/celo-blockchain/p2p/enode.(*FairMix).AddSource()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter.go:180 +0x305
  github.com/celo-org/celo-blockchain/p2p/enode.TestFairMixNextFromAll()
      /Users/tong/celo/celo-blockchain/p2p/enode/iter_test.go:124 +0x21d
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202
==================
--- FAIL: TestFairMixNextFromAll (0.01s)
    testing.go:1092: race detected during execution of test
FAIL
FAIL    github.com/celo-org/celo-blockchain/p2p/enode   3.763s
FAIL
```

### Tested

`go test -race ./p2p/enode` now looks good:
`ok      github.com/celo-org/celo-blockchain/p2p/enode   3.766s`

### Related issues

- Partly fixes #585 

### Backwards compatibility

Yes, only changed test
