### PR TITLE
Go back to using the transfer's sender in Tobin tax calculation.

### DIFF
--- a/contracts/reserve/tobin_tax.go
+++ b/contracts/reserve/tobin_tax.go
@@ -31,7 +31,7 @@ func TobinTax(vmRunner vm.EVMRunner, sender common.Address) (tax Ratio, reserveA
 		return Ratio{}, common.ZeroAddress, err
 	}
 
-	ret, err := vmRunner.Execute(reserveAddress, params.TobinTaxFunctionSelector, params.MaxGasForGetOrComputeTobinTax, big.NewInt(0))
+	ret, err := vmRunner.ExecuteFrom(sender, reserveAddress, params.TobinTaxFunctionSelector, params.MaxGasForGetOrComputeTobinTax, big.NewInt(0))
 	if err != nil {
 		return Ratio{}, common.ZeroAddress, err
 	}

--- a/contracts/testutil/fail_runner.go
+++ b/contracts/testutil/fail_runner.go
@@ -18,6 +18,10 @@ func (fvm FailingVmRunner) Execute(recipient common.Address, input []byte, gas u
 	return nil, ErrFailingRunner
 }
 
+func (fvm FailingVmRunner) ExecuteFrom(sender, recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error) {
+	return nil, ErrFailingRunner
+}
+
 func (fvm FailingVmRunner) Query(recipient common.Address, input []byte, gas uint64) (ret []byte, err error) {
 	return nil, ErrFailingRunner
 }

--- a/contracts/testutil/runner.go
+++ b/contracts/testutil/runner.go
@@ -50,7 +50,6 @@ func (ev *MockEVMRunner) ExecuteFrom(sender, recipient common.Address, input []b
 	return ev.Execute(recipient, input, gas, value)
 }
 
-
 func (ev *MockEVMRunner) Query(recipient common.Address, input []byte, gas uint64) (ret []byte, err error) {
 	mock, ok := ev.contracts[recipient]
 	if !ok {

--- a/contracts/testutil/runner.go
+++ b/contracts/testutil/runner.go
@@ -45,6 +45,12 @@ func (ev *MockEVMRunner) Execute(recipient common.Address, input []byte, gas uin
 	return mock.Call(input)
 }
 
+func (ev *MockEVMRunner) ExecuteFrom(sender, recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error) {
+	// No difference necessary for the mock runner between Execute() and ExecuteFrom()
+	return ev.Execute(recipient, input, gas, value)
+}
+
+
 func (ev *MockEVMRunner) Query(recipient common.Address, input []byte, gas uint64) (ret []byte, err error) {
 	mock, ok := ev.contracts[recipient]
 	if !ok {

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -89,6 +89,11 @@ type EVMRunner interface {
 	// It can be seen as a message (input,value) from sender to recipient that returns `ret`
 	Execute(recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error)
 
+	// ExecuteFrom is like Execute, but lets you specify the sender to use for the EVM call.
+	// It exists only for use in the Tobin tax calculation done as part of TobinTransfer, because that
+	// originally used the transaction's sender instead of the zero address.
+	ExecuteFrom(sender, recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error)
+
 	// Query performs a read operation over the runner's state
 	// It can be seen as a message (input,value) from sender to recipient that returns `ret`
 	Query(recipient common.Address, input []byte, gas uint64) (ret []byte, err error)

--- a/core/vm/vmcontext/runner.go
+++ b/core/vm/vmcontext/runner.go
@@ -25,7 +25,7 @@ type evmRunnerContext interface {
 }
 
 type evmRunner struct {
-	newEVM func() *vm.EVM
+	newEVM func(from common.Address) *vm.EVM
 	state  vm.StateDB
 
 	dontMeterGas bool
@@ -35,17 +35,17 @@ func NewEVMRunner(chain evmRunnerContext, header *types.Header, state vm.StateDB
 
 	return &evmRunner{
 		state: state,
-		newEVM: func() *vm.EVM {
+		newEVM: func(from common.Address) *vm.EVM {
 			// The EVM Context requires a msg, but the actual field values don't really matter for this case.
-			// Putting in zero values.
-			context := New(VMAddress, common.Big0, header, chain, nil)
+			// Putting in zero values for gas price and tx fee recipient
+			context := New(from, common.Big0, header, chain, nil)
 			return vm.NewEVM(context, state, chain.Config(), *chain.GetVMConfig())
 		},
 	}
 }
 
 func (ev *evmRunner) Execute(recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error) {
-	evm := ev.newEVM()
+	evm := ev.newEVM(VMAddress)
 	if ev.dontMeterGas {
 		evm.StopGasMetering()
 	}
@@ -54,7 +54,7 @@ func (ev *evmRunner) Execute(recipient common.Address, input []byte, gas uint64,
 }
 
 func (ev *evmRunner) ExecuteFrom(sender, recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error) {
-	evm := ev.newEVM()
+	evm := ev.newEVM(sender)
 	if ev.dontMeterGas {
 		evm.StopGasMetering()
 	}
@@ -63,7 +63,7 @@ func (ev *evmRunner) ExecuteFrom(sender, recipient common.Address, input []byte,
 }
 
 func (ev *evmRunner) Query(recipient common.Address, input []byte, gas uint64) (ret []byte, err error) {
-	evm := ev.newEVM()
+	evm := ev.newEVM(VMAddress)
 	if ev.dontMeterGas {
 		evm.StopGasMetering()
 	}

--- a/core/vm/vmcontext/runner.go
+++ b/core/vm/vmcontext/runner.go
@@ -53,6 +53,15 @@ func (ev *evmRunner) Execute(recipient common.Address, input []byte, gas uint64,
 	return ret, err
 }
 
+func (ev *evmRunner) ExecuteFrom(sender, recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error) {
+	evm := ev.newEVM()
+	if ev.dontMeterGas {
+		evm.StopGasMetering()
+	}
+	ret, _, err = evm.Call(vm.AccountRef(sender), recipient, input, gas, value)
+	return ret, err
+}
+
 func (ev *evmRunner) Query(recipient common.Address, input []byte, gas uint64) (ret []byte, err error) {
 	evm := ev.newEVM()
 	if ev.dontMeterGas {
@@ -82,6 +91,11 @@ type SharedEVMRunner struct{ *vm.EVM }
 
 func (sev *SharedEVMRunner) Execute(recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error) {
 	ret, _, err = sev.Call(vm.AccountRef(VMAddress), recipient, input, gas, value)
+	return ret, err
+}
+
+func (sev *SharedEVMRunner) ExecuteFrom(sender, recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error) {
+	ret, _, err = sev.Call(vm.AccountRef(sender), recipient, input, gas, value)
 	return ret, err
 }
 


### PR DESCRIPTION
### Description

Even though the Tobin tax calculation doesn't depend on the sender, the change (in PR #1465) of the sender from the transaction's sender to the zero account led to a bad block error (i.e. a hard fork change).  This was due to a conjunction of factors including the upstream implementation of EIP-161 not being quite correct for the case of Celo (because of the existence of system EVM calls made from celo-blockchain).  This commit reverts the change, by adding and using an `ExecuteFrom()` method on the EVMRunner type.

### Tested

Confirmed that this fixes the bad block which previously appeared trying to sync to Alfajores (block 536) and that it now syncs successfully past that block.

### Backwards compatibility

This fixes a breaking change that is currently on master.  As such, it is incompatible with what is currently on master (i.e. it could potentially cause bad blocks errors trying to sync to networks which have been running the current master).  However, it makes master backwards compatible (in this regard) relative to the stable releases and v1.3.2 in particular.
