### PR TITLE
Update prepare-system-contracts make rule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 parameters:
+  # Increment this to force cache rebuilding
+  system-contracts-cache-version:
+    type: integer
+    default: 1
   # Use this git tag or commit of the monorepo to build the system contracts. 
   system-contracts-monorepo-version:
     type: string
@@ -46,13 +50,17 @@ jobs:
             - geth
 
   prepare-system-contracts:
+    parameters:
+      cache-key:
+        type: string
+        default: system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>-<<pipeline.parameters.system-contracts-path>>-v<<pipeline.parameters.system-contracts-cache-version>>
     executor: node-v10
     resource_class: medium+
     steps:
       - checkout
       - restore_cache:
           keys:
-            - system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>-<<pipeline.parameters.system-contracts-path>>
+            - <<parameters.cache-key>>
       - attach_workspace:
           at: ~/repos
       - run:
@@ -68,7 +76,7 @@ jobs:
               make prepare-system-contracts MONOREPO_COMMIT=<<pipeline.parameters.system-contracts-monorepo-version>>
             fi
       - save_cache:
-          key: system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>-<<pipeline.parameters.system-contracts-path>>
+          key: <<parameters.cache-key>>
           paths:
             - ~/repos/geth/<<pipeline.parameters.system-contracts-path>>
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,10 @@ parameters:
     default: "celo-core-contracts-v3.rc0"
   system-contracts-path:
     type: string
-    default: "geth/monorepo/packages/protocol/build"
+    default: "compiled-system-contracts"
+  monorepo-checkout-path:
+    type: string
+    default: "monorepo"
 executors:
   golang:
     docker:
@@ -52,7 +55,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>
+            - system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>-<<pipeline.parameters.system-contracts-path>>-<<pipeline.parameters.monorepo-checkout-path>>
       - attach_workspace:
           at: ~/repos
       - run:
@@ -63,18 +66,20 @@ jobs:
           # work. We only do this if the cache has not been restored.
           command: |
             set -e
-            if [ ! -d ~/repos/<<pipeline.parameters.system-contracts-path>> ]; then
+            if [ ! -d <<pipeline.parameters.system-contracts-path>> ]; then
               mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-              make prepare-system-contracts MONOREPO_COMMIT=<<pipeline.parameters.system-contracts-monorepo-version>>
+              make prepare-system-contracts MONOREPO_COMMIT=<<pipeline.parameters.system-contracts-monorepo-version>> MONOREPO_PATH=../<<pipeline.parameters.monorepo-checkout-path>>
             fi
       - save_cache:
-          key: system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>
+          key: system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>-<<pipeline.parameters.system-contracts-path>>-<<pipeline.parameters.monorepo-checkout-path>>
           paths:
-            - ~/repos/<<pipeline.parameters.system-contracts-path>>
+            - ~/repos/geth/<<pipeline.parameters.system-contracts-path>>
+            - ~/repos/<<pipeline.parameters.monorepo-checkout-path>>/packages/protocol/build/contracts
       - persist_to_workspace:
           root: ~/repos
           paths:
-            - <<pipeline.parameters.system-contracts-path>>
+            - geth/<<pipeline.parameters.system-contracts-path>>
+            - <<pipeline.parameters.monorepo-checkout-path>>/packages/protocol/build/contracts
 
   unit-tests:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "celo-core-contracts-v3.rc0"
   system-contracts-path:
     type: string
-    default: "geth/monorepo/packages/protocol/build"
+    default: "compiled-system-contracts"
 executors:
   golang:
     docker:
@@ -52,7 +52,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>
+            - system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>-<<pipeline.parameters.system-contracts-path>>
       - attach_workspace:
           at: ~/repos
       - run:
@@ -63,16 +63,16 @@ jobs:
           # work. We only do this if the cache has not been restored.
           command: |
             set -e
-            if [ ! -d ~/repos/<<pipeline.parameters.system-contracts-path>> ]; then
+            if [ ! -d <<pipeline.parameters.system-contracts-path>> ]; then
               mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
               make prepare-system-contracts MONOREPO_COMMIT=<<pipeline.parameters.system-contracts-monorepo-version>>
             fi
       - save_cache:
-          key: system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>
+          key: system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>-<<pipeline.parameters.system-contracts-path>>
           paths:
-            - ~/repos/<<pipeline.parameters.system-contracts-path>>
+            - ~/repos/geth/<<pipeline.parameters.system-contracts-path>>
       - persist_to_workspace:
-          root: ~/repos
+          root: ~/repos/geth
           paths:
             - <<pipeline.parameters.system-contracts-path>>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,9 @@ jobs:
       - run:
           name: Run Tests
           command: |
+            pwd
+            ls 
+            ls compiled-system-contracts
             mkdir -p /tmp/test-results
             trap "go-junit-report < /tmp/test-results/go-test.out > /tmp/test-results/go-test-report.xml" EXIT
             go run build/ci.go test -v | tee /tmp/test-results/go-test.out

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,9 @@ jobs:
           paths:
             - ~/repos/geth/<<pipeline.parameters.system-contracts-path>>
       - persist_to_workspace:
-          root: ~/repos/geth
+          root: ~/repos
           paths:
-            - <<pipeline.parameters.system-contracts-path>>
+            - geth/<<pipeline.parameters.system-contracts-path>>
 
   unit-tests:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,9 @@ jobs:
           # to our known hosts in order for the monorepo post install script to
           # work. We only do this if the cache has not been restored.
           command: |
+            pwd
+            ls 
+            ls compiled-system-contracts
             set -e
             if [ ! -d <<pipeline.parameters.system-contracts-path>> ]; then
               mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,7 @@ parameters:
     default: "celo-core-contracts-v3.rc0"
   system-contracts-path:
     type: string
-    default: "compiled-system-contracts"
-  monorepo-checkout-path:
-    type: string
-    default: "monorepo"
+    default: "geth/monorepo/packages/protocol/build"
 executors:
   golang:
     docker:
@@ -55,7 +52,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>-<<pipeline.parameters.system-contracts-path>>-<<pipeline.parameters.monorepo-checkout-path>>
+            - system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>
       - attach_workspace:
           at: ~/repos
       - run:
@@ -66,20 +63,18 @@ jobs:
           # work. We only do this if the cache has not been restored.
           command: |
             set -e
-            if [ ! -d <<pipeline.parameters.system-contracts-path>> ]; then
+            if [ ! -d ~/repos/<<pipeline.parameters.system-contracts-path>> ]; then
               mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-              make prepare-system-contracts MONOREPO_COMMIT=<<pipeline.parameters.system-contracts-monorepo-version>> MONOREPO_PATH=../<<pipeline.parameters.monorepo-checkout-path>>
+              make prepare-system-contracts MONOREPO_COMMIT=<<pipeline.parameters.system-contracts-monorepo-version>>
             fi
       - save_cache:
-          key: system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>-<<pipeline.parameters.system-contracts-path>>-<<pipeline.parameters.monorepo-checkout-path>>
+          key: system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>
           paths:
-            - ~/repos/geth/<<pipeline.parameters.system-contracts-path>>
-            - ~/repos/<<pipeline.parameters.monorepo-checkout-path>>/packages/protocol/build/contracts
+            - ~/repos/<<pipeline.parameters.system-contracts-path>>
       - persist_to_workspace:
           root: ~/repos
           paths:
-            - geth/<<pipeline.parameters.system-contracts-path>>
-            - <<pipeline.parameters.monorepo-checkout-path>>/packages/protocol/build/contracts
+            - <<pipeline.parameters.system-contracts-path>>
 
   unit-tests:
     executor: golang

--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,5 @@ docs/Gemfile.lock
 docs/_site
 docs/.jekyll-metadata
 
-# Ignore monorepo checkout
-**/monorepo
+# Ignore compiled contracts
+compiled-system-contracts

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ $(MONOREPO_PATH):
 		echo "Cloning monorepo at $(MONOREPO_COMMIT)"; \
 		git clone --quiet --depth 1 --branch $(MONOREPO_COMMIT) https://github.com/celo-org/celo-monorepo.git $(MONOREPO_PATH); \
 		echo $(MONOREPO_COMMIT) > $(MONOREPO_PATH)/current_commit; \
-	elif [ $(MONOREPO_COMMIT) != $(shell cat $(MONOREPO_PATH)/current_commit || echo "") ]; \
+	elif [ $(MONOREPO_COMMIT) != $(shell cat $(MONOREPO_PATH)/current_commit 2>/dev/null || echo "") ]; \
 	then \
 		echo "Checking out monorepo at $(MONOREPO_COMMIT)"; \
 		cd $(MONOREPO_PATH); \

--- a/Makefile
+++ b/Makefile
@@ -48,15 +48,14 @@ geth:
 	@echo "Run \"$(GOBIN)/geth\" to launch geth."
 
 # This rule checks out celo-monorepo under MONOREPO_PATH at commit
-# MONOREPO_COMMIT and compiles the system solidty contracts. It then creates a
-# symlink (compiled-system-contracts) pointing to the compiled contracts dir in
-# the monorepo, so that this repo can always access the contracts at a
-# consistent path.
+# MONOREPO_COMMIT and compiles the system solidty contracts. It then copies the
+# compiled contracts from the monorepo to the compiled-system-contracts, so
+# that this repo can always access the contracts at a consistent path.
 prepare-system-contracts: $(MONOREPO_PATH)/packages/protocol/build
-	@rm -f compiled-system-contracts
-	@ln -s $(MONOREPO_PATH)/packages/protocol/build/contracts compiled-system-contracts
+	@rm -rf compiled-system-contracts
+	@cp -ar $(MONOREPO_PATH)/packages/protocol/build/contracts compiled-system-contracts
 
-# If any of the source files found by the find command are more recent than the
+# If any of the source files in CONTRACT_SOURCE_FILES are more recent than the
 # build dir or the build dir does not exist then we remove the build dir, yarn
 # install and rebuild the contracts.
 $(MONOREPO_PATH)/packages/protocol/build: $(CONTRACT_SOURCE_FILES)

--- a/README.md
+++ b/README.md
@@ -58,10 +58,9 @@ The Celo blockchain client comes with several wrappers/executables found in the 
 
 Prior to running tests you will need to run `make prepare-system-contracts`.
 This will checkout the celo-monorepo and compile the system contracts for use
-in full network tests. The rule will create the symlink
-(`compiled-system-contracts`) linking to the directory in celo-monorepo
-containing the compiled contracts. If you subsequently edit the system
-contracts source, running the make rule again will re-compile them.
+in full network tests. The rule will copy the compiled contracts from
+celo-monorepo to `compiled-system-contracts`. If you subsequently edit the
+system contracts source, running the make rule again will re-compile them.
 
 This make rule will shallow checkout
 [celo-monorepo](https://github.com/celo-org/celo-monorepo) under

--- a/README.md
+++ b/README.md
@@ -58,13 +58,16 @@ The Celo blockchain client comes with several wrappers/executables found in the 
 
 Prior to running tests you will need to run `make prepare-system-contracts`.
 This will checkout the celo-monorepo and compile the system contracts for use
-in full network tests. If you subsequently edit the system contracts source,
-running the make rule again will re-compile them.
+in full network tests. The rule will create the symlink
+(`compiled-system-contracts`) linking to the directory in celo-monorepo
+containing the compiled contracts. If you subsequently edit the system
+contracts source, running the make rule again will re-compile them.
 
 This make rule will shallow checkout
-[celo-monorepo](https://github.com/celo-org/celo-monorepo) under `../monorepo`
-relative to this project's root and it will checkout the commit defined in the
-variable MONOREPO_COMMIT in the Makefile. 
+[celo-monorepo](https://github.com/celo-org/celo-monorepo) under
+`../.celo-blockchain-monorepo-checkout` relative to this project's root, and it
+will checkout the commit defined in the variable MONOREPO_COMMIT in the
+Makefile. 
 
 These values can be overridden if required, by setting those variables in the
 make command, for example:
@@ -72,10 +75,8 @@ make command, for example:
 make prepare-system-contracts MONOREPO_COMMIT=master MONOREPO_PATH=../alt-monorepo
 ```
 
-This is only required on the first invocation, as both the path and commit
-are then stored on disk.
-
-Without first running this certain tests will fail with errors such as:
+Without first running this make rule, certain tests will fail with errors such
+as:
 
 ```
 panic: Can't read bytecode for monorepo/packages/protocol/build/contracts/FixidityLib.json: open

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Prior to running tests you will need to run `make prepare-system-contracts`.
 This will checkout the celo-monorepo and compile the system contracts for use
 in full network tests. The rule will copy the compiled contracts from
 celo-monorepo to `compiled-system-contracts`. If you subsequently edit the
-system contracts source, running the make rule again will re-compile them.
+system contracts source, running the make rule again will re-compile them and
+copy them into place.
 
 This make rule will shallow checkout
 [celo-monorepo](https://github.com/celo-org/celo-monorepo) under

--- a/scripts/check_imports.sh
+++ b/scripts/check_imports.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-grep --exclude-dir=monorepo --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
+grep --exclude-dir=compiled-system-contracts --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
 if [ "$?" -gt "0" ]; then
     exit 0
 else

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -46,7 +46,7 @@ EOF
 fi
 
 # Check imports
-grep --exclude-dir=monorepo --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
+grep --exclude-dir=compiled-system-contracts --files-with-matches "github.com/ethereum/go-ethereum" --recursive . --include="*.go"
 if [ "$?" -gt "0" ]; then
     exit 0
 else

--- a/scripts/rename_imports.sh
+++ b/scripts/rename_imports.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 find . \
-     -not -path "./monorepo/*" \
+     -not -path "./compiled-system-contracts/*" \
      -type f \
      -name '*.go' \
      -exec sed -i "" "s|github.com/ethereum/go-ethereum|github.com/celo-org/celo-blockchain|" {} \;

--- a/test/node.go
+++ b/test/node.go
@@ -355,7 +355,7 @@ func GenesisConfig(accounts *env.AccountsConfig) *genesis.Config {
 // others not.
 func NewNetwork(accounts *env.AccountsConfig, gc *genesis.Config) (Network, error) {
 
-	genesis, err := genesis.GenerateGenesis(accounts, gc, "../monorepo/packages/protocol/build/contracts")
+	genesis, err := genesis.GenerateGenesis(accounts, gc, "../compiled-system-contracts")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

This commit makes two changes:

1. Instead of symlinking to the celo-monorepo root from the
celo-blockchain root, we now symlink just to the compiled contracts.
This should help our tooling by reducing the amount of files in scope of
searches etc.

2. The overrides for the make rule (MONOREPO_PATH & MONOREPO_COMMIT) now
are not persistent and need to be provided on all invocations of the
make rule. This change was made because the previous implementation
could end up functioning in strange ways due to the statefulness. This
approach is just more straightforward.


_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Tested

Works locally and on ci?

### Backwards compatibility

Yes, no node source code has been changed.