### PR TITLE
Fix logic bug in worker, and protect against blocking.

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -383,8 +383,12 @@ func (w *worker) mainLoop() {
 		case ev := <-w.txsCh:
 			// Drain tx sub channel as a validator,
 			// otherwise pass it to the full node loop
-			if w.isRunning() {
-				txsCh <- ev
+			// if the full node loop's channel is full, just drop the transaction
+			if !w.isRunning() {
+				select {
+				case txsCh <- ev:
+				default:
+				}
 			}
 		// System stopped
 		case <-w.exitCh:


### PR DESCRIPTION
### Description

Due to a logic bug in the `if`'s condition, the channel was only being sent to, never received from, causing it to hang on validators once enough transactions have been sent.  This PR fixes that and also ensures that if the channel is full we don't block the main loop.

### Tested

* Automated testing
* Added regression tests for validator and non-validator cases which send lots of transactions to the channel and fail if deadlock results.  These tests would fail if the fix in this PR is undone.