### PR TITLE
fix: Registry code size check

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -197,7 +197,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 	}
 
 	// Check if Registry sits in genesis
-	if s.GetCodeSize(params.RegistrySmartContractAddress) != params.RegistryCodeSize {
+	if s.GetCodeSize(params.RegistrySmartContractAddress) == 0 {
 		return params.MainnetChainConfig, common.Hash{}, errors.New("no Registry Smart Contract deployed in genesis")
 	}
 

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -217,7 +217,7 @@ func TestRegistryInGenesis(t *testing.T) {
 				t.Errorf("%s: Registry code size is %d, want 0", test.name, codeSize)
 			}
 		} else if codeSize == 0 {
-			t.Errorf("%s: Registry code size should not be 0, actual %d", test.name, codeSize)
+			t.Errorf("%s: Registry code size should not be 0", test.name)
 		}
 		chain.Stop()
 	}

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -179,36 +179,30 @@ func TestSetupGenesis(t *testing.T) {
 // TestRegistryInGenesis tests if the params.RegistrySmartContract that defined in the genesis block sits in the blockchain
 func TestRegistryInGenesis(t *testing.T) {
 	tests := []struct {
-		name     string
-		genesis  func() *Genesis
-		codeSize int
+		name    string
+		genesis func() *Genesis
 	}{
 		{
-			name:     "dev",
-			genesis:  DeveloperGenesisBlock,
-			codeSize: params.RegistryCodeSize,
+			name:    "dev",
+			genesis: DeveloperGenesisBlock,
 		},
 		{
-			name:     "alfajores",
-			genesis:  DefaultAlfajoresGenesisBlock,
-			codeSize: params.RegistryCodeSize,
+			name:    "alfajores",
+			genesis: DefaultAlfajoresGenesisBlock,
 		},
 		{
-			name:     "baklava",
-			genesis:  DefaultBaklavaGenesisBlock,
-			codeSize: params.RegistryCodeSize,
+			name:    "baklava",
+			genesis: DefaultBaklavaGenesisBlock,
 		},
 		{
-			name:     "mainnet",
-			genesis:  MainnetGenesisBlock,
-			codeSize: params.RegistryCodeSize,
+			name:    "mainnet",
+			genesis: MainnetGenesisBlock,
 		},
 		{
 			name: "emptyAlloc",
 			genesis: func() *Genesis {
 				return &Genesis{}
 			},
-			codeSize: 0,
 		},
 	}
 
@@ -218,8 +212,12 @@ func TestRegistryInGenesis(t *testing.T) {
 		chain, _ := NewBlockChain(db, nil, params.IstanbulTestChainConfig, mockEngine.NewFaker(), vm.Config{}, nil, nil)
 		state, _ := chain.State()
 		codeSize := state.GetCodeSize(params.RegistrySmartContractAddress)
-		if codeSize != test.codeSize {
-			t.Errorf("%s: Registry code size is %d, want %d", test.name, codeSize, test.codeSize)
+		if test.name == "emptyAlloc" {
+			if codeSize != 0 {
+				t.Errorf("%s: Registry code size is %d, want 0", test.name, codeSize)
+			}
+		} else if codeSize == 0 {
+			t.Errorf("%s: Registry code size should not be 0, actual %d", test.name, codeSize)
 		}
 		chain.Stop()
 	}

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -185,7 +185,6 @@ var Bls12381MultiExpDiscountTable = [128]uint64{1200, 888, 764, 641, 594, 547, 5
 
 var (
 	RegistrySmartContractAddress = common.HexToAddress("0x000000000000000000000000000000000000ce10")
-	RegistryCodeSize             = 2585 // According to core/***AllocJSON
 
 	// Celo registered contract IDs.
 	// The names are taken from celo-monorepo/packages/protocol/lib/registry-utils.ts


### PR DESCRIPTION
### Description

Currently the Registry Proxy check in genesis is set to be a static number 2585, which may not make sense since there may be change in Proxy code & different compiler. Hence we want to reset the check so that any non-zero code size of RegistrySmartContractAddress will pass.