### PR TITLE
Fix incorrect argument number in error logging

### DIFF
--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -223,7 +223,7 @@ func (sb *Backend) announceThread() {
 			var err error
 			shouldQuery, err = sb.announceManager.shouldParticipateInAnnounce()
 			if err != nil {
-				logger.Warn("Error in checking if should announce", err)
+				logger.Warn("Error in checking if should announce", "err", err)
 				break
 			}
 			shouldAnnounce = shouldQuery && sb.IsValidating()


### PR DESCRIPTION
### Description

This log line was incorrect, since the arguments after the log message (the first argument) have to come in key-value pairs.  This led to log lines such as:

```
{"":"\u003cnil\u003e","LOG15_ERROR":"Normalized odd number of arguments by adding nil","func":"announceThread","msg":"Error in checking if should announce","severity":"warning","timestamp":"2021-07-19T14:32:42.820625948Z"}
```

This PR fixes that.
