### PR TITLE
Add Codecov and CircleCI status badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Official golang implementation of the Celo blockchain, based off of the [official golang implementation of the Ethereum protocol](https://github.com/ethereum/go-ethereum).
 
+[![CircleCI](https://img.shields.io/circleci/build/github/celo-org/celo-blockchain/master)](https://circleci.com/gh/celo-org/celo-blockchain/tree/master)
+[![Codecov](https://img.shields.io/codecov/c/github/celo-org/celo-blockchain)](https://codecov.io/gh/celo-org/celo-blockchain)
 [![Discord](https://img.shields.io/badge/discord-join%20chat-blue.svg)](https://chat.celo.org)
 
 Prebuilt [Docker](https://en.wikipedia.org/wiki/Docker_\(software\)) images are available for immediate use: [us.gcr.io/celo-testnet/celo-node](https://us.gcr.io/celo-testnet/celo-node). See [docs.celo.org/getting-started](https://docs.celo.org/getting-started) for a guide to the Celo networks and how to get started.


### PR DESCRIPTION
### Description

Improve code coverage and build analysis by surfacing the latest status and making deeper insights reachable in one click.
Currently, looking up code coverage and build status requires knowing where to find the information.

### Tested

Markdown preview and https://shields.io.

### Related issues

N/A

### Backwards compatibility

N/A