### PR TITLE
Record values for the block construction metric

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -263,6 +263,14 @@ func (w *worker) constructAndSubmitNewBlock(ctx context.Context) {
 		return
 	}
 	w.updatePendingBlock(b)
+
+	// We update the block construction metric here, rather than at the end of the function, because
+	// `submitTaskToEngine` may take a long time if the engine's handler is busy (e.g. if we are not
+	// the proposer and the engine has already gotten and is verifying the proposal).  See
+	// https://github.com/celo-org/celo-blockchain/issues/1639#issuecomment-888611039
+	// And we subtract the time we spent sleeping, since we want the time spent actually building the block.
+	w.blockConstructGauge.Update(time.Since(start).Nanoseconds() - delay.Nanoseconds())
+
 	if w.isRunning() {
 		if w.fullTaskHook != nil {
 			w.fullTaskHook()


### PR DESCRIPTION
### Description

This metric was not being updated.  This PR updates it in such a way as to exclude the artificial inflation that can result on non-proposers due to the race condition described in https://github.com/celo-org/celo-blockchain/issues/1639#issuecomment-888611039

### Tested

Ran locally with `--metrics` and some print statements, verified the metric gets set and that the times make sense (for both empty and full blocks)