### PR TITLE
bug: fix data race on coreStarted

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -190,22 +190,21 @@ func (api *API) GetVersionCertificateTableInfo() (map[string]*vet.VersionCertifi
 
 // GetCurrentRoundState retrieves the current IBFT RoundState
 func (api *API) GetCurrentRoundState() (*core.RoundStateSummary, error) {
-	if !api.istanbul.coreStarted {
+	if !api.istanbul.coreStarted.Load().(bool) {
 		return nil, istanbul.ErrStoppedEngine
 	}
 	return api.istanbul.core.CurrentRoundState().Summary(), nil
 }
 
-// GetCurrentRoundState retrieves the current IBFT RoundState
 func (api *API) ForceRoundChange() (bool, error) {
-	if !api.istanbul.coreStarted {
+	if !api.istanbul.coreStarted.Load().(bool) {
 		return false, istanbul.ErrStoppedEngine
 	}
 	api.istanbul.core.ForceRoundChange()
 	return true, nil
 }
 
-// Proxies retrieves all the proxied validator's proxies' info
+// GetProxiesInfo retrieves all the proxied validator's proxies' info
 func (api *API) GetProxiesInfo() ([]*proxy.ProxyInfo, error) {
 	if api.istanbul.IsProxiedValidator() {
 		proxies, valAssignments, err := api.istanbul.proxiedValidatorEngine.GetProxiesAndValAssignments()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -201,7 +201,6 @@ func (w *worker) start() {
 	}
 
 	if istanbul, ok := w.engine.(consensus.Istanbul); ok {
-
 		if istanbul.IsPrimary() {
 			istanbul.StartValidating()
 		}


### PR DESCRIPTION
### Description

Fix data race on `backend.coreStarted`

### Other changes

None

### Tested

Run `go test -race ./e2e_test`, there is no more data race on `backend.coreStarted` 

### Related issues

- Fixes #1588 

### Backwards compatibility

Yes
