### PR TITLE
Fix race conditions in announce.go

### DIFF
--- a/consensus/istanbul/backend/announce.go
+++ b/consensus/istanbul/backend/announce.go
@@ -173,7 +173,6 @@ func (m *AnnounceManager) wallets() *Wallets {
 func (sb *Backend) announceThread() {
 	logger := sb.logger.New("func", "announceThread")
 
-	sb.announceThreadWg.Add(1)
 	defer sb.announceThreadWg.Done()
 
 	// Create a ticker to poll if istanbul core is running and if this node is in

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -718,10 +718,11 @@ func (sb *Backend) StartAnnouncing() error {
 		return istanbul.ErrStartedAnnounce
 	}
 
-	go sb.announceThread()
-
 	sb.announceThreadQuit = make(chan struct{})
 	sb.announceRunning = true
+
+	sb.announceThreadWg.Add(1)
+	go sb.announceThread()
 
 	if err := sb.vph.startThread(); err != nil {
 		sb.StopAnnouncing()


### PR DESCRIPTION
### Description

- Correct use of waitGroup, don't call Add in  a separate go-routine to the one in which the wait group was created.
- Declare announceThreadQuit before starting a go-routine that tries to read the variable.

### Other changes

None

### Tested

CI
`go test ./e2e_tests -race` doesn't report on announce.go

### Related issues

- Fixes #1586 #1583 

### Backwards compatibility

Yes
