### PR TITLE
Fix calculation and implementation of dial ratio and the max dialed connections limit

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1202,6 +1202,9 @@ func SetP2PConfig(ctx *cli.Context, cfg *p2p.Config) {
 	if lightClient {
 		ethPeers = 0
 	}
+	if lightServer {
+		cfg.MaxLightClients = lightPeers
+	}
 	log.Info("Maximum peer count", "ETH", ethPeers, "LES", lightPeers, "total", cfg.MaxPeers)
 
 	if ctx.GlobalIsSet(MaxPendingPeersFlag.Name) {

--- a/p2p/dial.go
+++ b/p2p/dial.go
@@ -378,7 +378,7 @@ func (d *dialScheduler) expireHistory() {
 // when peers are connected while their task is still running, or because static dials
 // are exempt from the limit.
 func (d *dialScheduler) freeDialSlots() int {
-	slots := (d.maxDialPeers - d.dialPeers) * 2
+	slots := d.maxDialPeers - d.dialPeers
 	if slots > d.maxActiveDials {
 		slots = d.maxActiveDials
 	}

--- a/p2p/dial_test.go
+++ b/p2p/dial_test.go
@@ -43,7 +43,7 @@ func TestDialSchedDynDial(t *testing.T) {
 		maxDialPeers:   4,
 	}
 	runDialTest(t, config, []dialTestRound{
-		// 3 out of 4 peers are connected, leaving 1 dial slots.
+		// 3 out of 4 peers are connected, leaving 1 dial slot.
 		// 9 nodes are discovered, but only 1 is dialed.
 		{
 			update: func(d *dialScheduler) {
@@ -58,8 +58,8 @@ func TestDialSchedDynDial(t *testing.T) {
 				newNode(uintID(0x01), "127.0.0.1:30303"), // not dialed because already connected as static peer
 				newNode(uintID(0x03), "127.0.0.1:30303"), // ...
 				newNode(uintID(0x04), "127.0.0.1:30303"),
-				newNode(uintID(0x05), "127.0.0.1:30303"), // not dialed because there are only two slots
-				newNode(uintID(0x06), "127.0.0.1:30303"), // ..
+				newNode(uintID(0x05), "127.0.0.1:30303"), // not dialed because there is only one slot
+				newNode(uintID(0x06), "127.0.0.1:30303"), // ...
 				newNode(uintID(0x07), "127.0.0.1:30303"), // ...
 				newNode(uintID(0x08), "127.0.0.1:30303"), // ...
 				newNode(uintID(0x09), "127.0.0.1:30303"), // ...

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -76,6 +76,10 @@ type Config struct {
 	// connected. It must be greater than zero.
 	MaxPeers int
 
+	// MaxLightClients is the maximum number of light clients that can be connected.
+	// It is zero if the LES server isn't running (includes the case that we are an LES client).
+	MaxLightClients int
+
 	// MaxPendingPeers is the maximum number of peers that can be pending in the
 	// handshake phase, counted separately for inbound and outbound connections.
 	// Zero defaults to preset values.
@@ -732,10 +736,11 @@ func (srv *Server) maxDialedConns() (limit int) {
 	if srv.NoDial || srv.MaxPeers == 0 {
 		return 0
 	}
+	maxEthPeers := srv.MaxPeers - srv.MaxLightClients
 	if srv.DialRatio == 0 {
-		limit = srv.MaxPeers / defaultDialRatio
+		limit = maxEthPeers / defaultDialRatio
 	} else {
-		limit = srv.MaxPeers / srv.DialRatio
+		limit = maxEthPeers / srv.DialRatio
 	}
 	if limit == 0 {
 		limit = 1
@@ -780,7 +785,7 @@ func (srv *Server) doPeerOp(fn peerOpFunc) {
 
 // run is the main loop of the server.
 func (srv *Server) run() {
-	srv.log.Info("Started P2P networking", "self", srv.localnode.Node().URLv4())
+	srv.log.Info("Started P2P networking", "self", srv.localnode.Node().URLv4(), "maxdialed", srv.maxDialedConns(), "maxinbound", srv.maxInboundConns())
 	defer srv.loopWG.Done()
 	defer srv.nodedb.Close()
 	defer srv.discmix.Close()


### PR DESCRIPTION
### Description

Fixes two behaviors in `p2p/Server` which cause it to get more dialed connections than it should based on the dial ratio (which in turn impairs the ability of new nodes joining the network to find peers with open incoming connection slots):

1. The bug described in #1669, which affects LES servers.
2. The fact that the dialer attempts two dials for every dialed peer connection it's missing: https://github.com/celo-org/celo-blockchain/blob/147571e5b5aab36b6de4d839a3ee9c1f85dbd94b/p2p/dial.go#L381

Initially I was planning to just fix #1669.  But then when I tested it out and saw that it still ends up with more dialed peers than it should, I remembered this `* 2` and realized that it would have to be removed in order to get the desired behavior.

This `* 2` was introduced upstream in https://github.com/ethereum/go-ethereum/pull/20592.  Prior to that, it would attempt one dial for every additional dialed peer that it wanted: https://github.com/ethereum/go-ethereum/blob/58cf5686eab9019cc01e202e846a6bbc70a3301d/p2p/dial.go#L149-L160

The new behavior was introduced in that PR, but was not mentioned in the PR description, commented on in the code, nor commented on during PR review.  But, seeing as it impairs the functioning of the dial ratio and geth was doing fine without it up to 1.9.10, I don't see a problem with removing it.  It means that you will be slower to dial peers initially (though there is at any rate the `maxActiveDials` limit which defaults to 50) and if a dialed peer connection drops you will try to refill it one at a time instead of two at a time (if that makes sense), but that seems reasonable.

### Other changes

Updated a test to work with the new behavior (the test assumed two dial slots for every dialed peer we want).

### Tested

Verified that the dial ratio is respected by connecting a node with low limits to Alfajores and seeing that it only connects to  the right number of dials peers, whether or not it's running the LES server.

### Related issues

- Fixes #1669
