### PR TITLE
mycelo: change copy-pasted variable name to reflect what it is

### DIFF
--- a/cmd/mycelo/main.go
+++ b/cmd/mycelo/main.go
@@ -162,16 +162,16 @@ func readWorkdir(ctx *cli.Context) (string, error) {
 }
 
 func readGethPath(ctx *cli.Context) (string, error) {
-	buildpath := ctx.String(gethPathFlag.Name)
-	if buildpath == "" {
-		buildpath = path.Join(os.Getenv("CELO_BLOCKCHAIN"), "build/bin/geth")
-		if fileutils.FileExists(buildpath) {
-			log.Info("Missing --geth flag, using CELO_BLOCKCHAIN derived path", "geth", buildpath)
+	gethPath := ctx.String(gethPathFlag.Name)
+	if gethPath == "" {
+		gethPath = path.Join(os.Getenv("CELO_BLOCKCHAIN"), "build/bin/geth")
+		if fileutils.FileExists(gethPath) {
+			log.Info("Missing --geth flag, using CELO_BLOCKCHAIN derived path", "geth", gethPath)
 		} else {
 			return "", fmt.Errorf("Missing --geth flag")
 		}
 	}
-	return buildpath, nil
+	return gethPath, nil
 }
 
 func readEnv(ctx *cli.Context) (*env.Environment, error) {


### PR DESCRIPTION
### Description

I noticed this local variable, `buildpath` was misnamed as a result of copy/paste from this function: https://github.com/celo-org/celo-blockchain/blob/e8b674392d7c60c4e13cfc3a95d9f293fec5db57/cmd/mycelo/genesis_commands.go#L82-L93

This PR just renames it to `gethpath`, which is what it actually is

### Tested

* CI tests
