### PR TITLE
Fix broken circleci setup for lightest sync test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   system-contracts-cache-version:
     type: integer
     default: 1
-  # Use this git tag or commit of the monorepo to build the system contracts. 
+  # Use this git tag or commit of the monorepo to build the system contracts.
   system-contracts-monorepo-version:
     type: string
     default: "celo-core-contracts-v3.rc0"
@@ -194,9 +194,7 @@ jobs:
       - run: ./scripts/publish-mobile-client.sh ${CIRCLE_SHA1} ${NPM_TOKEN_FOR_CELO_CLIENT}
 
   lightest-sync-test:
-    docker:
-      - image: circleci/node:10
-    working_directory: ~/repos/geth
+    executor: golang
     steps:
       - attach_workspace:
           at: ~/repos


### PR DESCRIPTION
### Description

As of today, the `lightest-sync-test` test in CircleCI started failing with the following error:

```
build/bin/geth: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by build/bin/geth)
```

It was using the `circleci/node:10` docker image, so presumably a new version of that image caused the change leading to this error.  However, the test doesn't use node.js, so there is no reason to use that image for it.  This PR modifies the test to use the golang executor we already have defined for other steps such as building geth.  That makes the error go away.

### Other changes

Trailing whitespace trimmed by my editor.

### Tested

Verified as a draft PR that this fixes the problem and that the test now passes.
