### PR TITLE
[CI] Update lightest-sync-test circleci workflow image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
 
   lightest-sync-test:
     docker:
-      - image: circleci/node:10
+      - image: circleci/golang:1.16
     working_directory: ~/repos/geth
     steps:
       - attach_workspace:

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -597,9 +597,6 @@ func (sb *Backend) Verify(proposal istanbul.Proposal) (*istanbulCore.StateProces
 		return nil, 0, err
 	}
 
-	// Make a copy of the state
-	state = state.Copy()
-
 	// Apply this block's transactions to update the state
 	receipts, logs, usedGas, err := sb.processBlock(block, state)
 	if err != nil {

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -31,6 +31,7 @@ import (
 	"github.com/celo-org/celo-blockchain/consensus/istanbul/validator"
 	"github.com/celo-org/celo-blockchain/contracts/blockchain_parameters"
 	gpm "github.com/celo-org/celo-blockchain/contracts/gasprice_minimum"
+	"github.com/celo-org/celo-blockchain/core"
 	ethCore "github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/state"
 	"github.com/celo-org/celo-blockchain/core/types"
@@ -509,14 +510,8 @@ func (sb *Backend) Finalize(chain consensus.ChainHeaderReader, header *types.Hea
 func (sb *Backend) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction, receipts []*types.Receipt, randomness *types.Randomness) (*types.Block, error) {
 
 	sb.Finalize(chain, header, state, txs)
-
-	// Add extra receipt for Block's Internal Transaction Logs
-	if len(state.GetLogs(common.Hash{})) > 0 {
-		receipt := types.NewReceipt(nil, false, 0)
-		receipt.Logs = state.GetLogs(common.Hash{})
-		receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
-		receipts = append(receipts, receipt)
-	}
+	// Add the block receipt with logs from the non-transaction core contract calls (if there were any)
+	receipts = core.AddBlockReceipt(receipts, state, header.Hash())
 
 	// Assemble and return the final block for sealing
 	block := types.NewBlock(header, txs, receipts, randomness)

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -466,6 +466,13 @@ func (sb *Backend) Finalize(chain consensus.ChainHeaderReader, header *types.Hea
 	logger := sb.logger.New("func", "Finalize", "block", header.Number.Uint64(), "epochSize", sb.config.Epoch)
 	logger.Trace("Finalizing")
 
+	// The contract calls in Finalize() may emit logs, which we later add to an extra "block" receipt
+	// (in FinalizeAndAssemble() during construction or in `StateProcessor.process()` during verification).
+	// They are looked up using the zero hash instead of a transaction hash, and so we need to first call
+	// `state.Prepare()` so that they get filed under the zero hash. Otherwise, they would get filed under
+	// the hash of the last transaction in the block (if there were any).
+	state.Prepare(common.Hash{}, header.Hash(), len(txs))
+
 	snapshot := state.Snapshot()
 	vmRunner := sb.chain.NewEVMRunner(header, state)
 	err := sb.setInitialGoldTokenTotalSupplyIfUnset(vmRunner)

--- a/core/block_receipt.go
+++ b/core/block_receipt.go
@@ -1,0 +1,40 @@
+// Copyright 2021 The Celo Authors
+// This file is part of the celo library.
+//
+// The celo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The celo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the celo library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/core/state"
+	"github.com/celo-org/celo-blockchain/core/types"
+)
+
+// AddBlockReceipt checks whether logs were emitted by the core contract calls made as part
+// of block processing outside of transactions.  If there are any, it creates a receipt for
+// them (the so-called "block receipt") and appends it to receipts
+func AddBlockReceipt(receipts types.Receipts, statedb *state.StateDB, blockHash common.Hash) types.Receipts {
+	if len(statedb.GetLogs(common.Hash{})) > 0 {
+		receipt := types.NewReceipt(nil, false, 0)
+		receipt.Logs = statedb.GetLogs(common.Hash{})
+		receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
+		for i := range receipt.Logs {
+			receipt.Logs[i].TxIndex = uint(len(receipts))
+			receipt.Logs[i].TxHash = blockHash
+		}
+		receipts = append(receipts, receipt)
+	}
+	return receipts
+}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -94,16 +94,8 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions())
 
-	if len(statedb.GetLogs(common.Hash{})) > 0 {
-		receipt := types.NewReceipt(nil, false, 0)
-		receipt.Logs = statedb.GetLogs(common.Hash{})
-		receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
-		for i := range receipt.Logs {
-			receipt.Logs[i].TxIndex = uint(len(receipts))
-			receipt.Logs[i].TxHash = block.Hash()
-		}
-		receipts = append(receipts, receipt)
-	}
+	// Add the block receipt with logs from the non-transaction core contract calls (if there were any)
+	receipts = AddBlockReceipt(receipts, statedb, block.Hash())
 
 	return receipts, allLogs, *usedGas, nil
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -92,7 +92,6 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		allLogs = append(allLogs, receipt.Logs...)
 	}
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
-	statedb.Prepare(common.Hash{}, block.Hash(), len(block.Transactions()))
 	p.engine.Finalize(p.bc, header, statedb, block.Transactions())
 
 	if len(statedb.GetLogs(common.Hash{})) > 0 {

--- a/miner/block.go
+++ b/miner/block.go
@@ -326,15 +326,10 @@ func (b *blockState) finalizeAndAssemble(w *worker) (*types.Block, error) {
 		}
 	}
 
-	if len(b.state.GetLogs(common.Hash{})) > 0 {
-		receipt := types.NewReceipt(nil, false, 0)
-		receipt.Logs = b.state.GetLogs(common.Hash{})
-		for i := range receipt.Logs {
-			receipt.Logs[i].TxIndex = uint(len(b.receipts))
-		}
-		receipt.Bloom = types.CreateBloom(types.Receipts{receipt})
-		b.receipts = append(b.receipts, receipt)
-	}
+	// FinalizeAndAssemble adds the "block receipt" for the calculating the Bloom filter and receipts hash.
+	// But it doesn't return the receipts.  So we have to add the "block receipt" to b.receipts here, for
+	// use in calculating the "pending" block (and also in the `task`, though we could remove it from that).
+	b.receipts = core.AddBlockReceipt(b.receipts, b.state, block.Hash())
 
 	return block, nil
 }

--- a/miner/block.go
+++ b/miner/block.go
@@ -314,9 +314,6 @@ func (b *blockState) commitTransaction(w *worker, tx *types.Transaction, txFeeRe
 
 // finalizeAndAssemble runs post-transaction state modification and assembles the final block.
 func (b *blockState) finalizeAndAssemble(w *worker) (*types.Block, error) {
-	// Need to copy the state here otherwise block production stalls. Not sure why.
-	b.state = b.state.Copy()
-
 	block, err := w.engine.FinalizeAndAssemble(w.chain, b.header, b.state, b.txs, b.receipts, b.randomness)
 	if err != nil {
 		return nil, fmt.Errorf("Error in FinalizeAndAssemble: %w", err)


### PR DESCRIPTION
### Description

Update lightest-sync-test circleci workflow image to fix the error:
```
build/bin/geth: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by build/bin/geth)
```

