### PR TITLE
add custom marshal function for epochsnarkdata

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -18,6 +18,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/big"
@@ -170,6 +171,37 @@ func (r *EpochSnarkData) EncodeRLP(w io.Writer) error {
 
 func (r *EpochSnarkData) IsEmpty() bool {
 	return len(r.Signature) == 0
+}
+
+// MarshalJSON marshals as JSON.
+func (r EpochSnarkData) MarshalJSON() ([]byte, error) {
+	type EpochSnarkData struct {
+		Bitmap    hexutil.Bytes
+		Signature hexutil.Bytes
+	}
+	var enc EpochSnarkData
+	enc.Bitmap = r.Bitmap.Bytes()
+	enc.Signature = r.Signature
+	return json.Marshal(&enc)
+}
+
+// UnmarshalJSON unmarshals from JSON.
+func (r *EpochSnarkData) UnmarshalJSON(input []byte) error {
+	type EpochSnarkData struct {
+		Bitmap    hexutil.Bytes
+		Signature hexutil.Bytes
+	}
+	var dec EpochSnarkData
+	if err := json.Unmarshal(input, &dec); err != nil {
+		return err
+	}
+	if dec.Bitmap != nil {
+		r.Bitmap = new(big.Int).SetBytes(dec.Bitmap)
+	}
+	if dec.Signature != nil {
+		r.Signature = dec.Signature
+	}
+	return nil
 }
 
 // Body is a simple (mutable, non-safe) data container for storing and moving

--- a/test/node.go
+++ b/test/node.go
@@ -356,7 +356,7 @@ func GenesisConfig(accounts *env.AccountsConfig) *genesis.Config {
 // others not.
 func NewNetwork(accounts *env.AccountsConfig, gc *genesis.Config) (Network, error) {
 
-	genesis, err := genesis.GenerateGenesis(accounts, gc, "../../monorepo/packages/protocol/build/contracts")
+	genesis, err := genesis.GenerateGenesis(accounts, gc, "../monorepo/packages/protocol/build/contracts")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description

Currently, when unmarshalling `EpochSnarkData` structs from epoch blocks, the standard UnmarshalJSON function fails to convert a `hexutil.Bytes` value to `big.Int`.

This update adds a custom `UnmarshalJSON` function for `EpochSnarkData` in order to properly convert byte arrays into big.Int objects. 

I was not able to get the `gencodec` library to automatically generate an `UnmarshalJSON` function that properly handle conversions from `hexutil.Bytes` to `big.Int`, so I modified `gencodec` generated code and added it to `block.go` instead.

### Other changes

Also added a `MarshalJSON` function. Doesn't solve the bug, but added in case it was needed.

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

These changes were tested via the e2e test added on the previous commit. (See the related issue for more details.)

`go test ./e2e_test -count 1 -v`

 The marshal errors are no longer thrown with the new unmarshal function.

### Related issues

- Fixes #1574 

### Backwards compatibility

AFAIK, this custom unmarshal function should not create any issues with backwards compatibility.
