### PR TITLE
Fix failure to close in validatorPeerHandler

### DIFF
--- a/consensus/istanbul/backend/peer_handler.go
+++ b/consensus/istanbul/backend/peer_handler.go
@@ -50,6 +50,7 @@ func (vph *validatorPeerHandler) startThread() error {
 		return istanbul.ErrStartedVPHThread
 	}
 
+	vph.threadRunning = true
 	go vph.thread()
 
 	return nil


### PR DESCRIPTION
### Description
The validatorPeerHandler could not be closed because threadRunning
was never set to true so calling stopThread would exit early thinking the
validatorPeerHandler was already stopped and not actually stop anything.

### Tested

CI is passing

### Related issues

Discovered while investigating #1657 

### Backwards compatibility

Yes
