### PR TITLE
Simplify e2e test configuration

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -20,8 +20,9 @@ func init() {
 // network to process the transaction.
 func TestSendCelo(t *testing.T) {
 	accounts := test.Accounts(3)
-	gc := test.GenesisConfig(accounts)
-	network, err := test.NewNetwork(accounts, gc)
+	gc, ec, err := test.BuildConfig(accounts)
+	require.NoError(t, err)
+	network, err := test.NewNetwork(accounts, gc, ec)
 	require.NoError(t, err)
 	defer network.Shutdown()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)

--- a/mycelo/genesis/base_config.go
+++ b/mycelo/genesis/base_config.go
@@ -138,7 +138,6 @@ func BaseConfig() *Config {
 			Version:                 Version{1, 0, 0},
 			GasForNonGoldCurrencies: 50000,
 			BlockGasLimit:           13000000,
-			UptimeLookbackWindow:    12,
 		},
 		DoubleSigningSlasher: DoubleSigningSlasherParameters{
 			Reward:  bigIntStr("1000000000000000000000"), // 1000 cGLD

--- a/mycelo/genesis/config.go
+++ b/mycelo/genesis/config.go
@@ -143,7 +143,6 @@ type BlockchainParameters struct {
 	Version                 Version `json:"version"`
 	GasForNonGoldCurrencies uint64  `json:"gasForNonGoldCurrencies"`
 	BlockGasLimit           uint64  `json:"blockGasLimit"`
-	UptimeLookbackWindow    uint64  `json:"uptimeLookbackWindow"`
 }
 
 //go:generate gencodec -type DoubleSigningSlasherParameters -field-override DoubleSigningSlasherParametersMarshaling -out gen_double_signing_slasher_parameters_json.go

--- a/mycelo/genesis/genesis.go
+++ b/mycelo/genesis/genesis.go
@@ -28,7 +28,6 @@ func CreateCommonGenesisConfig(chainID *big.Int, adminAccountAddress common.Addr
 		ChurritoBlock: common.Big0,
 		DonutBlock:    common.Big0,
 	}
-	genesisConfig.Blockchain.UptimeLookbackWindow = genesisConfig.Istanbul.LookbackWindow
 
 	// Make admin account manager of Governance & Reserve
 	adminMultisig := MultiSigParameters{

--- a/mycelo/genesis/genesis_state.go
+++ b/mycelo/genesis/genesis_state.go
@@ -379,7 +379,7 @@ func (ctx *deployContext) deployBlockchainParameters() error {
 			big.NewInt(ctx.genesisConfig.Blockchain.Version.Patch),
 			newBigInt(ctx.genesisConfig.Blockchain.GasForNonGoldCurrencies),
 			newBigInt(ctx.genesisConfig.Blockchain.BlockGasLimit),
-			newBigInt(ctx.genesisConfig.Blockchain.UptimeLookbackWindow),
+			newBigInt(ctx.genesisConfig.Istanbul.LookbackWindow),
 		)
 	})
 }


### PR DESCRIPTION
### Description

Because of the duplication of istanbul config in the codebase, (see #1693)
when using the test package it was difficult to understand which config
should be used, and possible to end up with conflicting istanbul config
in different parts of the system.

This commit makes it clear where the config should be set and enforces
consistent config across the two config objects.

### Other changes

Removes duplicated config field `UptiimeLookbackWindow` from mycelo config, mycelo now has one source of truth for this value.

### Tested
Ran the following command:
```
make all && DIRNAME=mynew && rm -rf $DIRNAME && \
 ./build/bin/mycelo genesis --validators 3 --newenv $DIRNAME \
 --buildpath ./monorepo/packages/protocol/build/contracts && \
 ./build/bin/mycelo validator-init $DIRNAME && ./build/bin/mycelo validator-run  $DIRNAME
```
And saw that all 3 validators has started up and seemed to be were processing blocks correctly.

Also CI is passing.

### Related issues
* #1642 
To add additional tests we need to be able to manipulate the config easily.

### Backwards compatibility

Yes
