### PR TITLE
Cherry-pick: node: relax websocket connection header check (#21646)

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -313,7 +313,7 @@ func (h *httpServer) wsAllowed() bool {
 // isWebsocket checks the header of an http request for a websocket upgrade request.
 func isWebsocket(r *http.Request) bool {
 	return strings.ToLower(r.Header.Get("Upgrade")) == "websocket" &&
-		strings.ToLower(r.Header.Get("Connection")) == "upgrade"
+		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
 }
 
 // NewHTTPHandlerStack returns wrapped http-related handlers

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -73,6 +73,21 @@ func TestWebsocketOrigins(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestIsWebsocket tests if an incoming websocket upgrade request is handled properly.
+func TestIsWebsocket(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/", nil)
+
+	assert.False(t, isWebsocket(r))
+	r.Header.Set("upgrade", "websocket")
+	assert.False(t, isWebsocket(r))
+	r.Header.Set("connection", "upgrade")
+	assert.True(t, isWebsocket(r))
+	r.Header.Set("connection", "upgrade,keep-alive")
+	assert.True(t, isWebsocket(r))
+	r.Header.Set("connection", " UPGRADE,keep-alive")
+	assert.True(t, isWebsocket(r))
+}
+
 func createAndStartServer(t *testing.T, conf httpConfig, ws bool, wsConf wsConfig) *httpServer {
 	t.Helper()
 


### PR DESCRIPTION
### Description

Cherry-picking from go-ethereum [this PR](https://github.com/ethereum/go-ethereum/pull/21646).
The fix from the PR is needed for Kong and the GCP LB to be able to redirect the websocket properly.

### Tested

Tested in baklava forno env with and without Kong as proxy:
```
╰─ wscat -c wss://baklava-forno-k8s.celo-testnet.org/ws
Connected (press CTRL+C to quit)
> {"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}
< {"jsonrpc":"2.0","id":1,"result":"0x768513"}
```
```
╰─ geth attach wss://baklava-forno-k8s.celo-testnet.org/ws
Welcome to the Geth JavaScript console!

instance: celo/v1.4.0-unstable/linux-amd64/go1.16.8
at block: 7767331 (Wed Sep 22 2021 10:01:28 GMT+0200 (CEST))
 modules: eth:1.0 net:1.0 rpc:1.0 web3:1.0

To exit, press ctrl-d
>
```

### Related issues

- Fixes #1683 

### Backwards compatibility

[This celo-monorepo PR](https://github.com/celo-org/celo-monorepo/pull/8100) needs to be merged/used to deploy new celo-blockchain versions to Forno due to [this issue](https://github.com/ethereum/go-ethereum/issues/21441) (this endpoint change is already on master).
