### PR TITLE
Add start stop e2e test

### DIFF
--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -211,6 +211,7 @@ type Backend struct {
 
 	aWallets atomic.Value
 
+	wg           sync.WaitGroup
 	core         istanbulCore.Engine
 	logger       log.Logger
 	db           ethdb.Database
@@ -460,6 +461,7 @@ func (sb *Backend) Close() error {
 			concatenatedErrs = fmt.Errorf("%v; %v", concatenatedErrs, err)
 		}
 	}
+	sb.wg.Wait()
 	return concatenatedErrs
 }
 
@@ -550,7 +552,11 @@ func (sb *Backend) Commit(proposal istanbul.Proposal, aggregatedSeal types.Istan
 			return err
 		}
 	}
-	go sb.onNewConsensusBlock(block, result.Receipts, result.Logs, result.State)
+	sb.wg.Add(1)
+	go func() {
+		defer sb.wg.Done()
+		sb.onNewConsensusBlock(block, result.Receipts, result.Logs, result.State)
+	}()
 
 	return nil
 }

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -211,7 +211,6 @@ type Backend struct {
 
 	aWallets atomic.Value
 
-	wg           sync.WaitGroup
 	core         istanbulCore.Engine
 	logger       log.Logger
 	db           ethdb.Database
@@ -461,7 +460,6 @@ func (sb *Backend) Close() error {
 			concatenatedErrs = fmt.Errorf("%v; %v", concatenatedErrs, err)
 		}
 	}
-	sb.wg.Wait()
 	return concatenatedErrs
 }
 
@@ -552,12 +550,7 @@ func (sb *Backend) Commit(proposal istanbul.Proposal, aggregatedSeal types.Istan
 			return err
 		}
 	}
-	sb.wg.Add(1)
-	go func() {
-		defer sb.wg.Done()
-		sb.onNewConsensusBlock(block, result.Receipts, result.Logs, result.State)
-	}()
-
+	sb.onNewConsensusBlock(block, result.Receipts, result.Logs, result.State)
 	return nil
 }
 

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -346,6 +346,8 @@ func (sb *Backend) newChainHead(newBlock *types.Block) {
 
 		sb.logger.Info("Validator Election Results", "address", sb.ValidatorAddress(), "elected", valSetIndex >= 0, "number", newBlock.Number().Uint64())
 
+		sb.announceMu.Lock()
+		defer sb.announceMu.Unlock()
 		if sb.announceRunning {
 			sb.logger.Trace("At end of epoch and going to refresh validator peers", "new_block_number", newBlock.Number().Uint64())
 			if err := sb.RefreshValPeers(); err != nil {

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -346,6 +346,9 @@ func (sb *Backend) newChainHead(newBlock *types.Block) {
 
 		sb.logger.Info("Validator Election Results", "address", sb.ValidatorAddress(), "elected", valSetIndex >= 0, "number", newBlock.Number().Uint64())
 
+		// We lock here to protect access to announceRunning because
+		// announceRunning is also accessed in StartAnnouncing and
+		// StopAnnouncing.
 		sb.announceMu.Lock()
 		defer sb.announceMu.Unlock()
 		if sb.announceRunning {

--- a/consensus/istanbul/backend/peer_handler.go
+++ b/consensus/istanbul/backend/peer_handler.go
@@ -51,6 +51,7 @@ func (vph *validatorPeerHandler) startThread() error {
 	}
 
 	vph.threadRunning = true
+	vph.threadWg.Add(1)
 	go vph.thread()
 
 	return nil
@@ -72,7 +73,6 @@ func (vph *validatorPeerHandler) stopThread() error {
 }
 
 func (vph *validatorPeerHandler) thread() {
-	vph.threadWg.Add(1)
 	defer vph.threadWg.Done()
 
 	refreshValidatorPeersTicker := time.NewTicker(1 * time.Minute)

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -115,8 +115,9 @@ type core struct {
 	finalCommittedSub *event.TypeMuxSubscription
 	timeoutSub        *event.TypeMuxSubscription
 
-	futurePreprepareTimer         *time.Timer
-	resendRoundChangeMessageTimer *time.Timer
+	futurePreprepareTimer           *time.Timer
+	resendRoundChangeMessageTimer   *time.Timer
+	resendRoundChangeMessageTimerMu sync.Mutex
 
 	roundChangeTimer   *time.Timer
 	roundChangeTimerMu sync.RWMutex
@@ -688,6 +689,8 @@ func (c *core) stopRoundChangeTimer() {
 }
 
 func (c *core) stopResendRoundChangeTimer() {
+	c.resendRoundChangeMessageTimerMu.Lock()
+	defer c.resendRoundChangeMessageTimerMu.Unlock()
 	if c.resendRoundChangeMessageTimer != nil {
 		c.resendRoundChangeMessageTimer.Stop()
 		c.resendRoundChangeMessageTimer = nil
@@ -777,6 +780,8 @@ func (c *core) resetResendRoundChangeTimer() {
 			resendTimeout = maxResendTimeout
 		}
 		view := &istanbul.View{Sequence: c.current.Sequence(), Round: c.current.DesiredRound()}
+		c.resendRoundChangeMessageTimerMu.Lock()
+		defer c.resendRoundChangeMessageTimerMu.Unlock()
 		c.resendRoundChangeMessageTimer = time.AfterFunc(resendTimeout, func() {
 			c.sendEvent(resendRoundChangeEvent{view})
 		})

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -127,6 +127,7 @@ type core struct {
 
 	rsdb      RoundStateDB
 	current   RoundState
+	currentMu sync.RWMutex
 	handlerWg *sync.WaitGroup
 
 	roundChangeSet *roundChangeSet
@@ -200,6 +201,11 @@ func (c *core) CurrentView() *istanbul.View {
 func (c *core) CurrentRoundState() RoundState { return c.current }
 
 func (c *core) ParentCommits() MessageSet {
+	// ParentCommits is called by Prepare which is called by miner.worker the
+	// main loop, we need to synchronise this access with the write which
+	// occurs in Stop, which is called from the miner's update loop.
+	c.currentMu.RLock()
+	defer c.currentMu.RUnlock()
 	if c.current == nil {
 		return nil
 	}

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -193,6 +193,11 @@ func (c *core) SetAddress(address common.Address) {
 }
 
 func (c *core) CurrentView() *istanbul.View {
+	// CurrentView is called by Prepare which is called by miner.worker the
+	// main loop, we need to synchronise this access with the write which occurs
+	// in Stop, which is called from the miner's update loop.
+	c.currentMu.RLock()
+	defer c.currentMu.RUnlock()
 	if c.current == nil {
 		return nil
 	}

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -47,6 +47,8 @@ func (c *core) Start() error {
 	// Tests will handle events itself, so we have to make subscribeEvents()
 	// be able to call in test.
 	c.subscribeEvents()
+
+	c.handlerWg.Add(1)
 	go c.handleEvents()
 
 	return nil
@@ -94,8 +96,6 @@ func (c *core) unsubscribeEvents() {
 func (c *core) handleEvents() {
 	// Clear state
 	defer c.handlerWg.Done()
-
-	c.handlerWg.Add(1)
 
 	for {
 		logger := c.newLogger("func", "handleEvents")

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -62,6 +62,8 @@ func (c *core) Stop() error {
 	// Make sure the handler goroutine exits
 	c.handlerWg.Wait()
 
+	c.currentMu.Lock()
+	defer c.currentMu.Unlock()
 	c.current = nil
 	return nil
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -42,6 +42,7 @@ import (
 	"github.com/celo-org/celo-blockchain/core/vm/vmcontext"
 	"github.com/celo-org/celo-blockchain/ethdb"
 	"github.com/celo-org/celo-blockchain/event"
+	"github.com/celo-org/celo-blockchain/internal/syncx"
 	"github.com/celo-org/celo-blockchain/log"
 	"github.com/celo-org/celo-blockchain/metrics"
 	"github.com/celo-org/celo-blockchain/params"
@@ -84,6 +85,7 @@ var (
 
 	errInsertionInterrupted = errors.New("insertion is interrupted")
 	errCommitmentNotFound   = errors.New("randomness commitment not found")
+	errChainStopped         = errors.New("blockchain is stopped")
 )
 
 const (
@@ -187,7 +189,9 @@ type BlockChain struct {
 	scope         event.SubscriptionScope
 	genesisBlock  *types.Block
 
-	chainmu sync.RWMutex // blockchain insertion lock
+	// This mutex synchronizes chain write operations.
+	// Readers don't need to take it, they can just read the database.
+	chainmu *syncx.ClosableMutex
 
 	currentBlock     atomic.Value // Current head of the block chain
 	currentFastBlock atomic.Value // Current head of the fast-sync chain (may be above the block chain!)
@@ -200,8 +204,8 @@ type BlockChain struct {
 	txLookupCache *lru.Cache     // Cache for the most recent transaction lookup data.
 	futureBlocks  *lru.Cache     // future blocks are blocks added for later processing
 
-	quit          chan struct{}  // blockchain quit channel
-	wg            sync.WaitGroup // chain processing wait group for shutting down
+	wg            sync.WaitGroup //
+	quit          chan struct{}  // shutdown signal, closed in Stop.
 	running       int32          // 0 if chain is running, 1 when stopped
 	procInterrupt int32          // interrupt signaler for block processing
 
@@ -240,6 +244,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 			Preimages: cacheConfig.Preimages,
 		}),
 		quit:           make(chan struct{}),
+		chainmu:        syncx.NewClosableMutex(),
 		shouldPreserve: shouldPreserve,
 		bodyCache:      bodyCache,
 		bodyRLPCache:   bodyRLPCache,
@@ -283,6 +288,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	if err := bc.loadLastState(); err != nil {
 		return nil, err
 	}
+
 	// Make sure the state associated with the block is available
 	head := bc.CurrentBlock()
 	if _, err := state.New(head.Root(), bc.stateCache, bc.snaps); err != nil {
@@ -311,6 +317,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 			}
 		}
 	}
+
 	// Ensure that a previous crash in SetHead doesn't leave extra ancients
 	if frozen, err := bc.db.Ancients(); err == nil && frozen > 0 {
 		var (
@@ -362,6 +369,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 			}
 		}
 	}
+
 	// Load any existing snapshot, regenerating it if loading failed
 	if bc.cacheConfig.SnapshotLimit > 0 {
 		// If the chain was rewound past the snapshot persistent layer (causing
@@ -377,14 +385,19 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 		}
 		bc.snaps, _ = snapshot.New(bc.db, bc.stateCache.TrieDB(), bc.cacheConfig.SnapshotLimit, head.Root(), !bc.cacheConfig.SnapshotWait, true, recover)
 	}
-	// Take ownership of this particular state
-	go bc.update()
+
+	// Start future block processor.
+	bc.wg.Add(1)
+	go bc.futureBlocksLoop()
+
+	// Start tx indexer/unindexer.
 	if txLookupLimit != nil {
 		bc.txLookupLimit = *txLookupLimit
 
 		bc.wg.Add(1)
 		go bc.maintainTxIndex(txIndexBlock)
 	}
+
 	// If periodic cache journal is required, spin it up.
 	if bc.cacheConfig.TrieCleanRejournal > 0 {
 		if bc.cacheConfig.TrieCleanRejournal < time.Minute {
@@ -510,7 +523,9 @@ func (bc *BlockChain) SetHead(head uint64) error {
 //
 // The method returns the block number where the requested root cap was found.
 func (bc *BlockChain) SetHeadBeyondRoot(head uint64, root common.Hash) (uint64, error) {
-	bc.chainmu.Lock()
+	if !bc.chainmu.TryLock() {
+		return 0, errChainStopped
+	}
 	defer bc.chainmu.Unlock()
 
 	// Track the block number of the requested root hash
@@ -656,8 +671,11 @@ func (bc *BlockChain) FastSyncCommitHead(hash common.Hash) error {
 	if _, err := trie.NewSecure(block.Root(), bc.stateCache.TrieDB()); err != nil {
 		return err
 	}
-	// If all checks out, manually set the head block
-	bc.chainmu.Lock()
+
+	// If all checks out, manually set the head block.
+	if !bc.chainmu.TryLock() {
+		return errChainStopped
+	}
 	bc.currentBlock.Store(block)
 	headBlockGauge.Update(int64(block.NumberU64()))
 	bc.chainmu.Unlock()
@@ -725,7 +743,9 @@ func (bc *BlockChain) ResetWithGenesisBlock(genesis *types.Block) error {
 	if err := bc.SetHead(0); err != nil {
 		return err
 	}
-	bc.chainmu.Lock()
+	if !bc.chainmu.TryLock() {
+		return errChainStopped
+	}
 	defer bc.chainmu.Unlock()
 
 	// Prepare the genesis block and reinitialise the chain
@@ -755,8 +775,10 @@ func (bc *BlockChain) Export(w io.Writer) error {
 
 // ExportN writes a subset of the active chain to the given writer.
 func (bc *BlockChain) ExportN(w io.Writer, first uint64, last uint64) error {
-	bc.chainmu.RLock()
-	defer bc.chainmu.RUnlock()
+	if !bc.chainmu.TryLock() {
+		return errChainStopped
+	}
+	defer bc.chainmu.Unlock()
 
 	if first > last {
 		return fmt.Errorf("export failed: first (%d) is greater than last (%d)", first, last)
@@ -998,10 +1020,21 @@ func (bc *BlockChain) Stop() {
 	if !atomic.CompareAndSwapInt32(&bc.running, 0, 1) {
 		return
 	}
-	// Unsubscribe all subscriptions registered from blockchain
+
+	// Unsubscribe all subscriptions registered from blockchain.
 	bc.scope.Close()
+
+	// Signal shutdown to all goroutines.
 	close(bc.quit)
 	bc.StopInsert()
+
+	// Now wait for all chain modifications to end and persistent goroutines to exit.
+	//
+	// Note: Close waits for the mutex to become available, i.e. any running chain
+	// modification will have exited when Close returns. Since we also called StopInsert,
+	// the mutex should become available quickly. It cannot be taken again after Close has
+	// returned.
+	bc.chainmu.Close()
 	bc.wg.Wait()
 
 	// Ensure that the entirety of the state snapshot is journalled to disk.
@@ -1012,6 +1045,7 @@ func (bc *BlockChain) Stop() {
 			log.Error("Failed to journal state snapshot", "err", err)
 		}
 	}
+
 	// Ensure the state of a recent block is also stored to disk before exiting.
 	// We're writing three different states to catch different restart scenarios:
 	//  - HEAD:     So we don't need to reprocess any blocks in the general case
@@ -1155,7 +1189,10 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 	// updateHead updates the head fast sync block if the inserted blocks are better
 	// and returns an indicator whether the inserted blocks are canonical.
 	updateHead := func(head *types.Block) bool {
-		bc.chainmu.Lock()
+		if !bc.chainmu.TryLock() {
+			return false
+		}
+		defer bc.chainmu.Unlock()
 
 		// Rewind may have occurred, skip in that case.
 		if bc.CurrentHeader().Number.Cmp(head.Number()) >= 0 {
@@ -1164,11 +1201,9 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 				rawdb.WriteHeadFastBlockHash(bc.db, head.Hash())
 				bc.currentFastBlock.Store(head)
 				headFastBlockGauge.Update(int64(head.NumberU64()))
-				bc.chainmu.Unlock()
 				return true
 			}
 		}
-		bc.chainmu.Unlock()
 		return false
 	}
 	// writeAncient writes blockchain and corresponding receipt chain into ancient store.
@@ -1402,8 +1437,9 @@ var lastWrite uint64
 // but does not write any state. This is used to construct competing side forks
 // up to the point where they exceed the canonical total difficulty.
 func (bc *BlockChain) writeBlockWithoutState(block *types.Block, td *big.Int) (err error) {
-	bc.wg.Add(1)
-	defer bc.wg.Done()
+	if bc.insertStopped() {
+		return errInsertionInterrupted
+	}
 
 	batch := bc.db.NewBatch()
 	rawdb.WriteTd(batch, block.Hash(), block.NumberU64(), td)
@@ -1417,9 +1453,6 @@ func (bc *BlockChain) writeBlockWithoutState(block *types.Block, td *big.Int) (e
 // writeKnownBlock updates the head block flag with a known block
 // and introduces chain reorg if necessary.
 func (bc *BlockChain) writeKnownBlock(block *types.Block) error {
-	bc.wg.Add(1)
-	defer bc.wg.Done()
-
 	current := bc.CurrentBlock()
 	if block.ParentHash() != current.Hash() {
 		if err := bc.reorg(current, block); err != nil {
@@ -1433,7 +1466,9 @@ func (bc *BlockChain) writeKnownBlock(block *types.Block) error {
 // InsertPreprocessedBlock inserts a block which is already processed.
 // It can only insert the new Head block
 func (bc *BlockChain) InsertPreprocessedBlock(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB) error {
-	bc.chainmu.Lock()
+	if !bc.chainmu.TryLock() {
+		return errInsertionInterrupted
+	}
 	defer bc.chainmu.Unlock()
 
 	// check we are trying to insert the NEXT block
@@ -1448,8 +1483,9 @@ func (bc *BlockChain) InsertPreprocessedBlock(block *types.Block, receipts []*ty
 // insertPreprocessedBlock writes the block and all associated state to the database,
 // but is expects the chain mutex to be held.
 func (bc *BlockChain) insertPreprocessedBlock(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (status WriteStatus, err error) {
-	bc.wg.Add(1)
-	defer bc.wg.Done()
+	if bc.insertStopped() {
+		return NonStatTy, errInsertionInterrupted
+	}
 
 	randomCommitment := common.Hash{}
 	if istEngine, isIstanbul := bc.engine.(consensus.Istanbul); isIstanbul {
@@ -1649,14 +1685,9 @@ func (bc *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 	bc.blockProcFeed.Send(true)
 	defer bc.blockProcFeed.Send(false)
 
-	// Remove already known canon-blocks
-	var (
-		block, prev *types.Block
-	)
-	// Do a sanity check that the provided chain is actually ordered and linked
+	// Do a sanity check that the provided chain is actually ordered and linked.
 	for i := 1; i < len(chain); i++ {
-		block = chain[i]
-		prev = chain[i-1]
+		block, prev := chain[i], chain[i-1]
 		if block.NumberU64() != prev.NumberU64()+1 || block.ParentHash() != prev.Hash() {
 			// Chain broke ancestry, log a message (programming error) and skip insertion
 			log.Error("Non contiguous block insert", "number", block.Number(), "hash", block.Hash(),
@@ -1666,14 +1697,13 @@ func (bc *BlockChain) InsertChain(chain types.Blocks) (int, error) {
 				prev.Hash().Bytes()[:4], i, block.NumberU64(), block.Hash().Bytes()[:4], block.ParentHash().Bytes()[:4])
 		}
 	}
-	// Pre-checks passed, start the full block imports
-	bc.wg.Add(1)
-	bc.chainmu.Lock()
-	n, err := bc.insertChain(chain, true)
-	bc.chainmu.Unlock()
-	bc.wg.Done()
 
-	return n, err
+	// Pre-check passed, start the full block imports.
+	if !bc.chainmu.TryLock() {
+		return 0, errChainStopped
+	}
+	defer bc.chainmu.Unlock()
+	return bc.insertChain(chain, true)
 }
 
 // InsertChainWithoutSealVerification works exactly the same
@@ -1682,14 +1712,11 @@ func (bc *BlockChain) InsertChainWithoutSealVerification(block *types.Block) (in
 	bc.blockProcFeed.Send(true)
 	defer bc.blockProcFeed.Send(false)
 
-	// Pre-checks passed, start the full block imports
-	bc.wg.Add(1)
-	bc.chainmu.Lock()
-	n, err := bc.insertChain(types.Blocks([]*types.Block{block}), false)
-	bc.chainmu.Unlock()
-	bc.wg.Done()
-
-	return n, err
+	if !bc.chainmu.TryLock() {
+		return 0, errChainStopped
+	}
+	defer bc.chainmu.Unlock()
+	return bc.insertChain(types.Blocks([]*types.Block{block}), false)
 }
 
 // insertChain is the internal implementation of InsertChain, which assumes that
@@ -1701,10 +1728,11 @@ func (bc *BlockChain) InsertChainWithoutSealVerification(block *types.Block) (in
 // is imported, but then new canon-head is added before the actual sidechain
 // completes, then the historic state could be pruned again
 func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, error) {
-	// If the chain is terminating, don't even bother starting up
-	if atomic.LoadInt32(&bc.procInterrupt) == 1 {
+	// If the chain is terminating, don't even bother starting up.
+	if bc.insertStopped() {
 		return 0, nil
 	}
+
 	// Start a parallel signature recovery (signer will fluke on fork transition, minimal perf loss)
 	senderCacher.recoverFromBlocks(types.MakeSigner(bc.chainConfig, chain[0].Number()), chain)
 
@@ -1739,8 +1767,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 		// First block (and state) is known
 		//   1. We did a roll-back, and should now do a re-import
 		//   2. The block is stored as a sidechain, and is lying about it's stateroot, and passes a stateroot
-		// 	    from the canonical chain, which has not been verified.
-		// Skip all known blocks that are behind us
+		//      from the canonical chain, which has not been verified.
+		// Skip all known blocks that are behind us.
 		var (
 			current  = bc.CurrentBlock()
 			localTd  = bc.GetTd(current.Hash(), current.NumberU64())
@@ -1856,9 +1884,9 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 			lastCanon = block
 			continue
 		}
+
 		// Retrieve the parent block and it's state to execute on top
 		start := time.Now()
-
 		parent := it.previous()
 		if parent == nil {
 			parent = bc.GetHeader(block.ParentHash(), block.NumberU64()-1)
@@ -1870,7 +1898,6 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 		// Enable prefetching to pull in trie node paths while processing transactions
 		statedb.StartPrefetcher("chain")
 		activeState = statedb
-
 		// If we have a followup block, run that against the current state to pre-cache
 		// transactions and probabilistically some of the account/storage trie nodes.
 		var followupInterrupt uint32
@@ -1888,6 +1915,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 				}(time.Now(), followup, throwaway, &followupInterrupt)
 			}
 		}
+
 		// Process block using the parent state as reference point
 		substart := time.Now()
 		receipts, logs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig)
@@ -1896,6 +1924,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 			atomic.StoreUint32(&followupInterrupt, 1)
 			return it.index, err
 		}
+
 		// Update the metrics touched during block processing
 		accountReadTimer.Update(statedb.AccountReads)                 // Account reads are complete, we can mark them
 		storageReadTimer.Update(statedb.StorageReads)                 // Storage reads are complete, we can mark them
@@ -1970,6 +1999,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 		dirty, _ := bc.stateCache.TrieDB().Size()
 		stats.report(chain, it.index, dirty)
 	}
+
 	// Any blocks remaining here? The only ones we care about are the future ones
 	if block != nil && errors.Is(err, consensus.ErrFutureBlock) {
 		if err := bc.addFutureBlock(block); err != nil {
@@ -2296,7 +2326,10 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	return nil
 }
 
-func (bc *BlockChain) update() {
+// futureBlocksLoop processes the 'future block' queue.
+func (bc *BlockChain) futureBlocksLoop() {
+	defer bc.wg.Done()
+
 	futureTimer := time.NewTicker(5 * time.Second)
 	defer futureTimer.Stop()
 	for {
@@ -2333,6 +2366,7 @@ func (bc *BlockChain) maintainTxIndex(ancients uint64) {
 		}
 		rawdb.IndexTransactions(bc.db, from, ancients, bc.quit)
 	}
+
 	// indexBlocks reindexes or unindexes transactions depending on user configuration
 	indexBlocks := func(tail *uint64, head uint64, done chan struct{}) {
 		defer func() { done <- struct{}{} }()
@@ -2365,6 +2399,7 @@ func (bc *BlockChain) maintainTxIndex(ancients uint64) {
 			rawdb.UnindexTransactions(bc.db, *tail, head-bc.txLookupLimit+1, bc.quit)
 		}
 	}
+
 	// Any reindexing done, start listening to chain events and moving the index window
 	var (
 		done   chan struct{}                  // Non-nil if background unindexing or reindexing routine is active.
@@ -2432,12 +2467,11 @@ func (bc *BlockChain) InsertHeaderChain(chain []*types.Header, checkFreq int, co
 		return i, err
 	}
 
-	// Make sure only one thread manipulates the chain at once
-	bc.chainmu.Lock()
+	if !bc.chainmu.TryLock() {
+		return 0, errChainStopped
+	}
 	defer bc.chainmu.Unlock()
 
-	bc.wg.Add(1)
-	defer bc.wg.Done()
 	_, err := bc.hc.InsertHeaderChain(chain, start)
 	return 0, err
 }

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -162,7 +162,7 @@ func testBlockChainImport(chain types.Blocks, blockchain *BlockChain) error {
 			blockchain.reportBlock(block, receipts, err)
 			return err
 		}
-		blockchain.chainmu.Lock()
+		blockchain.chainmu.MustLock()
 		rawdb.WriteTd(blockchain.db, block.Hash(), block.NumberU64(), block.TotalDifficulty())
 		rawdb.WriteBlock(blockchain.db, block)
 		statedb.Commit(false)
@@ -180,7 +180,7 @@ func testHeaderChainImport(chain []*types.Header, blockchain *BlockChain) error 
 			return err
 		}
 		// Manually insert the header into the database, but don't reorganise (allows subsequent testing)
-		blockchain.chainmu.Lock()
+		blockchain.chainmu.MustLock()
 		rawdb.WriteTd(blockchain.db, header.Hash(), header.Number.Uint64(), new(big.Int).Add(header.Number, big.NewInt(1)))
 		rawdb.WriteHeader(blockchain.db, header)
 		blockchain.chainmu.Unlock()

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -2,9 +2,11 @@ package e2e_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +16,7 @@ func init() {
 	// This statement is commented out but left here since its very useful for
 	// debugging problems and its non trivial to construct.
 	//
-	//log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
+	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlDebug, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
 }
 
 // This test starts a network submits a transaction and waits for the whole
@@ -65,4 +67,110 @@ func TestEpochBlockMarshaling(t *testing.T) {
 	// something there.
 	assert.True(t, len(b.EpochSnarkData().Signature) > 0)
 	assert.True(t, b.EpochSnarkData().Bitmap.Uint64() > 0)
+}
+
+// This test checks that a network can have validators shut down mid operation
+// and that it can continue to function, it also checks that if more than f
+// validators are shut down, when they restart the network is able to continue.
+func TestStartStopValidators(t *testing.T) {
+	accounts := test.Accounts(4)
+	gc, ec, err := test.BuildConfig(accounts)
+	require.NoError(t, err)
+	network, err := test.NewNetwork(accounts, gc, ec)
+	require.NoError(t, err)
+	defer network.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	var txs []*types.Transaction
+
+	// Send 1 celo from the dev account attached to node 0 to the dev account
+	// attached to node 1.
+	tx, err := network[0].SendCelo(ctx, network[1].DevAddress, 1)
+	require.NoError(t, err)
+	txs = append(txs, tx)
+
+	// Wait for the whole network to process the transaction.
+	err = network.AwaitTransactions(ctx, txs...)
+	require.NoError(t, err)
+
+	// Stop one node, the rest of the network should still be able to progress
+	err = network[3].Close()
+	require.NoError(t, err)
+
+	// Send 1 celo from the dev account attached to node 0 to the dev account
+	// attached to node 1.
+	tx, err = network[0].SendCelo(ctx, network[1].DevAddress, 1)
+	require.NoError(t, err)
+	txs = append(txs, tx)
+
+	// Check that the remaining network can still process this transction.
+	err = network[:3].AwaitTransactions(ctx, txs...)
+	require.NoError(t, err)
+
+	// Stop another node, the network should now be stuck
+	err = network[2].Close()
+	require.NoError(t, err)
+
+	// Now we will check that the network does not process transactions in this
+	// state, by waiting for a reasonable amount of time for it to process a
+	// transaction and assuming it is not processing transactions if we time out.
+	shortCtx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	// Send 1 celo from the dev account attached to node 0 to the dev account
+	// attached to node 1.
+	tx, err = network[0].SendCelo(shortCtx, network[1].DevAddress, 1)
+	require.NoError(t, err)
+	txs = append(txs, tx)
+
+	err = network[:2].AwaitTransactions(shortCtx, txs...)
+	// Expect DeadlineExceeded error
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expecting %q, instead got: %v ", context.DeadlineExceeded.Error(), err)
+	}
+
+	// Start the last stopped node
+	err = network[2].Start()
+	require.NoError(t, err)
+
+	// Connect last stopped node to running nodes
+	network[2].AddPeers(network[:2]...)
+	time.Sleep(25 * time.Millisecond)
+	for _, n := range network[:3] {
+		err = n.GossipEnodeCertificatge()
+		require.NoError(t, err)
+	}
+
+	// Check that the  network now processes the previous transaction.
+	err = network[:3].AwaitTransactions(ctx, txs...)
+	require.NoError(t, err)
+
+	// Check that the network now quickly processes incoming transactions.
+	tx, err = network[0].SendCelo(ctx, network[1].DevAddress, 1)
+	require.NoError(t, err)
+	txs = append(txs, tx)
+
+	err = network[:3].AwaitTransactions(ctx, txs...)
+	require.NoError(t, err)
+
+	// Start the first stopped node
+	err = network[3].Start()
+	require.NoError(t, err)
+
+	// Connect final node to rest of network
+	network[3].AddPeers(network[:3]...)
+	time.Sleep(25 * time.Millisecond)
+	for _, n := range network {
+		err = n.GossipEnodeCertificatge()
+		require.NoError(t, err)
+	}
+
+	// Check that the network continues to quickly processes incoming transactions.
+	tx, err = network[0].SendCelo(ctx, network[1].DevAddress, 1)
+	require.NoError(t, err)
+	txs = append(txs, tx)
+
+	err = network.AwaitTransactions(ctx, txs...)
+	require.NoError(t, err)
+
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -216,17 +216,18 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		checkpoint = params.TrustedCheckpoints[genesisHash]
 	}
 	if eth.handler, err = newHandler(&handlerConfig{
-		Database:    chainDb,
-		Chain:       eth.blockchain,
-		TxPool:      eth.txPool,
-		Network:     config.NetworkId,
-		Sync:        config.SyncMode,
-		BloomCache:  uint64(cacheLimit),
-		EventMux:    eth.eventMux,
-		Checkpoint:  checkpoint,
-		Whitelist:   config.Whitelist,
-		server:      stack.Server(),
-		proxyServer: stack.ProxyServer(),
+		Database:     chainDb,
+		Chain:        eth.blockchain,
+		TxPool:       eth.txPool,
+		Network:      config.NetworkId,
+		Sync:         config.SyncMode,
+		BloomCache:   uint64(cacheLimit),
+		EventMux:     eth.eventMux,
+		Checkpoint:   checkpoint,
+		Whitelist:    config.Whitelist,
+		server:       stack.Server(),
+		proxyServer:  stack.ProxyServer(),
+		MinSyncPeers: config.MinSyncPeers,
 	}); err != nil {
 		return nil, err
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -608,6 +608,7 @@ func (s *Ethereum) Stop() error {
 	close(s.closeBloomHandler)
 	s.txPool.Stop()
 	s.miner.Stop()
+	s.miner.Close()
 	s.blockchain.Stop()
 	s.engine.Close()
 	rawdb.PopUncleanShutdownMarker(s.chainDb)

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -121,6 +121,7 @@ type Downloader struct {
 	notified        int32
 	committed       int32
 	ancientLimit    uint64 // The maximum block number which can be regarded as ancient data.
+	ancientLimitMu  sync.Mutex
 
 	// Channels
 	headerCh      chan dataPack        // Channel receiving inbound block headers
@@ -646,6 +647,10 @@ func (d *Downloader) cancel() {
 func (d *Downloader) Cancel() {
 	d.cancel()
 	d.cancelWg.Wait()
+	d.ancientLimitMu.Lock()
+	defer d.ancientLimitMu.Unlock()
+	d.ancientLimit = 0
+	log.Debug("Reset ancient limit to zero")
 }
 
 // Terminate interrupts the downloader, canceling all pending operations.

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -150,6 +150,10 @@ type Config struct {
 
 	// E block override (TODO: remove after the fork)
 	OverrideEHardfork *big.Int `toml:",omitempty"`
+
+	// The minimum required peers in order for syncing to be initiated, if left
+	// at 0 then the default will be used.
+	MinSyncPeers int `toml:",omitempty"`
 }
 
 // CreateConsensusEngine creates the required type of consensus engine instance for an Ethereum service

--- a/internal/syncx/mutex.go
+++ b/internal/syncx/mutex.go
@@ -1,0 +1,64 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package syncx contains exotic synchronization primitives.
+package syncx
+
+// ClosableMutex is a mutex that can also be closed.
+// Once closed, it can never be taken again.
+type ClosableMutex struct {
+	ch chan struct{}
+}
+
+func NewClosableMutex() *ClosableMutex {
+	ch := make(chan struct{}, 1)
+	ch <- struct{}{}
+	return &ClosableMutex{ch}
+}
+
+// TryLock attempts to lock cm.
+// If the mutex is closed, TryLock returns false.
+func (cm *ClosableMutex) TryLock() bool {
+	_, ok := <-cm.ch
+	return ok
+}
+
+// MustLock locks cm.
+// If the mutex is closed, MustLock panics.
+func (cm *ClosableMutex) MustLock() {
+	_, ok := <-cm.ch
+	if !ok {
+		panic("mutex closed")
+	}
+}
+
+// Unlock unlocks cm.
+func (cm *ClosableMutex) Unlock() {
+	select {
+	case cm.ch <- struct{}{}:
+	default:
+		panic("Unlock of already-unlocked ClosableMutex")
+	}
+}
+
+// Close locks the mutex, then closes it.
+func (cm *ClosableMutex) Close() {
+	_, ok := <-cm.ch
+	if !ok {
+		panic("Close of already-closed ClosableMutex")
+	}
+	close(cm.ch)
+}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -171,6 +171,7 @@ func (miner *Miner) update() {
 			miner.worker.stop()
 		case <-miner.exitCh:
 			miner.worker.close()
+			miner.exitCh <- struct{}{}
 			return
 		}
 	}
@@ -187,7 +188,8 @@ func (miner *Miner) Stop() {
 }
 
 func (miner *Miner) Close() {
-	close(miner.exitCh)
+	miner.exitCh <- struct{}{}
+	<-miner.exitCh
 }
 
 func (miner *Miner) Mining() bool {

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -166,6 +166,8 @@ func (p *Peer) RemovePurpose(purpose PurposeFlag) {
 }
 
 func (p *Peer) HasPurpose(purpose PurposeFlag) bool {
+	p.purposesMu.Lock()
+	defer p.purposesMu.Unlock()
 	return p.purposes.IsSet(purpose)
 }
 

--- a/test/node.go
+++ b/test/node.go
@@ -38,9 +38,11 @@ var (
 		Name:    "celo",
 		Version: params.Version,
 		P2P: p2p.Config{
-			MaxPeers:    100,
-			NoDiscovery: true,
-			ListenAddr:  "0.0.0.0:0",
+			MaxPeers:              100,
+			NoDiscovery:           true,
+			ListenAddr:            "0.0.0.0:0",
+			InboundThrottleTime:   200 * time.Millisecond,
+			DialHistoryExpiration: 210 * time.Millisecond,
 		},
 		NoUSB: true,
 		// It is important that HTTPHost and WSHost remain the same. This

--- a/test/node.go
+++ b/test/node.go
@@ -110,8 +110,13 @@ func NewNode(
 
 	// Copy the node config so we can modify it without damaging the original
 	ncCopy := *nc
-	// p2p key and address
-	ncCopy.P2P.PrivateKey = validatorAccount.PrivateKey
+
+	// p2p key and address, this is not the same as the validator key.
+	p2pKey, err := crypto.GenerateKey()
+	if err != nil {
+		return nil, err
+	}
+	ncCopy.P2P.PrivateKey = p2pKey
 
 	// Make temp datadir
 	datadir, err := ioutil.TempDir("", "celo_datadir")

--- a/test/node.go
+++ b/test/node.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/celo-org/celo-blockchain/accounts/keystore"
 	"github.com/celo-org/celo-blockchain/common"
-	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul/backend"
 	"github.com/celo-org/celo-blockchain/core"
@@ -235,11 +234,6 @@ func (n *Node) Start() error {
 	n.Enode = n.Server().LocalNode().Node()
 
 	return nil
-}
-
-// Provides a short representation of a hash
-func shortAddress(a common.Address) string {
-	return hexutil.Encode(a[:2])
 }
 
 func (n *Node) AddPeers(nodes ...*Node) {

--- a/test/node.go
+++ b/test/node.go
@@ -53,6 +53,7 @@ var (
 
 	baseEthConfig = &eth.Config{
 		SyncMode:        downloader.FullSync,
+		MinSyncPeers:    1,
 		DatabaseCache:   256,
 		DatabaseHandles: 256,
 		TxPool:          core.DefaultTxPoolConfig,

--- a/test/tracker.go
+++ b/test/tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sync"
 
 	ethereum "github.com/celo-org/celo-blockchain"
@@ -192,7 +193,7 @@ func (tr *Tracker) await(ctx context.Context, condition func() bool) error {
 // StopTracking shuts down all the goroutines in the tracker.
 func (tr *Tracker) StopTracking() error {
 	if tr.sub == nil {
-		return errors.New("attempted to stop already stopped tracker")
+		return fmt.Errorf("attempted to stop already stopped tracker - stack: \n%s", string(debug.Stack()))
 	}
 	tr.sub.Unsubscribe()
 	close(tr.stopCh)

--- a/test/tracker.go
+++ b/test/tracker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime/debug"
 	"sync"
 
 	ethereum "github.com/celo-org/celo-blockchain"
@@ -15,7 +14,8 @@ import (
 )
 
 var (
-	errStopped = errors.New("transaction tracker closed")
+	errStopped               = errors.New("transaction tracker closed")
+	ErrTrackerAlreadyStopped = errors.New("attempted to stop already stopped tracker")
 )
 
 // Tracker tracks processed blocks and transactions through a subscription with
@@ -193,7 +193,7 @@ func (tr *Tracker) await(ctx context.Context, condition func() bool) error {
 // StopTracking shuts down all the goroutines in the tracker.
 func (tr *Tracker) StopTracking() error {
 	if tr.sub == nil {
-		return fmt.Errorf("attempted to stop already stopped tracker - stack: \n%s", string(debug.Stack()))
+		return ErrTrackerAlreadyStopped
 	}
 	tr.sub.Unsubscribe()
 	close(tr.stopCh)

--- a/test/tracker.go
+++ b/test/tracker.go
@@ -197,6 +197,9 @@ func (tr *Tracker) StopTracking() error {
 	tr.sub.Unsubscribe()
 	close(tr.stopCh)
 	tr.wg.Wait()
+	// Set this to nil to mark the tracker as stopped. This must be done after
+	// waiting for wg, to avoid a data race in trackTransactions.
+	tr.sub = nil
 	tr.wg = sync.WaitGroup{}
 	return nil
 }


### PR DESCRIPTION
### Description

This PR adds a test that starts and stops nodes in a small network and verifies that the network can continue to function correctly throughout the process.

A quick overview of what the test does:

1. Start 4 nodes
2. Verify they can confirm a tx
3. Stop one node
4. Verify the remaining 3 can confirm a tx
5. Stop another node
6. Verify the remaining 2 cannot confirm a tx
7. Start the last stopped node
8. Verify that the previously un-confirmable tx can now be confirmed by the 3 running nodes.
9. Verify that the 3 running nodes can confirm a further tx
10. Start the remaining node
11. Verify that the netowrk can process another tx and that all sent txs have been processed by all nodes.

### Other changes

This PR makes the minSyncPeers, dialHistoryExpiration and InboundThrottleTime configurable, in order for this test to run/run quickly these values needed to be set and they were previously hardcoded.

This PR also ensures correct shutdown of the miner, worker and backend.Backend, and fixes a number of data races/ race conditions. Each fix is described in the associated commit messages, it's probably easier to review this PR commit by commit, since these changes otherwise look unrelated.

I think this PR would be best merged rater than 'squashed and merged' due to the large number of commits containing unrelated fixes.

#### Upstream PRs that came out of this work
* https://github.com/ethereum/go-ethereum/pull/23673
* https://github.com/ethereum/go-ethereum/pull/23674
* https://github.com/ethereum/go-ethereum/pull/23675

### Tested

I managed to run this test 200 times on my local machine with no failures.

### Related issues

#1642 

### Backwards compatibility

Yes