### PR TITLE
Reduce noise of e2e coverage comment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
             - <<parameters.cache-key>>
       - attach_workspace:
           at: ~/repos
+      - run: jq -h
       - run:
           name: prepare system contracts
           # Runs make prepare-system-contracts and sets the MONOREPO_COMMIT to
@@ -155,26 +156,51 @@ jobs:
             # Only post on PR if this build is running on a PR. If this build
             # is running on a PR then CIRCLE_PULL_REQUEST contains the link to
             # the PR.
-            if [[ ! -z ${CIRCLE_PULL_REQUEST} ]] ; then
-              # Build comment
-              echo "Coverage from tests in \`./e2e_test/...\` for \`./consensus/istanbul/...\` at commit ${CIRCLE_SHA1}" > comment
-              echo "\`\`\`" >> comment
-              cat summary >> comment
-              echo "\`\`\`" >> comment
-
-              # This command is quite involved, its posting the comment on the
-              # associated PR.
-              # ${CIRCLE_PULL_REQUEST##*/} expands to just the pr number at the
-              # end of the PR link.
-              # "{\"body\":\"`awk -v ORS='\\\\n' '1' comment`\"}" evaluates to
-              # a json object with comment as the content of body with newlines
-              # replaced by '\n'. Using backtics causes there to be a round of
-              # backslash processing on the command before execution, so we
-              # need to double the backslashes in the awk command.
-              curl -u piersy:${PR_COMMENT_TOKEN} -X POST \
-              https://api.github.com/repos/celo-org/celo-blockchain/issues/${CIRCLE_PULL_REQUEST##*/}/comments \
-              -d "{\"body\":\"`awk -v ORS='\\\\n' '1' comment`\"}" ;
+            if [[ -z ${CIRCLE_PULL_REQUEST} ]] ; then
+              exit 0
             fi
+
+            # Generate per PR MARKER for this comment.
+            COMMENT_MARKER=`echo ${CIRCLE_PULL_REQUEST}| shasum | head -c 10`
+
+            # Build comment
+            echo "Coverage from tests in \`./e2e_test/...\` for \`./consensus/istanbul/...\` at commit ${CIRCLE_SHA1}" > comment
+            echo "\`\`\`" >> comment
+            cat summary >> comment
+            echo "\`\`\`" >> comment
+            # Add a per PR unique ID to the comment
+            echo "CommentID: `echo ${COMMENT_MARKER}`" >> comment
+
+            # This expansion deletes everything up to and including the final slash
+            # leaving just the PR ID.
+            PR_ID=${CIRCLE_PULL_REQUEST##*/}
+
+            # This command grabs the list of comments for this PR and selects
+            # the id of the first one that contains the comment marker in its
+            # body, jq returns 'null' when it doesn't find anything.
+            COMMENT_ID=`curl https://api.github.com/repos/celo-org/celo-blockchain/issues/${PR_ID}/comments | jq "[.[] | select(.body | contains(\"${COMMENT_MARKER}\"))][0]| .id"`
+
+            # Determine if we are posting  a new comment or patching an
+            # existing one.
+            if [[ $COMMENT_ID == "null" ]]; then
+              # There was no previous comment
+              CURL_VERB=POST
+              URL=https://api.github.com/repos/celo-org/celo-blockchain/issues/${PR_ID}/comments
+            else
+              # We are updating a previous comment
+              CURL_VERB=PATCH
+              URL=https://api.github.com/repos/celo-org/celo-blockchain/issues/comments/${COMMENT_ID}
+            fi
+
+            # This command is quite involved, its posting the comment on the
+            # associated PR.
+            # "{\"body\":\"`awk -v ORS='\\\\n' '1' comment`\"}" evaluates to
+            # a json object with comment as the content of body with newlines
+            # replaced by '\n'. Using backtics causes there to be a round of
+            # backslash processing on the command before execution, so we
+            # need to double the backslashes in the awk command.
+            curl -u piersy:${PR_COMMENT_TOKEN} -X ${CURL_VERB} $URL -d "{\"body\":\"`awk -v ORS='\\\\n' '1' comment`\"}" ;
+
 
   lint:
     executor: golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
               URL=https://api.github.com/repos/celo-org/celo-blockchain/issues/comments/${COMMENT_ID}
             fi
 
-            # This command is quite involved, its posting the comment on the
+            # This command is quite involved, it's posting the comment on the
             # associated PR.
             # "{\"body\":\"`awk -v ORS='\\\\n' '1' comment`\"}" evaluates to
             # a json object with comment as the content of body with newlines

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,6 @@ jobs:
             - <<parameters.cache-key>>
       - attach_workspace:
           at: ~/repos
-      - run: jq -h
       - run:
           name: prepare system contracts
           # Runs make prepare-system-contracts and sets the MONOREPO_COMMIT to

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,11 @@ jobs:
             # leaving just the PR ID.
             PR_ID=${CIRCLE_PULL_REQUEST##*/}
 
+            # Note all the api paths here seem to be referencing issue comments
+            # rather than pr comments, but this is correct, since github's
+            # definition of an issue comment is a comment not attached to a
+            # review or attached to a specific section of code.
+
             # This command grabs the list of comments for this PR and selects
             # the id of the first one that contains the comment marker in its
             # body, jq returns 'null' when it doesn't find anything.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,13 +163,18 @@ jobs:
             # Generate per PR MARKER for this comment.
             COMMENT_MARKER=`echo ${CIRCLE_PULL_REQUEST}| shasum | head -c 10`
 
+            line1=`head -n 1 summary`
+            remainder=`tail -n +2 summary`
+
             # Build comment
             echo "Coverage from tests in \`./e2e_test/...\` for \`./consensus/istanbul/...\` at commit ${CIRCLE_SHA1}" > comment
-            echo "\`\`\`" >> comment
-            cat summary >> comment
-            echo "\`\`\`" >> comment
+            echo "<details><summary>${line1}</summary><br>" >> comment
+            echo "<pre>" >> comment
+            echo "${remainder}" >> comment
+            echo "</pre>" >> comment
             # Add a per PR unique ID to the comment
             echo "CommentID: `echo ${COMMENT_MARKER}`" >> comment
+            echo "</details>" >> comment
 
             # This expansion deletes everything up to and including the final slash
             # leaving just the PR ID.


### PR DESCRIPTION
### Description

This PR aims to make posting the the istanbul coverage comment summary on PRs less noisy.

* Rather than posting a new comment on every commit, (which can be pretty distracting for PRs that are undergoing lots of changes) we now update the coverage comment if it exists already.
* The coverage comment is now expandable and by default only shows overall coverage.

### Tested

See it below, notice it has been edited several times.

### Related issues

#1692 

### Backwards compatibility

No system code was changed.
