### PR TITLE
Release 1.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,6 +363,32 @@ jobs:
             export PATH=${PATH}:~/repos/golang/go/bin
             ./ci_test_validator_order.sh local ~/repos/geth
 
+  end-to-end-cip35-eth-compatibility-test:
+    executor: e2e
+    resource_class: xlarge
+    steps:
+      - attach_workspace:
+          at: ~/repos
+      - run:
+          name: End-to-end test of CIP 35
+          no_output_timeout: 15m
+          command: |
+            export PATH=${PATH}:~/repos/golang/go/bin
+            ./ci_test_cip35.sh local ~/repos/geth
+
+  end-to-end-replica-test:
+    executor: e2e
+    resource_class: xlarge
+    steps:
+      - attach_workspace:
+          at: ~/repos
+      - run:
+          name: End-to-end test of hotswap functionality
+          no_output_timeout: 15m
+          command: |
+            export PATH=${PATH}:~/repos/golang/go/bin
+            ./ci_test_replicas.sh local ~/repos/geth
+
 workflows:
   version: 2
   build:
@@ -430,6 +456,14 @@ workflows:
             - checkout-monorepo
             - build-geth
       - end-to-end-validator-order-test:
+          requires:
+            - checkout-monorepo
+            - build-geth
+      - end-to-end-cip35-eth-compatibility-test:
+          requires:
+            - checkout-monorepo
+            - build-geth
+      - end-to-end-replica-test:
           requires:
             - checkout-monorepo
             - build-geth

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -193,7 +193,7 @@ func (api *API) GetCurrentRoundState() (*core.RoundStateSummary, error) {
 	api.istanbul.coreMu.RLock()
 	defer api.istanbul.coreMu.RUnlock()
 
-	if !api.istanbul.coreStarted {
+	if !api.istanbul.isCoreStarted() {
 		return nil, istanbul.ErrStoppedEngine
 	}
 	return api.istanbul.core.CurrentRoundState().Summary(), nil
@@ -203,7 +203,7 @@ func (api *API) ForceRoundChange() (bool, error) {
 	api.istanbul.coreMu.RLock()
 	defer api.istanbul.coreMu.RUnlock()
 
-	if !api.istanbul.coreStarted {
+	if !api.istanbul.isCoreStarted() {
 		return false, istanbul.ErrStoppedEngine
 	}
 	api.istanbul.core.ForceRoundChange()

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -113,13 +113,15 @@ func New(config *istanbul.Config, db ethdb.Database) consensus.Istanbul {
 		logger.Crit("Failed to create recent snapshots cache", "err", err)
 	}
 
+	coreStarted := atomic.Value{}
+	coreStarted.Store(false)
 	backend := &Backend{
 		config:                             config,
 		istanbulEventMux:                   new(event.TypeMux),
 		logger:                             logger,
 		db:                                 db,
 		recentSnapshots:                    recentSnapshots,
-		coreStarted:                        false,
+		coreStarted:                        coreStarted,
 		announceRunning:                    false,
 		gossipCache:                        NewLRUGossipCache(inmemoryPeers, inmemoryMessages),
 		announceThreadWg:                   new(sync.WaitGroup),
@@ -221,7 +223,16 @@ type Backend struct {
 	validateState       func(block *types.Block, statedb *state.StateDB, receipts types.Receipts, usedGas uint64) error
 	onNewConsensusBlock func(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB)
 
-	coreStarted bool
+	// We need this to be an atomic value so that we can access it in a lock
+	// free way from IsValidating. This is required because StartValidating
+	// makes a call to RefreshValPeers while holding coreMu and RefreshValPeers
+	// waits for all validator peers to be deleted and then reconnects to known
+	// validators. If any of those peers has called IsValidating before
+	// RefreshValPeers tries to delete them the system gets stuck in a
+	// deadlock, the peer will never acquire coreMu because it is held by
+	// StartValidating, and StartValidating will never return because it is
+	// waiting for all peers to disconnect.
+	coreStarted atomic.Value
 	coreMu      sync.RWMutex
 
 	// Snapshots for recent blocks to speed up reorgs
@@ -325,6 +336,10 @@ type Backend struct {
 	abortCommitHook func(result *istanbulCore.StateProcessResult) bool // Method to call upon committing a proposal
 }
 
+func (sb *Backend) isCoreStarted() bool {
+	return sb.coreStarted.Load().(bool)
+}
+
 // IsProxy returns true if instance has proxy flag
 func (sb *Backend) IsProxy() bool {
 	return sb.config.Proxy
@@ -350,9 +365,7 @@ func (sb *Backend) GetProxiedValidatorEngine() proxy.ProxiedValidatorEngine {
 // IsValidating return true if instance is validating
 func (sb *Backend) IsValidating() bool {
 	// TODO: Maybe a little laggy, but primary / replica should track the core
-	sb.coreMu.RLock()
-	defer sb.coreMu.RUnlock()
-	return sb.coreStarted
+	return sb.isCoreStarted()
 }
 
 // IsValidator return if instance is a validator (either proxied or standalone)

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -629,12 +629,10 @@ func (sb *Backend) updateReplicaStateLoop(bc *ethCore.BlockChain) {
 	for {
 		select {
 		case chainEvent := <-chainEventCh:
-			sb.coreMu.RLock()
 			if !sb.isCoreStarted() && sb.replicaState != nil {
 				consensusBlock := new(big.Int).Add(chainEvent.Block.Number(), common.Big1)
 				sb.replicaState.NewChainHead(consensusBlock)
 			}
-			sb.coreMu.RUnlock()
 		case err := <-chainEventSub.Err():
 			log.Error("Error in istanbul's subscription to the blockchain's chain event", "err", err)
 			return

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -203,7 +203,7 @@ func (sb *Backend) NewWork() error {
 
 	sb.coreMu.RLock()
 	defer sb.coreMu.RUnlock()
-	if !sb.coreStarted {
+	if !sb.isCoreStarted() {
 		return istanbul.ErrStoppedEngine
 	}
 

--- a/params/version.go
+++ b/params/version.go
@@ -27,7 +27,7 @@ import (
 const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 4        // Minor version component of the current release
-	VersionPatch = 0        // Patch version component of the current release
+	VersionPatch = 1        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 

--- a/test/node.go
+++ b/test/node.go
@@ -396,12 +396,9 @@ func NewNetwork(accounts *env.AccountsConfig, gc *genesis.Config, ec *eth.Config
 	// each other nodes don't start sending consensus messages to another node
 	// until they have received an enode certificate from that node.
 	for i, en := range enodes {
-		for j, n := range network {
-			if j == i {
-				continue
-			}
+		// Connect to the remaining nodes
+		for _, n := range network[i+1:] {
 			n.Server().AddPeer(en, p2p.ValidatorPurpose)
-			n.Server().AddTrustedPeer(en, p2p.ValidatorPurpose)
 		}
 	}
 


### PR DESCRIPTION
### Description
This cherry-picks a set of commits from master that was a deadlock with StartValidating on 1.4.0.
This includes the minimal set of commits to test & fix the issue.

Commits
* Fix deadlock on engine start (#1685)
* Add more e2e tests to the celo-blockchain repo
* Remove coreMu read lock around rs.NewChainHead

### Related issues

- Fixes #1715 
