### PR TITLE
Fix Deadlock with StartValidating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -439,19 +439,6 @@ jobs:
             export PATH=${PATH}:~/repos/golang/go/bin
             ./ci_test_cip35.sh local ~/repos/geth
 
-  end-to-end-attestations-test:
-    executor: e2e
-    resource_class: xlarge
-    steps:
-      - attach_workspace:
-          at: ~/repos
-      - run:
-          name: End-to-end test of attestations
-          no_output_timeout: 15m
-          command: |
-            export PATH=${PATH}:~/repos/golang/go/bin
-            ./ci_test_attestations.sh local ~/repos/build-geth
-
   end-to-end-replica-test:
     executor: e2e
     resource_class: xlarge
@@ -536,10 +523,6 @@ workflows:
             - checkout-monorepo
             - build-geth
       - end-to-end-validator-order-test:
-          requires:
-            - checkout-monorepo
-            - build-geth
-      - end-to-end-attestations-test:
           requires:
             - checkout-monorepo
             - build-geth

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,6 +426,45 @@ jobs:
             export PATH=${PATH}:~/repos/golang/go/bin
             ./ci_test_validator_order.sh local ~/repos/geth
 
+  end-to-end-cip35-eth-compatibility-test:
+    executor: e2e
+    resource_class: xlarge
+    steps:
+      - attach_workspace:
+          at: ~/repos
+      - run:
+          name: End-to-end test of CIP 35
+          no_output_timeout: 15m
+          command: |
+            export PATH=${PATH}:~/repos/golang/go/bin
+            ./ci_test_cip35.sh local ~/repos/geth
+
+  end-to-end-attestations-test:
+    executor: e2e
+    resource_class: xlarge
+    steps:
+      - attach_workspace:
+          at: ~/repos
+      - run:
+          name: End-to-end test of attestations
+          no_output_timeout: 15m
+          command: |
+            export PATH=${PATH}:~/repos/golang/go/bin
+            ./ci_test_attestations.sh local ~/repos/build-geth
+
+  end-to-end-replica-test:
+    executor: e2e
+    resource_class: xlarge
+    steps:
+      - attach_workspace:
+          at: ~/repos
+      - run:
+          name: End-to-end test of hotswap functionality
+          no_output_timeout: 15m
+          command: |
+            export PATH=${PATH}:~/repos/golang/go/bin
+            ./ci_test_replicas.sh local ~/repos/geth
+
 workflows:
   version: 2
   build:
@@ -497,6 +536,18 @@ workflows:
             - checkout-monorepo
             - build-geth
       - end-to-end-validator-order-test:
+          requires:
+            - checkout-monorepo
+            - build-geth
+      - end-to-end-attestations-test:
+          requires:
+            - checkout-monorepo
+            - build-geth
+      - end-to-end-cip35-eth-compatibility-test:
+          requires:
+            - checkout-monorepo
+            - build-geth
+      - end-to-end-replica-test:
           requires:
             - checkout-monorepo
             - build-geth

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -629,12 +629,10 @@ func (sb *Backend) updateReplicaStateLoop(bc *ethCore.BlockChain) {
 	for {
 		select {
 		case chainEvent := <-chainEventCh:
-			sb.coreMu.RLock()
 			if !sb.isCoreStarted() && sb.replicaState != nil {
 				consensusBlock := new(big.Int).Add(chainEvent.Block.Number(), common.Big1)
 				sb.replicaState.NewChainHead(consensusBlock)
 			}
-			sb.coreMu.RUnlock()
 		case err := <-chainEventSub.Err():
 			log.Error("Error in istanbul's subscription to the blockchain's chain event", "err", err)
 			return

--- a/consensus/istanbul/backend/internal/replica/state.go
+++ b/consensus/istanbul/backend/internal/replica/state.go
@@ -132,6 +132,9 @@ func (rs *replicaStateImpl) Close() error {
 
 // NewChainHead updates replica state and starts/stops the core if needed
 func (rs *replicaStateImpl) NewChainHead(blockNumber *big.Int) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
 	logger := log.New("func", "NewChainHead", "seq", blockNumber)
 	switch rs.state {
 	case primaryInRange:
@@ -397,6 +400,10 @@ type replicaStateRLP struct {
 // not verified at the moment, but a future version might. It is
 // recommended to write only a single value but writing multiple
 // values or no value at all is also permitted.
+//
+// Note: This is called when StoreReplicaState is called so
+// mu should be held by functions that call StoreReplicaState
+// but mu should not be locked in this function.
 func (rs *replicaStateImpl) EncodeRLP(w io.Writer) error {
 	entry := replicaStateRLP{
 		State:                rs.state,


### PR DESCRIPTION
### Description

Fixes the deadlock in 1.4.0 by removing the read lock on `coreMu`.

### Other changes

* Adds a lock in the replica state & explains why one lock should not be held.
* Adds a replica E2E test
* Adds a CIP35 E2E test

### Tested

CI (now with e2e replica test running.


### Related issues

- Fixes #1715 
