### PR TITLE
Remove coreMu read lock uses when it's only for coreStarted

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -645,8 +645,6 @@ func (sb *Backend) SetCallBacks(hasBadBlock func(common.Hash) bool,
 	processBlock func(*types.Block, *state.StateDB) (types.Receipts, []*types.Log, uint64, error),
 	validateState func(*types.Block, *state.StateDB, types.Receipts, uint64) error,
 	onNewConsensusBlock func(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB)) error {
-	sb.coreMu.RLock()
-	defer sb.coreMu.RUnlock()
 	if sb.isCoreStarted() {
 		return istanbul.ErrStartedEngine
 	}

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -201,8 +201,6 @@ func (sb *Backend) SetP2PServer(p2pserver consensus.P2PServer) {
 func (sb *Backend) NewWork() error {
 	sb.logger.Debug("NewWork called, acquiring core lock", "func", "NewWork")
 
-	sb.coreMu.RLock()
-	defer sb.coreMu.RUnlock()
 	if !sb.isCoreStarted() {
 		return istanbul.ErrStoppedEngine
 	}


### PR DESCRIPTION
### Description

Remove coreMu read lock uses when it's only for coreStarted
A use case fixed in #1719 caused deadlock, removing others to avoid potential bugs.

### Tested

CI

### Backwards compatibility

Yes
