### PR TITLE
Bump the resource class for the ci lint job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,7 @@ jobs:
 
   lint:
     executor: golang
+    resource_class: medium+
     steps:
       - attach_workspace:
           at: ~/repos


### PR DESCRIPTION
### Description

The lint job was regularly failing with status code 137 which indicates an out of
memory error.

This commit ups the memory from the default of 4GB to 6GB.

### Tested

The lint job has not failed so far on CI for this branch.