### PR TITLE
Switch to node12 for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,11 @@ executors:
     working_directory: ~/repos/geth
   node-v10:
     docker:
-      - image: celohq/node10-gcloud:v3
+      - image: us.gcr.io/celo-testnet/circleci-node12:1.0.0
     working_directory: ~/repos/geth
   e2e:
     docker:
-      - image: celohq/node10-gcloud:v3
+      - image: us.gcr.io/celo-testnet/circleci-node12:1.0.0
     working_directory: ~/repos/celo-monorepo/packages/celotool
     environment:
       GO_VERSION: "1.16.4"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
     docker:
       - image: circleci/golang:1.16
     working_directory: ~/repos/geth
-  node-v10:
+  node-v12:
     docker:
       - image: us.gcr.io/celo-testnet/circleci-node12:1.0.0
     working_directory: ~/repos/geth
@@ -78,7 +78,7 @@ jobs:
       cache-key:
         type: string
         default: system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>-<<pipeline.parameters.system-contracts-path>>-v<<pipeline.parameters.system-contracts-cache-version>>
-    executor: node-v10
+    executor: node-v12
     resource_class: medium+
     steps:
       - checkout


### PR DESCRIPTION
### Description

Switches from node 10 to 12 to fix an issue with yarn using an unauthenticated git
protocol in the `monorepo-checkout` step


