### PR TITLE
Celo Typed Transactions

### DIFF
--- a/accounts/abi/bind_v2/auth.go
+++ b/accounts/abi/bind_v2/auth.go
@@ -62,7 +62,7 @@ func NewTransactor(keyin io.Reader, passphrase string) (*TransactOpts, error) {
 // Deprecated: Use NewKeyStoreTransactorWithChainID instead.
 func NewKeyStoreTransactor(keystore *keystore.KeyStore, account accounts.Account) (*TransactOpts, error) {
 	log.Warn("WARNING: NewKeyStoreTransactor has been deprecated in favour of NewTransactorWithChainID")
-	signer := types.HomesteadSigner{}
+	signer := types.LatestSignerForChainID(nil)
 	return &TransactOpts{
 		From: account.Address,
 		Signer: func(address common.Address, tx *types.Transaction) (*types.Transaction, error) {
@@ -86,7 +86,7 @@ func NewKeyStoreTransactor(keystore *keystore.KeyStore, account accounts.Account
 func NewKeyedTransactor(key *ecdsa.PrivateKey) *TransactOpts {
 	log.Warn("WARNING: NewKeyedTransactor has been deprecated in favour of NewKeyedTransactorWithChainID")
 	keyAddr := crypto.PubkeyToAddress(key.PublicKey)
-	signer := types.HomesteadSigner{}
+	signer := types.LatestSignerForChainID(nil)
 	return &TransactOpts{
 		From: keyAddr,
 		Signer: func(address common.Address, tx *types.Transaction) (*types.Transaction, error) {

--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -219,7 +219,7 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 	switch tx.Type() {
 	case types.LegacyTxType, types.AccessListTxType:
 		args.GasPrice = (*hexutil.Big)(tx.GasPrice())
-	case types.DynamicFeeTxType:
+	case types.DynamicFeeTxType, types.CeloDynamicFeeTxType:
 		args.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap())
 		args.MaxPriorityFeePerGas = (*hexutil.Big)(tx.GasTipCap())
 	default:

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -664,7 +664,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrTxTypeNotSupported
 	}
 	// Reject dynamic fee transactions until EIP-1559 activates.
-	if !pool.espresso && tx.Type() == types.DynamicFeeTxType {
+	if !pool.espresso && (tx.Type() == types.DynamicFeeTxType || tx.Type() == types.CeloDynamicFeeTxType) {
 		return ErrTxTypeNotSupported
 	}
 	// Reject transactions over defined size to prevent DOS attacks

--- a/core/types/celo_dynamic_fee_tx.go
+++ b/core/types/celo_dynamic_fee_tx.go
@@ -1,0 +1,117 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"math/big"
+
+	"github.com/celo-org/celo-blockchain/common"
+)
+
+type CeloDynamicFeeTx struct {
+	ChainID             *big.Int
+	Nonce               uint64
+	GasTipCap           *big.Int
+	GasFeeCap           *big.Int
+	Gas                 uint64
+	FeeCurrency         *common.Address `rlp:"nil"` // nil means native currency
+	GatewayFeeRecipient *common.Address `rlp:"nil"` // nil means no gateway fee is paid
+	GatewayFee          *big.Int        `rlp:"nil"`
+	To                  *common.Address `rlp:"nil"` // nil means contract creation
+	Value               *big.Int
+	Data                []byte
+	AccessList          AccessList
+
+	// Signature values
+	V *big.Int `json:"v" gencodec:"required"`
+	R *big.Int `json:"r" gencodec:"required"`
+	S *big.Int `json:"s" gencodec:"required"`
+}
+
+// copy creates a deep copy of the transaction data and initializes all fields.
+func (tx *CeloDynamicFeeTx) copy() TxData {
+	cpy := &CeloDynamicFeeTx{
+		Nonce:               tx.Nonce,
+		To:                  tx.To, // TODO: copy pointed-to address
+		Data:                common.CopyBytes(tx.Data),
+		Gas:                 tx.Gas,
+		FeeCurrency:         tx.FeeCurrency,
+		GatewayFeeRecipient: tx.GatewayFeeRecipient,
+		// These are copied below.
+		AccessList: make(AccessList, len(tx.AccessList)),
+		GatewayFee: new(big.Int),
+		Value:      new(big.Int),
+		ChainID:    new(big.Int),
+		GasTipCap:  new(big.Int),
+		GasFeeCap:  new(big.Int),
+		V:          new(big.Int),
+		R:          new(big.Int),
+		S:          new(big.Int),
+	}
+	copy(cpy.AccessList, tx.AccessList)
+	if tx.Value != nil {
+		cpy.Value.Set(tx.Value)
+	}
+	if tx.ChainID != nil {
+		cpy.ChainID.Set(tx.ChainID)
+	}
+	if tx.GasTipCap != nil {
+		cpy.GasTipCap.Set(tx.GasTipCap)
+	}
+	if tx.GasFeeCap != nil {
+		cpy.GasFeeCap.Set(tx.GasFeeCap)
+	}
+	if tx.GatewayFee != nil {
+		cpy.GatewayFee.Set(tx.GatewayFee)
+	}
+	if tx.V != nil {
+		cpy.V.Set(tx.V)
+	}
+	if tx.R != nil {
+		cpy.R.Set(tx.R)
+	}
+	if tx.S != nil {
+		cpy.S.Set(tx.S)
+	}
+	return cpy
+}
+
+// accessors for innerTx.
+func (tx *CeloDynamicFeeTx) txType() byte                         { return CeloDynamicFeeTxType }
+func (tx *CeloDynamicFeeTx) chainID() *big.Int                    { return tx.ChainID }
+func (tx *CeloDynamicFeeTx) protected() bool                      { return true }
+func (tx *CeloDynamicFeeTx) accessList() AccessList               { return tx.AccessList }
+func (tx *CeloDynamicFeeTx) data() []byte                         { return tx.Data }
+func (tx *CeloDynamicFeeTx) gas() uint64                          { return tx.Gas }
+func (tx *CeloDynamicFeeTx) gasFeeCap() *big.Int                  { return tx.GasFeeCap }
+func (tx *CeloDynamicFeeTx) gasTipCap() *big.Int                  { return tx.GasTipCap }
+func (tx *CeloDynamicFeeTx) gasPrice() *big.Int                   { return tx.GasFeeCap }
+func (tx *CeloDynamicFeeTx) value() *big.Int                      { return tx.Value }
+func (tx *CeloDynamicFeeTx) nonce() uint64                        { return tx.Nonce }
+func (tx *CeloDynamicFeeTx) to() *common.Address                  { return tx.To }
+func (tx *CeloDynamicFeeTx) feeCurrency() *common.Address         { return tx.FeeCurrency }
+func (tx *CeloDynamicFeeTx) gatewayFeeRecipient() *common.Address { return tx.GatewayFeeRecipient }
+func (tx *CeloDynamicFeeTx) gatewayFee() *big.Int                 { return tx.GatewayFee }
+func (tx *CeloDynamicFeeTx) ethCompatible() bool                  { return false }
+
+func (tx *CeloDynamicFeeTx) rawSignatureValues() (v, r, s *big.Int) {
+	return tx.V, tx.R, tx.S
+}
+
+func (tx *CeloDynamicFeeTx) setSignatureValues(chainID, v, r, s *big.Int) {
+	tx.ChainID, tx.V, tx.R, tx.S = chainID, v, r, s
+}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -176,7 +176,7 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 			return errEmptyTypedReceipt
 		}
 		r.Type = b[0]
-		if r.Type == AccessListTxType || r.Type == DynamicFeeTxType {
+		if r.Type == AccessListTxType || r.Type == DynamicFeeTxType || r.Type == CeloDynamicFeeTxType {
 			var dec receiptRLP
 			if err := rlp.DecodeBytes(b[1:], &dec); err != nil {
 				return err
@@ -345,6 +345,9 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 		rlp.Encode(w, data)
 	case DynamicFeeTxType:
 		w.WriteByte(DynamicFeeTxType)
+		rlp.Encode(w, data)
+	case CeloDynamicFeeTxType:
+		w.WriteByte(CeloDynamicFeeTxType)
 		rlp.Encode(w, data)
 	default:
 		// For unsupported types, write nothing. Since this is for

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -50,9 +50,10 @@ var (
 
 // Transaction types.
 const (
-	LegacyTxType     = iota
-	AccessListTxType = 0x01
-	DynamicFeeTxType = 0x02
+	LegacyTxType         = iota
+	AccessListTxType     = 0x01
+	DynamicFeeTxType     = 0x02
+	CeloDynamicFeeTxType = 0x7c // Counting down
 )
 
 // Transaction is an Ethereum transaction.
@@ -202,6 +203,10 @@ func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
 		return &inner, err
 	case DynamicFeeTxType:
 		var inner DynamicFeeTx
+		err := rlp.DecodeBytes(b[1:], &inner)
+		return &inner, err
+	case CeloDynamicFeeTxType:
+		var inner CeloDynamicFeeTx
 		err := rlp.DecodeBytes(b[1:], &inner)
 		return &inner, err
 	default:

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -106,6 +106,22 @@ func (t *Transaction) MarshalJSON() ([]byte, error) {
 		enc.V = (*hexutil.Big)(tx.V)
 		enc.R = (*hexutil.Big)(tx.R)
 		enc.S = (*hexutil.Big)(tx.S)
+	case *CeloDynamicFeeTx:
+		enc.ChainID = (*hexutil.Big)(tx.ChainID)
+		enc.AccessList = &tx.AccessList
+		enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
+		enc.Gas = (*hexutil.Uint64)(&tx.Gas)
+		enc.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap)
+		enc.MaxPriorityFeePerGas = (*hexutil.Big)(tx.GasTipCap)
+		enc.FeeCurrency = tx.FeeCurrency // todo: check if needs deep copy
+		enc.GatewayFeeRecipient = tx.GatewayFeeRecipient
+		enc.GatewayFee = (*hexutil.Big)(tx.GatewayFee)
+		enc.Value = (*hexutil.Big)(tx.Value)
+		enc.Data = (*hexutil.Bytes)(&tx.Data)
+		enc.To = t.To()
+		enc.V = (*hexutil.Big)(tx.V)
+		enc.R = (*hexutil.Big)(tx.R)
+		enc.S = (*hexutil.Big)(tx.S)
 	}
 	return json.Marshal(&enc)
 }
@@ -255,6 +271,69 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 			return errors.New("missing required field 'gas' for txdata")
 		}
 		itx.Gas = uint64(*dec.Gas)
+		if dec.Value == nil {
+			return errors.New("missing required field 'value' in transaction")
+		}
+		itx.Value = (*big.Int)(dec.Value)
+		if dec.Data == nil {
+			return errors.New("missing required field 'input' in transaction")
+		}
+		itx.Data = *dec.Data
+		if dec.V == nil {
+			return errors.New("missing required field 'v' in transaction")
+		}
+		itx.V = (*big.Int)(dec.V)
+		if dec.R == nil {
+			return errors.New("missing required field 'r' in transaction")
+		}
+		itx.R = (*big.Int)(dec.R)
+		if dec.S == nil {
+			return errors.New("missing required field 's' in transaction")
+		}
+		itx.S = (*big.Int)(dec.S)
+		withSignature := itx.V.Sign() != 0 || itx.R.Sign() != 0 || itx.S.Sign() != 0
+		if withSignature {
+			if err := sanityCheckSignature(itx.V, itx.R, itx.S, false); err != nil {
+				return err
+			}
+		}
+
+	case CeloDynamicFeeTxType:
+		var itx CeloDynamicFeeTx
+		inner = &itx
+		// Access list is optional for now.
+		if dec.AccessList != nil {
+			itx.AccessList = *dec.AccessList
+		}
+		if dec.ChainID == nil {
+			return errors.New("missing required field 'chainId' in transaction")
+		}
+		itx.ChainID = (*big.Int)(dec.ChainID)
+		if dec.To != nil {
+			itx.To = dec.To
+		}
+		if dec.Nonce == nil {
+			return errors.New("missing required field 'nonce' in transaction")
+		}
+		itx.Nonce = uint64(*dec.Nonce)
+		if dec.MaxPriorityFeePerGas == nil {
+			return errors.New("missing required field 'maxPriorityFeePerGas' for txdata")
+		}
+		itx.GasTipCap = (*big.Int)(dec.MaxPriorityFeePerGas)
+		if dec.MaxFeePerGas == nil {
+			return errors.New("missing required field 'maxFeePerGas' for txdata")
+		}
+		itx.GasFeeCap = (*big.Int)(dec.MaxFeePerGas)
+		if dec.Gas == nil {
+			return errors.New("missing required field 'gas' for txdata")
+		}
+		itx.Gas = uint64(*dec.Gas)
+		itx.FeeCurrency = dec.FeeCurrency
+		itx.GatewayFeeRecipient = dec.GatewayFeeRecipient
+		itx.GatewayFee = new(big.Int)
+		if dec.GatewayFee != nil {
+			itx.GatewayFee.Set((*big.Int)(dec.GatewayFee))
+		}
 		if dec.Value == nil {
 			return errors.New("missing required field 'value' in transaction")
 		}

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -177,7 +177,7 @@ func NewLondonSigner(chainId *big.Int) Signer {
 }
 
 func (s londonSigner) Sender(tx *Transaction) (common.Address, error) {
-	if tx.Type() != DynamicFeeTxType {
+	if !(tx.Type() == DynamicFeeTxType || tx.Type() == CeloDynamicFeeTxType) {
 		return s.eip2930Signer.Sender(tx)
 	}
 	V, R, S := tx.RawSignatureValues()
@@ -196,15 +196,21 @@ func (s londonSigner) Equal(s2 Signer) bool {
 }
 
 func (s londonSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
-	txdata, ok := tx.inner.(*DynamicFeeTx)
-	if !ok {
+	switch txdata := tx.inner.(type) {
+	case *DynamicFeeTx:
+		// Check that chain ID of tx matches the signer. We also accept ID zero here,
+		// because it indicates that the chain ID was not specified in the tx.
+		if txdata.ChainID.Sign() != 0 && txdata.ChainID.Cmp(s.chainId) != 0 {
+			return nil, nil, nil, ErrInvalidChainId
+		}
+	case *CeloDynamicFeeTx:
+		if txdata.ChainID.Sign() != 0 && txdata.ChainID.Cmp(s.chainId) != 0 {
+			return nil, nil, nil, ErrInvalidChainId
+		}
+	default:
 		return s.eip2930Signer.SignatureValues(tx, sig)
 	}
-	// Check that chain ID of tx matches the signer. We also accept ID zero here,
-	// because it indicates that the chain ID was not specified in the tx.
-	if txdata.ChainID.Sign() != 0 && txdata.ChainID.Cmp(s.chainId) != 0 {
-		return nil, nil, nil, ErrInvalidChainId
-	}
+
 	R, S, _ = decodeSignature(sig)
 	V = big.NewInt(int64(sig[64]))
 	return R, S, V, nil

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -213,22 +213,42 @@ func (s londonSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 // Hash returns the hash to be signed by the sender.
 // It does not uniquely identify the transaction.
 func (s londonSigner) Hash(tx *Transaction) common.Hash {
-	if tx.Type() != DynamicFeeTxType {
+	switch tx.Type() {
+	case DynamicFeeTxType:
+		return prefixedRlpHash(
+			tx.Type(),
+			[]interface{}{
+				s.chainId,
+				tx.Nonce(),
+				tx.GasTipCap(),
+				tx.GasFeeCap(),
+				tx.Gas(),
+				tx.To(),
+				tx.Value(),
+				tx.Data(),
+				tx.AccessList(),
+			})
+	case CeloDynamicFeeTxType:
+		return prefixedRlpHash(
+			tx.Type(),
+			[]interface{}{
+				s.chainId,
+				tx.Nonce(),
+				tx.GasTipCap(),
+				tx.GasFeeCap(),
+				tx.Gas(),
+				tx.FeeCurrency(),
+				tx.GatewayFeeRecipient(),
+				tx.GatewayFee(),
+				tx.To(),
+				tx.Value(),
+				tx.Data(),
+				tx.AccessList(),
+			})
+	default:
 		return s.eip2930Signer.Hash(tx)
 	}
-	return prefixedRlpHash(
-		tx.Type(),
-		[]interface{}{
-			s.chainId,
-			tx.Nonce(),
-			tx.GasTipCap(),
-			tx.GasFeeCap(),
-			tx.Gas(),
-			tx.To(),
-			tx.Value(),
-			tx.Data(),
-			tx.AccessList(),
-		})
+
 }
 
 type eip2930Signer struct{ EIP155Signer }


### PR DESCRIPTION
### Description

Implements a typed transaction that is specific to the Celo network.

To Do

- [x] Update CIP proposal with constant
- [x] Generate typed transaction and run it through the system
- [ ] Add support in `transaction_args.go` (`func (args *TransactionArgs) toTransaction() *types.Transaction {`)

### Tested

I was able to send a dynamic fee transaction through the system. I have not tested more specific portions yet.
