### PR TITLE
[tx_pool] Invalidate txs with gasPrice < gasPriceMinimumFloor

### DIFF
--- a/contracts/abis/abi_str.go
+++ b/contracts/abis/abi_str.go
@@ -413,6 +413,21 @@ const GasPriceMinimumStr = `[
 		"type": "function"
 	},
 	{
+    "constant": true,
+    "inputs": [],
+    "name": "gasPriceMinimumFloor",
+    "outputs": [
+			{ 
+				"internalType": "uint256", 
+				"name": "", 
+				"type": "uint256"
+			}
+		],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+	{
 		"constant": false,
 		"inputs": [
 			{

--- a/contracts/gasprice_minimum/gasprice_minimum.go
+++ b/contracts/gasprice_minimum/gasprice_minimum.go
@@ -36,8 +36,9 @@ var (
 )
 
 var (
-	getGasPriceMinimumMethod    = contracts.NewRegisteredContractMethod(params.GasPriceMinimumRegistryId, abis.GasPriceMinimum, "getGasPriceMinimum", params.MaxGasForGetGasPriceMinimum)
-	updateGasPriceMinimumMethod = contracts.NewRegisteredContractMethod(params.GasPriceMinimumRegistryId, abis.GasPriceMinimum, "updateGasPriceMinimum", params.MaxGasForUpdateGasPriceMinimum)
+	getGasPriceMinimumMethod      = contracts.NewRegisteredContractMethod(params.GasPriceMinimumRegistryId, abis.GasPriceMinimum, "getGasPriceMinimum", params.MaxGasForGetGasPriceMinimum)
+	getGasPriceMinimumFloorMethod = contracts.NewRegisteredContractMethod(params.GasPriceMinimumRegistryId, abis.GasPriceMinimum, "gasPriceMinimumFloor", params.MaxGasForGetGasPriceMinimum)
+	updateGasPriceMinimumMethod   = contracts.NewRegisteredContractMethod(params.GasPriceMinimumRegistryId, abis.GasPriceMinimum, "updateGasPriceMinimum", params.MaxGasForUpdateGasPriceMinimum)
 )
 
 // GetGasTipCapSuggestion suggests a max tip of 2GWei in the appropriate currency.
@@ -86,6 +87,22 @@ func GetGasPriceMinimum(vmRunner vm.EVMRunner, currency *common.Address) (*big.I
 	}
 
 	return gasPriceMinimum, err
+}
+
+func GetGasPriceMinimumFloor(vmRunner vm.EVMRunner) (*big.Int, error) {
+	var err error
+
+	var gasPriceMinimumFloor *big.Int
+	err = getGasPriceMinimumFloorMethod.Query(vmRunner, &gasPriceMinimumFloor)
+
+	if err == contracts.ErrSmartContractNotDeployed || err == contracts.ErrRegistryContractNotDeployed {
+		return FallbackGasPriceMinimum, nil
+	}
+	if err != nil {
+		return FallbackGasPriceMinimum, err
+	}
+
+	return gasPriceMinimumFloor, err
 }
 
 func UpdateGasPriceMinimum(vmRunner vm.EVMRunner, lastUsedGas uint64) (*big.Int, error) {

--- a/core/error.go
+++ b/core/error.go
@@ -70,6 +70,10 @@ var (
 	// minimum specified by the GasPriceMinimum contract.
 	ErrGasPriceDoesNotExceedMinimum = errors.New("gasprice is less than gas price minimum")
 
+	// ErrGasPriceDoesNotExceedMinimumFloor is returned if the gas price specified doesn't meet the
+	// minimum floor specified by the GasPriceMinimum contract.
+	ErrGasPriceDoesNotExceedMinimumFloor = errors.New("gasprice is less than gas price minimum floor")
+
 	// ErrNonWhitelistedFeeCurrency is returned if the currency specified to use for the fees
 	// isn't one of the currencies whitelisted for that purpose.
 	ErrNonWhitelistedFeeCurrency = errors.New("non-whitelisted fee currency address")

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -728,6 +728,12 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrIntrinsicGas
 	}
 
+	// TODO(ponti): we can compare with the absolute gas price floor for each currency to cut more wrong txs
+	if tx.GasPrice().Cmp(common.Big0) <= 0 {
+		log.Debug("invalid gasPrice", "gasPrice", tx.GasPrice())
+		return ErrGasPriceDoesNotExceedMinimum
+	}
+
 	return nil
 }
 

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -475,17 +475,20 @@ func TestTransactionVeryHighValues(t *testing.T) {
 	}
 }
 
-func TestTransactionZeroGasPrice(t *testing.T) {
+func TestTransactionGasPriceLessThanFloor(t *testing.T) {
 	t.Parallel()
 
 	pool, key := setupTxPool()
 	defer pool.Stop()
 
-	tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(1), 200000, big.NewInt(0), nil, nil, nil, nil), types.HomesteadSigner{}, key)
+	ctx := pool.currentCtx.Load().(txPoolContext)
+	ctx.celoGasPriceMinimumFloor = common.Big2
+	pool.currentCtx.Store(ctx)
+	tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(1), 200000, big.NewInt(1), nil, nil, nil, nil), types.HomesteadSigner{}, key)
 	from, _ := deriveSender(tx)
 	pool.currentState.AddBalance(from, big.NewInt(100000000000000))
-	if err := pool.AddRemote(tx); err != ErrGasPriceDoesNotExceedMinimum {
-		t.Error("expected", ErrGasPriceDoesNotExceedMinimum, "got", err)
+	if err := pool.AddRemote(tx); err != ErrGasPriceDoesNotExceedMinimumFloor {
+		t.Error("expected", ErrGasPriceDoesNotExceedMinimumFloor, "got", err)
 	}
 }
 
@@ -2081,6 +2084,7 @@ func TestDualHeapEviction(t *testing.T) {
 			gasPriceMinimums: make(map[common.Address]*big.Int),
 		},
 		&currency.CurrencyManager{},
+		common.Big0,
 	}
 	for baseFee = 0; baseFee <= 1000; baseFee += 100 {
 		txCtx.SysContractCallCtx.gasPriceMinimums[common.ZeroAddress] = big.NewInt(int64(baseFee))

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -475,6 +475,20 @@ func TestTransactionVeryHighValues(t *testing.T) {
 	}
 }
 
+func TestTransactionZeroGasPrice(t *testing.T) {
+	t.Parallel()
+
+	pool, key := setupTxPool()
+	defer pool.Stop()
+
+	tx, _ := types.SignTx(types.NewTransaction(0, common.Address{}, big.NewInt(1), 200000, big.NewInt(0), nil, nil, nil, nil), types.HomesteadSigner{}, key)
+	from, _ := deriveSender(tx)
+	pool.currentState.AddBalance(from, big.NewInt(100000000000000))
+	if err := pool.AddRemote(tx); err != ErrGasPriceDoesNotExceedMinimum {
+		t.Error("expected", ErrGasPriceDoesNotExceedMinimum, "got", err)
+	}
+}
+
 func TestTransactionChainFork(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description

This fixes the issue that adds txs with gasPrice zero, which will not be executed but we keep for at lest 3 hours (default expiration time), and fill the txpool with peding txs

### Tested

Manually and add unit tests

### Related issues

- Fixes #1768 

### Backwards compatibility

Yes