### PR TITLE
Avoid calling NextBlockValidators for preparedCert

### DIFF
--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -84,11 +84,7 @@ func (c *core) verifyPreparedCertificate(preparedCertificate istanbul.PreparedCe
 				return nil, err
 			}
 
-			newValSet, err := c.backend.NextBlockValidators(preparedCertificate.Proposal)
-			if err != nil {
-				return nil, err
-			}
-			err = c.verifyEpochValidatorSetSeal(commit, preparedCertificate.Proposal.Number().Uint64(), newValSet, src)
+			err = c.verifyEpochValidatorSetSeal(commit, preparedCertificate.Proposal.Number().Uint64(), c.current.ValidatorSet(), src)
 			if err != nil {
 				logger.Error("Epoch validator set seal seal did not contain signature from message signer.", "err", err)
 				return nil, err


### PR DESCRIPTION
NextBlockValidators does processing to update the validator set in the
event that validators have been added or removed. In doing this it makes
contract calls.

Given that prepared certs are only used in the context of round changes,
the current validator set will never be different from the set used in
round 0 so the call to NextBlockValidators can be avoided.
