### PR TITLE
Fix espresso block config and rename E to espresso

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -564,7 +564,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 		return nil, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
 	head := b.blockchain.CurrentHeader()
-	if !b.blockchain.Config().IsEHardfork(head.Number) {
+	if !b.blockchain.Config().IsEspresso(head.Number) {
 		// If there's no basefee, then it must be a non-1559 execution
 		if call.GasPrice == nil {
 			call.GasPrice = new(big.Int)
@@ -615,7 +615,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	gasPool := new(core.GasPool).AddGas(math.MaxUint64)
 	vmRunner := b.blockchain.NewEVMRunner(block.Header(), stateDB)
 	var sysCtx *core.SysContractCallCtx
-	if b.config.IsEHardfork(block.Number()) {
+	if b.config.IsEspresso(block.Number()) {
 		parent := b.blockchain.GetBlockByNumber(block.NumberU64() - 1)
 		sysStateDB, err := b.blockchain.StateAt(parent.Root())
 		if err != nil {

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -250,7 +250,7 @@ func Main(ctx *cli.Context) error {
 		return NewError(ErrorJson, fmt.Errorf("failed signing transactions: %v", err))
 	}
 	// Sanity check, to not `panic` in state_transition
-	if chainConfig.IsEHardfork(big.NewInt(int64(prestate.Env.Number))) {
+	if chainConfig.IsEspresso(big.NewInt(int64(prestate.Env.Number))) {
 		if prestate.Env.BaseFee == nil {
 			return NewError(ErrorVMConfig, errors.New("EIP-1559 config but missing 'currentBaseFee' in env section"))
 		}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -240,8 +240,8 @@ var (
 
 	// Hard fork activation overrides
 	OverrideEHardforkFlag = cli.Uint64Flag{
-		Name:  "override.eHardfork",
-		Usage: "Manually specify E fork-block, overriding the bundled setting",
+		Name:  "override.espresso",
+		Usage: "Manually specify the espresso fork block, overriding the bundled setting",
 	}
 
 	BloomFilterSizeFlag = cli.Uint64Flag{

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -724,7 +724,7 @@ func (c *core) getRoundChangeTimeout() time.Duration {
 	if round == 0 {
 		return baseTimeout + blockTime
 	} else {
-		if c.backend.ChainConfig().IsEHardfork(c.current.Sequence()) {
+		if c.backend.ChainConfig().IsEspresso(c.current.Sequence()) {
 			return baseTimeout + blockTime + time.Duration(math.Pow(2, float64(round)))*time.Duration(c.config.TimeoutBackoffFactor)*time.Millisecond
 		} else {
 			return baseTimeout + time.Duration(math.Pow(2, float64(round)))*time.Duration(c.config.TimeoutBackoffFactor)*time.Millisecond

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -203,7 +203,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 	// Get the existing chain configuration.
 	newcfg := genesis.configOrDefault(stored)
 	if overrideEHardfork != nil {
-		newcfg.EBlock = overrideEHardfork
+		newcfg.EspressoBlock = overrideEHardfork
 	}
 
 	if err := newcfg.CheckConfigForkOrder(); err != nil {

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -60,7 +60,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 	)
 	// Iterate over and process the individual transactions
 	byzantium := p.config.IsByzantium(block.Number())
-	espresso := p.bc.chainConfig.IsEHardfork(block.Number())
+	espresso := p.bc.chainConfig.IsEspresso(block.Number())
 	if espresso {
 		sysCtx = NewSysContractCallCtx(p.bc.NewEVMRunner(header, statedb))
 	}
@@ -103,7 +103,7 @@ func precacheTransaction(config *params.ChainConfig, bc *BlockChain, author *com
 	vm := vm.NewEVM(context, txContext, statedb, config, cfg)
 
 	var sysCtx *SysContractCallCtx
-	if config.IsEHardfork(header.Number) {
+	if config.IsEspresso(header.Number) {
 		sysVmRunner := bc.NewEVMRunner(header, statedb)
 		sysCtx = NewSysContractCallCtx(sysVmRunner)
 	}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -85,7 +85,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		baseFee *big.Int
 		sysCtx  *SysContractCallCtx
 	)
-	if p.bc.Config().IsEHardfork(blockNumber) {
+	if p.bc.Config().IsEspresso(blockNumber) {
 		sysVmRunner := p.bc.NewEVMRunner(header, statedb)
 		sysCtx = NewSysContractCallCtx(sysVmRunner)
 		if p.bc.Config().Faker {
@@ -96,7 +96,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, p.config, cfg)
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
-		if p.bc.chainConfig.IsEHardfork(header.Number) {
+		if p.bc.chainConfig.IsEspresso(header.Number) {
 			baseFee = sysCtx.GetGasPriceMinimum(tx.FeeCurrency())
 		}
 		msg, err := tx.AsMessage(types.MakeSigner(p.config, header.Number), baseFee)
@@ -175,7 +175,7 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, gp *GasPool
 // indicating the block was invalid.
 func ApplyTransaction(config *params.ChainConfig, bc ChainContext, txFeeRecipient *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config, vmRunner vm.EVMRunner, sysCtx *SysContractCallCtx) (*types.Receipt, error) {
 	var baseFee *big.Int
-	if config.IsEHardfork(header.Number) {
+	if config.IsEspresso(header.Number) {
 		baseFee = sysCtx.GetGasPriceMinimum(tx.FeeCurrency())
 	}
 	msg, err := tx.AsMessage(types.MakeSigner(config, header.Number), baseFee)

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -50,7 +50,7 @@ func TestStateProcessorErrors(t *testing.T) {
 			IstanbulBlock:       big.NewInt(0),
 			ChurritoBlock:       big.NewInt(0),
 			DonutBlock:          big.NewInt(0),
-			EBlock:              big.NewInt(0),
+			EspressoBlock:       big.NewInt(0),
 			Faker:               true,
 		}
 		signer     = types.LatestSigner(config)

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -59,7 +59,7 @@ func init() {
 
 	cpy := *params.TestChainConfig
 	eip1559Config = &cpy
-	eip1559Config.EBlock = common.Big0
+	eip1559Config.EspressoBlock = common.Big0
 }
 
 type testBlockChain struct {

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,7 +40,7 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 	var signer Signer
 	switch {
-	case config.IsEHardfork(blockNumber):
+	case config.IsEspresso(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
 	case config.IsEIP155(blockNumber):
 		signer = NewEIP155Signer(config.ChainID)
@@ -61,7 +61,7 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
 	if config.ChainID != nil {
-		if config.EBlock != nil {
+		if config.EspressoBlock != nil {
 			return NewLondonSigner(config.ChainID)
 		}
 		if config.EIP155Block != nil {

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -275,7 +275,7 @@ func init() {
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
-	case rules.IsEHardfork:
+	case rules.IsEspresso:
 		return PrecompiledAddressesE
 	case rules.IsDonut:
 		return PrecompiledAddressesDonut

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -57,7 +57,7 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
-	case evm.chainRules.IsEHardfork:
+	case evm.chainRules.IsEspresso:
 		precompiles = PrecompiledContractsE
 	case evm.chainRules.IsDonut:
 		precompiles = PrecompiledContractsDonut
@@ -429,7 +429,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 	// We add this to the access list _before_ taking a snapshot. Even if the creation fails,
 	// the access-list change should not be rolled back
-	if evm.chainRules.IsEHardfork {
+	if evm.chainRules.IsEspresso {
 		evm.StateDB.AddAddressToAccessList(address)
 	}
 	// Ensure there's no existing contract already at the designated address
@@ -467,7 +467,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	}
 
 	// Reject code starting with 0xEF if EIP-3541 is enabled.
-	if err == nil && len(ret) >= 1 && ret[0] == 0xEF && evm.chainRules.IsEHardfork {
+	if err == nil && len(ret) >= 1 && ret[0] == 0xEF && evm.chainRules.IsEspresso {
 		err = ErrInvalidCode
 	}
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -74,7 +74,7 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	if cfg.JumpTable[STOP] == nil {
 		var jt JumpTable
 		switch {
-		case evm.chainRules.IsEHardfork:
+		case evm.chainRules.IsEspresso:
 			jt = espressoInstructionSet
 		case evm.chainRules.IsIstanbul:
 			jt = istanbulInstructionSet

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -66,7 +66,7 @@ func setDefaults(cfg *Config) {
 			IstanbulBlock:       new(big.Int),
 			ChurritoBlock:       new(big.Int),
 			DonutBlock:          new(big.Int),
-			EBlock:              new(big.Int),
+			EspressoBlock:       new(big.Int),
 		}
 	}
 	if cfg.Time == nil {
@@ -110,7 +110,7 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 		vmenv   = NewEnv(cfg)
 		sender  = vm.AccountRef(cfg.Origin)
 	)
-	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsEHardfork {
+	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsEspresso {
 		cfg.State.PrepareAccessList(cfg.Origin, &address, vm.ActivePrecompiles(rules), nil)
 	}
 	cfg.State.CreateAccount(address)
@@ -143,7 +143,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 		sender = vm.AccountRef(cfg.Origin)
 	)
 
-	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsEHardfork {
+	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsEspresso {
 		cfg.State.PrepareAccessList(cfg.Origin, nil, vm.ActivePrecompiles(rules), nil)
 	}
 	// Call the code with the given configuration.
@@ -169,7 +169,7 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 	sender := cfg.State.GetOrNewStateObject(cfg.Origin)
 	statedb := cfg.State
 
-	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsEHardfork {
+	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsEspresso {
 		statedb.PrepareAccessList(cfg.Origin, &address, vm.ActivePrecompiles(rules), nil)
 	}
 	// Call the code with the given configuration.

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -161,7 +161,7 @@ func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec 
 	}
 	// Get the SysContractCallCtx
 	var sysCtx *core.SysContractCallCtx
-	espresso := eth.blockchain.Config().IsEHardfork(block.Number())
+	espresso := eth.blockchain.Config().IsEspresso(block.Number())
 	if espresso {
 		sysCtx = core.NewSysContractCallCtx(eth.blockchain.NewEVMRunner(block.Header(), statedb))
 	}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -276,7 +276,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 				signer := types.MakeSigner(api.backend.ChainConfig(), task.block.Number())
 				blockCtx := core.NewEVMBlockContext(task.block.Header(), api.chainContext(localctx), nil)
 				var sysCtx *core.SysContractCallCtx
-				if api.backend.ChainConfig().IsEHardfork(blockCtx.BlockNumber) {
+				if api.backend.ChainConfig().IsEspresso(blockCtx.BlockNumber) {
 					sysVmRunner := api.backend.VmRunnerAtHeader(task.block.Header(), task.statedb)
 					sysCtx = core.NewSysContractCallCtx(sysVmRunner)
 				}
@@ -530,7 +530,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 	blockHash := block.Hash()
 	var sysCtx *core.SysContractCallCtx
-	if api.backend.ChainConfig().IsEHardfork(block.Number()) {
+	if api.backend.ChainConfig().IsEspresso(block.Number()) {
 		sysVmRunner := api.backend.VmRunnerAtHeader(block.Header(), statedb)
 		sysCtx = core.NewSysContractCallCtx(sysVmRunner)
 	}
@@ -640,13 +640,13 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		chainConfigCopy := new(params.ChainConfig)
 		*chainConfigCopy = *chainConfig
 		chainConfig = chainConfigCopy
-		if E := config.LogConfig.Overrides.EBlock; E != nil {
-			chainConfig.EBlock = E
+		if E := config.LogConfig.Overrides.EspressoBlock; E != nil {
+			chainConfig.EspressoBlock = E
 			canon = false
 		}
 	}
 	var sysCtx *core.SysContractCallCtx
-	if api.backend.ChainConfig().IsEHardfork(block.Number()) {
+	if api.backend.ChainConfig().IsEspresso(block.Number()) {
 		sysVmRunner := api.backend.VmRunnerAtHeader(block.Header(), statedb)
 		sysCtx = core.NewSysContractCallCtx(sysVmRunner)
 	}
@@ -740,7 +740,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 	}
 
 	var sysCtx *core.SysContractCallCtx
-	if api.backend.ChainConfig().IsEHardfork(block.Number()) {
+	if api.backend.ChainConfig().IsEspresso(block.Number()) {
 		parent, err := api.blockByNumber(ctx, rpc.BlockNumber(blockNumber-1))
 		if err != nil {
 			return nil, err
@@ -808,7 +808,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	vmctx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
 	vmRunner := api.backend.VmRunnerAtHeader(block.Header(), statedb)
 	var sysCtx *core.SysContractCallCtx
-	if api.backend.ChainConfig().IsEHardfork(block.Number()) {
+	if api.backend.ChainConfig().IsEspresso(block.Number()) {
 		sysVmRunner := api.backend.VmRunnerAtHeader(block.Header(), statedb)
 		sysCtx = core.NewSysContractCallCtx(sysVmRunner)
 	}

--- a/eth/tracers/tracer_test.go
+++ b/eth/tracers/tracer_test.go
@@ -208,10 +208,10 @@ func TestNoStepExec(t *testing.T) {
 }
 
 func TestIsPrecompile(t *testing.T) {
-	chaincfg := &params.ChainConfig{ChainID: big.NewInt(1), HomesteadBlock: big.NewInt(0), DAOForkBlock: nil, DAOForkSupport: false, EIP150Block: big.NewInt(0), EIP150Hash: common.Hash{}, EIP155Block: big.NewInt(0), EIP158Block: big.NewInt(0), ByzantiumBlock: big.NewInt(100), ConstantinopleBlock: big.NewInt(0), PetersburgBlock: big.NewInt(0), IstanbulBlock: big.NewInt(200), EBlock: big.NewInt(0)}
+	chaincfg := &params.ChainConfig{ChainID: big.NewInt(1), HomesteadBlock: big.NewInt(0), DAOForkBlock: nil, DAOForkSupport: false, EIP150Block: big.NewInt(0), EIP150Hash: common.Hash{}, EIP155Block: big.NewInt(0), EIP158Block: big.NewInt(0), ByzantiumBlock: big.NewInt(100), ConstantinopleBlock: big.NewInt(0), PetersburgBlock: big.NewInt(0), IstanbulBlock: big.NewInt(200), EspressoBlock: big.NewInt(0)}
 	chaincfg.ByzantiumBlock = big.NewInt(100)
 	chaincfg.IstanbulBlock = big.NewInt(200)
-	chaincfg.EBlock = big.NewInt(300)
+	chaincfg.EspressoBlock = big.NewInt(300)
 	txCtx := vm.TxContext{GasPrice: big.NewInt(100000)}
 	tracer, err := New("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", new(Context))
 	if err != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -848,7 +848,7 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 
 	// Create SysContractCallCtx
 	var sysCtx *core.SysContractCallCtx
-	if b.ChainConfig().IsEHardfork(header.Number) {
+	if b.ChainConfig().IsEspresso(header.Number) {
 		vmRunner := b.NewEVMRunner(header, state)
 		if err != nil {
 			return nil, err
@@ -1557,7 +1557,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 
 	fields := generateReceiptResponse(receipt, signer, tx, blockHash, blockNumber, index)
 	// Assign the effective gas price paid
-	if !s.b.ChainConfig().IsEHardfork(bigblock) {
+	if !s.b.ChainConfig().IsEspresso(bigblock) {
 		fields["effectiveGasPrice"] = hexutil.Uint64(tx.GasPrice().Uint64())
 	} else {
 		header, err := s.b.HeaderByHash(ctx, blockHash)

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -91,7 +91,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 	// need to consult the chain for defaults. It's definitely a London tx.
 	if args.MaxPriorityFeePerGas == nil || args.MaxFeePerGas == nil {
 		// In this clause, user left some fields unspecified.
-		if b.ChainConfig().IsEHardfork(head.Number) && (args.GasPrice == nil || args.GasPrice.ToInt().Cmp(big.NewInt(0)) == 0) {
+		if b.ChainConfig().IsEspresso(head.Number) && (args.GasPrice == nil || args.GasPrice.ToInt().Cmp(big.NewInt(0)) == 0) {
 			if args.MaxPriorityFeePerGas == nil {
 				tip, err := b.SuggestGasTipCap(ctx, args.FeeCurrency)
 				if err != nil {
@@ -122,7 +122,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 				if err != nil {
 					return err
 				}
-				if b.ChainConfig().IsEHardfork(head.Number) {
+				if b.ChainConfig().IsEspresso(head.Number) {
 					gasPriceMinimum, err := b.CurrentGasPriceMinimum(ctx, args.FeeCurrency)
 					if err != nil {
 						return err

--- a/les/state_accessor.go
+++ b/les/state_accessor.go
@@ -54,7 +54,7 @@ func (leth *LightEthereum) stateAtTransaction(ctx context.Context, block *types.
 	}
 	// Create SysContractCallCtx
 	var sysCtx *core.SysContractCallCtx
-	if leth.chainConfig.IsEHardfork(block.Number()) {
+	if leth.chainConfig.IsEspresso(block.Number()) {
 		vmRunner := vmcontext.NewEVMRunner(leth.blockchain, block.Header(), statedb.Copy())
 		sysCtx = core.NewSysContractCallCtx(vmRunner)
 	}

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -69,9 +69,9 @@ type TxPool struct {
 	mined        map[common.Hash][]*types.Transaction // mined transactions by block hash
 	clearIdx     uint64                               // earliest block nr that can contain mined tx info
 
-	istanbul  bool // Fork indicator whether we are in the istanbul stage
-	donut     bool // Fork indicator whether Donut has been activated
-	eHardfork bool // Fork indicator whether E hard fork has been activated
+	istanbul bool // Fork indicator whether we are in the istanbul stage
+	donut    bool // Fork indicator whether Donut has been activated
+	espresso bool // Fork indicator whether Espresso has been activated
 }
 
 // TxRelayBackend provides an interface to the mechanism that forwards transacions
@@ -326,7 +326,7 @@ func (pool *TxPool) setNewHead(head *types.Header) {
 	next := new(big.Int).Add(head.Number, big.NewInt(1))
 	pool.istanbul = pool.config.IsIstanbul(next)
 	pool.donut = pool.config.IsDonut(next)
-	pool.eHardfork = pool.config.IsEHardfork(next)
+	pool.espresso = pool.config.IsEspresso(next)
 }
 
 // Stop stops the light transaction pool
@@ -392,7 +392,7 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 
 	vmRunner := pool.chain.NewEVMRunner(pool.chain.CurrentHeader(), currentState)
 	// Transactor should have enough funds to cover the costs
-	err = core.ValidateTransactorBalanceCoversTx(tx, from, currentState, vmRunner, pool.eHardfork)
+	err = core.ValidateTransactorBalanceCoversTx(tx, from, currentState, vmRunner, pool.espresso)
 	if err != nil {
 		return err
 	}

--- a/miner/stress/1559/main.go
+++ b/miner/stress/1559/main.go
@@ -186,7 +186,7 @@ func makeGenesis(faucets []*ecdsa.PrivateKey) *core.Genesis {
 	genesis := core.DefaultBaklavaGenesisBlock()
 
 	genesis.Config = params.BaklavaChainConfig
-	genesis.Config.EBlock = espressoBlock
+	genesis.Config.EspressoBlock = espressoBlock
 
 	genesis.Config.ChainID = big.NewInt(18)
 	genesis.Config.EIP150Hash = common.Hash{}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -292,7 +292,7 @@ func (w *worker) constructAndSubmitNewBlock(ctx context.Context) {
 		}
 		w.submitTaskToEngine(&task{receipts: b.receipts, state: b.state, block: block, createdAt: time.Now()})
 		baseFeeFn, toCELO := createConversionFunctions(b.sysCtx, w.chain, b.header, b.state)
-		feesCelo := totalFees(block, b.receipts, baseFeeFn, toCELO, w.chainConfig.IsEHardfork(b.header.Number))
+		feesCelo := totalFees(block, b.receipts, baseFeeFn, toCELO, w.chainConfig.IsEspresso(b.header.Number))
 		log.Info("Commit new mining work", "number", block.Number(), "txs", b.tcount, "gas", block.GasUsed(),
 			"fees", feesCelo, "elapsed", common.PrettyDuration(time.Since(start)))
 

--- a/mycelo/genesis/config.go
+++ b/mycelo/genesis/config.go
@@ -81,6 +81,7 @@ func (cfg *Config) ChainConfig() *params.ChainConfig {
 
 		ChurritoBlock: cfg.Hardforks.ChurritoBlock,
 		DonutBlock:    cfg.Hardforks.DonutBlock,
+		EspressoBlock: cfg.Hardforks.EspressoBlock,
 
 		Istanbul: &params.IstanbulConfig{
 			Epoch:          cfg.Istanbul.Epoch,
@@ -96,6 +97,7 @@ func (cfg *Config) ChainConfig() *params.ChainConfig {
 type HardforkConfig struct {
 	ChurritoBlock *big.Int `json:"churritoBlock"`
 	DonutBlock    *big.Int `json:"donutBlock"`
+	EspressoBlock *big.Int `json:"espressoBlock"`
 }
 
 // MultiSigParameters are the initial configuration parameters for a MultiSig contract

--- a/mycelo/loadbot/bot.go
+++ b/mycelo/loadbot/bot.go
@@ -130,7 +130,7 @@ func runTransaction(ctx context.Context, client *ethclient.Client, chainID *big.
 	abi := contract.AbiFor("StableToken")
 	stableToken := bind.NewBoundContract(env.MustProxyAddressFor("StableToken"), *abi, client)
 
-	transactor := bind.NewKeyedTransactor(txCfg.Acc.PrivateKey)
+	transactor, _ := bind.NewKeyedTransactorWithChainID(txCfg.Acc.PrivateKey, chainID)
 	transactor.Context = ctx
 	transactor.ChainID = chainID
 	transactor.Nonce = new(big.Int).SetUint64(txCfg.Nonce)

--- a/params/config.go
+++ b/params/config.go
@@ -64,7 +64,7 @@ var (
 		IstanbulBlock:       big.NewInt(0),
 		ChurritoBlock:       big.NewInt(6774000),
 		DonutBlock:          big.NewInt(6774000),
-		EBlock:              nil,
+		EspressoBlock:       nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -89,7 +89,7 @@ var (
 		IstanbulBlock:       big.NewInt(0),
 		ChurritoBlock:       big.NewInt(2719099),
 		DonutBlock:          big.NewInt(5002000),
-		EBlock:              nil,
+		EspressoBlock:       nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -114,7 +114,7 @@ var (
 		IstanbulBlock:       big.NewInt(0),
 		ChurritoBlock:       big.NewInt(4960000),
 		DonutBlock:          big.NewInt(4960000),
-		EBlock:              nil,
+		EspressoBlock:       nil,
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -229,7 +229,7 @@ type ChainConfig struct {
 	EWASMBlock          *big.Int `json:"ewasmBlock,omitempty"`          // EWASM switch block (nil = no fork, 0 = already activated)
 	ChurritoBlock       *big.Int `json:"churritoBlock,omitempty"`       // Churrito switch block (nil = no fork, 0 = already activated)
 	DonutBlock          *big.Int `json:"donutBlock,omitempty"`          // Donut switch block (nil = no fork, 0 = already activated)
-	EBlock              *big.Int `json:"dBlock,omitempty"`              // E switch block (nil = no fork, 0 = already activated)
+	EspressoBlock       *big.Int `json:"espressoBlock,omitempty"`       // Espresso switch block (nil = no fork, 0 = already activated)
 
 	Istanbul *IstanbulConfig `json:"istanbul,omitempty"`
 	// This does not belong here but passing it to every function is not possible since that breaks
@@ -271,7 +271,7 @@ func (c *ChainConfig) String() string {
 	} else {
 		engine = "MockEngine"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v Churrito: %v, Donut: %v, EHardfork: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v Churrito: %v, Donut: %v, Espresso: %v, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -285,7 +285,7 @@ func (c *ChainConfig) String() string {
 		c.IstanbulBlock,
 		c.ChurritoBlock,
 		c.DonutBlock,
-		c.EBlock,
+		c.EspressoBlock,
 		engine,
 	)
 }
@@ -352,9 +352,9 @@ func (c *ChainConfig) IsDonut(num *big.Int) bool {
 	return isForked(c.DonutBlock, num)
 }
 
-// IsEHardfork returns whether num represents a block number after the E fork
-func (c *ChainConfig) IsEHardfork(num *big.Int) bool {
-	return isForked(c.EBlock, num)
+// IsEspresso returns whether num represents a block number after the E fork
+func (c *ChainConfig) IsEspresso(num *big.Int) bool {
+	return isForked(c.EspressoBlock, num)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
@@ -395,7 +395,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "istanbulBlock", block: c.IstanbulBlock},
 		{name: "churritoBlock", block: c.ChurritoBlock},
 		{name: "donutBlock", block: c.DonutBlock},
-		{name: "eBlock", block: c.EBlock},
+		{name: "espressoBlock", block: c.EspressoBlock},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -465,8 +465,8 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.DonutBlock, newcfg.DonutBlock, head) {
 		return newCompatError("Donut fork block", c.DonutBlock, newcfg.DonutBlock)
 	}
-	if isForkIncompatible(c.EBlock, newcfg.EBlock, head) {
-		return newCompatError("E fork block", c.EBlock, newcfg.EBlock)
+	if isForkIncompatible(c.EspressoBlock, newcfg.EspressoBlock, head) {
+		return newCompatError("E fork block", c.EspressoBlock, newcfg.EspressoBlock)
 	}
 	return nil
 }
@@ -535,7 +535,7 @@ type Rules struct {
 	ChainID                                                 *big.Int
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
-	IsChurrito, IsDonut, IsEHardfork                        bool
+	IsChurrito, IsDonut, IsEspresso                         bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -556,6 +556,6 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsIstanbul:       c.IsIstanbul(num),
 		IsChurrito:       c.IsChurrito(num),
 		IsDonut:          c.IsDonut(num),
-		IsEHardfork:      c.IsEHardfork(num),
+		IsEspresso:       c.IsEspresso(num),
 	}
 }

--- a/tests/init.go
+++ b/tests/init.go
@@ -154,7 +154,7 @@ var Forks = map[string]*params.ChainConfig{
 		IstanbulBlock:       big.NewInt(0),
 		ChurritoBlock:       big.NewInt(0),
 		DonutBlock:          big.NewInt(0),
-		EBlock:              big.NewInt(0),
+		EspressoBlock:       big.NewInt(0),
 	},
 	"DonutToEspressoAt5": {
 		ChainID:             big.NewInt(1),
@@ -168,7 +168,7 @@ var Forks = map[string]*params.ChainConfig{
 		IstanbulBlock:       big.NewInt(0),
 		ChurritoBlock:       big.NewInt(0),
 		DonutBlock:          big.NewInt(0),
-		EBlock:              big.NewInt(5),
+		EspressoBlock:       big.NewInt(5),
 	},
 }
 

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -183,7 +183,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	snaps, statedb := MakePreState(rawdb.NewMemoryDatabase(), t.json.Pre, snapshotter)
 
 	var baseFee *big.Int
-	if config.IsEHardfork(new(big.Int)) {
+	if config.IsEspresso(new(big.Int)) {
 		// baseFee = t.json.Env.BaseFee ?
 		if baseFee == nil {
 			// Retesteth uses `0x10` for genesis baseFee. Therefore, it defaults to


### PR DESCRIPTION
### Description

This enables mycelo and e2e tests to set the espresso block number.
This is was done to test celo typed transactions and espresso.

This commit also renames any reference of "E" hardfork or block
to "Espresso".

Also updates the mycelo load bot to use the latest signer instead of
the homestead signer.

### Tested

Unit test, CI. Tested that e2e tests can activate the Espresso fork.

### Backwards compatibility
Yes