### PR TITLE
e2e_test: separate account from nodes

### DIFF
--- a/test/account.go
+++ b/test/account.go
@@ -1,0 +1,92 @@
+package test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/mycelo/env"
+	"github.com/celo-org/celo-blockchain/params"
+)
+
+type Account struct {
+	Address     common.Address
+	Key         *ecdsa.PrivateKey
+	ChainConfig *params.ChainConfig
+	Nonce       *uint64
+}
+
+func NewAccount(key *ecdsa.PrivateKey, address common.Address, chainConfig *params.ChainConfig) *Account {
+	return &Account{
+		Address:     address,
+		Key:         key,
+		ChainConfig: chainConfig,
+	}
+}
+
+// SendCelo submits a value transfer transaction via the provided Node to send
+// celo to the recipient. The submitted transaction is returned.
+func (a *Account) SendCelo(ctx context.Context, recipient common.Address, value int64, node *Node) (*types.Transaction, error) {
+	var err error
+	// Lazy set nonce
+	if a.Nonce == nil {
+		a.Nonce = new(uint64)
+		*a.Nonce, err = node.WsClient.PendingNonceAt(ctx, a.Address)
+		if err != nil {
+			return nil, err
+		}
+	}
+	num, err := node.WsClient.BlockNumber(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	signer := types.MakeSigner(a.ChainConfig, new(big.Int).SetUint64(num))
+	tx, err := ValueTransferTransaction(
+		node.WsClient,
+		a.Key,
+		a.Address,
+		recipient,
+		*a.Nonce,
+		big.NewInt(value),
+		signer)
+
+	if err != nil {
+		return nil, err
+	}
+	err = node.WsClient.SendTransaction(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	*a.Nonce++
+	return tx, nil
+}
+
+// SendCeloTracked functions like SendCelo but also waits for the transaction
+// to be processed by the sending node.
+func (a *Account) SendCeloTracked(ctx context.Context, recipient common.Address, value int64, node *Node) (*types.Transaction, error) {
+	tx, err := a.SendCelo(ctx, recipient, value, node)
+	if err != nil {
+		return nil, err
+	}
+	err = node.AwaitTransactions(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	return node.Tracker.GetProcessedTx(tx.Hash()), nil
+}
+
+// Accounts converts a slice of env.Account objects to Account objects.
+func Accounts(accts []env.Account, chainConfig *params.ChainConfig) []*Account {
+	accounts := make([]*Account, 0, len(accts))
+	for _, a := range accts {
+		accounts = append(accounts, &Account{
+			Address:     a.Address,
+			Key:         a.PrivateKey,
+			ChainConfig: chainConfig,
+		})
+	}
+	return accounts
+}

--- a/test/account.go
+++ b/test/account.go
@@ -82,11 +82,7 @@ func (a *Account) SendCeloTracked(ctx context.Context, recipient common.Address,
 func Accounts(accts []env.Account, chainConfig *params.ChainConfig) []*Account {
 	accounts := make([]*Account, 0, len(accts))
 	for _, a := range accts {
-		accounts = append(accounts, &Account{
-			Address:     a.Address,
-			Key:         a.PrivateKey,
-			ChainConfig: chainConfig,
-		})
+		accounts = append(accounts, NewAccount(a.PrivateKey, a.Address, chainConfig))
 	}
 	return accounts
 }

--- a/test/node.go
+++ b/test/node.go
@@ -91,11 +91,8 @@ type Node struct {
 	Eth           *eth.Ethereum
 	EthConfig     *eth.Config
 	WsClient      *ethclient.Client
-	Nonce         uint64
 	Key           *ecdsa.PrivateKey
 	Address       common.Address
-	DevKey        *ecdsa.PrivateKey
-	DevAddress    common.Address
 	Tracker       *Tracker
 	// The transactions that this node has sent.
 	SentTxs []*types.Transaction
@@ -103,8 +100,7 @@ type Node struct {
 
 // NewNode creates a new running node with the provided config.
 func NewNode(
-	validatorAccount,
-	devAccount *env.Account,
+	validatorAccount *env.Account,
 	nc *node.Config,
 	ec *eth.Config,
 	genesis *core.Genesis,
@@ -140,13 +136,11 @@ func NewNode(
 	ecCopy.TxFeeRecipient = validatorAccount.Address
 
 	node := &Node{
-		Config:     &ncCopy,
-		EthConfig:  ecCopy,
-		Key:        validatorAccount.PrivateKey,
-		Address:    validatorAccount.Address,
-		DevAddress: devAccount.Address,
-		DevKey:     devAccount.PrivateKey,
-		Tracker:    NewTracker(),
+		Config:    &ncCopy,
+		EthConfig: ecCopy,
+		Key:       validatorAccount.PrivateKey,
+		Address:   validatorAccount.Address,
+		Tracker:   NewTracker(),
 	}
 
 	return node, node.Start()
@@ -210,10 +204,6 @@ func (n *Node) Start() error {
 		return err
 	}
 	n.WsClient, err = ethclient.Dial(n.WSEndpoint())
-	if err != nil {
-		return err
-	}
-	n.Nonce, err = n.WsClient.PendingNonceAt(context.Background(), n.DevAddress)
 	if err != nil {
 		return err
 	}
@@ -292,44 +282,6 @@ func (n *Node) Close() error {
 	return os.RemoveAll(n.Config.DataDir)
 }
 
-// SendCeloTracked functions like SendCelo but also waits for the transaction to be processed.
-func (n *Node) SendCeloTracked(ctx context.Context, recipient common.Address, value int64) (*types.Transaction, error) {
-	tx, err := n.SendCelo(ctx, recipient, value)
-	if err != nil {
-		return nil, err
-	}
-	err = n.AwaitTransactions(ctx, tx)
-	if err != nil {
-		return nil, err
-	}
-	return n.Tracker.GetProcessedTx(tx.Hash()), nil
-}
-
-// SendCelo submits a value transfer transaction to the network to send celo to
-// the recipient. The submitted transaction is returned.
-func (n *Node) SendCelo(ctx context.Context, recipient common.Address, value int64) (*types.Transaction, error) {
-	signer := types.MakeSigner(n.EthConfig.Genesis.Config, common.Big0)
-	tx, err := ValueTransferTransaction(
-		n.WsClient,
-		n.DevKey,
-		n.DevAddress,
-		recipient,
-		n.Nonce,
-		big.NewInt(value),
-		signer)
-
-	if err != nil {
-		return nil, err
-	}
-	err = n.WsClient.SendTransaction(ctx, tx)
-	if err != nil {
-		return nil, err
-	}
-	n.Nonce++
-	n.SentTxs = append(n.SentTxs, tx)
-	return tx, nil
-}
-
 // AwaitTransactions awaits all the provided transactions.
 func (n *Node) AwaitTransactions(ctx context.Context, txs ...*types.Transaction) error {
 	sentHashes := make([]common.Hash, len(txs))
@@ -337,12 +289,6 @@ func (n *Node) AwaitTransactions(ctx context.Context, txs ...*types.Transaction)
 		sentHashes[i] = tx.Hash()
 	}
 	return n.Tracker.AwaitTransactions(ctx, sentHashes)
-}
-
-// AwaitSentTransactions awaits all the transactions that this node has sent
-// via SendCelo.
-func (n *Node) AwaitSentTransactions(ctx context.Context) error {
-	return n.AwaitTransactions(ctx, n.SentTxs...)
 }
 
 // ProcessedTxBlock returns the block that the given transaction was processed
@@ -364,12 +310,12 @@ func (n *Node) TxFee(ctx context.Context, tx *types.Transaction) (*big.Int, erro
 // create, start and stop a collection of nodes.
 type Network []*Node
 
-func Accounts(numValidators int) *env.AccountsConfig {
+func AccountConfig(numValidators, numExternal int) *env.AccountsConfig {
 	return &env.AccountsConfig{
 		Mnemonic:             env.MustNewMnemonic(),
 		NumValidators:        numValidators,
 		ValidatorsPerGroup:   1,
-		NumDeveloperAccounts: numValidators,
+		NumDeveloperAccounts: numExternal,
 	}
 }
 
@@ -420,11 +366,10 @@ func NewNetwork(accounts *env.AccountsConfig, gc *genesis.Config, ec *eth.Config
 	}
 
 	va := accounts.ValidatorAccounts()
-	da := accounts.DeveloperAccounts()
 	var network Network = make([]*Node, len(va))
 
 	for i := range va {
-		n, err := NewNode(&va[i], &da[i], baseNodeConfig, ec, genesis)
+		n, err := NewNode(&va[i], baseNodeConfig, ec, genesis)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to build node for network: %v", err)
 		}


### PR DESCRIPTION
Previously each node owned a validator account and a 'dev' account and
nodes could execute txs using the dev account. Now transaction sending
has been moved to the account object and nodes simply hold the validator
account, this more closely represents the real world situation.