### PR TITLE
Simplify use of prepareBlock

### DIFF
--- a/miner/block.go
+++ b/miner/block.go
@@ -53,8 +53,10 @@ type blockState struct {
 	txFeeRecipient common.Address
 }
 
-// prepareBlock intializes a new blockState that is ready to have transaction included to.
-// If no error is returned blockState.close() needs to be called to shut down the state prefetcher.
+// prepareBlock intializes a new blockState that is ready to have transactions
+// included in it, and uses it to set the worker's pending block and state. If
+// no error is returned blockState.close() needs to be called to shut down the
+// state prefetcher.
 func prepareBlock(w *worker) (*blockState, error) {
 	w.mu.RLock()
 	defer w.mu.RUnlock()
@@ -155,6 +157,7 @@ func prepareBlock(w *worker) (*blockState, error) {
 	}
 
 	state.StartPrefetcher("miner")
+	w.updatePendingBlock(b)
 	return b, nil
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -250,7 +250,6 @@ func (w *worker) constructAndSubmitNewBlock(ctx context.Context) {
 		return
 	}
 	defer b.close()
-	w.updatePendingBlock(b)
 
 	// TODO: worker based adaptive sleep with this delay
 	// wait for the timestamp of header, use this to adjust the block period
@@ -305,7 +304,6 @@ func (w *worker) constructPendingStateBlock(ctx context.Context, txsCh chan core
 		return
 	}
 	defer b.close()
-	w.updatePendingBlock(b)
 
 	err = b.selectAndApplyTransactions(ctx, w)
 	if err != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -245,15 +245,11 @@ func (w *worker) constructAndSubmitNewBlock(ctx context.Context) {
 
 	// Initialize the block.
 	b, err := prepareBlock(w)
-	defer func() {
-		if b != nil {
-			b.close()
-		}
-	}()
 	if err != nil {
 		log.Error("Failed to create mining context", "err", err)
 		return
 	}
+	defer b.close()
 	w.updatePendingBlock(b)
 
 	// TODO: worker based adaptive sleep with this delay
@@ -304,15 +300,11 @@ func (w *worker) constructAndSubmitNewBlock(ctx context.Context) {
 func (w *worker) constructPendingStateBlock(ctx context.Context, txsCh chan core.NewTxsEvent) {
 	// Initialize the block.
 	b, err := prepareBlock(w)
-	defer func() {
-		if b != nil {
-			b.close()
-		}
-	}()
 	if err != nil {
 		log.Error("Failed to create mining context", "err", err)
 		return
 	}
+	defer b.close()
 	w.updatePendingBlock(b)
 
 	err = b.selectAndApplyTransactions(ctx, w)


### PR DESCRIPTION
Only start the prefether in the case that no error is returned.
This lets callers only have to deal with closing the block state when no
error is returned.

### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
