### PR TITLE
Fix checkout-monorepo ci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,6 +329,10 @@ jobs:
             cd celo-monorepo
             git fetch --depth 1 origin ${CELO_MONOREPO_COMMIT_OR_BRANCH}
             git checkout ${CELO_MONOREPO_COMMIT_OR_BRANCH}
+
+            # Github is phasing out the git protocol so we ensure that we use
+            # https for all git operations that yarn may perform.
+            git config --global url."https://github.com".insteadOf git://github.com
             yarn install || yarn install
             yarn build --scope @celo/celotool --include-filtered-dependencies
       - run:


### PR DESCRIPTION
Set git to re-write git urls to use https instead of git, we need to do this because github is phasing out the use of the git protocol -https://github.blog/2021-09-01-improving-git-protocol-security-github.
