### PR TITLE
Reinstate delay before signature aggregation in backend.Prepare

### DIFF
--- a/consensus/consensustest/mockprotocol.go
+++ b/consensus/consensustest/mockprotocol.go
@@ -350,6 +350,13 @@ func (e *MockEngine) Prepare(chain consensus.ChainHeaderReader, header *types.He
 	if parent == nil {
 		return consensus.ErrUnknownAncestor
 	}
+
+	// Matches delay in consensus/istanbul/backend/engine.go:386 in (*Backend).Prepare
+	delay := time.Until(time.Unix(int64(header.Time), 0))
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+
 	return nil
 }
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -383,12 +383,16 @@ func (sb *Backend) Prepare(chain consensus.ChainHeaderReader, header *types.Head
 		header.Time = nowTime
 	}
 
-	// Record what the delay should be, but sleep in the miner, not the consensus engine.
+	// Record what the delay should be and sleep if greater than 0.
+	// TODO(victor): Sleep here was previously removed and added to the miner instead, that change
+	// has been temporarily reverted until it can be reimplemented without causing fewer signatures
+	// to be included by the block producer.
 	delay := time.Until(time.Unix(int64(header.Time), 0))
 	if delay < 0 {
 		sb.sleepGauge.Update(0)
 	} else {
 		sb.sleepGauge.Update(delay.Nanoseconds())
+		time.Sleep(delay)
 	}
 
 	if err := writeEmptyIstanbulExtra(header); err != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -259,6 +259,7 @@ func (w *worker) constructAndSubmitNewBlock(ctx context.Context) {
 	}
 	w.updatePendingBlock(b)
 
+	startConstruction := time.Now()
 	err = b.selectAndApplyTransactions(ctx, w)
 	if err != nil {
 		log.Error("Failed to apply transactions to the block", "err", err)
@@ -278,7 +279,7 @@ func (w *worker) constructAndSubmitNewBlock(ctx context.Context) {
 	// the proposer and the engine has already gotten and is verifying the proposal).  See
 	// https://github.com/celo-org/celo-blockchain/issues/1639#issuecomment-888611039
 	// And we subtract the time we spent sleeping, since we want the time spent actually building the block.
-	w.blockConstructGauge.Update(time.Since(start).Nanoseconds() - delay.Nanoseconds())
+	w.blockConstructGauge.Update(time.Since(startConstruction).Nanoseconds())
 
 	if w.isRunning() {
 		if w.fullTaskHook != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -246,6 +246,7 @@ func (w *worker) constructAndSubmitNewBlock(ctx context.Context) {
 	start := time.Now()
 
 	// Initialize the block.
+	// Note: In the current implementation, this will sleep until the time of the next block.
 	b, err := prepareBlock(w)
 	defer func() {
 		if b != nil {
@@ -257,15 +258,6 @@ func (w *worker) constructAndSubmitNewBlock(ctx context.Context) {
 		return
 	}
 	w.updatePendingBlock(b)
-
-	// TODO: worker based adaptive sleep with this delay
-	// wait for the timestamp of header, use this to adjust the block period
-	delay := time.Until(time.Unix(int64(b.header.Time), 0))
-	select {
-	case <-time.After(delay):
-	case <-ctx.Done():
-		return
-	}
 
 	err = b.selectAndApplyTransactions(ctx, w)
 	if err != nil {


### PR DESCRIPTION
### Description

As a temporary measure to address low signature inclusion rates, this PR adds back a sleep in the
consensus engine before adding the parent seal to the block.

This sleep was removed in https://github.com/celo-org/celo-blockchain/pull/1545 as part of a
refactor and performance improvement, but was not implemented to account for adding time to
aggregate extra received commits to the parent seal. As a result, blocks produced by validators with
versions >= v1.4.0 include fewer signatures in the parent aggregated seal. This seal provides an
important signal to validators as to the performance of their nodes and is used by the protocol to
calculate rewards, although rewards will only be effected if the validators signature does not
appear in 13 or more consecutive blocks.

### Other changes

None

### Tested

WIP

### Related issues

- Realted: https://github.com/celo-org/celo-blockchain/issues/1304

### Backwards compatibility

No concerns
