### PR TITLE
Add e2e transfer test

### DIFF
--- a/e2e_test/e2e_transfer_test.go
+++ b/e2e_test/e2e_transfer_test.go
@@ -119,6 +119,7 @@ func TestTransferCELO(t *testing.T) {
 		require.NoError(t, err)
 		signer := types.MakeSigner(devAccounts[0].ChainConfig, new(big.Int).SetUint64(blockNum))
 		tx, err := prepareTransaction(*txArgs, sender.Key, sender.Address, signer, client)
+		require.NoError(t, err)
 		err = client.SendTransaction(ctx, tx)
 		require.NoError(t, err, "SendTransaction failed", "tx", *tx)
 		err = network.AwaitTransactions(ctx, tx)

--- a/e2e_test/e2e_transfer_test.go
+++ b/e2e_test/e2e_transfer_test.go
@@ -1,0 +1,207 @@
+package e2e
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	ethereum "github.com/celo-org/celo-blockchain"
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/common/hexutil"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/ethclient"
+	"github.com/celo-org/celo-blockchain/internal/ethapi"
+	"github.com/celo-org/celo-blockchain/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	oneCelo = 1000000000000000000
+)
+
+// TestTransferCELO checks following accounts:
+// - Sender account has transfer value, transaction fee deducted
+// - Receiver account has transfer value added.
+// - Governance account has base fee added.
+// - validator account has tip fee added.
+func TestTransferCELO(t *testing.T) {
+	ac := test.AccountConfig(1, 3)
+	gc, ec, err := test.BuildConfig(ac)
+	require.NoError(t, err)
+	network, shutdown, err := test.NewNetwork(ac, gc, ec)
+	require.NoError(t, err)
+	defer shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	node := network[0] // validator node
+	client := node.WsClient
+	devAccounts := test.Accounts(ac.DeveloperAccounts(), gc.ChainConfig())
+	sender := devAccounts[0]
+	recipient := devAccounts[1]
+	gateWayFeeRecipient := devAccounts[2]
+
+	// Get datum to set GasPrice/MaxFeePerGas/MaxPriorityFeePerGas to sensible values
+	header, err := network[0].WsClient.HeaderByNumber(ctx, common.Big0)
+	require.NoError(t, err)
+	datum, err := network[0].Eth.APIBackend.GasPriceMinimumForHeader(ctx, nil, header)
+	require.NoError(t, err)
+
+	testTransactionArgs := []*ethapi.TransactionArgs{
+		// LegacyTxType eth compatible
+		{
+			To:       &recipient.Address,
+			Value:    (*hexutil.Big)(new(big.Int).SetInt64(oneCelo)),
+			GasPrice: (*hexutil.Big)(datum.Mul(datum, new(big.Int).SetInt64(4))),
+		},
+		// LegacyTxType eth incompatible
+		{
+			To:                  &recipient.Address,
+			Value:               (*hexutil.Big)(new(big.Int).SetInt64(oneCelo)),
+			GasPrice:            (*hexutil.Big)(datum.Mul(datum, new(big.Int).SetInt64(4))),
+			GatewayFee:          (*hexutil.Big)(new(big.Int).SetInt64(oneCelo / 10)),
+			GatewayFeeRecipient: &gateWayFeeRecipient.Address,
+		},
+
+		// AccessListTxType eth compatible
+		{
+			To:         &recipient.Address,
+			Value:      (*hexutil.Big)(new(big.Int).SetInt64(oneCelo)),
+			GasPrice:   (*hexutil.Big)(datum.Mul(datum, new(big.Int).SetInt64(4))),
+			AccessList: &types.AccessList{},
+		},
+
+		// DynamicFeeTxType
+		// Tip gas will be MaxFeePerGas - BaseFee
+		{
+			To:                   &recipient.Address,
+			Value:                (*hexutil.Big)(new(big.Int).SetInt64(oneCelo)),
+			MaxFeePerGas:         (*hexutil.Big)(datum.Mul(datum, new(big.Int).SetInt64(4))),
+			MaxPriorityFeePerGas: (*hexutil.Big)(datum.Mul(datum, new(big.Int).SetInt64(4))),
+		},
+		// DynamicFeeTxType
+		// Tip gas will be MaxPriorityFeePerGas
+		{
+			To:                   &recipient.Address,
+			Value:                (*hexutil.Big)(new(big.Int).SetInt64(oneCelo)),
+			MaxFeePerGas:         (*hexutil.Big)(datum.Mul(datum, new(big.Int).SetInt64(4))),
+			MaxPriorityFeePerGas: (*hexutil.Big)(datum),
+		},
+
+		// CeloDynamicFeeTxType
+		// Tip gas will be MaxFeePerGas - BaseFee
+		{
+			To:                   &recipient.Address,
+			Value:                (*hexutil.Big)(new(big.Int).SetInt64(oneCelo)),
+			MaxFeePerGas:         (*hexutil.Big)(datum.Mul(datum, new(big.Int).SetInt64(4))),
+			MaxPriorityFeePerGas: (*hexutil.Big)(datum.Mul(datum, new(big.Int).SetInt64(4))),
+			GatewayFee:           (*hexutil.Big)(new(big.Int).SetInt64(oneCelo / 10)),
+			GatewayFeeRecipient:  &gateWayFeeRecipient.Address,
+		},
+		// CeloDynamicFeeTxType
+		// Tip gas will be MaxPriorityFeePerGas
+		{
+			To:                   &recipient.Address,
+			Value:                (*hexutil.Big)(new(big.Int).SetInt64(oneCelo)),
+			MaxFeePerGas:         (*hexutil.Big)(datum.Mul(datum, new(big.Int).SetInt64(4))),
+			MaxPriorityFeePerGas: (*hexutil.Big)(datum),
+			GatewayFee:           (*hexutil.Big)(new(big.Int).SetInt64(oneCelo / 10)),
+			GatewayFeeRecipient:  &gateWayFeeRecipient.Address,
+		},
+	}
+	for _, txArgs := range testTransactionArgs {
+		watcher := test.NewBalanceWatcher(client, []common.Address{sender.Address, recipient.Address, gateWayFeeRecipient.Address, node.Address})
+		blockNum, err := client.BlockNumber(ctx)
+		require.NoError(t, err)
+		signer := types.MakeSigner(devAccounts[0].ChainConfig, new(big.Int).SetUint64(blockNum))
+		tx, err := prepareTransaction(*txArgs, sender.Key, sender.Address, signer, client)
+		err = client.SendTransaction(ctx, tx)
+		require.NoError(t, err, "SendTransaction failed", "tx", *tx)
+		err = network.AwaitTransactions(ctx, tx)
+		require.NoError(t, err)
+		watcher.Update()
+		receipt, err := client.TransactionReceipt(ctx, tx.Hash())
+
+		// check value goes to recipient
+		expected := tx.Value()
+		actual := watcher.Delta(recipient.Address)
+		assert.Equal(t, expected, actual, "Recipient's balance increase unexpected", "expected", expected.Int64(), "actual", actual.Int64())
+
+		// Check tip goes to validator
+		header, err := network[0].WsClient.HeaderByNumber(ctx, receipt.BlockNumber)
+		require.NoError(t, err)
+		gpm, err := network[0].Eth.APIBackend.GasPriceMinimumForHeader(ctx, nil, header)
+		require.NoError(t, err)
+		baseFee := new(big.Int).Mul(gpm, new(big.Int).SetUint64(receipt.GasUsed))
+		switch tx.Type() {
+		case types.LegacyTxType, types.AccessListTxType:
+			fee := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(receipt.GasUsed))
+			expected = new(big.Int).Sub(fee, baseFee)
+		case types.DynamicFeeTxType, types.CeloDynamicFeeTxType:
+			expected = tx.EffectiveGasTipValue(gpm)
+			expected.Mul(expected, new(big.Int).SetUint64(receipt.GasUsed))
+		}
+		actual = watcher.Delta(node.Address)
+		assert.Equal(t, expected, actual, "Validator's balance increase unexpected", "expected", expected.Int64(), "actual", actual.Int64())
+
+		// check value + tx fee + gateway fee are subtracted from sender
+		var fee *big.Int
+		switch tx.Type() {
+		case types.LegacyTxType, types.AccessListTxType:
+			fee = new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(receipt.GasUsed))
+		case types.DynamicFeeTxType, types.CeloDynamicFeeTxType:
+			tip := tx.EffectiveGasTipValue(gpm)
+			tip.Mul(tip, new(big.Int).SetUint64(receipt.GasUsed))
+			fee = new(big.Int).Add(tip, baseFee)
+		}
+		consumed := new(big.Int).Add(tx.Value(), fee)
+		if tx.GatewayFeeRecipient() != nil && tx.GatewayFee() != nil {
+			consumed.Add(consumed, tx.GatewayFee())
+		}
+		expected = new(big.Int).Neg(consumed)
+		actual = watcher.Delta(sender.Address)
+		assert.Equal(t, expected, actual, "Sender's balance decrease unexpected", "expected", expected.Int64(), "actual", expected.Int64())
+
+		// Check gateway fee
+		if tx.GatewayFeeRecipient() != nil && tx.GatewayFee() != nil {
+			expected = tx.GatewayFee()
+			actual = watcher.Delta(gateWayFeeRecipient.Address)
+			assert.Equal(t, expected, actual, "gateWayFeeRecipient's balance increase unexpected", "expected", expected.Int64(), "actual", actual.Int64())
+		}
+	}
+}
+
+// prepareTransaction prepares gasPrice, gasLimit and sign the transaction.
+func prepareTransaction(txArgs ethapi.TransactionArgs, senderKey *ecdsa.PrivateKey, sender common.Address, signer types.Signer, client *ethclient.Client) (*types.Transaction, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
+	// Set nonce
+	nonce, err := client.PendingNonceAt(ctx, sender)
+	if err != nil {
+		return nil, err
+	}
+	txArgs.Nonce = (*hexutil.Uint64)(&nonce)
+
+	// Set gasLimit
+	if txArgs.Gas == nil {
+		msg := ethereum.CallMsg{From: sender, To: txArgs.To, GasPrice: txArgs.GasPrice.ToInt(), Value: txArgs.Value.ToInt()}
+		gasLimit, err := client.EstimateGas(ctx, msg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to estimate gas needed: %v", err)
+		}
+		txArgs.Gas = (*hexutil.Uint64)(&gasLimit)
+	}
+
+	// Create the transaction and sign it
+	rawTx := txArgs.ToTransaction()
+	signed, err := types.SignTx(rawTx, signer, senderKey)
+	if err != nil {
+		return nil, err
+	}
+	return signed, nil
+}

--- a/e2e_test/e2e_transfer_test.go
+++ b/e2e_test/e2e_transfer_test.go
@@ -67,7 +67,7 @@ func TestTransferCELO(t *testing.T) {
 			GatewayFeeRecipient: &gateWayFeeRecipient.Address,
 		},
 
-		// AccessListTxType eth compatible
+		// AccessListTxType
 		{
 			To:         &recipient.Address,
 			Value:      (*hexutil.Big)(new(big.Int).SetInt64(oneCelo)),
@@ -103,7 +103,7 @@ func TestTransferCELO(t *testing.T) {
 			GatewayFeeRecipient:  &gateWayFeeRecipient.Address,
 		},
 		// CeloDynamicFeeTxType
-		// Tip gas will be MaxPriorityFeePerGas
+		// Tip gas will be MaxPriorityFeePerGasBuildConfig
 		{
 			To:                   &recipient.Address,
 			Value:                (*hexutil.Big)(new(big.Int).SetInt64(oneCelo)),
@@ -125,6 +125,7 @@ func TestTransferCELO(t *testing.T) {
 		require.NoError(t, err)
 		watcher.Update()
 		receipt, err := client.TransactionReceipt(ctx, tx.Hash())
+		require.NoError(t, err)
 
 		// check value goes to recipient
 		expected := tx.Value()

--- a/e2e_test/e2e_transfer_test.go
+++ b/e2e_test/e2e_transfer_test.go
@@ -31,6 +31,7 @@ const (
 func TestTransferCELO(t *testing.T) {
 	ac := test.AccountConfig(1, 3)
 	gc, ec, err := test.BuildConfig(ac)
+	gc.Hardforks.EspressoBlock = big.NewInt(0)
 	require.NoError(t, err)
 	network, shutdown, err := test.NewNetwork(ac, gc, ec)
 	require.NoError(t, err)

--- a/mycelo/genesis/genesis.go
+++ b/mycelo/genesis/genesis.go
@@ -27,6 +27,7 @@ func CreateCommonGenesisConfig(chainID *big.Int, adminAccountAddress common.Addr
 	genesisConfig.Hardforks = HardforkConfig{
 		ChurritoBlock: common.Big0,
 		DonutBlock:    common.Big0,
+		EspressoBlock: common.Big0,
 	}
 
 	// Make admin account manager of Governance & Reserve

--- a/mycelo/genesis/genesis.go
+++ b/mycelo/genesis/genesis.go
@@ -27,7 +27,6 @@ func CreateCommonGenesisConfig(chainID *big.Int, adminAccountAddress common.Addr
 	genesisConfig.Hardforks = HardforkConfig{
 		ChurritoBlock: common.Big0,
 		DonutBlock:    common.Big0,
-		EspressoBlock: common.Big0,
 	}
 
 	// Make admin account manager of Governance & Reserve

--- a/test/node.go
+++ b/test/node.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	ethereum "github.com/celo-org/celo-blockchain"
+	"github.com/celo-org/celo-blockchain/eth/ethconfig"
 
 	"github.com/celo-org/celo-blockchain/accounts/keystore"
 	"github.com/celo-org/celo-blockchain/common"
@@ -325,7 +326,7 @@ func AccountConfig(numValidators, numExternal int) *env.AccountsConfig {
 // NOTE: Do not edit the Istanbul field of the returned genesis config it will
 // be overwritten with the corresponding config from the Istanbul field of the
 // returned eth config.
-func BuildConfig(accounts *env.AccountsConfig) (*genesis.Config, *eth.Config, error) {
+func BuildConfig(accounts *env.AccountsConfig) (*genesis.Config, *ethconfig.Config, error) {
 	gc := genesis.CreateCommonGenesisConfig(
 		big.NewInt(1),
 		accounts.AdminAccount().Address,

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,0 +1,86 @@
+package test
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/ethclient"
+)
+
+type Token int
+
+const (
+	Celo Token = iota
+	cUSD
+	cEUR
+	cREAL
+)
+
+type Balances map[common.Address]*big.Int
+
+// BalanceWatcher is a helper to watch balance changes over addresses.
+type BalanceWatcher struct {
+	accounts []common.Address
+	client   *ethclient.Client
+	initial  Balances
+	current  Balances
+}
+
+// NewBalanceWatcher creates a BalanceWatcher, records initial balances of the accounts.
+func NewBalanceWatcher(client *ethclient.Client, addresses []common.Address) *BalanceWatcher {
+	watcher := &BalanceWatcher{
+		client:   client,
+		accounts: addresses,
+	}
+	if initial, err := fetch(client, addresses); err != nil {
+		panic("Unable to initialize Balances")
+	} else {
+		watcher.initial = initial
+		watcher.current = initial
+	}
+
+	return watcher
+}
+
+// Initial returns initial balance of given address, or nil if address is not found.
+func (w *BalanceWatcher) Initial(address common.Address) *big.Int {
+	if _, ok := w.initial[address]; ok {
+		if balance, ok := w.initial[address]; ok {
+			return balance
+		}
+	}
+	return nil
+}
+
+// Current returns current balance of given address.
+func (w *BalanceWatcher) Current(address common.Address) *big.Int {
+	return w.current[address] // TODO: support stable coin
+}
+
+// Delta returns difference between current and initial balance of given address for given token.
+func (w *BalanceWatcher) Delta(address common.Address) *big.Int {
+	return new(big.Int).Sub(w.current[address], w.initial[address]) // TODO: support stable coin
+}
+
+// Update updates current balances in the BalanceWatcher
+func (w *BalanceWatcher) Update() {
+	if current, err := fetch(w.client, w.accounts); err != nil {
+		panic("Unable to fetch current balances")
+	} else {
+		w.current = current
+	}
+}
+
+// fetch retrieves balances of given addresses.
+func fetch(client *ethclient.Client, addresses []common.Address) (Balances, error) {
+	balances := make(Balances)
+	for _, address := range addresses {
+		balance, err := client.BalanceAt(context.Background(), address, nil)
+		if err != nil {
+			return nil, err
+		}
+		balances[address] = balance // TODO: support stable coin
+	}
+	return balances, nil
+}

--- a/test/utils.go
+++ b/test/utils.go
@@ -10,13 +10,6 @@ import (
 
 type Token int
 
-const (
-	Celo Token = iota
-	cUSD
-	cEUR
-	cREAL
-)
-
 type Balances map[common.Address]*big.Int
 
 // BalanceWatcher is a helper to watch balance changes over addresses.


### PR DESCRIPTION
### Description
Added e2e transfer test cases:
- LegacyTxType eth compatible
- LegacyTxType eth incompatible
- AccessListTxType
- DynamicFeeTxType with tip gas equal to `MaxFeePerGas - BaseFee`
- DynamicFeeTxType with tip gas equal to `MaxPriorityFeePerGas`
- CeloDynamicFeeTxType with tip gas equal to `MaxFeePerGas - BaseFee`
- CeloDynamicFeeTxType with tip gas equal to `MaxPriorityFeePerGas`

### Other changes

- Added Espressso Hardfork block in mycelo ChainConfig.
- Updated a usage of deprecated `eth.Config` to `ethconfig.Config`

### Tested

`go test ./e2e_test -run TestTransferCELO`

### Related issues

- Fixes #1788 

### Backwards compatibility

Yes, only added tests
