### PR TITLE
Ensure txPricedList reheaps regularly (avoid tx memory leak)

### DIFF
--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -779,7 +779,7 @@ func (l *txPricedList) Put(tx *types.Transaction, local bool) {
 // from the pool. The list will just keep a counter of stale objects and update
 // the heap if a large enough ratio of transactions go stale.
 func (l *txPricedList) Removed(count int) {
-	// Bump the stale counter, but exit if still too low (< 25%)
+	// Bump the stale counter
 	stales := atomic.AddInt64(&l.stales, int64(count))
 	urgentSize := l.urgent.Len()
 	floatingSize := l.floating.Len()
@@ -788,10 +788,8 @@ func (l *txPricedList) Removed(count int) {
 	overStalesRatio := int(stales) > (urgentSize+floatingSize)/4
 	// Reheap if stales exceed the max stales limit
 	overMaxStales := stales >= l.maxStales
-	// Reheap if the size of the heaps exceed twice of the all remotes size.
-	heapsTooBig := urgentSize+floatingSize > 2*len(l.all.remotes)
 
-	if overStalesRatio || overMaxStales || heapsTooBig {
+	if overStalesRatio || overMaxStales {
 		l.Reheap()
 	}
 }

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -734,6 +734,7 @@ type txPricedList struct {
 	all              *txLookup              // Pointer to the map of all transactions
 	urgent, floating multiCurrencyPriceHeap // Heaps of prices of all the stored **remote** transactions
 	stales           int64                  // Number of stale price points to (re-heap trigger)
+	maxStales        int64                  // Maximum amount of stale price points allowed before a forced re-heap
 	reheapMu         sync.Mutex             // Mutex asserts that only one routine is reheaping the list
 }
 
@@ -744,11 +745,12 @@ const (
 )
 
 // newTxPricedList creates a new price-sorted transaction heap.
-func newTxPricedList(all *txLookup, ctx *atomic.Value) *txPricedList {
+func newTxPricedList(all *txLookup, ctx *atomic.Value, maxStales int64) *txPricedList {
 	txCtx := ctx.Load().(txPoolContext)
 	return &txPricedList{
-		ctx: ctx,
-		all: all,
+		ctx:       ctx,
+		all:       all,
+		maxStales: maxStales,
 		urgent: multiCurrencyPriceHeap{
 			currencyCmpFn:       txCtx.CmpValues,
 			nilCurrencyHeap:     &priceHeap{},
@@ -779,11 +781,19 @@ func (l *txPricedList) Put(tx *types.Transaction, local bool) {
 func (l *txPricedList) Removed(count int) {
 	// Bump the stale counter, but exit if still too low (< 25%)
 	stales := atomic.AddInt64(&l.stales, int64(count))
-	if int(stales) <= (l.urgent.Len()+l.floating.Len())/4 {
-		return
+	urgentSize := l.urgent.Len()
+	floatingSize := l.floating.Len()
+
+	// Reheap if the ratio of stales is more than 25% of the heaps sizes
+	overStalesRatio := int(stales) > (urgentSize+floatingSize)/4
+	// Reheap if stales exceed the max stales limit
+	overMaxStales := stales >= l.maxStales
+	// Reheap if the size of the heaps exceed twice of the all remotes size.
+	heapsTooBig := urgentSize+floatingSize > 2*len(l.all.remotes)
+
+	if overStalesRatio || overMaxStales || heapsTooBig {
+		l.Reheap()
 	}
-	// Seems we've reached a critical number of stale transactions, reheap
-	l.Reheap()
 }
 
 // Underpriced checks whether a transaction is cheaper than (or as cheap as) the

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -336,7 +336,8 @@ func NewTxPool(config TxPoolConfig, chainconfig *params.ChainConfig, chain block
 	pool.reset(nil, chain.CurrentBlock().Header())
 	// TODO: Does this reordering cause a problem?
 	// priced list depends on the current ctx which is set in reset
-	pool.priced = newTxPricedList(pool.all, &pool.currentCtx)
+	// Use the global slots as the max amount of stale transactions in the priced heap before a re-heap.
+	pool.priced = newTxPricedList(pool.all, &pool.currentCtx, int64(pool.config.GlobalSlots))
 
 	// Start the reorg loop early so it can handle requests generated during journal loading.
 	pool.wg.Add(1)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1255,6 +1255,9 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 		pool.demoteUnexecutables()
 		if reset.newHead != nil && pool.chainconfig.IsEspresso(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
 			pool.priced.SetBaseFee(pool.ctx())
+		} else {
+			// Prevent the price heap from growing indefinitely
+			pool.priced.Reheap()
 		}
 	}
 	// Ensure pool.queue and pool.pending sizes stay within the configured limits.


### PR DESCRIPTION
This PR fixes a memory leak found while running v1.5.0 nodes before the Espresso fork.

`txPricedList` keeps both a list of all txs in the pool, and also a heap for fast access to the cheapest txs. These heaps are not always synchronized with the txs list: *they increment at the same time as the list, but they do not decrement at the same time*. To decrement, the txpool marks how many txs are 'stale', and after a critical point, a `Reheap()` is called, where the whole memory of the heaps is released and they are recreated.

The issue in the code was that the critical point was never reached, and the heaps grew indefinitely. Strangely, the behavior is different after Expresso HF activation, since then `Reheap()` is called periodically on changes for the base fee. But before the HF nothing forces this so the heaps grow forever. One of the reasons for the critical point never being reached is the tx pool not respecting the contract of calling `Removed` every time it should.

The issue seems to be similar to https://github.com/ethereum/go-ethereum/issues/23690, which was workarounded by reheaping after every pool reorg. Here we also add a couple of safeguards based on the size of the tx pool to ensure that, even if the node is stuck (due to a bad block or any other reason), proper reheaps are triggered if necessary.

A follow-up investigation should be made to have an exhaustive list of all the reasons why the de-synchronization occurs. An example of those is the method `demoteUnexecutables`, where many txs are removed from the pool but not from the pricedlist.