### PR TITLE
Fix concurrent map access error when tracing blocks

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/log"
 	"github.com/celo-org/celo-blockchain/node"
 	"github.com/celo-org/celo-blockchain/test"
 	"github.com/stretchr/testify/assert"
@@ -18,7 +19,10 @@ func init() {
 	// This statement is commented out but left here since its very useful for
 	// debugging problems and its non trivial to construct.
 	//
-	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlDebug, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
+	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
+
+	// This disables all logging which in general we want, because there is a lot
+	log.Root().SetHandler(log.DiscardHandler())
 }
 
 // This test starts a network submits a transaction and waits for the whole

--- a/test/node.go
+++ b/test/node.go
@@ -24,6 +24,7 @@ import (
 	"github.com/celo-org/celo-blockchain/crypto"
 	"github.com/celo-org/celo-blockchain/eth"
 	"github.com/celo-org/celo-blockchain/eth/downloader"
+	"github.com/celo-org/celo-blockchain/eth/tracers"
 	"github.com/celo-org/celo-blockchain/ethclient"
 	"github.com/celo-org/celo-blockchain/mycelo/env"
 	"github.com/celo-org/celo-blockchain/mycelo/genesis"
@@ -35,6 +36,7 @@ import (
 )
 
 var (
+	allModules                  = []string{"admin", "debug", "web3", "eth", "txpool", "personal", "istanbul", "miner", "net"}
 	baseNodeConfig *node.Config = &node.Config{
 		Name:    "celo",
 		Version: params.Version,
@@ -52,6 +54,8 @@ var (
 		HTTPHost:             "0.0.0.0",
 		WSHost:               "0.0.0.0",
 		UsePlaintextKeystore: true,
+		WSModules:            allModules,
+		HTTPModules:          allModules,
 	}
 
 	baseEthConfig = &eth.Config{
@@ -179,6 +183,9 @@ func (n *Node) Start() error {
 	if err != nil {
 		return err
 	}
+	// This manual step is required to enable tracing, it's messy but this is the
+	// approach taken by geth in cmd/utils.RegisterEthService.
+	n.Node.RegisterAPIs(tracers.APIs(n.Eth.APIBackend))
 
 	err = n.Node.Start()
 	if err != nil {


### PR DESCRIPTION
### Description

This PR fixes the concurrent map access error in the ticket linked below.

The problem was that `state.StateDB` instances were being accessed from multiple go-routines, and they are not safe for concurrent use.

### Tested

Added an e2e test to ensure that the fix is working.

### Related issues

- Fixes #1799 