### PR TITLE
Improve miner to recover from randomness cache miss on initialization

### DIFF
--- a/miner/block.go
+++ b/miner/block.go
@@ -134,12 +134,12 @@ func prepareBlock(w *worker) (*blockState, error) {
 				err := w.chain.RecoverRandomnessCache(lastCommitment, b.header.ParentHash)
 				if err != nil {
 					log.Error("Error in recovering randomness cache", "error", err, "number", header.Number.Uint64())
-					return b, errors.New("Failed to to recover the randomness cache after miss")
+					return b, errors.New("failed to to recover the randomness cache after miss")
 				}
 				lastRandomnessParentHash = rawdb.ReadRandomCommitmentCache(w.db, lastCommitment)
 				if (lastRandomnessParentHash == common.Hash{}) {
 					// Recover failed to fix the issue. Bail.
-					return b, errors.New("Failed to get last randomness cache entry and failed to recover")
+					return b, errors.New("failed to get last randomness cache entry and failed to recover")
 				}
 			}
 

--- a/miner/block.go
+++ b/miner/block.go
@@ -128,12 +128,12 @@ func prepareBlock(w *worker) (*blockState, error) {
 		if (lastCommitment != common.Hash{}) {
 			lastRandomnessParentHash := rawdb.ReadRandomCommitmentCache(w.db, lastCommitment)
 			if (lastRandomnessParentHash == common.Hash{}) {
-				log.Warn("Randomness cache miss while building a block. Attempting to recover.")
+				log.Warn("Randomness cache miss while building a block. Attempting to recover.", "number", header.Number.Uint64())
 
 				// We missed on the cache which should have been populated, attempt to repopulate the cache.
 				err := w.chain.RecoverRandomnessCache(lastCommitment, b.header.ParentHash)
 				if err != nil {
-					log.Error("Error in recovering randomness cache", "error", err)
+					log.Error("Error in recovering randomness cache", "error", err, "number", header.Number.Uint64())
 					return b, errors.New("Failed to to recover the randomness cache after miss")
 				}
 				lastRandomnessParentHash = rawdb.ReadRandomCommitmentCache(w.db, lastCommitment)

--- a/miner/block.go
+++ b/miner/block.go
@@ -137,10 +137,10 @@ func prepareBlock(w *worker) (*blockState, error) {
 					return b, errors.New("Failed to to recover the randomness cache after miss")
 				}
 				lastRandomnessParentHash = rawdb.ReadRandomCommitmentCache(w.db, lastCommitment)
-			}
-			if (lastRandomnessParentHash == common.Hash{}) {
-				// Recover failed to fix the issue. Bail.
-				return b, errors.New("Failed to get last randomness cache entry and failed to recover")
+				if (lastRandomnessParentHash == common.Hash{}) {
+					// Recover failed to fix the issue. Bail.
+					return b, errors.New("Failed to get last randomness cache entry and failed to recover")
+				}
 			}
 
 			var err error

--- a/params/version.go
+++ b/params/version.go
@@ -25,10 +25,10 @@ import (
 // On release branches, it should be a beta or stable.  For example:
 // "1.3.0-beta", "1.3.0-beta.2", etc. and then "1.3.0-stable", "1.3.1-stable", etc.
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 5        // Minor version component of the current release
-	VersionPatch = 2        // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 5          // Minor version component of the current release
+	VersionPatch = 3          // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 )
 
 type VersionInfo struct {


### PR DESCRIPTION

### Description

In the course of getting Baklava into condition to restart block production, I noticed that the
miner would fail to initialize on nodes that had replaced there chain data from backup. The observed
error was that the randomness commitment cache would fail to be populated, which is caused by
replacing the chain data on that node. This error is supposed to be recoverable, but no code
existed on the code path that was failing to do so. Recovery would only occur after syncing to the
network, which these nodes did not do.

This PR adds a conditional to try recovering the randomness cache once if there is a cache miss
during miner initialization.

### Other changes

None

### Tested

Ran these changes on cLabs Baklava validators and got to a correctly initialized state
