### PR TITLE
Cherry pick #1840 to master

### DIFF
--- a/miner/block.go
+++ b/miner/block.go
@@ -128,7 +128,19 @@ func prepareBlock(w *worker) (*blockState, error) {
 		if (lastCommitment != common.Hash{}) {
 			lastRandomnessParentHash := rawdb.ReadRandomCommitmentCache(w.db, lastCommitment)
 			if (lastRandomnessParentHash == common.Hash{}) {
-				return b, errors.New("Failed to get last randomness cache entry")
+				log.Warn("Randomness cache miss while building a block. Attempting to recover.", "number", header.Number.Uint64())
+
+				// We missed on the cache which should have been populated, attempt to repopulate the cache.
+				err := w.chain.RecoverRandomnessCache(lastCommitment, b.header.ParentHash)
+				if err != nil {
+					log.Error("Error in recovering randomness cache", "error", err, "number", header.Number.Uint64())
+					return b, errors.New("failed to to recover the randomness cache after miss")
+				}
+				lastRandomnessParentHash = rawdb.ReadRandomCommitmentCache(w.db, lastCommitment)
+				if (lastRandomnessParentHash == common.Hash{}) {
+					// Recover failed to fix the issue. Bail.
+					return b, errors.New("failed to get last randomness cache entry and failed to recover")
+				}
 			}
 
 			var err error

--- a/params/version.go
+++ b/params/version.go
@@ -26,7 +26,7 @@ import (
 // "1.3.0-beta", "1.3.0-beta.2", etc. and then "1.3.0-stable", "1.3.1-stable", etc.
 const (
 	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 4          // Minor version component of the current release
+	VersionMinor = 6          // Minor version component of the current release
 	VersionPatch = 0          // Patch version component of the current release
 	VersionMeta  = "unstable" // Version metadata to append to the version string
 )


### PR DESCRIPTION
### Description

_This PR cherry picks #1840 to `master`. A copy of the description is included here_

In the course of getting Baklava into condition to restart block production, I noticed that the
miner would fail to initialize on nodes that had replaced there chain data from backup. The observed
error was that the randomness commitment cache would fail to be populated, which is caused by
replacing the chain data on that node. This error is supposed to be recoverable, but no code
existed on the code path that was failing to do so. Recovery would only occur after syncing to the
network, which these nodes did not do.

This PR adds a conditional to try recovering the randomness cache once if there is a cache miss
during miner initialization.

### Other changes

* Changed the version number of 1.6.0-unstable to align with our stated release process.

### Tested

* Changes tested on Baklava
