### PR TITLE
Cherry pick #1837 to 1.5.x

### DIFF
--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"testing"
 	"time"
 
+	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/node"
 	"github.com/celo-org/celo-blockchain/test"
@@ -188,4 +190,161 @@ func TestStartStopValidators(t *testing.T) {
 	err = network.AwaitTransactions(ctx, txs...)
 	require.NoError(t, err)
 
+}
+
+type rpcCustomTransaction struct {
+	BlockNumber *hexutil.Big `json:"blockNumber"`
+	GasPrice    *hexutil.Big `json:"gasPrice"`
+}
+
+// TestRPCDynamicTxGasPriceWithBigFeeCap test that after a dynamic tx
+// was added to a block, the rpc sends in the gasPrice the actual consumed
+// price by the tx, which could be less than the feeCap (as in this example)
+func TestRPCDynamicTxGasPriceWithBigFeeCap(t *testing.T) {
+	ac := test.AccountConfig(3, 2)
+	gc, ec, err := test.BuildConfig(ac)
+	require.NoError(t, err)
+	network, shutdown, err := test.NewNetwork(ac, gc, ec)
+	require.NoError(t, err)
+	defer shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	accounts := test.Accounts(ac.DeveloperAccounts(), gc.ChainConfig())
+
+	suggestedGasPrice, err := network[0].WsClient.SuggestGasPrice(ctx)
+	require.NoError(t, err)
+	gasFeeCap := big.NewInt(0).Mul(suggestedGasPrice, big.NewInt(90))
+	gasTipCap := big.NewInt(0).Mul(suggestedGasPrice, big.NewInt(2))
+
+	// Send one celo from external account 0 to 1 via node 0.
+	tx, err := accounts[0].SendCeloWithDynamicFee(ctx, accounts[1].Address, 1, gasFeeCap, gasTipCap, network[0])
+	require.NoError(t, err)
+
+	// Wait for the whole network to process the transaction.
+	err = network.AwaitTransactions(ctx, tx)
+	require.NoError(t, err)
+
+	var json *rpcCustomTransaction
+	err = network[0].WsClient.GetRPCClient().CallContext(ctx, &json, "eth_getTransactionByHash", tx.Hash())
+	require.NoError(t, err)
+	require.NotNil(t, json.BlockNumber)
+	gasPrice := json.GasPrice.ToInt()
+	require.NotNil(t, json.GasPrice)
+	require.Greater(t, gasPrice.Int64(), gasTipCap.Int64())
+	require.Less(t, gasPrice.Int64(), gasFeeCap.Int64())
+}
+
+// TestRPCDynamicTxGasPriceWithState aims to test the scenario where a
+// an old dynamic tx is requested via rpc, to an archive node.
+// As right now on Celo, we are not storing the baseFee in the header (as ethereum does),
+// to know the exactly gasPrice expent in a dynamic tx, depends on consuming the
+// GasPriceMinimum contract
+func TestRPCDynamicTxGasPriceWithState(t *testing.T) {
+	ac := test.AccountConfig(3, 2)
+	gc, ec, err := test.BuildConfig(ac)
+	ec.TxLookupLimit = 0
+	ec.NoPruning = true
+	require.NoError(t, err)
+	network, shutdown, err := test.NewNetwork(ac, gc, ec)
+	require.NoError(t, err)
+	defer shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	accounts := test.Accounts(ac.DeveloperAccounts(), gc.ChainConfig())
+
+	suggestedGasPrice, err := network[0].WsClient.SuggestGasPrice(ctx)
+	require.NoError(t, err)
+	gasFeeCap := big.NewInt(0).Mul(suggestedGasPrice, big.NewInt(90))
+	gasTipCap := big.NewInt(0).Mul(suggestedGasPrice, big.NewInt(2))
+
+	// Send one celo from external account 0 to 1 via node 0.
+	tx, err := accounts[0].SendCeloWithDynamicFee(ctx, accounts[1].Address, 1, gasFeeCap, gasTipCap, network[0])
+	require.NoError(t, err)
+
+	// Wait for the whole network to process the transaction.
+	err = network.AwaitTransactions(ctx, tx)
+	require.NoError(t, err)
+
+	var json *rpcCustomTransaction
+	// Check that the transaction can be retrieved via the rpc api
+	err = network[0].WsClient.GetRPCClient().CallContext(ctx, &json, "eth_getTransactionByHash", tx.Hash())
+	require.NoError(t, err)
+	// Blocknumber != nil it means that it eas already processed
+	require.NotNil(t, json.BlockNumber)
+
+	// Wait until the state is prunned in the case of a full node.
+	// For this we create blocks with at least 1 tx
+	for i := 0; i < 200; i++ {
+		_, err := accounts[0].SendCeloTracked(ctx, accounts[1].Address, 1, network[0])
+		require.NoError(t, err)
+	}
+
+	var json2 *rpcCustomTransaction
+	// Check that the transaction can still be retrieved via the rpc api
+	err = network[0].WsClient.GetRPCClient().CallContext(ctx, &json2, "eth_getTransactionByHash", tx.Hash())
+	require.NoError(t, err)
+	// if the object is nil, it means that was not found
+	require.NotNil(t, json2)
+	// Blocknumber != nil it means that it eas already processed
+	require.NotNil(t, json2.BlockNumber)
+	require.Equal(t, json.GasPrice, json2.GasPrice)
+}
+
+// TestRPCDynamicTxGasPriceWithoutState aims to test the scenario where a
+// an old dynamic tx is requested via rpc, to a full node that does not have
+// the state anymore.
+// As right now on Celo, we are not storing the baseFee in the header (as ethereum does),
+// to know the exactly gasPrice expent in a dynamic tx, depends on consuming the
+// GasPriceMinimum contract
+func TestRPCDynamicTxGasPriceWithoutState(t *testing.T) {
+	ac := test.AccountConfig(3, 2)
+	gc, ec, err := test.BuildConfig(ac)
+	ec.TrieDirtyCache = 5
+	require.NoError(t, err)
+	network, shutdown, err := test.NewNetwork(ac, gc, ec)
+	require.NoError(t, err)
+	defer shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	accounts := test.Accounts(ac.DeveloperAccounts(), gc.ChainConfig())
+
+	suggestedGasPrice, err := network[0].WsClient.SuggestGasPrice(ctx)
+	require.NoError(t, err)
+	gasFeeCap := big.NewInt(0).Mul(suggestedGasPrice, big.NewInt(90))
+	gasTipCap := big.NewInt(0).Mul(suggestedGasPrice, big.NewInt(2))
+
+	// Send one celo from external account 0 to 1 via node 0.
+	tx, err := accounts[0].SendCeloWithDynamicFee(ctx, accounts[1].Address, 1, gasFeeCap, gasTipCap, network[0])
+	require.NoError(t, err)
+
+	// Wait for the whole network to process the transaction.
+	err = network.AwaitTransactions(ctx, tx)
+	require.NoError(t, err)
+
+	var json *rpcCustomTransaction
+	// Check that the transaction can be retrieved via the rpc api
+	err = network[0].WsClient.GetRPCClient().CallContext(ctx, &json, "eth_getTransactionByHash", tx.Hash())
+	require.NoError(t, err)
+	// Blocknumber != nil it means that it eas already processed
+	require.NotNil(t, json.BlockNumber)
+
+	// Wait until the state is prunned. For this we create blocks with at least 1 tx
+	for i := 0; i < 200; i++ {
+		_, err := accounts[0].SendCeloTracked(ctx, accounts[1].Address, 1, network[0])
+		require.NoError(t, err)
+	}
+
+	var json2 *rpcCustomTransaction
+	// Check that the transaction can still be retrieved via the rpc api
+	err = network[0].WsClient.GetRPCClient().CallContext(ctx, &json2, "eth_getTransactionByHash", tx.Hash())
+	require.NoError(t, err)
+	// if the object is nil, it means that was not found
+	require.NotNil(t, json2)
+	// Blocknumber != nil it means that it eas already processed
+	require.NotNil(t, json2.BlockNumber)
+
+	require.Nil(t, json2.GasPrice)
 }

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -2,9 +2,11 @@ package e2e_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +16,7 @@ func init() {
 	// This statement is commented out but left here since its very useful for
 	// debugging problems and its non trivial to construct.
 	//
-	//log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
+	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlDebug, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
 }
 
 // This test starts a network submits a transaction and waits for the whole
@@ -65,4 +67,110 @@ func TestEpochBlockMarshaling(t *testing.T) {
 	// something there.
 	assert.True(t, len(b.EpochSnarkData().Signature) > 0)
 	assert.True(t, b.EpochSnarkData().Bitmap.Uint64() > 0)
+}
+
+// This test checks that a network can have validators shut down mid operation
+// and that it can continue to function, it also checks that if more than f
+// validators are shut down, when they restart the network is able to continue.
+func TestStartStopValidators(t *testing.T) {
+	accounts := test.Accounts(4)
+	gc, ec, err := test.BuildConfig(accounts)
+	require.NoError(t, err)
+	network, err := test.NewNetwork(accounts, gc, ec)
+	require.NoError(t, err)
+	defer network.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	var txs []*types.Transaction
+
+	// Send 1 celo from the dev account attached to node 0 to the dev account
+	// attached to node 1.
+	tx, err := network[0].SendCelo(ctx, network[1].DevAddress, 1)
+	require.NoError(t, err)
+	txs = append(txs, tx)
+
+	// Wait for the whole network to process the transaction.
+	err = network.AwaitTransactions(ctx, txs...)
+	require.NoError(t, err)
+
+	// Stop one node, the rest of the network should still be able to progress
+	err = network[3].Close()
+	require.NoError(t, err)
+
+	// Send 1 celo from the dev account attached to node 0 to the dev account
+	// attached to node 1.
+	tx, err = network[0].SendCelo(ctx, network[1].DevAddress, 1)
+	require.NoError(t, err)
+	txs = append(txs, tx)
+
+	// Check that the remaining network can still process this transction.
+	err = network[:3].AwaitTransactions(ctx, txs...)
+	require.NoError(t, err)
+
+	// Stop another node, the network should now be stuck
+	err = network[2].Close()
+	require.NoError(t, err)
+
+	// Now we will check that the network does not process transactions in this
+	// state, by waiting for a reasonable amount of time for it to process a
+	// transaction and assuming it is not processing transactions if we time out.
+	shortCtx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+	// Send 1 celo from the dev account attached to node 0 to the dev account
+	// attached to node 1.
+	tx, err = network[0].SendCelo(shortCtx, network[1].DevAddress, 1)
+	require.NoError(t, err)
+	txs = append(txs, tx)
+
+	err = network[:2].AwaitTransactions(shortCtx, txs...)
+	// Expect DeadlineExceeded error
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expecting %q, instead got: %v ", context.DeadlineExceeded.Error(), err)
+	}
+
+	// Start the last stopped node
+	err = network[2].Start()
+	require.NoError(t, err)
+
+	// Connect last stopped node to running nodes
+	network[2].AddPeers(network[:2]...)
+	time.Sleep(25 * time.Millisecond)
+	for _, n := range network[:3] {
+		err = n.GossipEnodeCertificatge()
+		require.NoError(t, err)
+	}
+
+	// Check that the  network now processes the previous transaction.
+	err = network[:3].AwaitTransactions(ctx, txs...)
+	require.NoError(t, err)
+
+	// Check that the network now quickly processes incoming transactions.
+	tx, err = network[0].SendCelo(ctx, network[1].DevAddress, 1)
+	require.NoError(t, err)
+	txs = append(txs, tx)
+
+	err = network[:3].AwaitTransactions(ctx, txs...)
+	require.NoError(t, err)
+
+	// Start the first stopped node
+	err = network[3].Start()
+	require.NoError(t, err)
+
+	// Connect final node to rest of network
+	network[3].AddPeers(network[:3]...)
+	time.Sleep(25 * time.Millisecond)
+	for _, n := range network {
+		err = n.GossipEnodeCertificatge()
+		require.NoError(t, err)
+	}
+
+	// Check that the network continues to quickly processes incoming transactions.
+	tx, err = network[0].SendCelo(ctx, network[1].DevAddress, 1)
+	require.NoError(t, err)
+	txs = append(txs, tx)
+
+	err = network.AwaitTransactions(ctx, txs...)
+	require.NoError(t, err)
+
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -216,17 +216,18 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		checkpoint = params.TrustedCheckpoints[genesisHash]
 	}
 	if eth.handler, err = newHandler(&handlerConfig{
-		Database:    chainDb,
-		Chain:       eth.blockchain,
-		TxPool:      eth.txPool,
-		Network:     config.NetworkId,
-		Sync:        config.SyncMode,
-		BloomCache:  uint64(cacheLimit),
-		EventMux:    eth.eventMux,
-		Checkpoint:  checkpoint,
-		Whitelist:   config.Whitelist,
-		server:      stack.Server(),
-		proxyServer: stack.ProxyServer(),
+		Database:     chainDb,
+		Chain:        eth.blockchain,
+		TxPool:       eth.txPool,
+		Network:      config.NetworkId,
+		Sync:         config.SyncMode,
+		BloomCache:   uint64(cacheLimit),
+		EventMux:     eth.eventMux,
+		Checkpoint:   checkpoint,
+		Whitelist:    config.Whitelist,
+		server:       stack.Server(),
+		proxyServer:  stack.ProxyServer(),
+		MinSyncPeers: config.MinSyncPeers,
 	}); err != nil {
 		return nil, err
 	}

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -150,6 +150,10 @@ type Config struct {
 
 	// E block override (TODO: remove after the fork)
 	OverrideEHardfork *big.Int `toml:",omitempty"`
+
+	// The minimum required peers in order for syncing to be initiated, if left
+	// at 0 then the default will be used.
+	MinSyncPeers int `toml:",omitempty"`
 }
 
 // CreateConsensusEngine creates the required type of consensus engine instance for an Ethereum service

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -611,3 +611,8 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 	}
 	return arg
 }
+
+// getRPCClient returns the rpc.Client. Just for testing purpose
+func (ec *Client) GetRPCClient() *rpc.Client {
+	return ec.c
+}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1244,9 +1244,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		al := tx.AccessList()
 		result.Accesses = &al
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
-	case types.DynamicFeeTxType:
-		fallthrough
-	case types.CeloDynamicFeeTxType:
+	case types.DynamicFeeTxType, types.CeloDynamicFeeTxType:
 		al := tx.AccessList()
 		result.Accesses = &al
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
@@ -1255,12 +1253,13 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		// if the transaction has been mined, compute the effective gas price
 		if blockHash != (common.Hash{}) {
 			baseFee, err := baseFeeFn(tx.FeeCurrency())
-			if err != nil {
+			if err == nil {
 				// price = min(tip, gasFeeCap - baseFee) + baseFee
 				price := math.BigMin(new(big.Int).Add(tx.GasTipCap(), baseFee), tx.GasFeeCap())
 				result.GasPrice = (*hexutil.Big)(price)
 			} else {
-				// error != nil for DinamicFees implies that there is no state to retrieve the baseFee for that block
+				log.Warn("error retrieving baseFee for tx", "hash", tx.Hash().Hex(), "error", err)
+				// error != nil for DynamicFees implies that there is no state to retrieve the baseFee for that block
 				result.GasPrice = nil
 			}
 		} else {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -1,0 +1,109 @@
+package ethapi
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/common/hexutil"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewRPCTransactionCeloDynamic tests the newRPCTransaction method with a celo dynamic fee tx type.
+func TestNewRPCTransactionCeloDynamic(t *testing.T) {
+	currency := common.HexToAddress("0xCAFE")
+	baseFee := big.NewInt(600)
+	blockHash := common.BigToHash(big.NewInt(123456))
+	blockNumber := uint64(123456)
+	index := uint64(7)
+	chainId := big.NewInt(1234567)
+	gasTipCap := big.NewInt(888400)
+	bigFeeCap := big.NewInt(1999001)
+	smallFeeCap := big.NewInt(111222)
+	baseFeeFn := func(curr *common.Address) (*big.Int, error) {
+		if *curr == currency {
+			return baseFee, nil
+		}
+		return nil, errors.New("unexpected")
+	}
+
+	t.Run("GasPrice == GasFeeCap", func(*testing.T) {
+		rpcTx := newRPCTransaction(types.NewTx(&types.CeloDynamicFeeTx{
+			FeeCurrency: &currency,
+			ChainID:     chainId,
+
+			GasFeeCap: smallFeeCap,
+			GasTipCap: gasTipCap,
+		}), blockHash, blockNumber, index, baseFeeFn)
+		assert.Equal(t, (*hexutil.Big)(smallFeeCap), rpcTx.GasPrice)
+	})
+
+	t.Run("GasPrice == GasTipCap + baseFee", func(*testing.T) {
+		rpcTx := newRPCTransaction(types.NewTx(&types.CeloDynamicFeeTx{
+			FeeCurrency: &currency,
+			ChainID:     chainId,
+
+			GasFeeCap: bigFeeCap,
+			GasTipCap: gasTipCap,
+		}), blockHash, blockNumber, index, baseFeeFn)
+		assert.Equal(t, (*hexutil.Big)(big.NewInt(0).Add(gasTipCap, baseFee)), rpcTx.GasPrice)
+	})
+
+	t.Run("Unminned transaction. GasPrice == GasFeeCap", func(t *testing.T) {
+		rpcTx := newRPCTransaction(types.NewTx(&types.CeloDynamicFeeTx{
+			FeeCurrency: &currency,
+			ChainID:     chainId,
+
+			GasFeeCap: bigFeeCap,
+			GasTipCap: gasTipCap,
+		}), common.Hash{}, 0, 0, baseFeeFn)
+		assert.Equal(t, (*hexutil.Big)(bigFeeCap), rpcTx.GasPrice)
+	})
+}
+
+// TestNewRPCTransactionCeloDynamic tests the newRPCTransaction method with a celo dynamic fee tx type.
+func TestNewRPCTransactionDynamic(t *testing.T) {
+	baseFee := big.NewInt(600)
+	blockHash := common.BigToHash(big.NewInt(123456))
+	blockNumber := uint64(123456)
+	index := uint64(7)
+	chainId := big.NewInt(1234567)
+	gasTipCap := big.NewInt(888400)
+	bigFeeCap := big.NewInt(1999001)
+	smallFeeCap := big.NewInt(111222)
+	baseFeeFn := func(curr *common.Address) (*big.Int, error) {
+		return baseFee, nil
+	}
+
+	t.Run("GasPrice == GasFeeCap", func(*testing.T) {
+		rpcTx := newRPCTransaction(types.NewTx(&types.DynamicFeeTx{
+			ChainID: chainId,
+
+			GasFeeCap: smallFeeCap,
+			GasTipCap: gasTipCap,
+		}), blockHash, blockNumber, index, baseFeeFn)
+		assert.Equal(t, (*hexutil.Big)(smallFeeCap), rpcTx.GasPrice)
+	})
+
+	t.Run("GasPrice == GasTipCap + baseFee", func(*testing.T) {
+		rpcTx2 := newRPCTransaction(types.NewTx(&types.DynamicFeeTx{
+			ChainID: chainId,
+
+			GasFeeCap: bigFeeCap,
+			GasTipCap: gasTipCap,
+		}), blockHash, blockNumber, index, baseFeeFn)
+		assert.Equal(t, (*hexutil.Big)(big.NewInt(0).Add(gasTipCap, baseFee)), rpcTx2.GasPrice)
+	})
+
+	t.Run("Unminned transaction. GasPrice == GasFeeCap", func(t *testing.T) {
+		rpcTx := newRPCTransaction(types.NewTx(&types.DynamicFeeTx{
+			ChainID: chainId,
+
+			GasFeeCap: bigFeeCap,
+			GasTipCap: gasTipCap,
+		}), common.Hash{}, 0, 0, baseFeeFn)
+		assert.Equal(t, (*hexutil.Big)(bigFeeCap), rpcTx.GasPrice)
+	})
+}

--- a/test/account.go
+++ b/test/account.go
@@ -1,0 +1,88 @@
+package test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"math/big"
+
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/mycelo/env"
+	"github.com/celo-org/celo-blockchain/params"
+)
+
+type Account struct {
+	Address     common.Address
+	Key         *ecdsa.PrivateKey
+	ChainConfig *params.ChainConfig
+	Nonce       *uint64
+}
+
+func NewAccount(key *ecdsa.PrivateKey, address common.Address, chainConfig *params.ChainConfig) *Account {
+	return &Account{
+		Address:     address,
+		Key:         key,
+		ChainConfig: chainConfig,
+	}
+}
+
+// SendCelo submits a value transfer transaction via the provided Node to send
+// celo to the recipient. The submitted transaction is returned.
+func (a *Account) SendCelo(ctx context.Context, recipient common.Address, value int64, node *Node) (*types.Transaction, error) {
+	var err error
+	// Lazy set nonce
+	if a.Nonce == nil {
+		a.Nonce = new(uint64)
+		*a.Nonce, err = node.WsClient.PendingNonceAt(ctx, a.Address)
+		if err != nil {
+			return nil, err
+		}
+	}
+	num, err := node.WsClient.BlockNumber(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	signer := types.MakeSigner(a.ChainConfig, new(big.Int).SetUint64(num))
+	tx, err := ValueTransferTransaction(
+		node.WsClient,
+		a.Key,
+		a.Address,
+		recipient,
+		*a.Nonce,
+		big.NewInt(value),
+		signer)
+
+	if err != nil {
+		return nil, err
+	}
+	err = node.WsClient.SendTransaction(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	*a.Nonce++
+	return tx, nil
+}
+
+// SendCeloTracked functions like SendCelo but also waits for the transaction
+// to be processed by the sending node.
+func (a *Account) SendCeloTracked(ctx context.Context, recipient common.Address, value int64, node *Node) (*types.Transaction, error) {
+	tx, err := a.SendCelo(ctx, recipient, value, node)
+	if err != nil {
+		return nil, err
+	}
+	err = node.AwaitTransactions(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	return node.Tracker.GetProcessedTx(tx.Hash()), nil
+}
+
+// Accounts converts a slice of env.Account objects to Account objects.
+func Accounts(accts []env.Account, chainConfig *params.ChainConfig) []*Account {
+	accounts := make([]*Account, 0, len(accts))
+	for _, a := range accts {
+		accounts = append(accounts, NewAccount(a.PrivateKey, a.Address, chainConfig))
+	}
+	return accounts
+}

--- a/test/node.go
+++ b/test/node.go
@@ -38,9 +38,11 @@ var (
 		Name:    "celo",
 		Version: params.Version,
 		P2P: p2p.Config{
-			MaxPeers:    100,
-			NoDiscovery: true,
-			ListenAddr:  "0.0.0.0:0",
+			MaxPeers:              100,
+			NoDiscovery:           true,
+			ListenAddr:            "0.0.0.0:0",
+			InboundThrottleTime:   200 * time.Millisecond,
+			DialHistoryExpiration: 210 * time.Millisecond,
 		},
 		NoUSB: true,
 		// It is important that HTTPHost and WSHost remain the same. This

--- a/test/node.go
+++ b/test/node.go
@@ -110,8 +110,13 @@ func NewNode(
 
 	// Copy the node config so we can modify it without damaging the original
 	ncCopy := *nc
-	// p2p key and address
-	ncCopy.P2P.PrivateKey = validatorAccount.PrivateKey
+
+	// p2p key and address, this is not the same as the validator key.
+	p2pKey, err := crypto.GenerateKey()
+	if err != nil {
+		return nil, err
+	}
+	ncCopy.P2P.PrivateKey = p2pKey
 
 	// Make temp datadir
 	datadir, err := ioutil.TempDir("", "celo_datadir")

--- a/test/node.go
+++ b/test/node.go
@@ -339,6 +339,8 @@ func BuildConfig(accounts *env.AccountsConfig) (*genesis.Config, *eth.Config, er
 		accounts.AdminAccount().Address,
 		params.IstanbulConfig{},
 	)
+	gc.Hardforks.EspressoBlock = common.Big0
+
 	genesis.FundAccounts(gc, accounts.DeveloperAccounts())
 
 	// copy the base eth config, so we can modify it without damaging the
@@ -497,6 +499,43 @@ func ValueTransferTransaction(
 
 	// Create the transaction and sign it
 	rawTx := types.NewTransactionEthCompatible(nonce, recipient, value, gasLimit, gasPrice, nil)
+	signed, err := types.SignTx(rawTx, signer, senderKey)
+	if err != nil {
+		return nil, err
+	}
+	return signed, nil
+}
+
+// ValueTransferTransactionWithDynamicFee builds a signed value transfer transaction
+// from the sender to the recipient with the given value, nonce, gasFeeCap and gasTipCap.
+func ValueTransferTransactionWithDynamicFee(
+	client *ethclient.Client,
+	senderKey *ecdsa.PrivateKey,
+	sender,
+	recipient common.Address,
+	nonce uint64,
+	value *big.Int,
+	gasFeeCap *big.Int,
+	gasTipCap *big.Int,
+	signer types.Signer,
+) (*types.Transaction, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
+	msg := ethereum.CallMsg{From: sender, To: &recipient, Value: value}
+	gasLimit, err := client.EstimateGas(ctx, msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to estimate gas needed: %v", err)
+	}
+	// Create the transaction and sign it
+	rawTx := types.NewTx(&types.CeloDynamicFeeTx{
+		Nonce:     nonce,
+		To:        &recipient,
+		Value:     value,
+		Gas:       gasLimit,
+		GasFeeCap: gasFeeCap,
+		GasTipCap: gasTipCap,
+	})
 	signed, err := types.SignTx(rawTx, signer, senderKey)
 	if err != nil {
 		return nil, err

--- a/test/node.go
+++ b/test/node.go
@@ -5,10 +5,12 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
 	"os"
+	"path/filepath"
 	"time"
 
 	ethereum "github.com/celo-org/celo-blockchain"
@@ -346,6 +348,21 @@ func BuildConfig(accounts *env.AccountsConfig) (*genesis.Config, *eth.Config, er
 	return gc, ec, err
 }
 
+// GenerateGenesis checks that the contractsBuildPath exists and if so proceeds to generate the genesis.
+func GenerateGenesis(accounts *env.AccountsConfig, gc *genesis.Config, contractsBuildPath string) (*core.Genesis, error) {
+	// Check for the existence of the compiled-system-contracts dir
+	_, err := os.Stat(contractsBuildPath)
+	if errors.Is(err, os.ErrNotExist) {
+		abs, err := filepath.Abs(contractsBuildPath)
+		if err != nil {
+			panic(fmt.Sprintf("failed to get abs path for %s, error: %v", contractsBuildPath, err))
+		}
+		return nil, fmt.Errorf("Could not find dir %s, try running 'make compiled-system-contracts' and then re-running the test", abs)
+
+	}
+	return genesis.GenerateGenesis(accounts, gc, contractsBuildPath)
+}
+
 // NewNetwork generates a network of nodes that are running and mining. For
 // each provided validator account a corresponding node is created and each
 // node is also assigned a developer account, there must be at least as many
@@ -366,7 +383,7 @@ func NewNetwork(accounts *env.AccountsConfig, gc *genesis.Config, ec *eth.Config
 		RequestTimeout: ec.Istanbul.RequestTimeout,
 	}
 
-	genesis, err := genesis.GenerateGenesis(accounts, gc, "../compiled-system-contracts")
+	genesis, err := GenerateGenesis(accounts, gc, "../compiled-system-contracts")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate genesis: %v", err)
 	}

--- a/test/node.go
+++ b/test/node.go
@@ -283,18 +283,19 @@ func (n *Node) GossipEnodeCertificatge() error {
 
 // Close shuts down the node and releases all resources and removes the datadir
 // unless an error is returned, in which case there is no guarantee that all
-// resources are released.
+// resources are released. It is assumed that this is only called after calling
+// Start otherwise it will panic.
 func (n *Node) Close() error {
 	err := n.Tracker.StopTracking()
 	if err != nil {
 		return err
 	}
 	n.WsClient.Close()
-	if n.Node != nil {
-		err = n.Node.Close() // This also shuts down the Eth service
+	err = n.Node.Close() // This also shuts down the Eth service
+	if err != nil {
+		return err
 	}
-	os.RemoveAll(n.Config.DataDir)
-	return err
+	return os.RemoveAll(n.Config.DataDir)
 }
 
 // SendCeloTracked functions like SendCelo but also waits for the transaction to be processed.
@@ -402,10 +403,11 @@ func BuildConfig(accounts *env.AccountsConfig) (*genesis.Config, *eth.Config, er
 // NewNetwork generates a network of nodes that are running and mining. For
 // each provided validator account a corresponding node is created and each
 // node is also assigned a developer account, there must be at least as many
-// developer accounts provided as validator accounts. If there is an error it
-// will be returned immediately, meaning that some nodes may be running and
-// others not.
-func NewNetwork(accounts *env.AccountsConfig, gc *genesis.Config, ec *eth.Config) (Network, error) {
+// developer accounts provided as validator accounts. A shutdown function is
+// also returned which will shutdown and clean up the network when called.  In
+// the case that an error is returned the shutdown function will be nil and so
+// no attempt should be made to call it.
+func NewNetwork(accounts *env.AccountsConfig, gc *genesis.Config, ec *eth.Config) (Network, func(), error) {
 
 	// Copy eth istanbul config fields to the genesis istanbul config.
 	// There is a ticket to remove this duplication of config.
@@ -420,17 +422,17 @@ func NewNetwork(accounts *env.AccountsConfig, gc *genesis.Config, ec *eth.Config
 
 	genesis, err := genesis.GenerateGenesis(accounts, gc, "../compiled-system-contracts")
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate genesis: %v", err)
+		return nil, nil, fmt.Errorf("failed to generate genesis: %v", err)
 	}
 
 	va := accounts.ValidatorAccounts()
 	da := accounts.DeveloperAccounts()
-	network := make([]*Node, len(va))
-	for i := range va {
+	var network Network = make([]*Node, len(va))
 
+	for i := range va {
 		n, err := NewNode(&va[i], &da[i], baseNodeConfig, ec, genesis)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build node for network: %v", err)
+			return nil, nil, fmt.Errorf("failed to build node for network: %v", err)
 		}
 		network[i] = n
 	}
@@ -454,11 +456,18 @@ func NewNetwork(accounts *env.AccountsConfig, gc *genesis.Config, ec *eth.Config
 	for i := range network {
 		err := network[i].GossipEnodeCertificatge()
 		if err != nil {
-			return nil, err
+			network.Shutdown()
+			return nil, nil, err
 		}
 	}
 
-	return network, nil
+	shutdown := func() {
+		for _, err := range network.Shutdown() {
+			fmt.Println(err.Error())
+		}
+	}
+
+	return network, shutdown, nil
 }
 
 // AwaitTransactions ensures that the entire network has processed the provided transactions.
@@ -483,17 +492,19 @@ func (n Network) AwaitBlock(ctx context.Context, num uint64) error {
 	return nil
 }
 
-// Shutdown closes all nodes in the network, any errors that are encountered are
-// printed to stdout.
-func (n Network) Shutdown() {
-	for _, node := range n {
+// Shutdown closes all nodes in the network, any errors encountered when
+// shutting down nodes are returned in a slice.
+func (n Network) Shutdown() []error {
+	var errors []error
+	for i, node := range n {
 		if node != nil {
 			err := node.Close()
 			if err != nil {
-				fmt.Printf("error shutting down node %v: %v", node.Address.String(), err)
+				errors = append(errors, fmt.Errorf("error shutting down node %v index %d: %w", node.Address.String(), i, err))
 			}
 		}
 	}
+	return errors
 }
 
 // ValueTransferTransaction builds a signed value transfer transaction from the

--- a/test/node.go
+++ b/test/node.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/celo-org/celo-blockchain/accounts/keystore"
 	"github.com/celo-org/celo-blockchain/common"
-	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul/backend"
 	"github.com/celo-org/celo-blockchain/core"
@@ -227,11 +226,6 @@ func (n *Node) Start() error {
 	n.Enode = n.Server().LocalNode().Node()
 
 	return nil
-}
-
-// Provides a short representation of a hash
-func shortAddress(a common.Address) string {
-	return hexutil.Encode(a[:2])
 }
 
 func (n *Node) AddPeers(nodes ...*Node) {

--- a/test/node.go
+++ b/test/node.go
@@ -53,6 +53,7 @@ var (
 
 	baseEthConfig = &eth.Config{
 		SyncMode:        downloader.FullSync,
+		MinSyncPeers:    1,
 		DatabaseCache:   256,
 		DatabaseHandles: 256,
 		TxPool:          core.DefaultTxPoolConfig,

--- a/test/tracker.go
+++ b/test/tracker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sync"
 
 	ethereum "github.com/celo-org/celo-blockchain"
@@ -192,7 +193,7 @@ func (tr *Tracker) await(ctx context.Context, condition func() bool) error {
 // StopTracking shuts down all the goroutines in the tracker.
 func (tr *Tracker) StopTracking() error {
 	if tr.sub == nil {
-		return errors.New("attempted to stop already stopped tracker")
+		return fmt.Errorf("attempted to stop already stopped tracker - stack: \n%s", string(debug.Stack()))
 	}
 	tr.sub.Unsubscribe()
 	close(tr.stopCh)

--- a/test/tracker.go
+++ b/test/tracker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime/debug"
 	"sync"
 
 	ethereum "github.com/celo-org/celo-blockchain"
@@ -15,7 +14,8 @@ import (
 )
 
 var (
-	errStopped = errors.New("transaction tracker closed")
+	errStopped               = errors.New("transaction tracker closed")
+	ErrTrackerAlreadyStopped = errors.New("attempted to stop already stopped tracker")
 )
 
 // Tracker tracks processed blocks and transactions through a subscription with
@@ -193,7 +193,7 @@ func (tr *Tracker) await(ctx context.Context, condition func() bool) error {
 // StopTracking shuts down all the goroutines in the tracker.
 func (tr *Tracker) StopTracking() error {
 	if tr.sub == nil {
-		return fmt.Errorf("attempted to stop already stopped tracker - stack: \n%s", string(debug.Stack()))
+		return ErrTrackerAlreadyStopped
 	}
 	tr.sub.Unsubscribe()
 	close(tr.stopCh)

--- a/test/tracker.go
+++ b/test/tracker.go
@@ -197,6 +197,9 @@ func (tr *Tracker) StopTracking() error {
 	tr.sub.Unsubscribe()
 	close(tr.stopCh)
 	tr.wg.Wait()
+	// Set this to nil to mark the tracker as stopped. This must be done after
+	// waiting for wg, to avoid a data race in trackTransactions.
+	tr.sub = nil
 	tr.wg = sync.WaitGroup{}
 	return nil
 }


### PR DESCRIPTION
### Description

Cherry pick #1837 to release/1.5.x

Also cherry picked a few commits related to the e2e test, required for the #1837 to run properly:

67e6a6aba Add start stop validators e2e test
35b3d7e43 Fix panic on StopTracking
f9dbb7f6d Use ephemeral key for validator p2p network
2cb021a42 Allow configuring the min peers needed to sync
727c3e54b Allow modification of dial and connection timeouts
704ec7dfa Remove unused debug function
7c463961f Add debug stack trace to help track down failures
1ab51ee37 Dont print expected errors on e2e test shutdown
636d59437 e2e_test: separate account from nodes (#1777)
2a0c6ef4e Better err output when no contracts dir for e2etest (#1793)
