### PR TITLE
Run race test only on master and release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,6 +484,9 @@ workflows:
             - build-geth
             - prepare-system-contracts
       - race:
+          filters:
+            branches:
+              only: /master|release.*/
           requires:
             - build-geth
             - prepare-system-contracts


### PR DESCRIPTION
### Description

Circle CI race test is taking too long and always flaky. Flakyness needs to be addressed later, but for the moment it's best not to run on every branch but on master and release branches.