### PR TITLE
Skipping flaky tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -442,19 +442,18 @@ jobs:
             export PATH=${PATH}:~/repos/golang/go/bin
             ./ci_test_validator_order.sh local ~/repos/geth
 
-# Flaky!
-#  end-to-end-cip35-eth-compatibility-test:
-#    executor: e2e
-#    resource_class: xlarge
-#    steps:
-#      - attach_workspace:
-#          at: ~/repos
-#      - run:
-#          name: End-to-end test of CIP 35
-#          no_output_timeout: 15m
-#          command: |
-#            export PATH=${PATH}:~/repos/golang/go/bin
-#            ./ci_test_cip35.sh local ~/repos/geth
+  end-to-end-cip35-eth-compatibility-test:
+    executor: e2e
+    resource_class: xlarge
+    steps:
+      - attach_workspace:
+          at: ~/repos
+      - run:
+          name: End-to-end test of CIP 35
+          no_output_timeout: 15m
+          command: |
+            export PATH=${PATH}:~/repos/golang/go/bin
+            ./ci_test_cip35.sh local ~/repos/geth
 
   end-to-end-replica-test:
     executor: e2e
@@ -546,10 +545,11 @@ workflows:
           requires:
             - checkout-monorepo
             - build-geth
-      - end-to-end-cip35-eth-compatibility-test:
-          requires:
-            - checkout-monorepo
-            - build-geth
+# Flaky!
+#      - end-to-end-cip35-eth-compatibility-test:
+#          requires:
+#            - checkout-monorepo
+#            - build-geth
       - end-to-end-replica-test:
           requires:
             - checkout-monorepo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -442,18 +442,19 @@ jobs:
             export PATH=${PATH}:~/repos/golang/go/bin
             ./ci_test_validator_order.sh local ~/repos/geth
 
-  end-to-end-cip35-eth-compatibility-test:
-    executor: e2e
-    resource_class: xlarge
-    steps:
-      - attach_workspace:
-          at: ~/repos
-      - run:
-          name: End-to-end test of CIP 35
-          no_output_timeout: 15m
-          command: |
-            export PATH=${PATH}:~/repos/golang/go/bin
-            ./ci_test_cip35.sh local ~/repos/geth
+# Flaky!
+#  end-to-end-cip35-eth-compatibility-test:
+#    executor: e2e
+#    resource_class: xlarge
+#    steps:
+#      - attach_workspace:
+#          at: ~/repos
+#      - run:
+#          name: End-to-end test of CIP 35
+#          no_output_timeout: 15m
+#          command: |
+#            export PATH=${PATH}:~/repos/golang/go/bin
+#            ./ci_test_cip35.sh local ~/repos/geth
 
   end-to-end-replica-test:
     executor: e2e

--- a/consensus/istanbul/backend/announce_test.go
+++ b/consensus/istanbul/backend/announce_test.go
@@ -16,6 +16,7 @@ import (
 // This test function will test the announce message generator and handler.
 // It will also test the gossip query generator and handler.
 func TestAnnounceGossipQueryMsg(t *testing.T) {
+	t.Skip() // Flaky
 	// Create three backends
 	numValidators := 3
 	genesisCfg, nodeKeys := getGenesisAndKeys(numValidators, true)

--- a/e2e_test/e2e_bench_test.go
+++ b/e2e_test/e2e_bench_test.go
@@ -33,6 +33,7 @@ func BenchmarkNet100EmptyBlocks(b *testing.B) {
 }
 
 func BenchmarkNet1000Txs(b *testing.B) {
+	b.Skip() // Flaky
 	// Seed the random number generator so that the generated numbers are
 	// different on each run.
 	rand.Seed(time.Now().UnixNano())

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -241,6 +241,7 @@ func TestRPCDynamicTxGasPriceWithBigFeeCap(t *testing.T) {
 // to know the exactly gasPrice expent in a dynamic tx, depends on consuming the
 // GasPriceMinimum contract
 func TestRPCDynamicTxGasPriceWithState(t *testing.T) {
+	t.Skip() // Flaky (deadline exceeded)
 	ac := test.AccountConfig(3, 2)
 	gc, ec, err := test.BuildConfig(ac)
 	ec.TxLookupLimit = 0
@@ -299,6 +300,7 @@ func TestRPCDynamicTxGasPriceWithState(t *testing.T) {
 // to know the exactly gasPrice expent in a dynamic tx, depends on consuming the
 // GasPriceMinimum contract
 func TestRPCDynamicTxGasPriceWithoutState(t *testing.T) {
+	t.Skip() // Flaky (deadline exceeded)
 	ac := test.AccountConfig(3, 2)
 	gc, ec, err := test.BuildConfig(ac)
 	ec.TrieDirtyCache = 5

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -241,7 +241,6 @@ func TestRPCDynamicTxGasPriceWithBigFeeCap(t *testing.T) {
 // to know the exactly gasPrice expent in a dynamic tx, depends on consuming the
 // GasPriceMinimum contract
 func TestRPCDynamicTxGasPriceWithState(t *testing.T) {
-	t.Skip() // Flaky (deadline exceeded)
 	ac := test.AccountConfig(3, 2)
 	gc, ec, err := test.BuildConfig(ac)
 	ec.TxLookupLimit = 0
@@ -250,7 +249,7 @@ func TestRPCDynamicTxGasPriceWithState(t *testing.T) {
 	network, shutdown, err := test.NewNetwork(ac, gc, ec)
 	require.NoError(t, err)
 	defer shutdown()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*90)
 	defer cancel()
 
 	accounts := test.Accounts(ac.DeveloperAccounts(), gc.ChainConfig())
@@ -300,7 +299,6 @@ func TestRPCDynamicTxGasPriceWithState(t *testing.T) {
 // to know the exactly gasPrice expent in a dynamic tx, depends on consuming the
 // GasPriceMinimum contract
 func TestRPCDynamicTxGasPriceWithoutState(t *testing.T) {
-	t.Skip() // Flaky (deadline exceeded)
 	ac := test.AccountConfig(3, 2)
 	gc, ec, err := test.BuildConfig(ac)
 	ec.TrieDirtyCache = 5
@@ -308,7 +306,7 @@ func TestRPCDynamicTxGasPriceWithoutState(t *testing.T) {
 	network, shutdown, err := test.NewNetwork(ac, gc, ec)
 	require.NoError(t, err)
 	defer shutdown()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*90)
 	defer cancel()
 
 	accounts := test.Accounts(ac.DeveloperAccounts(), gc.ChainConfig())

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -477,6 +477,7 @@ func testStatusFunctions(t *testing.T, client *rpc.Client) {
 	}
 }
 
+// nolint:deadcode
 func testCallContract(t *testing.T, client *rpc.Client) {
 	ec := NewClient(client)
 

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -260,9 +260,10 @@ func TestEthClient(t *testing.T) {
 		"TestStatusFunctions": {
 			func(t *testing.T) { testStatusFunctions(t, client) },
 		},
-		"TestCallContract": {
-			func(t *testing.T) { testCallContract(t, client) },
-		},
+		// Flaky
+		// "TestCallContract": {
+		// 	func(t *testing.T) { testCallContract(t, client) },
+		// },
 		"TestAtFunctions": {
 			func(t *testing.T) { testAtFunctions(t, client) },
 		},

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -99,9 +99,10 @@ func TestGethClient(t *testing.T) {
 	tests := map[string]struct {
 		test func(t *testing.T)
 	}{
-		"TestAccessList": {
-			func(t *testing.T) { testAccessList(t, client) },
-		},
+		// Flaky
+		// "TestAccessList": {
+		// 	func(t *testing.T) { testAccessList(t, client) },
+		// },
 		"TestGetProof": {
 			func(t *testing.T) { testGetProof(t, client) },
 		},

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -131,6 +131,7 @@ func TestGethClient(t *testing.T) {
 	}
 }
 
+// nolint:deadcode
 func testAccessList(t *testing.T, client *rpc.Client) {
 	ec := New(client)
 	// Test transfer


### PR DESCRIPTION
This PR comments/skips tests, builds and benchmarks that are known to be flaky.

Unit tests:
- TestAnnounceGossipQueryMsg #1849
- TestEthClient/TestCallContract #1850
- TestGethClient/TestAccessList #1851

Benchmarks:
- BenchmarkNet1000Txs #1852

Circleci builds:
- end-to-end-cip35-eth-compatibility-test #1853


While creating this PR, the istanbul-e2e-coverage failed once, then worked when it was re-run. I'm not skipping this one right now since I'd like to test it a bit more. Most likely it is because the parent commit has flaky tests, which are run for coverage report.

codecov/project is failing because we are removing a few tests. It is expected.