### PR TITLE
Only sleep during prepare if node is validating

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -417,7 +417,7 @@ func (sb *Backend) Prepare(chain consensus.ChainHeaderReader, header *types.Head
 	// the miner's pending block is always one block old (I.E the pending block
 	// has the same number as the most recent block). This occurs because when
 	// a new block is inserted a request is made to update the pending block
-	// and that request calls Prepare wich waits here till the next block is
+	// and that request calls Prepare which waits here till the next block is
 	// due before returning. The hacky fix for now is to only wait here if the
 	// node is validating this should allow the pending block to be kept more
 	// up to date in non validating nodes, whilst still ensuring that


### PR DESCRIPTION
### Description

This change mitigates the problem of low gas estimates #1856, by ensuring that non validating nodes do not wait till the next block is due when engine.Prepare is called. This results in non validating nodes having an up to date pending block( I.E a pending block with a number 1 greater than the last inserted block). For some reason validating nodes produce the correct gas estimate even when they have an old pending block (I.E a pending block with the same number as the last inserted block).


### Tested

I have tested this locally using mycelo to start a network with 1 validator and then starting up a full node that connects to that network. Without the fix the tests [here](https://github.com/piersy/celo-nft-minter/blob/ft/update-celo-depency/test/nft-test.js) repeatedly show a low gas estimate for the first few gas estimation calls made against the pending block. With the fix I have not been able to elicit an incorrect gas estimate (although it is definitely possible because block insertion and pending block creation are not part of a single atomic operation).  Prior to the fix I observed from the logs that gas estimates using the latest and pending block would execute against a block with the same number, after the fix I observed from the logs that gas estimates with the pending block executed against a block with number one greater than gas estimates with the latest block.

### Related issues

-Mitigates #1856 