### PR TITLE
Ensure pending state is ready for tx execution

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -171,7 +171,19 @@ func (w *worker) pending() (*types.Block, *state.StateDB) {
 	stateCopy := w.snapshotState.Copy()
 	// Call Prepare to ensure that any access logs from the last executed
 	// transaction have been erased.
-	// See https://github.com/celo-org/celo-blockchain/pull/1858#issuecomment-1054159493
+	//
+	// Prior to the upstream PR
+	// https://github.com/ethereum/go-ethereum/pull/21509 the state returned
+	// from pending was ready to use for transaction execution, that PR
+	// essentially changed the contract of the pendng method, in that the
+	// returned state was not ready for transaction execution and required
+	// Prepare to be called on it first, but notably the PR did not update any
+	// of the callers of pending to ensure that Prepare was called. I think
+	// this broke some of the eth rpc apis.  Calling Prepare here essentially
+	// restores the previous contract for this method which was that the
+	// returned state is ready to use for transaction execution.
+	//
+	// See https://github.com/celo-org/celo-blockchain/pull/1858#issuecomment-1054159493 for more details.
 	stateCopy.Prepare(common.Hash{}, 0)
 	return w.snapshotBlock, stateCopy
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -168,7 +168,12 @@ func (w *worker) pending() (*types.Block, *state.StateDB) {
 	if w.snapshotState == nil {
 		return nil, nil
 	}
-	return w.snapshotBlock, w.snapshotState.Copy()
+	stateCopy := w.snapshotState.Copy()
+	// Call Prepare to ensure that any access logs from the last executed
+	// transaction have been erased.
+	// See https://github.com/celo-org/celo-blockchain/pull/1858#issuecomment-1054159493
+	stateCopy.Prepare(common.Hash{}, 0)
+	return w.snapshotBlock, stateCopy
 }
 
 // pendingBlock returns pending block.


### PR DESCRIPTION
What this PR does is better described [here](https://github.com/celo-org/celo-blockchain/pull/1858#issuecomment-1054159493)

Fixes #1856 

Before introducing this change gas estimations against the pending block on non validating nodes with the espresso fork enabled would sometimes be lower than they should be.

Its still not clear to me exactly how the lower gas estimates were being calculated but ensuring that the pending block is finalized and assembled seems to resolve this. Validating nodes were already finalizing and assembling their pending blocks and looking back it seems that prior to #1545 the pending block was always finalized and assembled (see permalink below). So this seems like this change is correcting a long running problem. https://github.com/celo-org/celo-blockchain/blob/ab78658ae3a738d91d877f289e37fead2a0f1cf7/miner/worker.go#L969

This change also changes the behaviour of the debug tracing apis when used run against the pending block.

Since #1545 caused the pending block to not be finalized, the state root in the pending block was zero. Strangely, looking up the zero root in  the state trie doesn't fail but the state returned is essentially empty, meaning that all transactions would be traced as a simple send ( because that is how a contract transaction executes if the contract does not exist).

With this change, calls to the tracing apis with the pending block will return the error `required historical state unavailable`.

This is because the pending block will have been finalized and will therefore have a state root, and the tracing apis first look up the block and then try to get the state for it using `Ethereum.StateAtBlock` which doesn't take into account the pending state and therefore the state cannot be found.

### Tested

I have verified that the tests linked in #1856 produce reliable gas estimates running against a local node connected to a 1 validator network run with mycelo and also on a fullnode deployed in alfajores.

### Backwards compatibility

The results of the rpc apis are chainging.
