### PR TITLE
Cherry pick #1858 to release/1.5.x

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -163,7 +163,24 @@ func (w *worker) pending() (*types.Block, *state.StateDB) {
 	if w.snapshotState == nil {
 		return nil, nil
 	}
-	return w.snapshotBlock, w.snapshotState.Copy()
+	stateCopy := w.snapshotState.Copy()
+	// Call Prepare to ensure that any access logs from the last executed
+	// transaction have been erased.
+	//
+	// Prior to the upstream PR
+	// https://github.com/ethereum/go-ethereum/pull/21509 the state returned
+	// from pending was ready to use for transaction execution, that PR
+	// essentially changed the contract of the pendng method, in that the
+	// returned state was not ready for transaction execution and required
+	// Prepare to be called on it first, but notably the PR did not update any
+	// of the callers of pending to ensure that Prepare was called. I think
+	// this broke some of the eth rpc apis.  Calling Prepare here essentially
+	// restores the previous contract for this method which was that the
+	// returned state is ready to use for transaction execution.
+	//
+	// See https://github.com/celo-org/celo-blockchain/pull/1858#issuecomment-1054159493 for more details.
+	stateCopy.Prepare(common.Hash{}, 0)
+	return w.snapshotBlock, stateCopy
 }
 
 // pendingBlock returns pending block.

--- a/params/version.go
+++ b/params/version.go
@@ -27,7 +27,7 @@ import (
 const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 5        // Minor version component of the current release
-	VersionPatch = 3        // Patch version component of the current release
+	VersionPatch = 4        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description

This PR cheery picks https://github.com/celo-org/celo-blockchain/pull/1858 to the release branch,
1.5.x and additionally sets the version number to `1.5.4-stable` for release.
