### PR TITLE
Drop Celo66: merge analog upstream commit (dropping eth65)

### DIFF
--- a/cmd/devp2p/internal/ethtest/suite_test.go
+++ b/cmd/devp2p/internal/ethtest/suite_test.go
@@ -46,7 +46,7 @@ func TestEthSuite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not create new test suite: %v", err)
 	}
-	for _, test := range suite.AllEthTests() {
+	for _, test := range suite.Eth66Tests() {
 		t.Run(test.Name, func(t *testing.T) {
 			result := utesting.RunTAP([]utesting.Test{{Name: test.Name, Fn: test.Fn}}, os.Stdout)
 			if result[0].Failed {

--- a/consensus/istanbul/protocol.go
+++ b/consensus/istanbul/protocol.go
@@ -22,13 +22,6 @@ import (
 
 // Constants to match up protocol versions and messages
 const (
-	// No longer supported, can be removed.
-	// The corresponding version upstream (eth/65) is removed in upstream PR #22636.
-	Celo64 = 64 // eth/63 + the istanbul messages
-	Celo65 = 65 // incorporates changes from eth/64 (EIP)
-
-	// Supported versions
-	Celo66 = 66 // incorporates changes from eth/65 (EIP-2464)
 	Celo67 = 67 // incorporates changes from eth/66 (EIP-2481)
 )
 
@@ -37,10 +30,10 @@ const ProtocolName = "istanbul"
 
 // ProtocolVersions are the supported versions of the istanbul protocol (first is primary).
 // (First is primary in the sense that it's the most current one supported)
-var ProtocolVersions = []uint{Celo67, Celo66}
+var ProtocolVersions = []uint{Celo67}
 
 // protocolLengths are the number of implemented message corresponding to different protocol versions.
-var ProtocolLengths = map[uint]uint64{Celo64: 22, Celo65: 27, Celo66: 27, Celo67: 25}
+var ProtocolLengths = map[uint]uint64{Celo67: 25}
 
 // NOTICE:
 // celo/67, uses as the last message the 0x18, so it has 25 messages (including the 0x00)

--- a/consensus/istanbul/protocol.go
+++ b/consensus/istanbul/protocol.go
@@ -22,6 +22,11 @@ import (
 
 // Constants to match up protocol versions and messages
 const (
+	// No longer supported, can be removed.
+	// The corresponding version upstream (eth/66) is removed in upstream PR #23120.
+	// Celo66 = 66
+
+	// Supported versions
 	Celo67 = 67 // incorporates changes from eth/66 (EIP-2481)
 )
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -483,8 +483,8 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, td *big.I
 			d.mux.Post(DoneEvent{latest})
 		}
 	}()
-	if p.version < istanbul.Celo66 {
-		return fmt.Errorf("%w: advertized %d < required %d", errTooOld, p.version, istanbul.Celo66)
+	if p.version < istanbul.Celo67 {
+		return fmt.Errorf("%w: advertized %d < required %d", errTooOld, p.version, istanbul.Celo67)
 	}
 	mode := d.getMode()
 

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -574,10 +574,6 @@ func assertOwnForkedChain(t *testing.T, tester *downloadTester, common int, leng
 	}
 }
 
-func TestCanonicalSynchronisation66Full(t *testing.T)  { testCanonSync(t, istanbul.Celo66, FullSync) }
-func TestCanonicalSynchronisation66Fast(t *testing.T)  { testCanonSync(t, istanbul.Celo66, FastSync) }
-func TestCanonicalSynchronisation66Light(t *testing.T) { testCanonSync(t, istanbul.Celo66, LightSync) }
-
 func TestCanonicalSynchronisation67Full(t *testing.T)  { testCanonSync(t, istanbul.Celo67, FullSync) }
 func TestCanonicalSynchronisation67Fast(t *testing.T)  { testCanonSync(t, istanbul.Celo67, FastSync) }
 func TestCanonicalSynchronisation67Light(t *testing.T) { testCanonSync(t, istanbul.Celo67, LightSync) }
@@ -601,9 +597,6 @@ func testCanonSync(t *testing.T, protocol uint, mode SyncMode) {
 
 // Tests that if a large batch of blocks are being downloaded, it is throttled
 // until the cached blocks are retrieved.
-func TestThrottling66Full(t *testing.T) { testThrottling(t, istanbul.Celo66, FullSync) }
-func TestThrottling66Fast(t *testing.T) { testThrottling(t, istanbul.Celo66, FastSync) }
-
 func TestThrottling67Full(t *testing.T) { testThrottling(t, istanbul.Celo67, FullSync) }
 func TestThrottling67Fast(t *testing.T) { testThrottling(t, istanbul.Celo67, FastSync) }
 
@@ -686,10 +679,6 @@ func testThrottling(t *testing.T, protocol uint, mode SyncMode) {
 // Tests that simple synchronization against a forked chain works correctly. In
 // this test common ancestor lookup should *not* be short circuited, and a full
 // binary search should be executed.
-func TestForkedSync66Full(t *testing.T)  { testForkedSync(t, istanbul.Celo66, FullSync) }
-func TestForkedSync66Fast(t *testing.T)  { testForkedSync(t, istanbul.Celo66, FastSync) }
-func TestForkedSync66Light(t *testing.T) { testForkedSync(t, istanbul.Celo66, LightSync) }
-
 func TestForkedSync67Full(t *testing.T)  { testForkedSync(t, istanbul.Celo67, FullSync) }
 func TestForkedSync67Fast(t *testing.T)  { testForkedSync(t, istanbul.Celo67, FastSync) }
 func TestForkedSync67Light(t *testing.T) { testForkedSync(t, istanbul.Celo67, LightSync) }
@@ -719,10 +708,6 @@ func testForkedSync(t *testing.T, protocol uint, mode SyncMode) {
 
 // Tests that synchronising against a much shorter but much heavyer fork works
 // corrently and is not dropped.
-func TestHeavyForkedSync66Full(t *testing.T)  { testHeavyForkedSync(t, istanbul.Celo66, FullSync) }
-func TestHeavyForkedSync66Fast(t *testing.T)  { testHeavyForkedSync(t, istanbul.Celo66, FastSync) }
-func TestHeavyForkedSync66Light(t *testing.T) { testHeavyForkedSync(t, istanbul.Celo66, LightSync) }
-
 func TestHeavyForkedSync67Full(t *testing.T)  { testHeavyForkedSync(t, istanbul.Celo67, FullSync) }
 func TestHeavyForkedSync67Fast(t *testing.T)  { testHeavyForkedSync(t, istanbul.Celo67, FastSync) }
 func TestHeavyForkedSync67Light(t *testing.T) { testHeavyForkedSync(t, istanbul.Celo67, LightSync) }
@@ -754,10 +739,6 @@ func testHeavyForkedSync(t *testing.T, protocol uint, mode SyncMode) {
 // Tests that chain forks are contained within a certain interval of the current
 // chain head, ensuring that malicious peers cannot waste resources by feeding
 // long dead chains.
-func TestBoundedForkedSync66Full(t *testing.T)  { testBoundedForkedSync(t, istanbul.Celo66, FullSync) }
-func TestBoundedForkedSync66Fast(t *testing.T)  { testBoundedForkedSync(t, istanbul.Celo66, FastSync) }
-func TestBoundedForkedSync66Light(t *testing.T) { testBoundedForkedSync(t, istanbul.Celo66, LightSync) }
-
 func TestBoundedForkedSync67Full(t *testing.T)  { testBoundedForkedSync(t, istanbul.Celo67, FullSync) }
 func TestBoundedForkedSync67Fast(t *testing.T)  { testBoundedForkedSync(t, istanbul.Celo67, FastSync) }
 func TestBoundedForkedSync67Light(t *testing.T) { testBoundedForkedSync(t, istanbul.Celo67, LightSync) }
@@ -788,16 +769,6 @@ func testBoundedForkedSync(t *testing.T, protocol uint, mode SyncMode) {
 // Tests that chain forks are contained within a certain interval of the current
 // chain head for short but heavy forks too. These are a bit special because they
 // take different ancestor lookup paths.
-func TestBoundedHeavyForkedSync66Full(t *testing.T) {
-	testBoundedHeavyForkedSync(t, istanbul.Celo66, FullSync)
-}
-func TestBoundedHeavyForkedSync66Fast(t *testing.T) {
-	testBoundedHeavyForkedSync(t, istanbul.Celo66, FastSync)
-}
-func TestBoundedHeavyForkedSync66Light(t *testing.T) {
-	testBoundedHeavyForkedSync(t, istanbul.Celo66, LightSync)
-}
-
 func TestBoundedHeavyForkedSync67Full(t *testing.T) {
 	testBoundedHeavyForkedSync(t, istanbul.Celo67, FullSync)
 }
@@ -852,10 +823,6 @@ func TestInactiveDownloader64(t *testing.T) {
 }
 
 // Tests that a canceled download wipes all previously accumulated state.
-func TestCancel66Full(t *testing.T)  { testCancel(t, istanbul.Celo66, FullSync) }
-func TestCancel66Fast(t *testing.T)  { testCancel(t, istanbul.Celo66, FastSync) }
-func TestCancel66Light(t *testing.T) { testCancel(t, istanbul.Celo66, LightSync) }
-
 func TestCancel67Full(t *testing.T)  { testCancel(t, istanbul.Celo67, FullSync) }
 func TestCancel67Fast(t *testing.T)  { testCancel(t, istanbul.Celo67, FastSync) }
 func TestCancel67Light(t *testing.T) { testCancel(t, istanbul.Celo67, LightSync) }
@@ -885,16 +852,6 @@ func testCancel(t *testing.T, protocol uint, mode SyncMode) {
 }
 
 // Tests that synchronisation from multiple peers works as intended (multi thread sanity test).
-func TestMultiSynchronisation66Full(t *testing.T) {
-	testMultiSynchronisation(t, istanbul.Celo66, FullSync)
-}
-func TestMultiSynchronisation66Fast(t *testing.T) {
-	testMultiSynchronisation(t, istanbul.Celo66, FastSync)
-}
-func TestMultiSynchronisation66Light(t *testing.T) {
-	testMultiSynchronisation(t, istanbul.Celo66, LightSync)
-}
-
 func TestMultiSynchronisation67Full(t *testing.T) {
 	testMultiSynchronisation(t, istanbul.Celo67, FullSync)
 }
@@ -927,16 +884,6 @@ func testMultiSynchronisation(t *testing.T, protocol uint, mode SyncMode) {
 
 // Tests that synchronisations behave well in multi-version protocol environments
 // and not wreak havoc on other nodes in the network.
-func TestMultiProtoSynchronisation66Full(t *testing.T) {
-	testMultiProtoSync(t, istanbul.Celo66, FullSync)
-}
-func TestMultiProtoSynchronisation66Fast(t *testing.T) {
-	testMultiProtoSync(t, istanbul.Celo66, FastSync)
-}
-func TestMultiProtoSynchronisation66Light(t *testing.T) {
-	testMultiProtoSync(t, istanbul.Celo66, LightSync)
-}
-
 func TestMultiProtoSynchronisation67Full(t *testing.T) {
 	testMultiProtoSync(t, istanbul.Celo67, FullSync)
 }
@@ -957,7 +904,6 @@ func testMultiProtoSync(t *testing.T, protocol uint, mode SyncMode) {
 	chain := testChainBase.shorten(blockCacheMaxItems - 15)
 
 	// Create peers of every type
-	tester.newPeer("peer 66", istanbul.Celo66, chain)
 	tester.newPeer("peer 67", istanbul.Celo67, chain)
 
 	// Synchronise with the requested peer and make sure all blocks were retrieved
@@ -967,7 +913,7 @@ func testMultiProtoSync(t *testing.T, protocol uint, mode SyncMode) {
 	assertOwnChain(t, tester, chain.len())
 
 	// Check that no peers have been dropped off
-	for _, version := range []int{66, 67} {
+	for _, version := range []int{67} {
 		peer := fmt.Sprintf("peer %d", version)
 		if _, ok := tester.peers[peer]; !ok {
 			t.Errorf("%s dropped", peer)
@@ -977,16 +923,6 @@ func testMultiProtoSync(t *testing.T, protocol uint, mode SyncMode) {
 
 // Tests that headers are enqueued continuously, preventing malicious nodes from
 // stalling the downloader by feeding gapped header chains.
-func TestMissingHeaderAttack66Full(t *testing.T) {
-	testMissingHeaderAttack(t, istanbul.Celo66, FullSync)
-}
-func TestMissingHeaderAttack66Fast(t *testing.T) {
-	testMissingHeaderAttack(t, istanbul.Celo66, FastSync)
-}
-func TestMissingHeaderAttack66Light(t *testing.T) {
-	testMissingHeaderAttack(t, istanbul.Celo66, LightSync)
-}
-
 func TestMissingHeaderAttack67Full(t *testing.T) {
 	testMissingHeaderAttack(t, istanbul.Celo67, FullSync)
 }
@@ -1021,16 +957,6 @@ func testMissingHeaderAttack(t *testing.T, protocol uint, mode SyncMode) {
 
 // Tests that if requested headers are shifted (i.e. first is missing), the queue
 // detects the invalid numbering.
-func TestShiftedHeaderAttack66Full(t *testing.T) {
-	testShiftedHeaderAttack(t, istanbul.Celo66, FullSync)
-}
-func TestShiftedHeaderAttack66Fast(t *testing.T) {
-	testShiftedHeaderAttack(t, istanbul.Celo66, FastSync)
-}
-func TestShiftedHeaderAttack66Light(t *testing.T) {
-	testShiftedHeaderAttack(t, istanbul.Celo66, LightSync)
-}
-
 func TestShiftedHeaderAttack67Full(t *testing.T) {
 	testShiftedHeaderAttack(t, istanbul.Celo67, FullSync)
 }
@@ -1070,9 +996,6 @@ func testShiftedHeaderAttack(t *testing.T, protocol uint, mode SyncMode) {
 // Tests that upon detecting an invalid header, the recent ones are rolled back
 // for various failure scenarios. Afterwards a full sync is attempted to make
 // sure no state was corrupted.
-func TestInvalidHeaderRollback66Fast(t *testing.T) {
-	testInvalidHeaderRollback(t, istanbul.Celo66, FastSync)
-}
 func TestInvalidHeaderRollback67Fast(t *testing.T) {
 	testInvalidHeaderRollback(t, istanbul.Celo67, FastSync)
 }
@@ -1165,16 +1088,6 @@ func testInvalidHeaderRollback(t *testing.T, protocol uint, mode SyncMode) {
 
 // Tests that a peer advertising a high TD doesn't get to stall the downloader
 // afterwards by not sending any useful hashes.
-func TestHighTDStarvationAttack66Full(t *testing.T) {
-	testHighTDStarvationAttack(t, istanbul.Celo66, FullSync)
-}
-func TestHighTDStarvationAttack66Fast(t *testing.T) {
-	testHighTDStarvationAttack(t, istanbul.Celo66, FastSync)
-}
-func TestHighTDStarvationAttack66Light(t *testing.T) {
-	testHighTDStarvationAttack(t, istanbul.Celo66, LightSync)
-}
-
 func TestHighTDStarvationAttack67Full(t *testing.T) {
 	testHighTDStarvationAttack(t, istanbul.Celo67, FullSync)
 }
@@ -1199,9 +1112,6 @@ func testHighTDStarvationAttack(t *testing.T, protocol uint, mode SyncMode) {
 }
 
 // Tests that misbehaving peers are disconnected, whilst behaving ones are not.
-func TestBlockHeaderAttackerDropping66(t *testing.T) {
-	testBlockHeaderAttackerDropping(t, istanbul.Celo66)
-}
 func TestBlockHeaderAttackerDropping67(t *testing.T) {
 	testBlockHeaderAttackerDropping(t, istanbul.Celo67)
 }
@@ -1256,10 +1166,6 @@ func testBlockHeaderAttackerDropping(t *testing.T, protocol uint) {
 
 // Tests that synchronisation progress (origin block number, current block number
 // and highest block number) is tracked and updated correctly.
-func TestSyncProgress66Full(t *testing.T)  { testSyncProgress(t, istanbul.Celo66, FullSync) }
-func TestSyncProgress66Fast(t *testing.T)  { testSyncProgress(t, istanbul.Celo66, FastSync) }
-func TestSyncProgress66Light(t *testing.T) { testSyncProgress(t, istanbul.Celo66, LightSync) }
-
 func TestSyncProgress67Full(t *testing.T)  { testSyncProgress(t, istanbul.Celo67, FullSync) }
 func TestSyncProgress67Fast(t *testing.T)  { testSyncProgress(t, istanbul.Celo67, FastSync) }
 func TestSyncProgress67Light(t *testing.T) { testSyncProgress(t, istanbul.Celo67, LightSync) }
@@ -1340,12 +1246,6 @@ func checkProgress(t *testing.T, d *Downloader, stage string, want ethereum.Sync
 // Tests that synchronisation progress (origin block number and highest block
 // number) is tracked and updated correctly in case of a fork (or manual head
 // revertal).
-func TestForkedSyncProgress66Full(t *testing.T) { testForkedSyncProgress(t, istanbul.Celo66, FullSync) }
-func TestForkedSyncProgress66Fast(t *testing.T) { testForkedSyncProgress(t, istanbul.Celo66, FastSync) }
-func TestForkedSyncProgress66Light(t *testing.T) {
-	testForkedSyncProgress(t, istanbul.Celo66, LightSync)
-}
-
 func TestForkedSyncProgress67Full(t *testing.T) { testForkedSyncProgress(t, istanbul.Celo67, FullSync) }
 func TestForkedSyncProgress67Fast(t *testing.T) { testForkedSyncProgress(t, istanbul.Celo67, FastSync) }
 func TestForkedSyncProgress67Light(t *testing.T) {
@@ -1420,12 +1320,6 @@ func testForkedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 // Tests that if synchronisation is aborted due to some failure, then the progress
 // origin is not updated in the next sync cycle, as it should be considered the
 // continuation of the previous sync and not a new instance.
-func TestFailedSyncProgress66Full(t *testing.T) { testFailedSyncProgress(t, istanbul.Celo66, FullSync) }
-func TestFailedSyncProgress66Fast(t *testing.T) { testFailedSyncProgress(t, istanbul.Celo66, FastSync) }
-func TestFailedSyncProgress66Light(t *testing.T) {
-	testFailedSyncProgress(t, istanbul.Celo66, LightSync)
-}
-
 func TestFailedSyncProgress67Full(t *testing.T) { testFailedSyncProgress(t, istanbul.Celo67, FullSync) }
 func TestFailedSyncProgress67Fast(t *testing.T) { testFailedSyncProgress(t, istanbul.Celo67, FastSync) }
 func TestFailedSyncProgress67Light(t *testing.T) {
@@ -1497,10 +1391,6 @@ func testFailedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 
 // Tests that if an attacker fakes a chain height, after the attack is detected,
 // the progress height is successfully reduced at the next sync invocation.
-func TestFakedSyncProgress66Full(t *testing.T)  { testFakedSyncProgress(t, istanbul.Celo66, FullSync) }
-func TestFakedSyncProgress66Fast(t *testing.T)  { testFakedSyncProgress(t, istanbul.Celo66, FastSync) }
-func TestFakedSyncProgress66Light(t *testing.T) { testFakedSyncProgress(t, istanbul.Celo66, LightSync) }
-
 func TestFakedSyncProgress67Full(t *testing.T)  { testFakedSyncProgress(t, istanbul.Celo67, FullSync) }
 func TestFakedSyncProgress67Fast(t *testing.T)  { testFakedSyncProgress(t, istanbul.Celo67, FastSync) }
 func TestFakedSyncProgress67Light(t *testing.T) { testFakedSyncProgress(t, istanbul.Celo67, LightSync) }
@@ -1574,15 +1464,9 @@ func testFakedSyncProgress(t *testing.T, protocol uint, mode SyncMode) {
 
 // This test reproduces an issue where unexpected deliveries would
 // block indefinitely if they arrived at the right time.
-func TestDeliverHeadersHang65Full(t *testing.T) { testDeliverHeadersHang(t, istanbul.Celo66, FullSync) }
-func TestDeliverHeadersHang65Fast(t *testing.T) { testDeliverHeadersHang(t, istanbul.Celo66, FastSync) }
-func TestDeliverHeadersHang65Light(t *testing.T) {
-	testDeliverHeadersHang(t, istanbul.Celo66, LightSync)
-}
-
-func TestDeliverHeadersHang66Full(t *testing.T) { testDeliverHeadersHang(t, istanbul.Celo67, FullSync) }
-func TestDeliverHeadersHang66Fast(t *testing.T) { testDeliverHeadersHang(t, istanbul.Celo67, FastSync) }
-func TestDeliverHeadersHang66Light(t *testing.T) {
+func TestDeliverHeadersHang67Full(t *testing.T) { testDeliverHeadersHang(t, istanbul.Celo67, FullSync) }
+func TestDeliverHeadersHang67Fast(t *testing.T) { testDeliverHeadersHang(t, istanbul.Celo67, FastSync) }
+func TestDeliverHeadersHang67Light(t *testing.T) {
 	testDeliverHeadersHang(t, istanbul.Celo67, LightSync)
 }
 
@@ -1739,16 +1623,6 @@ func TestRemoteHeaderRequestSpan(t *testing.T) {
 
 // Tests that peers below a pre-configured checkpoint block are prevented from
 // being fast-synced from, avoiding potential cheap eclipse attacks.
-func TestCheckpointEnforcement66Full(t *testing.T) {
-	testCheckpointEnforcement(t, istanbul.Celo66, FullSync)
-}
-func TestCheckpointEnforcement66Fast(t *testing.T) {
-	testCheckpointEnforcement(t, istanbul.Celo66, FastSync)
-}
-func TestCheckpointEnforcement66Light(t *testing.T) {
-	testCheckpointEnforcement(t, istanbul.Celo66, LightSync)
-}
-
 func TestCheckpointEnforcement67Full(t *testing.T) {
 	testCheckpointEnforcement(t, istanbul.Celo67, FullSync)
 }

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -414,7 +414,7 @@ func (ps *peerSet) HeaderIdlePeers() ([]*peerConnection, int) {
 	throughput := func(p *peerConnection) int {
 		return p.rates.Capacity(eth.BlockHeadersMsg, time.Second)
 	}
-	return ps.idlePeers(istanbul.Celo66, istanbul.Celo67, idle, throughput)
+	return ps.idlePeers(istanbul.Celo67, istanbul.Celo67, idle, throughput)
 }
 
 // BodyIdlePeers retrieves a flat list of all the currently body-idle peers within
@@ -426,7 +426,7 @@ func (ps *peerSet) BodyIdlePeers() ([]*peerConnection, int) {
 	throughput := func(p *peerConnection) int {
 		return p.rates.Capacity(eth.BlockBodiesMsg, time.Second)
 	}
-	return ps.idlePeers(istanbul.Celo66, istanbul.Celo67, idle, throughput)
+	return ps.idlePeers(istanbul.Celo67, istanbul.Celo67, idle, throughput)
 }
 
 // ReceiptIdlePeers retrieves a flat list of all the currently receipt-idle peers
@@ -438,7 +438,7 @@ func (ps *peerSet) ReceiptIdlePeers() ([]*peerConnection, int) {
 	throughput := func(p *peerConnection) int {
 		return p.rates.Capacity(eth.ReceiptsMsg, time.Second)
 	}
-	return ps.idlePeers(istanbul.Celo66, istanbul.Celo67, idle, throughput)
+	return ps.idlePeers(istanbul.Celo67, istanbul.Celo67, idle, throughput)
 }
 
 // NodeDataIdlePeers retrieves a flat list of all the currently node-data-idle
@@ -450,7 +450,7 @@ func (ps *peerSet) NodeDataIdlePeers() ([]*peerConnection, int) {
 	throughput := func(p *peerConnection) int {
 		return p.rates.Capacity(eth.NodeDataMsg, time.Second)
 	}
-	return ps.idlePeers(istanbul.Celo66, istanbul.Celo67, idle, throughput)
+	return ps.idlePeers(istanbul.Celo67, istanbul.Celo67, idle, throughput)
 }
 
 // idlePeers retrieves a flat list of all currently idle peers satisfying the

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -122,7 +122,6 @@ type handler struct {
 	whitelist map[uint64]common.Hash
 
 	// channels for fetcher, syncer, txsyncLoop
-	txsyncCh chan *txsync
 	quitSync chan struct{}
 
 	chainSync *chainSyncer
@@ -147,7 +146,6 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		chain:       config.Chain,
 		peers:       newPeerSet(),
 		whitelist:   config.Whitelist,
-		txsyncCh:    make(chan *txsync),
 		quitSync:    make(chan struct{}),
 		server:      config.server,
 		proxyServer: config.proxyServer,
@@ -467,9 +465,8 @@ func (h *handler) Start(maxPeers int) {
 	go h.minedBroadcastLoop()
 
 	// start sync handlers
-	h.wg.Add(2)
+	h.wg.Add(1)
 	go h.chainSync.loop()
-	go h.txsyncLoop64() // TODO(karalabe): Legacy initial tx echange, drop with eth/64.
 }
 
 func (h *handler) Stop() {

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -95,7 +95,6 @@ func (h *testEthHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 
 // Tests that peers are correctly accepted (or rejected) based on the advertised
 // fork IDs in the protocol handshake.
-func TestForkIDSplit66(t *testing.T) { testForkIDSplit(t, istanbul.Celo66) }
 func TestForkIDSplit67(t *testing.T) { testForkIDSplit(t, istanbul.Celo67) }
 
 func testForkIDSplit(t *testing.T, protocol uint) {
@@ -259,7 +258,6 @@ func testForkIDSplit(t *testing.T, protocol uint) {
 }
 
 // Tests that received transactions are added to the local pool.
-func TestRecvTransactions66(t *testing.T) { testRecvTransactions(t, istanbul.Celo66) }
 func TestRecvTransactions67(t *testing.T) { testRecvTransactions(t, istanbul.Celo67) }
 
 func testRecvTransactions(t *testing.T, protocol uint) {
@@ -317,7 +315,6 @@ func testRecvTransactions(t *testing.T, protocol uint) {
 }
 
 // This test checks that pending transactions are sent.
-func TestSendTransactions66(t *testing.T) { testSendTransactions(t, istanbul.Celo66) }
 func TestSendTransactions67(t *testing.T) { testSendTransactions(t, istanbul.Celo67) }
 
 func testSendTransactions(t *testing.T, protocol uint) {
@@ -329,7 +326,7 @@ func testSendTransactions(t *testing.T, protocol uint) {
 
 	insert := make([]*types.Transaction, 100)
 	for nonce := range insert {
-		tx := types.NewTransaction(uint64(nonce), common.Address{}, big.NewInt(0), 100000, big.NewInt(0), nil, nil, nil, make([]byte, txsyncPackSize/10))
+		tx := types.NewTransaction(uint64(nonce), common.Address{}, big.NewInt(0), 100000, big.NewInt(0), nil, nil, nil, make([]byte, 10240))
 		tx, _ = types.SignTx(tx, types.HomesteadSigner{}, testKey)
 
 		insert[nonce] = tx
@@ -404,7 +401,6 @@ func testSendTransactions(t *testing.T, protocol uint) {
 
 // Tests that transactions get propagated to all attached peers, either via direct
 // broadcasts or via announcements/retrievals.
-func TestTransactionPropagation66(t *testing.T) { testTransactionPropagation(t, istanbul.Celo66) }
 func TestTransactionPropagation67(t *testing.T) { testTransactionPropagation(t, istanbul.Celo67) }
 
 func testTransactionPropagation(t *testing.T, protocol uint) {
@@ -545,8 +541,8 @@ func testCheckpointChallenge(t *testing.T, syncmode downloader.SyncMode, checkpo
 	defer p2pLocal.Close()
 	defer p2pRemote.Close()
 
-	local := eth.NewPeer(istanbul.Celo66, p2p.NewPeerPipe(enode.ID{1}, "", nil, p2pLocal), p2pLocal, handler.txpool)
-	remote := eth.NewPeer(istanbul.Celo66, p2p.NewPeerPipe(enode.ID{2}, "", nil, p2pRemote), p2pRemote, handler.txpool)
+	local := eth.NewPeer(istanbul.Celo67, p2p.NewPeerPipe(enode.ID{1}, "", nil, p2pLocal), p2pLocal, handler.txpool)
+	remote := eth.NewPeer(istanbul.Celo67, p2p.NewPeerPipe(enode.ID{2}, "", nil, p2pRemote), p2pRemote, handler.txpool)
 	defer local.Close()
 	defer remote.Close()
 
@@ -567,30 +563,39 @@ func testCheckpointChallenge(t *testing.T, syncmode downloader.SyncMode, checkpo
 	if err := remote.Handshake(1, td, head.Hash(), genesis.Hash(), forkid.NewIDWithChain(handler.chain), forkid.NewFilter(handler.chain)); err != nil {
 		t.Fatalf("failed to run protocol handshake")
 	}
-
 	// Connect a new peer and check that we receive the checkpoint challenge.
 	if checkpoint {
-		if err := remote.ExpectRequestHeadersByNumber(response.Number.Uint64(), 1, 0, false); err != nil {
-			t.Fatalf("challenge mismatch: %v", err)
+		msg, err := p2pRemote.ReadMsg()
+		if err != nil {
+			t.Fatalf("failed to read checkpoint challenge: %v", err)
+		}
+		request := new(eth.GetBlockHeadersPacket67)
+		if err := msg.Decode(request); err != nil {
+			t.Fatalf("failed to decode checkpoint challenge: %v", err)
+		}
+		query := request.GetBlockHeadersPacket
+		if query.Origin.Number != response.Number.Uint64() || query.Amount != 1 || query.Skip != 0 || query.Reverse {
+			t.Fatalf("challenge mismatch: have [%d, %d, %d, %v] want [%d, %d, %d, %v]",
+				query.Origin.Number, query.Amount, query.Skip, query.Reverse,
+				response.Number.Uint64(), 1, 0, false)
 		}
 		// Create a block to reply to the challenge if no timeout is simulated.
 		if !timeout {
 			if empty {
-				if err := remote.SendBlockHeaders([]*types.Header{}); err != nil {
+				if err := remote.ReplyBlockHeaders(request.RequestId, []*types.Header{}); err != nil {
 					t.Fatalf("failed to answer challenge: %v", err)
 				}
 			} else if match {
-				if err := remote.SendBlockHeaders([]*types.Header{response}); err != nil {
+				if err := remote.ReplyBlockHeaders(request.RequestId, []*types.Header{response}); err != nil {
 					t.Fatalf("failed to answer challenge: %v", err)
 				}
 			} else {
-				if err := remote.SendBlockHeaders([]*types.Header{{Number: response.Number}}); err != nil {
+				if err := remote.ReplyBlockHeaders(request.RequestId, []*types.Header{{Number: response.Number}}); err != nil {
 					t.Fatalf("failed to answer challenge: %v", err)
 				}
 			}
 		}
 	}
-
 	// Wait until the test timeout passes to ensure proper cleanup
 	time.Sleep(syncChallengeTimeout + 300*time.Millisecond)
 
@@ -644,8 +649,8 @@ func testBroadcastBlock(t *testing.T, peers, bcasts int) {
 		defer sourcePipe.Close()
 		defer sinkPipe.Close()
 
-		sourcePeer := eth.NewPeer(istanbul.Celo66, p2p.NewPeerPipe(enode.ID{byte(i)}, "", nil, sourcePipe), sourcePipe, nil)
-		sinkPeer := eth.NewPeer(istanbul.Celo66, p2p.NewPeerPipe(enode.ID{0}, "", nil, sinkPipe), sinkPipe, nil)
+		sourcePeer := eth.NewPeer(istanbul.Celo67, p2p.NewPeerPipe(enode.ID{byte(i)}, "", nil, sourcePipe), sourcePipe, nil)
+		sinkPeer := eth.NewPeer(istanbul.Celo67, p2p.NewPeerPipe(enode.ID{0}, "", nil, sinkPipe), sinkPipe, nil)
 		defer sourcePeer.Close()
 		defer sinkPeer.Close()
 
@@ -696,7 +701,6 @@ func testBroadcastBlock(t *testing.T, peers, bcasts int) {
 
 // Tests that a propagated malformed block (uncles or transactions don't match
 // with the hashes in the header) gets discarded and not broadcast forward.
-func TestBroadcastMalformedBlock66(t *testing.T) { testBroadcastMalformedBlock(t, istanbul.Celo66) }
 func TestBroadcastMalformedBlock67(t *testing.T) { testBroadcastMalformedBlock(t, istanbul.Celo67) }
 
 func testBroadcastMalformedBlock(t *testing.T, protocol uint) {

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -174,39 +174,21 @@ type Decoder interface {
 	Time() time.Time
 }
 
-var celo66 = map[uint64]msgHandler{
-	GetBlockHeadersMsg:            handleGetBlockHeaders,
-	BlockHeadersMsg:               handleBlockHeaders,
-	GetBlockBodiesMsg:             handleGetBlockBodies,
-	BlockBodiesMsg:                handleBlockBodies,
-	GetNodeDataMsg:                handleGetNodeData,
-	NodeDataMsg:                   handleNodeData,
-	GetReceiptsMsg:                handleGetReceipts,
-	ReceiptsMsg:                   handleReceipts,
-	NewBlockHashesMsg:             handleNewBlockhashes,
-	NewBlockMsg:                   handleNewBlock,
-	TransactionsMsg:               handleTransactions,
-	NewPooledTransactionHashesMsg: handleNewPooledTransactionHashes,
-	GetPooledTransactionsMsg:      handleGetPooledTransactions,
-	PooledTransactionsMsg:         handlePooledTransactions,
-}
-
 var celo67 = map[uint64]msgHandler{
 	NewBlockHashesMsg:             handleNewBlockhashes,
 	NewBlockMsg:                   handleNewBlock,
 	TransactionsMsg:               handleTransactions,
 	NewPooledTransactionHashesMsg: handleNewPooledTransactionHashes,
-	// celo67 messages with request-id
-	GetBlockHeadersMsg:       handleGetBlockHeaders67,
-	BlockHeadersMsg:          handleBlockHeaders67,
-	GetBlockBodiesMsg:        handleGetBlockBodies67,
-	BlockBodiesMsg:           handleBlockBodies67,
-	GetNodeDataMsg:           handleGetNodeData67,
-	NodeDataMsg:              handleNodeData67,
-	GetReceiptsMsg:           handleGetReceipts67,
-	ReceiptsMsg:              handleReceipts67,
-	GetPooledTransactionsMsg: handleGetPooledTransactions67,
-	PooledTransactionsMsg:    handlePooledTransactions67,
+	GetBlockHeadersMsg:            handleGetBlockHeaders67,
+	BlockHeadersMsg:               handleBlockHeaders67,
+	GetBlockBodiesMsg:             handleGetBlockBodies67,
+	BlockBodiesMsg:                handleBlockBodies67,
+	GetNodeDataMsg:                handleGetNodeData67,
+	NodeDataMsg:                   handleNodeData67,
+	GetReceiptsMsg:                handleGetReceipts67,
+	ReceiptsMsg:                   handleReceipts67,
+	GetPooledTransactionsMsg:      handleGetPooledTransactions67,
+	PooledTransactionsMsg:         handlePooledTransactions67,
 }
 
 // handleMessage is invoked whenever an inbound message is received from a remote
@@ -230,10 +212,11 @@ func handleMessage(backend Backend, peer *Peer) error {
 		}
 	}
 
-	var handlers = celo66
-	if peer.Version() >= istanbul.Celo67 {
-		handlers = celo67
-	}
+	var handlers = celo67
+	//if peer.Version() >= celo68 { // Left in as a sample when new protocol is added
+	//	handlers = celo68
+	//}
+
 	// Track the amount of time it takes to serve the request and run the handler
 	if metrics.Enabled {
 		h := fmt.Sprintf("%s/%s/%d/%#02x", p2p.HandleHistName, ProtocolName, peer.Version(), msg.Code)

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -111,7 +111,6 @@ func (b *testBackend) Handle(*Peer, Packet) error {
 }
 
 // Tests that block headers can be retrieved from a remote chain based on user queries.
-func TestGetBlockHeaders66(t *testing.T) { testGetBlockHeaders(t, istanbul.Celo66) }
 func TestGetBlockHeaders67(t *testing.T) { testGetBlockHeaders(t, istanbul.Celo67) }
 
 func testGetBlockHeaders(t *testing.T, protocol uint) {
@@ -255,52 +254,37 @@ func testGetBlockHeaders(t *testing.T, protocol uint) {
 			headers = append(headers, backend.chain.GetBlockByHash(hash).Header())
 		}
 		// Send the hash request and verify the response
-		if protocol <= istanbul.Celo66 {
-			p2p.Send(peer.app, GetBlockHeadersMsg, tt.query)
-			if err := p2p.ExpectMsg(peer.app, BlockHeadersMsg, headers); err != nil {
-				t.Errorf("test %d: headers mismatch: %v", i, err)
-			}
-		} else {
-			p2p.Send(peer.app, GetBlockHeadersMsg, GetBlockHeadersPacket67{
-				RequestId:             123,
-				GetBlockHeadersPacket: tt.query,
-			})
-			if err := p2p.ExpectMsg(peer.app, BlockHeadersMsg, BlockHeadersPacket67{
-				RequestId:          123,
-				BlockHeadersPacket: headers,
-			}); err != nil {
-				t.Errorf("test %d: headers mismatch: %v", i, err)
-			}
+		p2p.Send(peer.app, GetBlockHeadersMsg, GetBlockHeadersPacket67{
+			RequestId:             123,
+			GetBlockHeadersPacket: tt.query,
+		})
+		if err := p2p.ExpectMsg(peer.app, BlockHeadersMsg, BlockHeadersPacket67{
+			RequestId:          123,
+			BlockHeadersPacket: headers,
+		}); err != nil {
+			t.Errorf("test %d: headers mismatch: %v", i, err)
 		}
 		// If the test used number origins, repeat with hashes as the too
 		if tt.query.Origin.Hash == (common.Hash{}) {
 			if origin := backend.chain.GetBlockByNumber(tt.query.Origin.Number); origin != nil {
 				tt.query.Origin.Hash, tt.query.Origin.Number = origin.Hash(), 0
-
-				if protocol <= istanbul.Celo66 {
-					p2p.Send(peer.app, GetBlockHeadersMsg, tt.query)
-					if err := p2p.ExpectMsg(peer.app, BlockHeadersMsg, headers); err != nil {
-						t.Errorf("test %d: headers mismatch: %v", i, err)
-					}
-				} else {
-					p2p.Send(peer.app, GetBlockHeadersMsg, GetBlockHeadersPacket67{
-						RequestId:             456,
-						GetBlockHeadersPacket: tt.query,
-					})
-					if err := p2p.ExpectMsg(peer.app, BlockHeadersMsg, BlockHeadersPacket67{
-						RequestId:          456,
-						BlockHeadersPacket: headers,
-					}); err != nil {
-						t.Errorf("test %d: headers mismatch: %v", i, err)
-					}
+				p2p.Send(peer.app, GetBlockHeadersMsg, GetBlockHeadersPacket67{
+					RequestId:             456,
+					GetBlockHeadersPacket: tt.query,
+				})
+				if err := p2p.ExpectMsg(peer.app, BlockHeadersMsg, BlockHeadersPacket67{
+					RequestId:          456,
+					BlockHeadersPacket: headers,
+				}); err != nil {
+					t.Errorf("test %d: headers mismatch: %v", i, err)
 				}
+
 			}
 		}
 	}
 }
 
 // Tests that block contents can be retrieved from a remote chain based on their hashes.
-func TestGetBlockBodies66(t *testing.T) { testGetBlockBodies(t, istanbul.Celo66) }
 func TestGetBlockBodies67(t *testing.T) { testGetBlockBodies(t, istanbul.Celo67) }
 
 func testGetBlockBodies(t *testing.T, protocol uint) {
@@ -378,28 +362,20 @@ func testGetBlockBodies(t *testing.T, protocol uint) {
 			}
 		}
 		// Send the hash request and verify the response
-		if protocol <= istanbul.Celo66 {
-			p2p.Send(peer.app, GetBlockBodiesMsg, hashes)
-			if err := p2p.ExpectMsg(peer.app, BlockBodiesMsg, bodiesAndBlockHashes); err != nil {
-				t.Errorf("test %d: bodies mismatch: %v", i, err)
-			}
-		} else {
-			p2p.Send(peer.app, GetBlockBodiesMsg, GetBlockBodiesPacket67{
-				RequestId:            123,
-				GetBlockBodiesPacket: hashes,
-			})
-			if err := p2p.ExpectMsg(peer.app, BlockBodiesMsg, BlockBodiesPacket67{
-				RequestId:         123,
-				BlockBodiesPacket: bodiesAndBlockHashes,
-			}); err != nil {
-				t.Errorf("test %d: bodies mismatch: %v", i, err)
-			}
+		p2p.Send(peer.app, GetBlockBodiesMsg, GetBlockBodiesPacket67{
+			RequestId:            123,
+			GetBlockBodiesPacket: hashes,
+		})
+		if err := p2p.ExpectMsg(peer.app, BlockBodiesMsg, BlockBodiesPacket67{
+			RequestId:         123,
+			BlockBodiesPacket: bodiesAndBlockHashes,
+		}); err != nil {
+			t.Errorf("test %d: bodies mismatch: %v", i, err)
 		}
 	}
 }
 
 // Tests that the state trie nodes can be retrieved based on hashes.
-func TestGetNodeData66(t *testing.T) { testGetNodeData(t, istanbul.Celo66) }
 func TestGetNodeData67(t *testing.T) { testGetNodeData(t, istanbul.Celo67) }
 
 func testGetNodeData(t *testing.T, protocol uint) {
@@ -449,15 +425,10 @@ func testGetNodeData(t *testing.T, protocol uint) {
 		}
 	}
 	it.Release()
-
-	if protocol <= istanbul.Celo66 {
-		p2p.Send(peer.app, GetNodeDataMsg, hashes)
-	} else {
-		p2p.Send(peer.app, GetNodeDataMsg, GetNodeDataPacket67{
-			RequestId:         123,
-			GetNodeDataPacket: hashes,
-		})
-	}
+	p2p.Send(peer.app, GetNodeDataMsg, GetNodeDataPacket67{
+		RequestId:         123,
+		GetNodeDataPacket: hashes,
+	})
 	msg, err := peer.app.ReadMsg()
 	if err != nil {
 		t.Fatalf("failed to read node data response: %v", err)
@@ -465,18 +436,14 @@ func testGetNodeData(t *testing.T, protocol uint) {
 	if msg.Code != NodeDataMsg {
 		t.Fatalf("response packet code mismatch: have %x, want %x", msg.Code, NodeDataMsg)
 	}
-	var data [][]byte
-	if protocol <= istanbul.Celo66 {
-		if err := msg.Decode(&data); err != nil {
-			t.Fatalf("failed to decode response node data: %v", err)
-		}
-	} else {
-		var res NodeDataPacket67
-		if err := msg.Decode(&res); err != nil {
-			t.Fatalf("failed to decode response node data: %v", err)
-		}
-		data = res.NodeDataPacket
+	var (
+		data [][]byte
+		res  NodeDataPacket67
+	)
+	if err := msg.Decode(&res); err != nil {
+		t.Fatalf("failed to decode response node data: %v", err)
 	}
+	data = res.NodeDataPacket
 	// Verify that all hashes correspond to the requested data, and reconstruct a state tree
 	for i, want := range hashes {
 		if hash := crypto.Keccak256Hash(data[i]); hash != want {
@@ -507,7 +474,6 @@ func testGetNodeData(t *testing.T, protocol uint) {
 }
 
 // Tests that the transaction receipts can be retrieved based on hashes.
-func TestGetBlockReceipts66(t *testing.T) { testGetBlockReceipts(t, istanbul.Celo66) }
 func TestGetBlockReceipts67(t *testing.T) { testGetBlockReceipts(t, istanbul.Celo67) }
 
 func testGetBlockReceipts(t *testing.T, protocol uint) {
@@ -559,21 +525,14 @@ func testGetBlockReceipts(t *testing.T, protocol uint) {
 		receipts = append(receipts, backend.chain.GetReceiptsByHash(block.Hash()))
 	}
 	// Send the hash request and verify the response
-	if protocol <= istanbul.Celo66 {
-		p2p.Send(peer.app, GetReceiptsMsg, hashes)
-		if err := p2p.ExpectMsg(peer.app, ReceiptsMsg, receipts); err != nil {
-			t.Errorf("receipts mismatch: %v", err)
-		}
-	} else {
-		p2p.Send(peer.app, GetReceiptsMsg, GetReceiptsPacket67{
-			RequestId:         123,
-			GetReceiptsPacket: hashes,
-		})
-		if err := p2p.ExpectMsg(peer.app, ReceiptsMsg, ReceiptsPacket67{
-			RequestId:      123,
-			ReceiptsPacket: receipts,
-		}); err != nil {
-			t.Errorf("receipts mismatch: %v", err)
-		}
+	p2p.Send(peer.app, GetReceiptsMsg, GetReceiptsPacket67{
+		RequestId:         123,
+		GetReceiptsPacket: hashes,
+	})
+	if err := p2p.ExpectMsg(peer.app, ReceiptsMsg, ReceiptsPacket67{
+		RequestId:      123,
+		ReceiptsPacket: receipts,
+	}); err != nil {
+		t.Errorf("receipts mismatch: %v", err)
 	}
 }

--- a/eth/protocols/eth/handshake_test.go
+++ b/eth/protocols/eth/handshake_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 // Tests that handshake failures are detected and reported correctly.
-func TestHandshake66(t *testing.T) { testHandshake(t, istanbul.Celo66) }
 func TestHandshake67(t *testing.T) { testHandshake(t, istanbul.Celo67) }
 
 func testHandshake(t *testing.T, protocol uint) {

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 
 	"github.com/celo-org/celo-blockchain/common"
-	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/p2p"
 	"github.com/celo-org/celo-blockchain/rlp"
@@ -110,9 +109,8 @@ func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter, txpool TxPool) *Pe
 	// Start up all the broadcasters
 	go peer.broadcastBlocks()
 	go peer.broadcastTransactions()
-	if version >= istanbul.Celo66 {
-		go peer.announceTransactions()
-	}
+	go peer.announceTransactions()
+
 	return peer
 }
 
@@ -260,22 +258,6 @@ func (p *Peer) AsyncSendPooledTransactionHashes(hashes []common.Hash) {
 	}
 }
 
-// SendPooledTransactionsRLP sends requested transactions to the peer and adds the
-// hashes in its transaction hash set for future reference.
-//
-// Note, the method assumes the hashes are correct and correspond to the list of
-// transactions being sent.
-func (p *Peer) SendPooledTransactionsRLP(hashes []common.Hash, txs []rlp.RawValue) error {
-	// Mark all the transactions as known, but ensure we don't overflow our limits
-	for p.knownTxs.Cardinality() > max(0, maxKnownTxs-len(hashes)) {
-		p.knownTxs.Pop()
-	}
-	for _, hash := range hashes {
-		p.knownTxs.Add(hash)
-	}
-	return p2p.Send(p.rw, PooledTransactionsMsg, txs) // Not packed into PooledTransactionsPacket to avoid RLP decoding
-}
-
 // ReplyPooledTransactionsRLP is the celo/67 (eth/66) version of SendPooledTransactionsRLP.
 func (p *Peer) ReplyPooledTransactionsRLP(id uint64, hashes []common.Hash, txs []rlp.RawValue) error {
 	// Mark all the transactions as known, but ensure we don't overflow our limits
@@ -354,23 +336,12 @@ func (p *Peer) AsyncSendNewBlock(block *types.Block, td *big.Int) {
 	}
 }
 
-// SendBlockHeaders sends a batch of block headers to the remote peer.
-func (p *Peer) SendBlockHeaders(headers []*types.Header) error {
-	return p2p.Send(p.rw, BlockHeadersMsg, BlockHeadersPacket(headers))
-}
-
 // ReplyBlockHeaders is the celo/67 (eth/66) version of SendBlockHeaders.
 func (p *Peer) ReplyBlockHeaders(id uint64, headers []*types.Header) error {
 	return p2p.Send(p.rw, BlockHeadersMsg, BlockHeadersPacket67{
 		RequestId:          id,
 		BlockHeadersPacket: headers,
 	})
-}
-
-// SendBlockBodiesRLP sends a batch of block contents to the remote peer from
-// an already RLP encoded format.
-func (p *Peer) SendBlockBodiesRLP(bodies []rlp.RawValue) error {
-	return p2p.Send(p.rw, BlockBodiesMsg, bodies) // Not packed into BlockBodiesPacket to avoid RLP decoding
 }
 
 // ReplyBlockBodiesRLP is the celo/67 (eth/66) version of SendBlockBodiesRLP.
@@ -382,24 +353,12 @@ func (p *Peer) ReplyBlockBodiesRLP(id uint64, bodies []rlp.RawValue) error {
 	})
 }
 
-// SendNodeDataRLP sends a batch of arbitrary internal data, corresponding to the
-// hashes requested.
-func (p *Peer) SendNodeData(data [][]byte) error {
-	return p2p.Send(p.rw, NodeDataMsg, NodeDataPacket(data))
-}
-
 // ReplyNodeData is the celo/67 (eth/66) response to GetNodeData.
 func (p *Peer) ReplyNodeData(id uint64, data [][]byte) error {
 	return p2p.Send(p.rw, NodeDataMsg, NodeDataPacket67{
 		RequestId:      id,
 		NodeDataPacket: data,
 	})
-}
-
-// SendReceiptsRLP sends a batch of transaction receipts, corresponding to the
-// ones requested from an already RLP encoded format.
-func (p *Peer) SendReceiptsRLP(receipts []rlp.RawValue) error {
-	return p2p.Send(p.rw, ReceiptsMsg, receipts) // Not packed into ReceiptsPacket to avoid RLP decoding
 }
 
 // ReplyReceiptsRLP is the celo/67 (eth/66) response to GetReceipts.
@@ -414,140 +373,104 @@ func (p *Peer) ReplyReceiptsRLP(id uint64, receipts []rlp.RawValue) error {
 // single header. It is used solely by the fetcher.
 func (p *Peer) RequestOneHeader(hash common.Hash) error {
 	p.Log().Debug("Fetching single header", "hash", hash)
-	query := GetBlockHeadersPacket{
-		Origin:  HashOrNumber{Hash: hash},
-		Amount:  uint64(1),
-		Skip:    uint64(0),
-		Reverse: false,
-	}
-	if p.Version() >= istanbul.Celo67 {
-		id := rand.Uint64()
+	id := rand.Uint64()
 
-		requestTracker.Track(p.id, p.version, GetBlockHeadersMsg, BlockHeadersMsg, id)
-		return p2p.Send(p.rw, GetBlockHeadersMsg, &GetBlockHeadersPacket67{
-			RequestId:             id,
-			GetBlockHeadersPacket: &query,
-		})
-	}
-	return p2p.Send(p.rw, GetBlockHeadersMsg, &query)
+	requestTracker.Track(p.id, p.version, GetBlockHeadersMsg, BlockHeadersMsg, id)
+	return p2p.Send(p.rw, GetBlockHeadersMsg, &GetBlockHeadersPacket67{
+		RequestId: id,
+		GetBlockHeadersPacket: &GetBlockHeadersPacket{
+			Origin:  HashOrNumber{Hash: hash},
+			Amount:  uint64(1),
+			Skip:    uint64(0),
+			Reverse: false,
+		},
+	})
 }
 
 // RequestHeadersByHash fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the hash of an origin block.
 func (p *Peer) RequestHeadersByHash(origin common.Hash, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromhash", origin, "skip", skip, "reverse", reverse)
-	query := GetBlockHeadersPacket{
-		Origin:  HashOrNumber{Hash: origin},
-		Amount:  uint64(amount),
-		Skip:    uint64(skip),
-		Reverse: reverse,
-	}
-	if p.Version() >= istanbul.Celo67 {
-		id := rand.Uint64()
+	id := rand.Uint64()
 
-		requestTracker.Track(p.id, p.version, GetBlockHeadersMsg, BlockHeadersMsg, id)
-		return p2p.Send(p.rw, GetBlockHeadersMsg, &GetBlockHeadersPacket67{
-			RequestId:             id,
-			GetBlockHeadersPacket: &query,
-		})
-	}
-	return p2p.Send(p.rw, GetBlockHeadersMsg, &query)
+	requestTracker.Track(p.id, p.version, GetBlockHeadersMsg, BlockHeadersMsg, id)
+	return p2p.Send(p.rw, GetBlockHeadersMsg, &GetBlockHeadersPacket67{
+		RequestId: id,
+		GetBlockHeadersPacket: &GetBlockHeadersPacket{
+			Origin:  HashOrNumber{Hash: origin},
+			Amount:  uint64(amount),
+			Skip:    uint64(skip),
+			Reverse: reverse,
+		},
+	})
 }
 
 // RequestHeadersByNumber fetches a batch of blocks' headers corresponding to the
 // specified header query, based on the number of an origin block.
 func (p *Peer) RequestHeadersByNumber(origin uint64, amount int, skip int, reverse bool) error {
 	p.Log().Debug("Fetching batch of headers", "count", amount, "fromnum", origin, "skip", skip, "reverse", reverse)
-	query := GetBlockHeadersPacket{
-		Origin:  HashOrNumber{Number: origin},
-		Amount:  uint64(amount),
-		Skip:    uint64(skip),
-		Reverse: reverse,
-	}
-	if p.Version() >= istanbul.Celo67 {
-		id := rand.Uint64()
+	id := rand.Uint64()
 
-		requestTracker.Track(p.id, p.version, GetBlockHeadersMsg, BlockHeadersMsg, id)
-		return p2p.Send(p.rw, GetBlockHeadersMsg, &GetBlockHeadersPacket67{
-			RequestId:             id,
-			GetBlockHeadersPacket: &query,
-		})
-	}
-	return p2p.Send(p.rw, GetBlockHeadersMsg, &query)
-}
-
-// ExpectRequestHeadersByNumber is a testing method to mirror the recipient side
-// of the RequestHeadersByNumber operation.
-func (p *Peer) ExpectRequestHeadersByNumber(origin uint64, amount int, skip int, reverse bool) error {
-	req := &GetBlockHeadersPacket{
-		Origin:  HashOrNumber{Number: origin},
-		Amount:  uint64(amount),
-		Skip:    uint64(skip),
-		Reverse: reverse,
-	}
-	return p2p.ExpectMsg(p.rw, GetBlockHeadersMsg, req)
+	requestTracker.Track(p.id, p.version, GetBlockHeadersMsg, BlockHeadersMsg, id)
+	return p2p.Send(p.rw, GetBlockHeadersMsg, &GetBlockHeadersPacket67{
+		RequestId: id,
+		GetBlockHeadersPacket: &GetBlockHeadersPacket{
+			Origin:  HashOrNumber{Number: origin},
+			Amount:  uint64(amount),
+			Skip:    uint64(skip),
+			Reverse: reverse,
+		},
+	})
 }
 
 // RequestBodies fetches a batch of blocks' bodies corresponding to the hashes
 // specified.
 func (p *Peer) RequestBodies(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of block bodies", "count", len(hashes))
-	if p.Version() >= istanbul.Celo67 {
-		id := rand.Uint64()
+	id := rand.Uint64()
 
-		requestTracker.Track(p.id, p.version, GetBlockBodiesMsg, BlockBodiesMsg, id)
-		return p2p.Send(p.rw, GetBlockBodiesMsg, &GetBlockBodiesPacket67{
-			RequestId:            id,
-			GetBlockBodiesPacket: hashes,
-		})
-	}
-	return p2p.Send(p.rw, GetBlockBodiesMsg, GetBlockBodiesPacket(hashes))
+	requestTracker.Track(p.id, p.version, GetBlockBodiesMsg, BlockBodiesMsg, id)
+	return p2p.Send(p.rw, GetBlockBodiesMsg, &GetBlockBodiesPacket67{
+		RequestId:            id,
+		GetBlockBodiesPacket: hashes,
+	})
 }
 
 // RequestNodeData fetches a batch of arbitrary data from a node's known state
 // data, corresponding to the specified hashes.
 func (p *Peer) RequestNodeData(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of state data", "count", len(hashes))
-	if p.Version() >= istanbul.Celo67 {
-		id := rand.Uint64()
+	id := rand.Uint64()
 
-		requestTracker.Track(p.id, p.version, GetNodeDataMsg, NodeDataMsg, id)
-		return p2p.Send(p.rw, GetNodeDataMsg, &GetNodeDataPacket67{
-			RequestId:         id,
-			GetNodeDataPacket: hashes,
-		})
-	}
-	return p2p.Send(p.rw, GetNodeDataMsg, GetNodeDataPacket(hashes))
+	requestTracker.Track(p.id, p.version, GetNodeDataMsg, NodeDataMsg, id)
+	return p2p.Send(p.rw, GetNodeDataMsg, &GetNodeDataPacket67{
+		RequestId:         id,
+		GetNodeDataPacket: hashes,
+	})
 }
 
 // RequestReceipts fetches a batch of transaction receipts from a remote node.
 func (p *Peer) RequestReceipts(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of receipts", "count", len(hashes))
-	if p.Version() >= istanbul.Celo67 {
-		id := rand.Uint64()
+	id := rand.Uint64()
 
-		requestTracker.Track(p.id, p.version, GetReceiptsMsg, ReceiptsMsg, id)
-		return p2p.Send(p.rw, GetReceiptsMsg, &GetReceiptsPacket67{
-			RequestId:         id,
-			GetReceiptsPacket: hashes,
-		})
-	}
-	return p2p.Send(p.rw, GetReceiptsMsg, GetReceiptsPacket(hashes))
+	requestTracker.Track(p.id, p.version, GetReceiptsMsg, ReceiptsMsg, id)
+	return p2p.Send(p.rw, GetReceiptsMsg, &GetReceiptsPacket67{
+		RequestId:         id,
+		GetReceiptsPacket: hashes,
+	})
 }
 
 // RequestTxs fetches a batch of transactions from a remote node.
 func (p *Peer) RequestTxs(hashes []common.Hash) error {
 	p.Log().Debug("Fetching batch of transactions", "count", len(hashes))
-	if p.Version() >= istanbul.Celo67 {
-		id := rand.Uint64()
+	id := rand.Uint64()
 
-		requestTracker.Track(p.id, p.version, GetPooledTransactionsMsg, PooledTransactionsMsg, id)
-		return p2p.Send(p.rw, GetPooledTransactionsMsg, &GetPooledTransactionsPacket67{
-			RequestId:                   id,
-			GetPooledTransactionsPacket: hashes,
-		})
-	}
-	return p2p.Send(p.rw, GetPooledTransactionsMsg, GetPooledTransactionsPacket(hashes))
+	requestTracker.Track(p.id, p.version, GetPooledTransactionsMsg, PooledTransactionsMsg, id)
+	return p2p.Send(p.rw, GetPooledTransactionsMsg, &GetPooledTransactionsPacket67{
+		RequestId:                   id,
+		GetPooledTransactionsPacket: hashes,
+	})
 }
 
 func (p *Peer) ReadMsg() (p2p.Msg, error) {

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -30,7 +30,6 @@ import (
 
 // Constants to match up protocol versions and messages
 const (
-	ETH65 = 65
 	ETH66 = 66
 )
 
@@ -40,27 +39,24 @@ const ProtocolName = "eth"
 
 // ProtocolVersions are the supported versions of the `eth` protocol (first
 // is primary).
-var ProtocolVersions = []uint{ETH66, ETH65}
+var ProtocolVersions = []uint{ETH66}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
 const maxMessageSize = 10 * 1024 * 1024
 
 const (
-	// Protocol messages in eth/64 (celo65)
-	StatusMsg          = 0x00
-	NewBlockHashesMsg  = 0x01
-	TransactionsMsg    = 0x02
-	GetBlockHeadersMsg = 0x03
-	BlockHeadersMsg    = 0x04
-	GetBlockBodiesMsg  = 0x05
-	BlockBodiesMsg     = 0x06
-	NewBlockMsg        = 0x07
-	GetNodeDataMsg     = 0x0d
-	NodeDataMsg        = 0x0e
-	GetReceiptsMsg     = 0x0f
-	ReceiptsMsg        = 0x10
-
-	// Protocol messages overloaded in eth/65 (celo66)
+	StatusMsg                     = 0x00
+	NewBlockHashesMsg             = 0x01
+	TransactionsMsg               = 0x02
+	GetBlockHeadersMsg            = 0x03
+	BlockHeadersMsg               = 0x04
+	GetBlockBodiesMsg             = 0x05
+	BlockBodiesMsg                = 0x06
+	NewBlockMsg                   = 0x07
+	GetNodeDataMsg                = 0x0d
+	NodeDataMsg                   = 0x0e
+	GetReceiptsMsg                = 0x0f
+	ReceiptsMsg                   = 0x10
 	NewPooledTransactionHashesMsg = 0x08
 	GetPooledTransactionsMsg      = 0x09
 	PooledTransactionsMsg         = 0x0a

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -18,33 +18,21 @@ package eth
 
 import (
 	"math/big"
-	"math/rand"
 	"sync/atomic"
 	"time"
 
 	"github.com/celo-org/celo-blockchain/common"
-	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/eth/downloader"
 	"github.com/celo-org/celo-blockchain/eth/protocols/eth"
 	"github.com/celo-org/celo-blockchain/log"
-	"github.com/celo-org/celo-blockchain/p2p/enode"
 )
 
 const (
 	forceSyncCycle      = 10 * time.Second // Time interval to force syncs, even if few peers are available
 	defaultMinSyncPeers = 5                // Amount of peers desired to start syncing
-
-	// This is the target size for the packs of transactions sent by txsyncLoop64.
-	// A pack can get larger than this if a single transactions exceeds this size.
-	txsyncPackSize = 100 * 1024
 )
-
-type txsync struct {
-	p   *eth.Peer
-	txs []*types.Transaction
-}
 
 // syncTransactions starts sending all currently pending transactions to the given peer.
 func (h *handler) syncTransactions(p *eth.Peer) {
@@ -65,96 +53,11 @@ func (h *handler) syncTransactions(p *eth.Peer) {
 	// The eth/65 (celo/66) protocol introduces proper transaction announcements, so instead
 	// of dripping transactions across multiple peers, just send the entire list as
 	// an announcement and let the remote side decide what they need (likely nothing).
-	if p.Version() >= istanbul.Celo66 {
-		hashes := make([]common.Hash, len(txs))
-		for i, tx := range txs {
-			hashes[i] = tx.Hash()
-		}
-		p.AsyncSendPooledTransactionHashes(hashes)
-		return
+	hashes := make([]common.Hash, len(txs))
+	for i, tx := range txs {
+		hashes[i] = tx.Hash()
 	}
-	// Out of luck, peer is running legacy protocols, drop the txs over
-	select {
-	case h.txsyncCh <- &txsync{p: p, txs: txs}:
-	case <-h.quitSync:
-	}
-}
-
-// Needed for eth/64 (celo/65).  With eth/65+ (celo/66+), this runs but
-// won't get any messages through pm.txsyncCh and so won't do anything.
-// txsyncLoop64 takes care of the initial transaction sync for each new
-// connection. When a new peer appears, we relay all currently pending
-// transactions. In order to minimise egress bandwidth usage, we send
-// the transactions in small packs to one peer at a time.
-func (h *handler) txsyncLoop64() {
-	defer h.wg.Done()
-
-	var (
-		pending = make(map[enode.ID]*txsync)
-		sending = false               // whether a send is active
-		pack    = new(txsync)         // the pack that is being sent
-		done    = make(chan error, 1) // result of the send
-	)
-
-	// send starts a sending a pack of transactions from the sync.
-	send := func(s *txsync) {
-		if s.p.Version() >= istanbul.Celo66 {
-			panic("initial transaction syncer running on eth/65+ (celo/66+)")
-		}
-		// Fill pack with transactions up to the target size.
-		size := common.StorageSize(0)
-		pack.p = s.p
-		pack.txs = pack.txs[:0]
-		for i := 0; i < len(s.txs) && size < txsyncPackSize; i++ {
-			pack.txs = append(pack.txs, s.txs[i])
-			size += s.txs[i].Size()
-		}
-		// Remove the transactions that will be sent.
-		s.txs = s.txs[:copy(s.txs, s.txs[len(pack.txs):])]
-		if len(s.txs) == 0 {
-			delete(pending, s.p.Peer.ID())
-		}
-		// Send the pack in the background.
-		s.p.Log().Trace("Sending batch of transactions", "count", len(pack.txs), "bytes", size)
-		sending = true
-		go func() { done <- pack.p.SendTransactions(pack.txs) }()
-	}
-	// pick chooses the next pending sync.
-	pick := func() *txsync {
-		if len(pending) == 0 {
-			return nil
-		}
-		n := rand.Intn(len(pending)) + 1
-		for _, s := range pending {
-			if n--; n == 0 {
-				return s
-			}
-		}
-		return nil
-	}
-
-	for {
-		select {
-		case s := <-h.txsyncCh:
-			pending[s.p.Peer.ID()] = s
-			if !sending {
-				send(s)
-			}
-		case err := <-done:
-			sending = false
-			// Stop tracking peers that cause send failures.
-			if err != nil {
-				pack.p.Log().Debug("Transaction send failed", "err", err)
-				delete(pending, pack.p.Peer.ID())
-			}
-			// Schedule the next send.
-			if s := pick(); s != nil {
-				send(s)
-			}
-		case <-h.quitSync:
-			return
-		}
-	}
+	p.AsyncSendPooledTransactionHashes(hashes)
 }
 
 // chainSyncer coordinates blockchain sync components.

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 // Tests that fast sync is disabled after a successful sync cycle.
-func TestFastSyncDisabling66(t *testing.T) { testFastSyncDisabling(t, istanbul.Celo66) }
 func TestFastSyncDisabling67(t *testing.T) { testFastSyncDisabling(t, istanbul.Celo67) }
 
 // Tests that fast sync gets disabled as soon as a real block is successfully

--- a/les/client_handler.go
+++ b/les/client_handler.go
@@ -610,7 +610,7 @@ func (d *downloaderPeerNotify) registerPeer(p *serverPeer) {
 		handler: h,
 		peer:    p,
 	}
-	h.downloader.RegisterLightPeer(p.id, istanbul.Celo66, pc)
+	h.downloader.RegisterLightPeer(p.id, istanbul.Celo67, pc)
 }
 
 func (d *downloaderPeerNotify) unregisterPeer(p *serverPeer) {


### PR DESCRIPTION
This PR merges upstream commit: https://github.com/ethereum/go-ethereum/commit/d3f018fde839fa7ee3fb5eeb14a9eb7e34870636

Since it is critical enough, I'd rather merge this individually instead of merging it with the whole 1.10.8 minor.

// Should not be squashed, to preserve the upstream commit metadata