### PR TITLE
Gas Inflation Rate flag

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -194,6 +194,7 @@ var (
 		utils.IPCDisabledFlag,
 		utils.IPCPathFlag,
 		utils.InsecureUnlockAllowedFlag,
+		utils.RPCGlobalGasInflationRateFlag,
 		utils.RPCGlobalGasCapFlag,
 		utils.RPCGlobalTxFeeCapFlag,
 	}

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -139,6 +139,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.GraphQLEnabledFlag,
 			utils.GraphQLCORSDomainFlag,
 			utils.GraphQLVirtualHostsFlag,
+			utils.RPCGlobalGasInflationRateFlag,
 			utils.RPCGlobalGasCapFlag,
 			utils.RPCGlobalTxFeeCapFlag,
 			utils.JSpathFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -444,6 +444,11 @@ var (
 		Name:  "allow-insecure-unlock",
 		Usage: "Allow insecure account unlocking when account-related RPCs are exposed by http",
 	}
+	RPCGlobalGasInflationRateFlag = cli.Float64Flag{
+		Name:  "rpc.gasinflationrate",
+		Usage: "Multiplier applied to the gasEstimation rpc call (1 = gasEstimation, 1.3 = gasEstimation + 30%, etc. Defaults to 1.3)",
+		Value: ethconfig.Defaults.RPCGasInflationRate,
+	}
 	RPCGlobalGasCapFlag = cli.Uint64Flag{
 		Name:  "rpc.gascap",
 		Usage: "Sets a cap on gas that can be used in eth_call/estimateGas (0=infinite)",
@@ -1741,6 +1746,14 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		// TODO(fjl): force-enable this in --dev mode
 		cfg.EnablePreimageRecording = ctx.GlobalBool(VMEnableDebugFlag.Name)
 	}
+
+	if ctx.GlobalIsSet(RPCGlobalGasInflationRateFlag.Name) {
+		cfg.RPCGasInflationRate = ctx.GlobalFloat64(RPCGlobalGasInflationRateFlag.Name)
+	}
+	if cfg.RPCGasInflationRate < 1 {
+		Fatalf("The inflation rate shouldn't be less than 1: %f", cfg.RPCGasInflationRate)
+	}
+	log.Info("Set global gas inflation rate", "rate", cfg.RPCGasInflationRate)
 
 	if ctx.GlobalIsSet(RPCGlobalGasCapFlag.Name) {
 		cfg.RPCGasCap = ctx.GlobalUint64(RPCGlobalGasCapFlag.Name)

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -364,6 +364,10 @@ func (b *EthAPIBackend) UnprotectedAllowed() bool {
 	return b.allowUnprotectedTxs
 }
 
+func (b *EthAPIBackend) RPCGasInflationRate() float64 {
+	return b.eth.config.RPCGasInflationRate
+}
+
 func (b *EthAPIBackend) RPCGasCap() uint64 {
 	return b.eth.config.RPCGasCap
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -141,6 +141,10 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if err := pruner.RecoverPruning(stack.ResolvePath(""), chainDb, stack.ResolvePath(config.TrieCleanCacheJournal)); err != nil {
 		log.Error("Failed to recover state", "error", err)
 	}
+	if config.RPCGasInflationRate == 0 {
+		// if it was not set, default it as 1
+		config.RPCGasInflationRate = 1
+	}
 	eth := &Ethereum{
 		config:            config,
 		chainDb:           chainDb,

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -53,9 +53,10 @@ var Defaults = Config{
 	SnapshotCache:           102,
 	GatewayFee:              big.NewInt(0),
 
-	TxPool:      core.DefaultTxPoolConfig,
-	RPCGasCap:   25000000,
-	RPCTxFeeCap: 500, // 500 celo
+	TxPool:              core.DefaultTxPoolConfig,
+	RPCGasInflationRate: 1.3,
+	RPCGasCap:           25000000,
+	RPCTxFeeCap:         500, // 500 celo
 
 	Istanbul: *istanbul.DefaultConfig,
 }
@@ -134,6 +135,9 @@ type Config struct {
 
 	// Miscellaneous options
 	DocRoot string `toml:"-"`
+
+	// RPCGasInflationRate is a global multiplier applied to the gas estimations
+	RPCGasInflationRate float64
 
 	// RPCGasCap is the global gas cap for eth-call variants.
 	RPCGasCap uint64

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -56,6 +56,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		EnablePreimageRecording bool
 		Istanbul                istanbul.Config
 		DocRoot                 string `toml:"-"`
+		RPCGasInflationRate     float64
 		RPCGasCap               uint64
 		RPCTxFeeCap             float64
 		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
@@ -102,6 +103,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.EnablePreimageRecording = c.EnablePreimageRecording
 	enc.Istanbul = c.Istanbul
 	enc.DocRoot = c.DocRoot
+	enc.RPCGasInflationRate = c.RPCGasInflationRate
 	enc.RPCGasCap = c.RPCGasCap
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
 	enc.Checkpoint = c.Checkpoint
@@ -152,6 +154,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		EnablePreimageRecording *bool
 		Istanbul                *istanbul.Config
 		DocRoot                 *string `toml:"-"`
+		RPCGasInflationRate     *float64
 		RPCGasCap               *uint64
 		RPCTxFeeCap             *float64
 		Checkpoint              *params.TrustedCheckpoint      `toml:",omitempty"`
@@ -278,6 +281,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.DocRoot != nil {
 		c.DocRoot = *dec.DocRoot
+	}
+	if dec.RPCGasInflationRate != nil {
+		c.RPCGasInflationRate = *dec.RPCGasInflationRate
 	}
 	if dec.RPCGasCap != nil {
 		c.RPCGasCap = *dec.RPCGasCap

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -122,6 +122,10 @@ func (b *testBackend) GetTransaction(ctx context.Context, txHash common.Hash) (*
 	return tx, hash, blockNumber, index, nil
 }
 
+func (b *testBackend) RPCGasInflationRate() float64 {
+	return 1
+}
+
 func (b *testBackend) RPCGasCap() uint64 {
 	return 25000000
 }

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -247,6 +247,7 @@ func createGQLService(t *testing.T, stack *node.Node) {
 		TrieDirtyCache:          5,
 		TrieTimeout:             60 * time.Minute,
 		SnapshotCache:           5,
+		RPCGasInflationRate:     1,
 	}
 	ethConf.Genesis.Config.Faker = true
 	ethBackend, err := eth.New(stack, ethConf)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1013,7 +1013,8 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 			return 0, fmt.Errorf("gas required exceeds allowance (%d)", cap)
 		}
 	}
-	return hexutil.Uint64(hi), nil
+	inflatedGas := hexutil.Uint64(uint64(float64(hi) * b.RPCGasInflationRate()))
+	return inflatedGas, nil
 }
 
 // EstimateGas returns an estimate of the amount of gas needed to execute the

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -48,9 +48,10 @@ type Backend interface {
 	ChainDb() ethdb.Database
 	AccountManager() *accounts.Manager
 	ExtRPCEnabled() bool
-	RPCGasCap() uint64        // global gas cap for eth_call over rpc: DoS protection
-	RPCTxFeeCap() float64     // global tx fee cap for all transaction related APIs
-	UnprotectedAllowed() bool // allows only for EIP155 transactions.
+	RPCGasInflationRate() float64 // global multiplier applied to the gas estimations
+	RPCGasCap() uint64            // global gas cap for eth_call over rpc: DoS protection
+	RPCTxFeeCap() float64         // global tx fee cap for all transaction related APIs
+	UnprotectedAllowed() bool     // allows only for EIP155 transactions.
 
 	// Blockchain API
 	SetHead(number uint64)

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -338,6 +338,10 @@ func (b *LesApiBackend) UnprotectedAllowed() bool {
 	return b.allowUnprotectedTxs
 }
 
+func (b *LesApiBackend) RPCGasInflationRate() float64 {
+	return b.eth.config.RPCGasInflationRate
+}
+
 func (b *LesApiBackend) RPCGasCap() uint64 {
 	return b.eth.config.RPCGasCap
 }


### PR DESCRIPTION
### Description

Adding a gas inflation rate flag, to multiply the gas estimations from the rpc call.
This aims to mitigate the gas estimation bug until we found the actual fix for it

### Tested

Run tests

### Backwards compatibility

Yes