### PR TITLE
Update contracts release for new e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
   # Use this git tag or commit of the monorepo to build the system contracts.
   system-contracts-monorepo-version:
     type: string
-    default: "celo-core-contracts-v3.rc0"
+    default: "core-contracts.v6"
   system-contracts-path:
     type: string
     default: "compiled-system-contracts"

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ else
 	OS = linux
 endif
 
-MONOREPO_COMMIT=celo-core-contracts-v3.rc0
+MONOREPO_COMMIT=core-contracts.v6
 
 # We checkout the monorepo as a sibling to the celo-blockchain dir because the
 # huge amount of files in the monorepo interferes with tooling such as gopls,


### PR DESCRIPTION
Updates the contracts release that is built by make-prepare-system
contracts to be core-contracts.v6, this is what defines the contracts
version that our e2e tests under ./e2e_test will use.

Currently it seems that we can no longer build the previous version,
because it contained dependencies that tried to access github
through the insecure git protocol, which github retired on the 15th
of March.
