### PR TITLE
Ensure CI doesn't use deprecated git protocol

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,11 @@ jobs:
           command: |
             set -e
             if [ ! -d <<pipeline.parameters.system-contracts-path>> ]; then
+              # Github is phasing out the git protocol so we ensure that we use
+              # https for all git operations that yarn may perform. Yarn is used by
+              # the prepare-system-contracts make rule since it partially builds celo-monorepo.
+              git config --global url."https://github.com".insteadOf git://github.com
+
               mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
               make prepare-system-contracts MONOREPO_COMMIT=<<pipeline.parameters.system-contracts-monorepo-version>>
             fi


### PR DESCRIPTION
Ensure the deprecated git protocol is not used when preparing the system
contracts.

### Tested

Indirectly tested, builds of our latest release branch were failing because the `checkout-monorepo` job was being executed without the git config provided here, on master the config exists for `checkout-monorepo` so that is not failing and the cache is currently being used for preparing the system contracts so that is also not failing. But I believe it would fail if the cache was not used.