### PR TITLE
Remove unused methods in evmRunnerContext interface

### DIFF
--- a/core/vm/vmcontext/runner.go
+++ b/core/vm/vmcontext/runner.go
@@ -4,7 +4,6 @@ import (
 	"math/big"
 
 	"github.com/celo-org/celo-blockchain/common"
-	"github.com/celo-org/celo-blockchain/core/state"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/core/vm"
 )
@@ -18,10 +17,6 @@ type evmRunnerContext interface {
 
 	// GetVMConfig returns the node's vm configuration
 	GetVMConfig() *vm.Config
-
-	CurrentHeader() *types.Header
-
-	State() (*state.StateDB, error)
 }
 
 type evmRunner struct {


### PR DESCRIPTION
### Description

Removed two unused methods in the evmRunnerContext interface in order to implement it more easily. e.g. in `cmd/evm/execution.go`

### Other changes

None

### Tested

N/A

### Backwards compatibility

Yes
