### PR TITLE
p2p: define DiscReason as uint8 (#1886)

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -393,11 +393,11 @@ func (p *Peer) handle(msg Msg) error {
 		msg.Discard()
 		go SendItems(p.rw, pongMsg)
 	case msg.Code == discMsg:
-		var reason [1]DiscReason
 		// This is the last message. We don't need to discard or
 		// check errors because, the connection will be closed after it.
-		rlp.Decode(msg.Payload, &reason)
-		return reason[0]
+		var m struct{ R DiscReason }
+		rlp.Decode(msg.Payload, &m)
+		return m.R
 	case msg.Code < baseProtocolLength:
 		// ignore other base protocol messages
 		return msg.Discard()

--- a/p2p/peer_error.go
+++ b/p2p/peer_error.go
@@ -54,7 +54,7 @@ func (pe *peerError) Error() string {
 
 var errProtocolReturned = errors.New("protocol returned")
 
-type DiscReason uint
+type DiscReason uint8
 
 const (
 	DiscRequested DiscReason = iota


### PR DESCRIPTION
Cherry picking this to `release/1.5.x` from  our master originally from
upstream PR (#24507) 

All other implementations store disconnect reasons as a single byte,
so go-ethereum should do it too.

Co-authored-by: Felix Lange <fjl@twurst.com>