### PR TITLE
Update core system contracts for new e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,17 +4,14 @@ parameters:
   system-contracts-cache-version:
     type: integer
     default: 1
-  # Use this git tag or commit of the monorepo to build the system contracts.
-  system-contracts-monorepo-version:
-    type: string
-    default: "celo-core-contracts-v3.rc0"
   system-contracts-path:
     type: string
     default: "compiled-system-contracts"
   system-contracts-executor-image:
     type: string
-      # The system contracts executor needs node 10 to function, this should
-      # only be changed when system-contracts-monorepo-version is changed.
+      # The system contracts executor curr ently needs node 10 to function,
+      # this should only be changed when the version in `monorepo_commit` is
+      # changed.
     default: "celohq/node10-gcloud:v3"
 executors:
   golang:
@@ -81,7 +78,7 @@ jobs:
     parameters:
       cache-key:
         type: string
-        default: system-contracts-cache-<<pipeline.parameters.system-contracts-monorepo-version>>-<<pipeline.parameters.system-contracts-path>>-v<<pipeline.parameters.system-contracts-cache-version>>-<<pipeline.parameters.system-contracts-executor-image>>
+        default: system-contracts-cache-{{ checksum "monorepo_commit" }}-<<pipeline.parameters.system-contracts-path>>-v<<pipeline.parameters.system-contracts-cache-version>>-<<pipeline.parameters.system-contracts-executor-image>>
     executor: system-contracts-executor
     resource_class: medium+
     steps:
@@ -106,7 +103,7 @@ jobs:
               git config --global url."https://github.com".insteadOf git://github.com
 
               mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-              make prepare-system-contracts MONOREPO_COMMIT=<<pipeline.parameters.system-contracts-monorepo-version>>
+              make prepare-system-contracts 
             fi
       - save_cache:
           key: <<parameters.cache-key>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,10 @@ parameters:
     default: "compiled-system-contracts"
   system-contracts-executor-image:
     type: string
-      # The system contracts executor curr ently needs node 10 to function,
+      # The system contracts executor currently needs node 12 to function,
       # this should only be changed when the version in `monorepo_commit` is
       # changed.
-    default: "celohq/node10-gcloud:v3"
+    default: "us.gcr.io/celo-testnet/circleci-node12:1.0.0"
 executors:
   golang:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 .PHONY: geth-linux-arm geth-linux-arm-5 geth-linux-arm-6 geth-linux-arm-7 geth-linux-arm64
 .PHONY: geth-darwin geth-darwin-amd64
 .PHONY: geth-windows geth-windows-386 geth-windows-amd64
-.PHONY: prepare-system-contracts $(MONOREPO_PATH)
+.PHONY: prepare-system-contracts
 
 GOBIN = ./build/bin
 GO ?= latest
@@ -62,8 +62,13 @@ $(MONOREPO_PATH)/packages/protocol/build: $(CONTRACT_SOURCE_FILES)
 	@cd $(MONOREPO_PATH) && rm -rf packages/protocol/build && yarn && cd packages/protocol && yarn run build:sol
 
 
-# The source files depend on the MONOREPO_PATH rule to ensure that the monorepo is
-# checked out before we try to build.
+# This target serves as an intermediate step to avoid running the
+# $(MONOREPO_PATH) target once per contract source file.  This could also be
+# achieved by using the group targets separator '&:' instead of just ':', but
+# that functionality was added in make version 4.3 which doesn't seem to be
+# readily available on most systems yet. So although this rule will be run once
+# for each source file, since it is empty that is very quick. $(MONOREPO_PATH)
+# as a prerequisite of this will be run at most onece.
 $(CONTRACT_SOURCE_FILES): $(MONOREPO_PATH)
 
 # Clone the monorepo.

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ prepare-system-contracts: $(MONOREPO_PATH)/packages/protocol/build
 # build dir or the build dir does not exist then we remove the build dir, yarn
 # install and rebuild the contracts.
 $(MONOREPO_PATH)/packages/protocol/build: $(CONTRACT_SOURCE_FILES)
-	@node --version | grep "^v10" || (echo "node v10 is required to build the monorepo (nvm use 10)" && exit 1)
+	@node --version | grep "^v12" || (echo "node v12 is required to build the monorepo (nvm use 12)" && exit 1)
 	@echo Running yarn install and compiling contracts
 	@cd $(MONOREPO_PATH) && rm -rf packages/protocol/build && yarn && cd packages/protocol && yarn run build:sol
 

--- a/README.md
+++ b/README.md
@@ -59,28 +59,29 @@ The Celo blockchain client comes with several wrappers/executables found in the 
 ## Running tests
 
 Prior to running tests you will need to run `make prepare-system-contracts`.
-This will checkout the celo-monorepo and compile the system contracts for use
-in full network tests. The rule will copy the compiled contracts from
-celo-monorepo to `compiled-system-contracts`. If you subsequently edit the
-system contracts source, running the make rule again will re-compile them and
-copy them into place.
+This will checkout the
+[celo-monorepo](https://github.com/celo-org/celo-monorepo) under
+`../.celo-blockchain-monorepo-checkout` relative to this project's root at the
+commit defined in the file `monorepo_commit`. Then it will compile the system
+contracts for use in full network tests. The rule will copy the compiled
+contracts from celo-monorepo to `compiled-system-contracts`. If you
+subsequently edit the system contracts source or `monorepo_commit`, running the
+make rule again will re-checkout the monorepo, re-compile the contracts and
+copy them into place. 
 
 This make rule will shallow checkout
 [celo-monorepo](https://github.com/celo-org/celo-monorepo) under
-`../.celo-blockchain-monorepo-checkout` relative to this project's root, and it
-will checkout the commit defined in the variable MONOREPO_COMMIT in the
-Makefile. 
+`../.celo-blockchain-monorepo-checkout` relative to this project's root.
 
-These values can be overridden if required, by setting those variables in the
+This value can be overridden if required, by setting it in the
 make command, for example:
 ```
-make prepare-system-contracts MONOREPO_COMMIT=master MONOREPO_PATH=../alt-monorepo
-```
+make prepare-system-contracts MONOREPO_PATH=../alt-monorepo
+``` 
 
 Without first running this make rule, certain tests will fail with errors such
 as:
 
-```
 panic: Can't read bytecode for monorepo/packages/protocol/build/contracts/FixidityLib.json: open
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,20 @@ subsequently edit the system contracts source or `monorepo_commit`, running the
 make rule again will re-checkout the monorepo, re-compile the contracts and
 copy them into place. 
 
-The checkout location  can be overridden if required, by setting it in the
-make command, for example:
+In the case that you would like to change the default monorepo checkout
+location, or that you would like to have multipe checkouts of the monorepo (at
+different versions) you can set the `MONOREPO_PATH` variable in the make
+command, for example:
+
 ```
 make prepare-system-contracts MONOREPO_PATH=../alt-monorepo
-``` 
+
+```
+Note that `MONOREPO_PATH` should not be set to point at checkouts other than
+those checked out by the `prepare-system-contracts` rule, and the checkouts
+created by the `prepare-system-contracts` rule should not be manually modifed,
+aside from changing the contract source.
+
 
 Without first running this make rule, certain tests will fail.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The Celo blockchain client comes with several wrappers/executables found in the 
 ## Running tests
 
 Prior to running tests you will need to run `make prepare-system-contracts`.
-This will checkout the
+This will shallow checkout the
 [celo-monorepo](https://github.com/celo-org/celo-monorepo) under
 `../.celo-blockchain-monorepo-checkout` relative to this project's root at the
 commit defined in the file `monorepo_commit`. Then it will compile the system
@@ -69,11 +69,7 @@ subsequently edit the system contracts source or `monorepo_commit`, running the
 make rule again will re-checkout the monorepo, re-compile the contracts and
 copy them into place. 
 
-This make rule will shallow checkout
-[celo-monorepo](https://github.com/celo-org/celo-monorepo) under
-`../.celo-blockchain-monorepo-checkout` relative to this project's root.
-
-This value can be overridden if required, by setting it in the
+The checkout location  can be overridden if required, by setting it in the
 make command, for example:
 ```
 make prepare-system-contracts MONOREPO_PATH=../alt-monorepo

--- a/README.md
+++ b/README.md
@@ -79,11 +79,7 @@ make command, for example:
 make prepare-system-contracts MONOREPO_PATH=../alt-monorepo
 ``` 
 
-Without first running this make rule, certain tests will fail with errors such
-as:
-
-panic: Can't read bytecode for monorepo/packages/protocol/build/contracts/FixidityLib.json: open
-```
+Without first running this make rule, certain tests will fail.
 
 ## Running Celo
 

--- a/monorepo_commit
+++ b/monorepo_commit
@@ -1,1 +1,1 @@
-celo-core-contracts-v3.rc0
+core-contracts.v6

--- a/monorepo_commit
+++ b/monorepo_commit
@@ -1,0 +1,1 @@
+celo-core-contracts-v3.rc0


### PR DESCRIPTION
### Description

The tests under `./e2e_test` were running against the system
contracts at version `celo-core-contracts-v3.rc0`, this PR updates
that version to be `core-contracts.v6` (because that is the most recently deployed version) .

Please test this by running `make prepare-system-contracts` and checking that the monorepo checkout (normally under `../.celo-blockchain-monorepo-checkout` relative to the `celo-blockchain` root) is set to version `core-contracts.v6` and that the contracts under `./compiled-system-contracts` have been updated and then run the new e2e tests `go test ./e2e_test` and check that they pass.

You will need node v12 installed for this to work, which is a change from the previous requirement of v10.

### Other changes

The make rule `prepare-system-contracts` was broken and didn't
build new versions when the target version was changed. The mechanism
for setting the version has been changed, it is now stored in a file 
(`monorepo_commit`) at the repo root, and the make rule will now rebuild
the contracts if the version in this file is changed.

CI and the README have been updated accordingly.

### Backwards compatibility

This just changes how we run our tests.
