### PR TITLE
Ensure copy of state used to generate block context

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -621,7 +621,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 		if err != nil {
 			return nil, err
 		}
-		sysCtx = core.NewSysContractCallCtx2(block.Header(), sysStateDB, b.blockchain)
+		sysCtx = core.NewSysContractCallCtx(block.Header(), sysStateDB, b.blockchain)
 	}
 	return core.NewStateTransition(vmEnv, msg, gasPool, vmRunner, sysCtx).TransitionDb()
 }

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -621,8 +621,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 		if err != nil {
 			return nil, err
 		}
-		sysVmRunner := b.blockchain.NewEVMRunner(block.Header(), sysStateDB)
-		sysCtx = core.NewSysContractCallCtx(sysVmRunner)
+		sysCtx = core.NewSysContractCallCtx2(block.Header(), sysStateDB, b.blockchain)
 	}
 	return core.NewStateTransition(vmEnv, msg, gasPool, vmRunner, sysCtx).TransitionDb()
 }

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -62,7 +62,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 	byzantium := p.config.IsByzantium(block.Number())
 	espresso := p.bc.chainConfig.IsEspresso(block.Number())
 	if espresso {
-		sysCtx = NewSysContractCallCtx2(header, statedb, p.bc)
+		sysCtx = NewSysContractCallCtx(header, statedb, p.bc)
 	}
 	for i, tx := range block.Transactions() {
 		// If block precaching was interrupted, abort
@@ -104,7 +104,7 @@ func precacheTransaction(config *params.ChainConfig, bc *BlockChain, author *com
 
 	var sysCtx *SysContractCallCtx
 	if config.IsEspresso(header.Number) {
-		sysCtx = NewSysContractCallCtx2(header, statedb, bc)
+		sysCtx = NewSysContractCallCtx(header, statedb, bc)
 	}
 	_, err = ApplyMessage(vm, msg, gaspool, bc.NewEVMRunner(header, statedb), sysCtx)
 	return err

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -62,7 +62,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 	byzantium := p.config.IsByzantium(block.Number())
 	espresso := p.bc.chainConfig.IsEspresso(block.Number())
 	if espresso {
-		sysCtx = NewSysContractCallCtx(p.bc.NewEVMRunner(header, statedb))
+		sysCtx = NewSysContractCallCtx2(header, statedb, p.bc)
 	}
 	for i, tx := range block.Transactions() {
 		// If block precaching was interrupted, abort
@@ -104,8 +104,7 @@ func precacheTransaction(config *params.ChainConfig, bc *BlockChain, author *com
 
 	var sysCtx *SysContractCallCtx
 	if config.IsEspresso(header.Number) {
-		sysVmRunner := bc.NewEVMRunner(header, statedb)
-		sysCtx = NewSysContractCallCtx(sysVmRunner)
+		sysCtx = NewSysContractCallCtx2(header, statedb, bc)
 	}
 	_, err = ApplyMessage(vm, msg, gaspool, bc.NewEVMRunner(header, statedb), sysCtx)
 	return err

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -86,7 +86,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		sysCtx  *SysContractCallCtx
 	)
 	if p.bc.Config().IsEspresso(blockNumber) {
-		sysCtx = NewSysContractCallCtx2(header, statedb, p.bc)
+		sysCtx = NewSysContractCallCtx(header, statedb, p.bc)
 		if p.bc.Config().Faker {
 			sysCtx = MockSysContractCallCtx()
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -86,8 +86,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		sysCtx  *SysContractCallCtx
 	)
 	if p.bc.Config().IsEspresso(blockNumber) {
-		sysVmRunner := p.bc.NewEVMRunner(header, statedb)
-		sysCtx = NewSysContractCallCtx(sysVmRunner)
+		sysCtx = NewSysContractCallCtx2(header, statedb, p.bc)
 		if p.bc.Config().Faker {
 			sysCtx = MockSysContractCallCtx()
 		}

--- a/core/sys_context.go
+++ b/core/sys_context.go
@@ -7,6 +7,8 @@ import (
 	"github.com/celo-org/celo-blockchain/contracts/blockchain_parameters"
 	"github.com/celo-org/celo-blockchain/contracts/currency"
 	"github.com/celo-org/celo-blockchain/contracts/gasprice_minimum"
+	"github.com/celo-org/celo-blockchain/core/state"
+	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/core/vm"
 )
 
@@ -46,6 +48,16 @@ func NewSysContractCallCtx(vmRunner vm.EVMRunner) (sc *SysContractCallCtx) {
 	}
 
 	return
+}
+
+type runnerFactory interface {
+	NewEVMRunner(*types.Header, vm.StateDB) vm.EVMRunner
+}
+
+// NewSysContractCallCtx2 creates the SysContractCallCtx object and makes the contract calls.
+func NewSysContractCallCtx2(header *types.Header, state *state.StateDB, factory runnerFactory) (sc *SysContractCallCtx) {
+	vmRunner := factory.NewEVMRunner(header, state.Copy())
+	return NewSysContractCallCtx(vmRunner)
 }
 
 // GetIntrinsicGasForAlternativeFeeCurrency retrieves intrinsic gas for non-native fee currencies.

--- a/core/sys_context.go
+++ b/core/sys_context.go
@@ -12,11 +12,12 @@ import (
 	"github.com/celo-org/celo-blockchain/core/vm"
 )
 
-// SysContractCallCtx represents a system contract call context for a given block (represented by vm.EVMRunner).
-// It MUST sit on the header.Root of a block, which is parent of the block we intend to deal with.
+// SysContractCallCtx acts as a cache holding information obtained through
+// system contract calls to be used during block processing.
 type SysContractCallCtx struct {
-	whitelistedCurrencies     map[common.Address]struct{}
-	gasForAlternativeCurrency uint64
+	whitelistedCurrencies map[common.Address]struct{}
+	// The gas required for a non celo (cUSD, cEUR, ...) transfer.
+	nonCeloCurrencyIntrinsicGas uint64
 	// gasPriceMinimums stores values for whitelisted currencies keyed by their contract address
 	// Note that native token(CELO) is keyed by common.ZeroAddress
 	gasPriceMinimums GasPriceMinimums
@@ -28,9 +29,16 @@ type runnerFactory interface {
 	NewEVMRunner(*types.Header, vm.StateDB) vm.EVMRunner
 }
 
-// NewSysContractCallCtx creates the SysContractCallCtx object and makes the
-// contract calls. It copies the provided state before operating on it, so the
-// provided state is not modified.
+// NewSysContractCallCtx returns a SysContractCallCtx filled with data obtained
+// by calling the relevant system contracts.  This is a read only operation, no
+// state changing operations should be performed here. The provided header and
+// state should be for the parent of the block to be processed, in normal
+// operation that will be the head block.
+//
+// Since geth introduced the access list, even read only contract calls modify
+// the state (by adding to the access list) as such the provided state is
+// copied to ensure that the state provided by the caller is not modified by
+// this operation.
 func NewSysContractCallCtx(header *types.Header, state *state.StateDB, factory runnerFactory) (sc *SysContractCallCtx) {
 	vmRunner := factory.NewEVMRunner(header, state.Copy())
 	sc = &SysContractCallCtx{
@@ -38,7 +46,7 @@ func NewSysContractCallCtx(header *types.Header, state *state.StateDB, factory r
 		gasPriceMinimums:      make(map[common.Address]*big.Int),
 	}
 	// intrinsic gas
-	sc.gasForAlternativeCurrency = blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrencyOrDefault(vmRunner)
+	sc.nonCeloCurrencyIntrinsicGas = blockchain_parameters.GetIntrinsicGasForAlternativeFeeCurrencyOrDefault(vmRunner)
 	// whitelist
 	whiteListedArr, err := currency.CurrencyWhitelist(vmRunner)
 	if err != nil {
@@ -60,7 +68,7 @@ func NewSysContractCallCtx(header *types.Header, state *state.StateDB, factory r
 
 // GetIntrinsicGasForAlternativeFeeCurrency retrieves intrinsic gas for non-native fee currencies.
 func (sc *SysContractCallCtx) GetIntrinsicGasForAlternativeFeeCurrency() uint64 {
-	return sc.gasForAlternativeCurrency
+	return sc.nonCeloCurrencyIntrinsicGas
 }
 
 // IsWhitelisted indicates if the fee currency is whitelisted, or it's native token(CELO).

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1372,7 +1372,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	gasPriceMinimumFloor, _ := gpm.GetGasPriceMinimumFloor(pool.currentVMRunner)
 	// atomic store of the new txPoolContext
 	newCtx := txPoolContext{
-		NewSysContractCallCtx(pool.currentVMRunner),
+		NewSysContractCallCtx2(newHead, statedb, pool.chain),
 		currency.NewManager(pool.currentVMRunner),
 		gasPriceMinimumFloor,
 	}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1372,7 +1372,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	gasPriceMinimumFloor, _ := gpm.GetGasPriceMinimumFloor(pool.currentVMRunner)
 	// atomic store of the new txPoolContext
 	newCtx := txPoolContext{
-		NewSysContractCallCtx2(newHead, statedb, pool.chain),
+		NewSysContractCallCtx(newHead, statedb, pool.chain),
 		currency.NewManager(pool.currentVMRunner),
 		gasPriceMinimumFloor,
 	}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -418,7 +418,3 @@ func (b *EthAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, vm.EVMRunner, *state.StateDB, error) {
 	return b.eth.stateAtTransaction(block, txIndex, reexec)
 }
-
-func (b *EthAPIBackend) VmRunnerAtHeader(header *types.Header, state *state.StateDB) vm.EVMRunner {
-	return b.eth.blockchain.NewEVMRunner(header, state)
-}

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -163,7 +163,7 @@ func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec 
 	var sysCtx *core.SysContractCallCtx
 	espresso := eth.blockchain.Config().IsEspresso(block.Number())
 	if espresso {
-		sysCtx = core.NewSysContractCallCtx(eth.blockchain.NewEVMRunner(block.Header(), statedb))
+		sysCtx = core.NewSysContractCallCtx2(block.Header(), statedb, eth.blockchain)
 	}
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(eth.blockchain.Config(), block.Number())

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -163,7 +163,7 @@ func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec 
 	var sysCtx *core.SysContractCallCtx
 	espresso := eth.blockchain.Config().IsEspresso(block.Number())
 	if espresso {
-		sysCtx = core.NewSysContractCallCtx2(block.Header(), statedb, eth.blockchain)
+		sysCtx = core.NewSysContractCallCtx(block.Header(), statedb, eth.blockchain)
 	}
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(eth.blockchain.Config(), block.Number())

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -277,7 +277,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 				blockCtx := core.NewEVMBlockContext(task.block.Header(), api.chainContext(localctx), nil)
 				var sysCtx *core.SysContractCallCtx
 				if api.backend.ChainConfig().IsEspresso(blockCtx.BlockNumber) {
-					sysCtx = core.NewSysContractCallCtx2(task.block.Header(), task.statedb, api.backend)
+					sysCtx = core.NewSysContractCallCtx(task.block.Header(), task.statedb, api.backend)
 				}
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
@@ -536,7 +536,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 			for task := range jobs {
 				var sysCtx *core.SysContractCallCtx
 				if api.backend.ChainConfig().IsEspresso(block.Number()) {
-					sysCtx = core.NewSysContractCallCtx2(block.Header(), task.statedb, api.backend)
+					sysCtx = core.NewSysContractCallCtx(block.Header(), task.statedb, api.backend)
 				}
 				msg, _ := txs[task.index].AsMessage(signer, nil)
 				txctx := &Context{
@@ -556,7 +556,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	}
 	var sysCtx *core.SysContractCallCtx
 	if api.backend.ChainConfig().IsEspresso(block.Number()) {
-		sysCtx = core.NewSysContractCallCtx2(block.Header(), statedb, api.backend)
+		sysCtx = core.NewSysContractCallCtx(block.Header(), statedb, api.backend)
 	}
 	vmRunner := api.backend.NewEVMRunner(block.Header(), statedb)
 	// Feed the transactions into the tracers and return
@@ -649,7 +649,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	}
 	var sysCtx *core.SysContractCallCtx
 	if api.backend.ChainConfig().IsEspresso(block.Number()) {
-		sysCtx = core.NewSysContractCallCtx2(block.Header(), statedb, api.backend)
+		sysCtx = core.NewSysContractCallCtx(block.Header(), statedb, api.backend)
 	}
 	for i, tx := range block.Transactions() {
 		// Prepare the trasaction for un-traced execution
@@ -750,7 +750,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 		if err != nil {
 			return nil, err
 		}
-		sysCtx = core.NewSysContractCallCtx2(block.Header(), sysStateDB, api.backend)
+		sysCtx = core.NewSysContractCallCtx(block.Header(), sysStateDB, api.backend)
 	}
 
 	msg, vmctx, vmRunner, statedb, err := api.backend.StateAtTransaction(ctx, block, int(index), reexec)
@@ -807,7 +807,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	}
 	var sysCtx *core.SysContractCallCtx
 	if api.backend.ChainConfig().IsEspresso(block.Number()) {
-		sysCtx = core.NewSysContractCallCtx2(block.Header(), statedb, api.backend)
+		sysCtx = core.NewSysContractCallCtx(block.Header(), statedb, api.backend)
 	}
 	var traceConfig *TraceConfig
 	if config != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -69,7 +69,7 @@ type Backend interface {
 	ChainDb() ethdb.Database
 	StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive bool) (*state.StateDB, error)
 	StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, vm.EVMRunner, *state.StateDB, error)
-	VmRunnerAtHeader(header *types.Header, state *state.StateDB) vm.EVMRunner
+	NewEVMRunner(*types.Header, vm.StateDB) vm.EVMRunner
 }
 
 // API is the collection of tracing APIs exposed over the private debugging endpoint.
@@ -277,8 +277,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 				blockCtx := core.NewEVMBlockContext(task.block.Header(), api.chainContext(localctx), nil)
 				var sysCtx *core.SysContractCallCtx
 				if api.backend.ChainConfig().IsEspresso(blockCtx.BlockNumber) {
-					sysVmRunner := api.backend.VmRunnerAtHeader(task.block.Header(), task.statedb)
-					sysCtx = core.NewSysContractCallCtx(sysVmRunner)
+					sysCtx = core.NewSysContractCallCtx2(task.block.Header(), task.statedb, api.backend)
 				}
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
@@ -288,7 +287,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 						TxIndex:   i,
 						TxHash:    tx.Hash(),
 					}
-					vmRunner := api.backend.VmRunnerAtHeader(task.block.Header(), task.statedb)
+					vmRunner := api.backend.NewEVMRunner(task.block.Header(), task.statedb)
 					res, err := api.traceTx(localctx, msg, txctx, blockCtx, vmRunner, task.statedb, sysCtx, config)
 					if err != nil {
 						task.results[i] = &txTraceResult{Error: err.Error()}
@@ -536,9 +535,8 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 			// Fetch and execute the next transaction trace tasks
 			for task := range jobs {
 				var sysCtx *core.SysContractCallCtx
-				vmRunner := api.backend.VmRunnerAtHeader(block.Header(), task.statedb)
 				if api.backend.ChainConfig().IsEspresso(block.Number()) {
-					sysCtx = core.NewSysContractCallCtx(vmRunner)
+					sysCtx = core.NewSysContractCallCtx2(block.Header(), task.statedb, api.backend)
 				}
 				msg, _ := txs[task.index].AsMessage(signer, nil)
 				txctx := &Context{
@@ -546,6 +544,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 					TxIndex:   task.index,
 					TxHash:    txs[task.index].Hash(),
 				}
+				vmRunner := api.backend.NewEVMRunner(block.Header(), task.statedb)
 				res, err := api.traceTx(ctx, msg, txctx, blockCtx, vmRunner, task.statedb, sysCtx, config)
 				if err != nil {
 					results[task.index] = &txTraceResult{Error: err.Error()}
@@ -556,10 +555,10 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		}()
 	}
 	var sysCtx *core.SysContractCallCtx
-	vmRunner := api.backend.VmRunnerAtHeader(block.Header(), statedb)
 	if api.backend.ChainConfig().IsEspresso(block.Number()) {
-		sysCtx = core.NewSysContractCallCtx(vmRunner)
+		sysCtx = core.NewSysContractCallCtx2(block.Header(), statedb, api.backend)
 	}
+	vmRunner := api.backend.NewEVMRunner(block.Header(), statedb)
 	// Feed the transactions into the tracers and return
 	var failed error
 	for i, tx := range txs {
@@ -650,8 +649,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	}
 	var sysCtx *core.SysContractCallCtx
 	if api.backend.ChainConfig().IsEspresso(block.Number()) {
-		sysVmRunner := api.backend.VmRunnerAtHeader(block.Header(), statedb)
-		sysCtx = core.NewSysContractCallCtx(sysVmRunner)
+		sysCtx = core.NewSysContractCallCtx2(block.Header(), statedb, api.backend)
 	}
 	for i, tx := range block.Transactions() {
 		// Prepare the trasaction for un-traced execution
@@ -687,7 +685,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
 		statedb.Prepare(tx.Hash(), i)
-		vmRunner := api.backend.VmRunnerAtHeader(block.Header(), statedb)
+		vmRunner := api.backend.NewEVMRunner(block.Header(), statedb)
 		_, err = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), vmRunner, sysCtx)
 		if writer != nil {
 			writer.Flush()
@@ -752,8 +750,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 		if err != nil {
 			return nil, err
 		}
-		sysVmRunner := api.backend.VmRunnerAtHeader(block.Header(), sysStateDB)
-		sysCtx = core.NewSysContractCallCtx(sysVmRunner)
+		sysCtx = core.NewSysContractCallCtx2(block.Header(), sysStateDB, api.backend)
 	}
 
 	msg, vmctx, vmRunner, statedb, err := api.backend.StateAtTransaction(ctx, block, int(index), reexec)
@@ -808,12 +805,9 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	if err != nil {
 		return nil, err
 	}
-	vmctx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
-	vmRunner := api.backend.VmRunnerAtHeader(block.Header(), statedb)
 	var sysCtx *core.SysContractCallCtx
 	if api.backend.ChainConfig().IsEspresso(block.Number()) {
-		sysVmRunner := api.backend.VmRunnerAtHeader(block.Header(), statedb)
-		sysCtx = core.NewSysContractCallCtx(sysVmRunner)
+		sysCtx = core.NewSysContractCallCtx2(block.Header(), statedb, api.backend)
 	}
 	var traceConfig *TraceConfig
 	if config != nil {
@@ -824,6 +818,8 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 			Reexec:    config.Reexec,
 		}
 	}
+	vmctx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
+	vmRunner := api.backend.NewEVMRunner(block.Header(), statedb)
 	return api.traceTx(ctx, msg, new(Context), vmctx, vmRunner, statedb, sysCtx, traceConfig)
 }
 

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/consensus"
 	mockEngine "github.com/celo-org/celo-blockchain/consensus/consensustest"
+	"github.com/celo-org/celo-blockchain/contracts/testutil"
 	"github.com/celo-org/celo-blockchain/core"
 	"github.com/celo-org/celo-blockchain/core/rawdb"
 	"github.com/celo-org/celo-blockchain/core/state"
@@ -151,7 +152,7 @@ func (b *testBackend) StateAtBlock(ctx context.Context, block *types.Block, reex
 }
 
 func (b *testBackend) NewEVMRunner(header *types.Header, state vm.StateDB) vm.EVMRunner {
-	panic("NewEVMRunner not implemented for testBackend")
+	return testutil.NewMockEVMRunner()
 }
 
 func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, vm.EVMRunner, *state.StateDB, error) {

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -150,6 +150,10 @@ func (b *testBackend) StateAtBlock(ctx context.Context, block *types.Block, reex
 	return statedb, nil
 }
 
+func (b *testBackend) NewEVMRunner(header *types.Header, state vm.StateDB) vm.EVMRunner {
+	panic("NewEVMRunner not implemented for testBackend")
+}
+
 func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, vm.EVMRunner, *state.StateDB, error) {
 	parent := b.chain.GetBlock(block.ParentHash(), block.NumberU64()-1)
 	if parent == nil {
@@ -179,10 +183,6 @@ func (b *testBackend) StateAtTransaction(ctx context.Context, block *types.Block
 		statedb.Finalise(vmenv.ChainConfig().IsEIP158(block.Number()))
 	}
 	return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("transaction index %d out of range for block %#x", txIndex, block.Hash())
-}
-
-func (b *testBackend) VmRunnerAtHeader(header *types.Header, state *state.StateDB) vm.EVMRunner {
-	return b.chain.NewEVMRunner(header, state)
 }
 
 func TestTraceCall(t *testing.T) {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -851,7 +851,7 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 	// Create SysContractCallCtx
 	var sysCtx *core.SysContractCallCtx
 	if b.ChainConfig().IsEspresso(header.Number) {
-		sysCtx = core.NewSysContractCallCtx2(header, state, b)
+		sysCtx = core.NewSysContractCallCtx(header, state, b)
 	}
 
 	// Get a new instance of the EVM.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -851,11 +851,7 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 	// Create SysContractCallCtx
 	var sysCtx *core.SysContractCallCtx
 	if b.ChainConfig().IsEspresso(header.Number) {
-		vmRunner := b.NewEVMRunner(header, state)
-		if err != nil {
-			return nil, err
-		}
-		sysCtx = core.NewSysContractCallCtx(vmRunner)
+		sysCtx = core.NewSysContractCallCtx2(header, state, b)
 	}
 
 	// Get a new instance of the EVM.

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -388,7 +388,3 @@ func (b *LesApiBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 func (b *LesApiBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, vm.EVMRunner, *state.StateDB, error) {
 	return b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
 }
-
-func (b *LesApiBackend) VmRunnerAtHeader(header *types.Header, state *state.StateDB) vm.EVMRunner {
-	return b.eth.blockchain.NewEVMRunner(header, state)
-}

--- a/les/state_accessor.go
+++ b/les/state_accessor.go
@@ -25,7 +25,6 @@ import (
 	"github.com/celo-org/celo-blockchain/core/state"
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/core/vm"
-	"github.com/celo-org/celo-blockchain/core/vm/vmcontext"
 	"github.com/celo-org/celo-blockchain/light"
 )
 
@@ -55,8 +54,7 @@ func (leth *LightEthereum) stateAtTransaction(ctx context.Context, block *types.
 	// Create SysContractCallCtx
 	var sysCtx *core.SysContractCallCtx
 	if leth.chainConfig.IsEspresso(block.Number()) {
-		vmRunner := vmcontext.NewEVMRunner(leth.blockchain, block.Header(), statedb.Copy())
-		sysCtx = core.NewSysContractCallCtx(vmRunner)
+		sysCtx = core.NewSysContractCallCtx2(block.Header(), statedb.Copy(), leth.blockchain)
 	}
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(leth.blockchain.Config(), block.Number())

--- a/les/state_accessor.go
+++ b/les/state_accessor.go
@@ -54,7 +54,7 @@ func (leth *LightEthereum) stateAtTransaction(ctx context.Context, block *types.
 	// Create SysContractCallCtx
 	var sysCtx *core.SysContractCallCtx
 	if leth.chainConfig.IsEspresso(block.Number()) {
-		sysCtx = core.NewSysContractCallCtx2(block.Header(), statedb.Copy(), leth.blockchain)
+		sysCtx = core.NewSysContractCallCtx(block.Header(), statedb.Copy(), leth.blockchain)
 	}
 	// Recompute transactions up to the target index.
 	signer := types.MakeSigner(leth.blockchain.Config(), block.Number())

--- a/miner/block.go
+++ b/miner/block.go
@@ -108,7 +108,7 @@ func prepareBlock(w *worker) (*blockState, error) {
 		gasLimit:       blockchain_parameters.GetBlockGasLimitOrDefault(vmRunner),
 		header:         header,
 		txFeeRecipient: txFeeRecipient,
-		sysCtx:         core.NewSysContractCallCtx2(header, state.Copy(), w.chain),
+		sysCtx:         core.NewSysContractCallCtx(header, state.Copy(), w.chain),
 	}
 	b.gasPool = new(core.GasPool).AddGas(b.gasLimit)
 

--- a/miner/block.go
+++ b/miner/block.go
@@ -108,7 +108,7 @@ func prepareBlock(w *worker) (*blockState, error) {
 		gasLimit:       blockchain_parameters.GetBlockGasLimitOrDefault(vmRunner),
 		header:         header,
 		txFeeRecipient: txFeeRecipient,
-		sysCtx:         core.NewSysContractCallCtx(w.chain.NewEVMRunner(header, state.Copy())),
+		sysCtx:         core.NewSysContractCallCtx2(header, state.Copy(), w.chain),
 	}
 	b.gasPool = new(core.GasPool).AddGas(b.gasLimit)
 


### PR DESCRIPTION
Instead of providing an `EVMRunner` to `core.NewSysContractCallCtx` we now provide the header, state and an evm runner factory. This allows us to ensure that the state is copied before passing it to the evm runner, thus ensuring that the given state is not modified. This also encapsulates that responsibility so that callers do not have to be aware of it.

This solves our gas estimation problem, that was being caused by executing multiple transactions/call with the same access list, specifically in this case executing all the calls for `core.NewSysContractCallCtx` and then estimating gas for a transaction without first clearing the access list.

We could have instead ensured that we called `StateDB.Prepare` on the state after calling `core.NewSysContractCallCtx` but copying the state seemed neater because: 

1. `core.NewSysContractCallCtx` is intended to be read only, so making it copy state aligns well with it conceptually.
2. `StateDB.Prepare` should be called just prior to executing a transaction and additionally to clearing the access list also contains functionality to allow retrieval of transaction logs for a specific transaction. So if we wanted to use this correctly we would need to call it not immediately after calling, or inside `core.NewSysContractCallCtx`, but instead before each tx executed with that system contract call context. This means we cannot neatly encapsulate calls to `StateDB.Prepare` in `core.NewSysContractCallCtx`.

Renamed `VmRunnerAtHeader` to `NewEVMRunner` since both methods did the same thing and in some cases both methods had been implemented on structs.

Updated godoc for NewSysContractCallCtx.

### Tested

Manually checked that the the state root of the state used to execute `core.NewSysContractCallCtx` is not modified by `core.NewSysContractCallCtx` meaning we are safe to treat `core.NewSysContractCallCtx` as a read only operation and therefore it is safe to let it execute on a copy of the state.

Manually checked that gas estimation was correct for tx 0x5fb4082c0c92330c38ccd0fc64f92384c7161f8670b27972b7895a46e5710063 after making this change. Used a lightest client connected to an archive node to verify this.

Also checked that the same results were obtained for 0x5fb4082c0c92330c38ccd0fc64f92384c7161f8670b27972b7895a46e5710063 if calling `StateDB.Prepare` as opposed to copying the state.

### Backwards compatibility

There were two approaches that we could have used to solve this.
1. Calling `StateDB.Prepare` before tx execution.
2. Using a state copy for building the system contract call context.

Both approaches were being used prior to this PR in the critical path of the blockchain, one by the miner for creating a block and the other during block processing when applying the block. Given that we have not seen any problems so far, it seems reasonable to assume that both approaches result in the same chain state, so this should not result in a hardfork.

It is possible that this change would cause a difference in execution in all the other places that `StateDB.Prepare` was not being called before tx execution, the only place I can see that was not calling `StateDB.Prepare` before tx execution is in the state prefetcher, so we could expect the prefetched state to be more accurate than it previously was but the outcome of transaction processing should remain the same.
