### PR TITLE
Faster CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,111 @@
+# A note on performance.
+#
+# TL;DR: Storing and retrieving from workspaces is slow so use it sparingly.
+#
+# Workspaces are useful in sharing data between jobs where the overhead
+# involved in using a cache and providing functionality to rebuild the cache in
+# each job is too high.
+#
+# Long version:
+#
+# Storing and retrieving data from workspaces seems to be slow. And
+# caches/checkouts/plain downloads appear to be faster. Some numbers ...
+#
+####
+#
+# Restoring repo dir (no binaries) (65M) + gocache (243M) + gomodcache (1.5G)
+# from a workspace takes approx 121s
+#
+# Restoring repo dir (no binaries) (65M) + gocache (243M) from a workspace
+# takes approx 52s and then restoring the gomodcache (1.5G) from a cache takes
+# approx 12s, so 64s total, so a reduction of 57s which is almost half the
+# time!
+#
+####
+#
+# Restoring monorepo dir + celo-blockchain  + go install (684M) from workspace
+# approx 51s.
+#
+# Restoring monorepo dir + go install (659M) from workspace approx 37s +
+# shallow ceckout celo-monorepo 2s, so a total of 39s a 12 second improvement.
+#
+####
+#
+# Restoring monorepo dir + golang install from workspace (659M) takes
+# approx 35s.
+#
+# Downloading and installing go (109M) takes approx 4s and restoring monorepo
+# dir from (414M) takes approx 28s, so a total of 32s, so a 3s improvement.
+#
+#######
+#
+# As can be seen from the above numbers restoring from workspaces are
+# significantly slower than caches, a fair bit slower than github checkouts and
+# a little bit slower than downloading and installing go.
+#
+# Since workspaces are scoped to a workflow you need to persist to a workspace
+# in your workflow before you can read from it, which further slows the build
+# time and persisting seems to take about twice as long as retrieving. And on
+# top of that remember that before persisting you will need to run the task
+# that you would otherwise run directly in a downstream job.
+#
+# Workspaces work best for small amounts of data that take a long time to
+# generate that we want to share between many jobs without having to duplicate
+# everywhere the logic to generate the data.
+#
+# How are we using them?
+#
+# We are currently using workspaces to store the compiled-system-contracts
+# (4.7M) which take about 5 minutes to generate 2s to persist to the workspace
+# and 0s to restore from the workspace, we also cache them so that most of the
+# time we can skip the build step and simply persist the cache to the
+# workspace. Having this functionality contained in one job makes the config
+# simpler than if we tried to add compiled system contract generation to all of
+# the downstream jobs and since this job is quite fast and not in the critical
+# path for the workflow it's ok to be a bit slower here.
+#
+########
+#
+# The structure of this workflow
+#
+# We have a central folder ~/repos under which there are paths which are used
+# throughout the workflow:
+#
+# - geth: The celo-blockchain checkout
+# - celo-monorepo: The celo-monorepo checkout
+# - golang: A golang installation
+# - gocache: A folder containing intermediate compilation results for golang
+# - gomodcache: A folder containing downloaded modules for golang
 version: 2.1
 parameters:
-  # Increment this to force cache rebuilding
+  # Increment these to force cache rebuilding
   system-contracts-cache-version:
     type: integer
-    default: 1
+    default: 2
+  go-mod-cache-version:
+    type: integer
+    default: 3
+  go-cache-version:
+    type: integer
+    default: 3
+  checkout-monorepo-cache-version:
+    type: integer
+    default: 3
+  # Location where compiled system contracts are stored under the root of this
+  # repo.
   system-contracts-path:
     type: string
     default: "compiled-system-contracts"
   system-contracts-executor-image:
-    type: string
+    type:
+      string
+      # The system contracts executor currently needs node 12 to function,
+      # this should only be changed when the version in `monorepo_commit` is
+      # changed.
+    default: "us.gcr.io/celo-testnet/circleci-node12:1.0.0"
+  e2e-executor-image:
+    type:
+      string
       # The system contracts executor currently needs node 12 to function,
       # this should only be changed when the version in `monorepo_commit` is
       # changed.
@@ -18,30 +115,26 @@ executors:
     docker:
       - image: circleci/golang:1.16
     working_directory: ~/repos/geth
+    environment:
+      # Change the go modules to be cached under ~/repos so that we can add
+      # them to the workspace, this doesn't seem to work if you use the ~
+      # symbol to represent the home dir.
+      GOMODCACHE: /home/circleci/repos/gomodcache
+      GOCACHE: /home/circleci/repos/gocache
   system-contracts-executor:
     docker:
       - image: <<pipeline.parameters.system-contracts-executor-image>>
     working_directory: ~/repos/geth
   e2e:
     docker:
-      - image: us.gcr.io/celo-testnet/circleci-node12:1.0.0
-    working_directory: ~/repos/celo-monorepo/packages/celotool
+      - image: <<pipeline.parameters.e2e-executor-image>>
     environment:
-      GO_VERSION: "1.16.4"
-      # CELO_MONOREPO_COMMIT_OR_BRANCH should point to a monorepo commit which is known to work, so that
-      # our CI doesn't break due to another team making changes in monorepo.
-      # * It should be updated when:
-      #     (a) changes or additions are made to the blockchain e2e tests in celo-monorepo, or
-      #     (b) a new contracts release has been merged to monorepo's master
-      #    In the latter case, we need to check whether the new contract release breaks things and update the mycelo
-      #    contracts ABI and migrations accordingly if necessary.
-      # * When updating it, update the comment with (a) the branch or commit hash, (b) the date of the change, and
-      #   (c) the contracts release it includes (`RELEASE_TAG` in the monorepo)
+      # Change the go modules and build cache to be cached under ~/repos so
+      # that we can add them to the workspace, this doesn't seem to work if you
+      # use the ~ symbol to represent the home dir.
+      GOMODCACHE: /home/circleci/repos/gomodcache
+      GOCACHE: /home/circleci/repos/gocache
 
-      # b16a2d472a7cf24858f9d8b33a7185c8b81a261a is the current commit on master as of August 25, 2021, and
-      # includes contracts release 5 (core-contracts.v5)
-      CELO_MONOREPO_COMMIT_OR_BRANCH: b16a2d472a7cf24858f9d8b33a7185c8b81a261a
-      GITHUB_RSA_FINGERPRINT: SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
 # Unfortunately we cannot use anchors to represent a set of standard steps and
 # then add or override one or more of those steps when referencing the anchor.
 # This would be useful because a lot of jobs share many steps, it is not
@@ -53,26 +146,122 @@ unit-tests-defaults: &unit-tests-defaults
   executor: golang
   resource_class: medium+
 
+# The default circle ci checkout does a full checkout and that brings about
+# 450M of history that we don't need.
+shallow-checkout: &shallow-checkout
+  run:
+    name: shallow checkout
+    command: |
+      mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+      git clone --quiet --depth 1 "$CIRCLE_REPOSITORY_URL" --branch "$CIRCLE_BRANCH" ~/repos/geth
+
+install-go: &install-go
+  run:
+    name: install go
+    command: |
+      # Install go so the e2e tests can build geth
+      mkdir -p ~/repos/golang
+      wget https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz
+      tar xf go1.16.4.linux-amd64.tar.gz -C ~/repos/golang
+      ~/repos/golang/go/bin/go version
+
+save-go-cache: &save-go-cache
+  save_cache:
+    key: go-cache-<<pipeline.parameters.go-cache-version>>-{{ checksum "~/repos/geth/go.sum" }}-{{ checksum "~/repos/month" }}
+    paths:
+      - ~/repos/gocache
+
+restore-go-cache: &restore-go-cache
+  restore_cache:
+    keys:
+      - go-cache-<<pipeline.parameters.go-cache-version>>-{{ checksum "~/repos/geth/go.sum" }}-{{ checksum "~/repos/month" }}
+
+go-mod-cache: &save-go-mod-cache
+  save_cache:
+    key: go-mod-<<pipeline.parameters.go-cache-version>>-{{ checksum "~/repos/geth/go.sum" }}
+    paths:
+      - ~/repos/gocache
+
+restore-go-mod-cache: &restore-go-mod-cache
+  restore_cache:
+    keys:
+      - go-mod-<<pipeline.parameters.go-cache-version>>-{{ checksum "~/repos/geth/go.sum" }}
+
+store-month-in-file: &store-month-in-file
+  # output the current month to a file, we'll use this to rotate the gocache
+  # monthly.  This is because most of what is in the gocache will be related to
+  # the go modules but some of it will be related to the repo code, but we
+  # don't want to rebuild on every commit, so instead we regenerate the cache
+  # monthly and of course if the modules change that will change the cache key.
+  run: date +%m > ~/repos/month
+
+end-to-end-test: &end-to-end-test
+  executor: e2e
+  resource_class: large
+  working_directory: ~/repos
+  parameters:
+    cache-key:
+      type: string
+      default: checkout-monorepo-{{ checksum "~/repos/geth/monorepo_commit" }}-v<<pipeline.parameters.checkout-monorepo-cache-version>>-<<pipeline.parameters.e2e-executor-image>>
+  steps:
+    - *shallow-checkout
+    - restore_cache:
+        keys:
+          - <<parameters.cache-key>>
+    - run:
+        name: Setup celo-monorepo for e2e tests
+        command: |
+          set -e
+          # only run this if the cache was not restored
+          if [ ! -d ./celo-monorepo ]; then
+            mc=`cat geth/monorepo_commit`
+            git clone --quiet --depth 1 --branch ${mc} https://github.com/celo-org/celo-monorepo.git
+            cd celo-monorepo
+
+            # Github is phasing out the git protocol so we ensure that we use
+            # https for all git operations that yarn may perform.
+            git config --global url."https://github.com".insteadOf git://github.com
+
+            # See if we can chuck some files by autocleaning
+            yarn autoclean --init
+
+            # Note we can't install for production only since the the build
+            # script and many others depend on lerna, which is a dev
+            # dependency.
+            yarn install
+            yarn build --scope @celo/celotool --include-filtered-dependencies
+
+            # Clear out unnecessary stuff
+            rm -rf .git
+          fi
+    - save_cache:
+        key: <<parameters.cache-key>>
+        paths:
+          - ~/repos/celo-monorepo
+    - *install-go
+    - *restore-go-mod-cache
+    - *store-month-in-file
+    - *restore-go-cache
+    - run:
+        name: Run e2e test
+        no_output_timeout: 15m
+        command: |
+          export PATH=${PATH}:~/repos/golang/go/bin
+          cd celo-monorepo/packages/celotool
+          ./${TEST_NAME} local ~/repos/geth
+    # Note, all e2e tests call 'make all' in ~/repos/geth, this causes most code
+    # to be built and so results in a faifly well populated go cache.
+    - *save-go-cache
+
 jobs:
-  build-geth:
+  go-modules:
     executor: golang
-    resource_class: medium+
+    resource_class: small
     steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
-      - run:
-          name: Build Geth
-          command: go run build/ci.go install
-      - save_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
-          paths:
-            - "/go/pkg/mod"
-      - persist_to_workspace:
-          root: ~/repos
-          paths:
-            - geth
+      - *shallow-checkout
+      - *restore-go-mod-cache
+      - run: go mod download
+      - *save-go-mod-cache
 
   prepare-system-contracts:
     parameters:
@@ -82,12 +271,10 @@ jobs:
     executor: system-contracts-executor
     resource_class: medium+
     steps:
-      - checkout
+      - *shallow-checkout
       - restore_cache:
           keys:
             - <<parameters.cache-key>>
-      - attach_workspace:
-          at: ~/repos
       - run:
           name: prepare system contracts
           # Runs make prepare-system-contracts and sets the MONOREPO_COMMIT to
@@ -117,11 +304,10 @@ jobs:
   race:
     <<: *unit-tests-defaults
     steps:
+      - *shallow-checkout
       - attach_workspace:
           at: ~/repos
-      - restore_cache:
-          keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
+      - *restore-go-mod-cache
       - run: go get github.com/jstemmer/go-junit-report
       - run:
           name: Run tests
@@ -136,20 +322,20 @@ jobs:
           path: /tmp/test-results
 
   unit-tests:
-    <<: *unit-tests-defaults
+    executor: golang
+    resource_class: xlarge
     steps:
+      - *shallow-checkout
       - attach_workspace:
           at: ~/repos
-      - restore_cache:
-          keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
+      - *restore-go-mod-cache
       - run: go get github.com/jstemmer/go-junit-report
       - run:
           name: Run tests
           command: |
             mkdir -p /tmp/test-results
             trap "go-junit-report < /tmp/test-results/go-test.out > /tmp/test-results/go-test-report.xml" EXIT
-            go test -p 1 -v -covermode=atomic -cover -coverprofile=coverage.out ./... | tee /tmp/test-results/go-test.out
+            go test -v -cover -coverprofile=coverage.out ./... | tee /tmp/test-results/go-test.out
             bash <(curl -s https://codecov.io/bash)
       - store_artifacts:
           path: /tmp/test-results
@@ -160,20 +346,19 @@ jobs:
   istanbul-e2e-coverage:
     <<: *unit-tests-defaults
     steps:
+      - *shallow-checkout
       - attach_workspace:
           at: ~/repos
-      - restore_cache:
-          keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
+      - *restore-go-mod-cache
         # Run the tests with coverage parse the coverage and output the summary
-      - run: 
+      - run:
           name: Run tests and print coverage summary
           command: |
             go test -coverprofile cov.out -coverpkg ./consensus/istanbul/... ./e2e_test 
             go run tools/parsecov/main.go -packagePrefix github.com/celo-org/celo-blockchain/ cov.out > summary
             cat summary
 
-      - run: 
+      - run:
           name: Post summary comment on PR
           command: |
             # Only post on PR if this build is running on a PR. If this build
@@ -238,11 +423,10 @@ jobs:
     executor: golang
     resource_class: medium+
     steps:
+      - *shallow-checkout
       - attach_workspace:
           at: ~/repos
-      - restore_cache:
-          keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
+      - *restore-go-mod-cache
       - run:
           name: Run benchmarks
           command: |
@@ -256,8 +440,7 @@ jobs:
     executor: golang
     resource_class: medium+
     steps:
-      - attach_workspace:
-          at: ~/repos
+      - *shallow-checkout
       - run: go get github.com/jstemmer/go-junit-report
       - run:
           name: Run Linter
@@ -274,7 +457,7 @@ jobs:
   check-imports:
     executor: golang
     steps:
-      - checkout
+      - *shallow-checkout
       - run:
           name: Check imports to ensure we are using github.com/celo-org/celo-blockchain
           command: ./scripts/check_imports.sh
@@ -284,7 +467,8 @@ jobs:
       - image: us.gcr.io/celo-testnet/android:v3
     working_directory: ~/repos/geth
     steps:
-      - checkout
+      - *shallow-checkout
+      - *restore-go-mod-cache
       - run:
           name: Compile android client
           command: make android
@@ -298,7 +482,8 @@ jobs:
       xcode: "12.5.1"
     working_directory: ~/repos/geth
     steps:
-      - checkout
+      # Note the macos executor does not seem to be able to restore caches.
+      - *shallow-checkout
       - run:
           name: Setup Go language
           command: |
@@ -330,175 +515,83 @@ jobs:
   lightest-sync-test:
     executor: golang
     steps:
-      - attach_workspace:
-          at: ~/repos
+      - *shallow-checkout
+      - *restore-go-mod-cache
+      - *store-month-in-file
+      - *restore-go-cache
+      - run: make geth
       - run: DATADIR=/tmp/lightest_sync_test_data MODE=lightest ./scripts/sync_test.sh
 
-  checkout-monorepo:
-    executor: e2e
-    working_directory: ~/repos
-    steps:
-      - run:
-          name: Setup celo-monorepo
-          command: |
-            set -e
-            mkdir ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-            ssh-keygen -F github.com -l -f ~/.ssh/known_hosts | grep "github.com RSA ${GITHUB_RSA_FINGERPRINT}"
-            git clone --depth 1 https://github.com/celo-org/celo-monorepo.git celo-monorepo
-            cd celo-monorepo
-            git fetch --depth 1 origin ${CELO_MONOREPO_COMMIT_OR_BRANCH}
-            git checkout ${CELO_MONOREPO_COMMIT_OR_BRANCH}
-
-            # Github is phasing out the git protocol so we ensure that we use
-            # https for all git operations that yarn may perform.
-            git config --global url."https://github.com".insteadOf git://github.com
-            yarn install || yarn install
-            yarn build --scope @celo/celotool --include-filtered-dependencies
-      - run:
-          name: Setup Go language
-          command: |
-            mkdir -p ~/repos/golang
-            wget https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
-            tar xf go${GO_VERSION}.linux-amd64.tar.gz -C ~/repos/golang
-            ~/repos/golang/go/bin/go version
-      - persist_to_workspace:
-          root: ~/repos
-          paths:
-            - celo-monorepo
-            - golang
-
   end-to-end-blockchain-parameters-test:
-    executor: e2e
-    resource_class: large
-    steps:
-      - attach_workspace:
-          at: ~/repos
-      - run:
-          name: End-to-end test of governable blockchain parameters
-          command: |
-            export PATH=${PATH}:~/repos/golang/go/bin
-            ./ci_test_blockchain_parameters.sh local ~/repos/geth
+    environment:
+      TEST_NAME: ci_test_blockchain_parameters.sh
+    <<: *end-to-end-test
 
   end-to-end-governance-test:
-    executor: e2e
+    environment:
+      TEST_NAME: ci_test_governance.sh
     resource_class: xlarge
-    steps:
-      - attach_workspace:
-          at: ~/repos
-      - run:
-          name: End-to-end test of proof-of-stake
-          no_output_timeout: 15m
-          command: |
-            export PATH=${PATH}:~/repos/golang/go/bin
-            ./ci_test_governance.sh local ~/repos/geth
+    <<: *end-to-end-test
 
   end-to-end-sync-test:
-    executor: e2e
-    resource_class: large
-    steps:
-      - attach_workspace:
-          at: ~/repos
-      - run:
-          name: End-to-end test of syncing
-          no_output_timeout: 15m
-          command: |
-            export PATH=${PATH}:~/repos/golang/go/bin
-            ./ci_test_sync.sh local ~/repos/geth
+    environment:
+      TEST_NAME: ci_test_sync.sh
+    <<: *end-to-end-test
 
   end-to-end-slashing-test:
-    executor: e2e
-    resource_class: large
-    steps:
-      - attach_workspace:
-          at: ~/repos
-      - run:
-          name: End-to-end test of slashing
-          no_output_timeout: 15m
-          command: |
-            export PATH=${PATH}:~/repos/golang/go/bin
-            ./ci_test_slashing.sh local ~/repos/geth
+    environment:
+      TEST_NAME: ci_test_slashing.sh
+    <<: *end-to-end-test
 
   end-to-end-transfer-test:
-    executor: e2e
-    resource_class: large
-    steps:
-      - attach_workspace:
-          at: ~/repos
-      - run:
-          name: End-to-end test of transfers
-          no_output_timeout: 15m
-          command: |
-            export PATH=${PATH}:~/repos/golang/go/bin
-            ./ci_test_transfers.sh local ~/repos/geth
+    environment:
+      TEST_NAME: ci_test_transfers.sh
+    <<: *end-to-end-test
 
   end-to-end-validator-order-test:
-    executor: e2e
+    environment:
+      TEST_NAME: ci_test_validator_order.sh
     resource_class: xlarge
-    steps:
-      - attach_workspace:
-          at: ~/repos
-      - run:
-          name: End-to-end test of random validator order
-          no_output_timeout: 15m
-          command: |
-            export PATH=${PATH}:~/repos/golang/go/bin
-            ./ci_test_validator_order.sh local ~/repos/geth
+    <<: *end-to-end-test
 
   end-to-end-cip35-eth-compatibility-test:
-    executor: e2e
+    environment:
+      TEST_NAME: ci_test_cip35.sh
     resource_class: xlarge
-    steps:
-      - attach_workspace:
-          at: ~/repos
-      - run:
-          name: End-to-end test of CIP 35
-          no_output_timeout: 15m
-          command: |
-            export PATH=${PATH}:~/repos/golang/go/bin
-            ./ci_test_cip35.sh local ~/repos/geth
+    <<: *end-to-end-test
 
   end-to-end-replica-test:
-    executor: e2e
+    environment:
+      TEST_NAME: ci_test_replicas.sh
     resource_class: xlarge
-    steps:
-      - attach_workspace:
-          at: ~/repos
-      - run:
-          name: End-to-end test of hotswap functionality
-          no_output_timeout: 15m
-          command: |
-            export PATH=${PATH}:~/repos/golang/go/bin
-            ./ci_test_replicas.sh local ~/repos/geth
+    <<: *end-to-end-test
 
 workflows:
   version: 2
   build:
     jobs:
-      - checkout-monorepo
-      - build-geth
+      - go-modules
       - prepare-system-contracts
       - check-imports
-      - lint:
-          requires:
-            - build-geth
+      - lint
       - unit-tests:
           requires:
-            - build-geth
+            - go-modules
             - prepare-system-contracts
       - race:
           filters:
             branches:
               only: /master|release.*/
           requires:
-            - build-geth
+            - go-modules
             - prepare-system-contracts
       - istanbul-e2e-coverage:
           requires:
-            - build-geth
+            - go-modules
             - prepare-system-contracts
       - e2e-benchmarks:
           requires:
-            - build-geth
+            - go-modules
             - prepare-system-contracts
       - android
       - ios
@@ -522,37 +615,29 @@ workflows:
               only: master
       - lightest-sync-test:
           requires:
-            - build-geth
+            - go-modules
       - end-to-end-blockchain-parameters-test:
           requires:
-            - checkout-monorepo
-            - build-geth
+            - go-modules
       - end-to-end-governance-test:
           requires:
-            - checkout-monorepo
-            - build-geth
+            - go-modules
       - end-to-end-slashing-test:
           requires:
-            - checkout-monorepo
-            - build-geth
+            - go-modules
       - end-to-end-sync-test:
           requires:
-            - checkout-monorepo
-            - build-geth
+            - go-modules
       - end-to-end-transfer-test:
           requires:
-            - checkout-monorepo
-            - build-geth
+            - go-modules
       - end-to-end-validator-order-test:
           requires:
-            - checkout-monorepo
-            - build-geth
-# Flaky!
-#      - end-to-end-cip35-eth-compatibility-test:
-#          requires:
-#            - checkout-monorepo
-#            - build-geth
+            - go-modules
+      # Flaky!
+      #      - end-to-end-cip35-eth-compatibility-test:
+      #          requires:
+      #            - go-modules
       - end-to-end-replica-test:
           requires:
-            - checkout-monorepo
-            - build-geth
+            - go-modules

--- a/common/task/task_test.go
+++ b/common/task/task_test.go
@@ -5,16 +5,34 @@ import (
 	"time"
 )
 
+type testTicker struct {
+	tc chan time.Time
+}
+
+func (t *testTicker) stop() {}
+
+func (t *testTicker) tickChan() <-chan time.Time {
+	return t.tc
+}
+func (t *testTicker) sendTick() {
+	t.tc <- time.Now()
+}
+
 func TestRunTaskRepeateadly(t *testing.T) {
 	t.Parallel()
 
 	counter := 0
-	ping := func() { counter++ }
+	ping := func() { println("tick"); counter++ }
 
-	stopTask := RunTaskRepeateadly(ping, 50*time.Millisecond)
-	time.Sleep((3*50 + 30) * time.Millisecond)
+	tt := &testTicker{
+		tc: make(chan time.Time),
+	}
+
+	stopTask := RunTaskRepeateadly(ping, tt)
+	tt.sendTick()
+	tt.sendTick()
+	tt.sendTick()
 	stopTask()
-	time.Sleep(30 * time.Millisecond)
 
 	if counter != 3 {
 		t.Errorf("Expect task to run 3 times but got %d", counter)

--- a/consensus/istanbul/core/roundstate_db.go
+++ b/consensus/istanbul/core/roundstate_db.go
@@ -111,7 +111,7 @@ func newRoundStateDB(path string, opts *RoundStateDBOptions) (RoundStateDB, erro
 	}
 
 	if rsdb.opts.withGarbageCollector {
-		rsdb.stopGarbageCollector = task.RunTaskRepeateadly(rsdb.garbageCollectEntries, rsdb.opts.garbageCollectorPeriod)
+		rsdb.stopGarbageCollector = task.RunTaskRepeateadly(rsdb.garbageCollectEntries, task.NewDefaultTicker(rsdb.opts.garbageCollectorPeriod))
 	}
 
 	return rsdb, nil

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -630,7 +630,7 @@ func testThrottling(t *testing.T, protocol uint, mode SyncMode) {
 		}
 		// Wait a bit for sync to throttle itself
 		var cached, frozen int
-		for start := time.Now(); time.Since(start) < 3*time.Second; {
+		for start := time.Now(); time.Since(start) < 6*time.Second; {
 			time.Sleep(25 * time.Millisecond)
 
 			tester.lock.Lock()


### PR DESCRIPTION
This update reduces overall build time from about 22m to 15m, a 7m
saving or about a 32% improvement.

The time taken for the unit-tests job to complete has been dropped from
around 19m to about 4m, this should be beneficial to developers by
providing a much shorter feedback loop.

These changes were made possible by taking steps to minimise the amount
of data downloaded and shared between jobs, and most pertinently
removing usages of workspaces to persist and retrieve intermediate build
artefacts. And in place of that relying more on caches and modifying
jobs so that they are able to rebuild those caches. Greater use of
caches was enabled by better understanding of how to reuse portions of
config via yaml anchors.


### Other changes

Updated a couple of tests to prevent flakey failures.
