### PR TITLE
Reduce Preprepare size

### DIFF
--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -28,6 +28,7 @@ import (
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/crypto"
 	blscrypto "github.com/celo-org/celo-blockchain/crypto/bls"
+	"github.com/celo-org/celo-blockchain/log"
 	"github.com/celo-org/celo-blockchain/p2p/enode"
 	"github.com/celo-org/celo-blockchain/rlp"
 )
@@ -145,6 +146,7 @@ func (c *RoundChangeCertificate) EncodeRLP(w io.Writer) error {
 	if err != nil {
 		return err
 	}
+	log.Debug("Proposals count on the round change certificate", len(proposals))
 	return rlp.Encode(w, []interface{}{proposals, messages})
 }
 

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -211,11 +211,6 @@ type IndexedRoundChangeMessage struct {
 func NewIndexedRoundChangeMessage(message *Message) *IndexedRoundChangeMessage {
 	roundChange := getRoundChange(message)
 	pc := roundChange.PreparedCertificate
-	if pc == nil {
-		return &IndexedRoundChangeMessage{
-			Message: *message,
-		}
-	}
 
 	// Assume message.Code = MsgRoundChange
 	indexedMsg := IndexedRoundChangeMessage{

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -180,12 +180,12 @@ type IndexedRoundChangeMessage struct {
 	Message      Message // PreparedCertificate.Proposal = nil if any
 }
 
-func NewIndexedRoundChangeMessage(message Message) *IndexedRoundChangeMessage {
+func NewIndexedRoundChangeMessage(message *Message) *IndexedRoundChangeMessage {
 	roundChange := message.RoundChange()
 	pc := roundChange.PreparedCertificate
 	if pc == nil {
 		return &IndexedRoundChangeMessage{
-			Message: message,
+			Message: *message,
 		}
 	}
 	
@@ -217,7 +217,7 @@ func NewIndexedRoundChangeMessage(message Message) *IndexedRoundChangeMessage {
 func (c *RoundChangeCertificate) indexedMessages() []*IndexedRoundChangeMessage {
 	r := make([]*IndexedRoundChangeMessage, len(c.RoundChangeMessages))
 	for i, message := range c.RoundChangeMessages {
-		r[i] = NewIndexedRoundChangeMessage(message)
+		r[i] = NewIndexedRoundChangeMessage(&message)
 	}
 	return r
 }

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -164,11 +164,16 @@ func getRoundChange(message *Message) RoundChange {
 	return nil
 }
 
+// setValues recreates the RoundChange messages from the props (Proposal set/index) and the
+// list of IndexedRoundChangeMessage, which is supposed to be the same as the RoundChange
+// Messages but with the proposals just referenced to the Proposals set.
 func (c *RoundChangeCertificate) setValues(props []Proposal, iMess []IndexedRoundChangeMessage) error {
+	// create a Proposal index from the list
 	propIndex := make(map[common.Hash]Proposal)
 	for _, prop := range props {
 		propIndex[prop.Hash()] = prop
 	}
+	// Recreate Messages one by one
 	mess := make([]Message, len(iMess))
 	for i, im := range iMess {
 		mess[i] = Message{
@@ -177,6 +182,7 @@ func (c *RoundChangeCertificate) setValues(props []Proposal, iMess []IndexedRoun
 			Signature: im.Message.Signature,
 		}
 
+		// Add the proposal to the message if it had one
 		roundChange := getRoundChange(&im.Message)
 		if proposal, ok := propIndex[im.ProposalHash]; ok {
 			roundChange.PreparedCertificate.Proposal = proposal

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -265,13 +265,13 @@ func extractProposal(message *Message) (*types.Block, *IndexedRoundChangeMessage
 		indexedMsg.ProposalHash = pc.Proposal.Hash()
 	}
 
+	curatedPC := EmptyPreparedCertificate()
+	curatedPC.PrepareOrCommitMessages = pc.PrepareOrCommitMessages
+
 	setMessageBytes(&indexedMsg.Message,
 		&RoundChange{
-			View: roundChange.View,
-			PreparedCertificate: PreparedCertificate{
-				Proposal:                &types.Block{}, // Empty Block
-				PrepareOrCommitMessages: pc.PrepareOrCommitMessages,
-			},
+			View:                roundChange.View,
+			PreparedCertificate: curatedPC,
 		})
 
 	return pc.Proposal.(*types.Block), &indexedMsg, nil

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -141,7 +141,7 @@ func (b *RoundChangeCertificate) IsEmpty() bool {
 
 // EncodeRLP serializes b into the Ethereum RLP format.
 func (c *RoundChangeCertificate) EncodeRLP(w io.Writer) error {
-	proposals, messages, err := c.asData()
+	proposals, messages, err := c.asValues()
 	if err != nil {
 		return err
 	}
@@ -159,18 +159,6 @@ func (c *RoundChangeCertificate) DecodeRLP(s *rlp.Stream) error {
 		return err
 	}
 	return c.setValues(decodestr.Proposals, decodestr.IndexedMessages)
-}
-
-func getRoundChange(message *Message) (*RoundChange, error) {
-	if message.Code != MsgRoundChange {
-		return nil, fmt.Errorf("Expected round change message, received code: %d", message.Code)
-	}
-	var p *RoundChange
-	err := message.decode(&p)
-	if err != nil {
-		return nil, err
-	}
-	return p, nil
 }
 
 // setValues recreates the RoundChange messages from the props (Proposal set/index) and the
@@ -212,7 +200,7 @@ type IndexedRoundChangeMessage struct {
 }
 
 
-func (c *RoundChangeCertificate) asData() ([]Proposal, []*IndexedRoundChangeMessage, error) {
+func (c *RoundChangeCertificate) asValues() ([]Proposal, []*IndexedRoundChangeMessage, error) {
 	var err error
 
 	messages := make([]*IndexedRoundChangeMessage, len(c.RoundChangeMessages))
@@ -237,6 +225,18 @@ func (c *RoundChangeCertificate) asData() ([]Proposal, []*IndexedRoundChangeMess
 		proposals[i] = p
 	}
 	return proposals, messages, nil
+}
+
+func getRoundChange(message *Message) (*RoundChange, error) {
+	if message.Code != MsgRoundChange {
+		return nil, fmt.Errorf("Expected round change message, received code: %d", message.Code)
+	}
+	var p *RoundChange
+	err := message.decode(&p)
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
 }
 
 func extractProposal(message *Message) (Proposal, *IndexedRoundChangeMessage, error) {

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -146,7 +146,7 @@ func (c *RoundChangeCertificate) EncodeRLP(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	log.Debug("Proposals count on the round change certificate", len(proposals))
+	log.Debug("Round change certificate proposals", "count", len(proposals))
 	return rlp.Encode(w, []interface{}{proposals, messages})
 }
 

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -664,7 +664,7 @@ type Message struct {
 func setMessageBytes(msg *Message, innerMessage interface{}) {
 	bytes, err := rlp.EncodeToBytes(innerMessage)
 	if err != nil {
-		panic(fmt.Sprintf("attempt to serialise inner message of type %T failed", innerMessage))
+		panic(fmt.Sprintf("attempt to serialise inner message of type %T failed. %s", innerMessage, err))
 	}
 	msg.Msg = bytes
 }

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -199,7 +199,6 @@ type IndexedRoundChangeMessage struct {
 	Message      Message // PreparedCertificate.Proposal = nil if any
 }
 
-
 func (c *RoundChangeCertificate) asValues() ([]Proposal, []*IndexedRoundChangeMessage, error) {
 	var err error
 
@@ -212,17 +211,19 @@ func (c *RoundChangeCertificate) asValues() ([]Proposal, []*IndexedRoundChangeMe
 		if err != nil {
 			return nil, nil, err
 		}
-		
+
 		if proposal != nil {
 			// we don't use the height since we know they MUST be the same
 			proposalsMap[proposal.Hash()] = proposal
-		}		
+		}
 	}
 
 	// Iterate values. RLP does not support maps
 	proposals := make([]Proposal, len(proposalsMap))
-	for i, p := range r {
+	var i = 0
+	for _, p := range proposalsMap {
 		proposals[i] = p
+		i++
 	}
 	return proposals, messages, nil
 }
@@ -245,12 +246,9 @@ func extractProposal(message *Message) (Proposal, *IndexedRoundChangeMessage, er
 	if err != nil {
 		return nil, nil, err
 	}
-	
+
 	pc := roundChange.PreparedCertificate
-	if pc == nil {
-		return nil, &IndexedRoundChangeMessage{Message: *message},nil
-	}
-	
+
 	// Assume message.Code = MsgRoundChange
 	indexedMsg := IndexedRoundChangeMessage{
 		Message: Message{

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -126,6 +126,10 @@ func (v *View) Cmp(y *View) int {
 }
 
 // ## RoundChangeCertificate ##############################################################
+// To considerably reduce the bandwith used by the RoundChangeCertificate type (which often
+// contains repeated Proposal from different RoundChange messages), we break it apart during
+// RLP encoding and then build it back during decoding. Proposals are sent just once, and
+// Messages referencing them will use their Hash instead.
 
 type RoundChangeCertificate struct {
 	RoundChangeMessages []Message

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -189,6 +189,7 @@ func (c *RoundChangeCertificate) setValues(props []*types.Block, iMess []Indexed
 		}
 
 		setMessageBytes(&mess[i], roundChange)
+		mess[i].roundChange = roundChange
 	}
 	c.RoundChangeMessages = mess
 	return nil

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -199,6 +199,9 @@ type IndexedRoundChangeMessage struct {
 	Message      Message // PreparedCertificate.Proposal = nil if any
 }
 
+// asValues presents the RoundChangeCertificate as values for RLP Serialization.
+// This is done using a list of proposals, and the RoundChange messages using
+// hash references instead of the full proposal objects, to reduce bandwith.
 func (c *RoundChangeCertificate) asValues() ([]Proposal, []*IndexedRoundChangeMessage, error) {
 	var err error
 

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -163,6 +163,9 @@ func (c *RoundChangeCertificate) DecodeRLP(s *rlp.Stream) error {
 }
 
 func getRoundChange(message *Message) (*RoundChange, error) {
+	if message.Code != MsgRoundChange {
+		return nil, fmt.Errorf("Expected round change message, received code: %d", message.Code)
+	}
 	var p *RoundChange
 	err := message.decode(&p)
 	if err != nil {

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -126,7 +126,7 @@ func (v *View) Cmp(y *View) int {
 }
 
 // ## RoundChangeCertificate ##############################################################
-// To considerably reduce the bandwith used by the RoundChangeCertificate type (which often
+// To considerably reduce the bandwidth used by the RoundChangeCertificate type (which often
 // contains repeated Proposal from different RoundChange messages), we break it apart during
 // RLP encoding and then build it back during decoding. Proposals are sent just once, and
 // Messages referencing them will use their Hash instead.
@@ -201,7 +201,7 @@ type IndexedRoundChangeMessage struct {
 
 // asValues presents the RoundChangeCertificate as values for RLP Serialization.
 // This is done using a list of proposals, and the RoundChange messages using
-// hash references instead of the full proposal objects, to reduce bandwith.
+// hash references instead of the full proposal objects, to reduce bandwidth.
 func (c *RoundChangeCertificate) asValues() ([]*types.Block, []*IndexedRoundChangeMessage, error) {
 	var err error
 

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -266,10 +266,10 @@ func extractProposal(message *Message) (Proposal, *IndexedRoundChangeMessage, er
 	}
 
 	setMessageBytes(&indexedMsg.Message,
-		RoundChange{
+		&RoundChange{
 			View: roundChange.View,
 			PreparedCertificate: PreparedCertificate{
-				Proposal:                nil, // Removed
+				Proposal:                &types.Block{}, // Empty Block
 				PrepareOrCommitMessages: pc.PrepareOrCommitMessages,
 			},
 		})

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -188,36 +188,30 @@ func NewIndexedRoundChangeMessage(message Message) *IndexedRoundChangeMessage {
 			Message: message,
 		}
 	}
-
+	
 	// Assume message.Code = MsgRoundChange
-	var pHash common.Hash
+	indexedMsg := IndexedRoundChangeMessage{
+		Message: Message{
+			Code: message.Code,
+			Address: message.Address,
+			Signature: message.Signature,
+		}
+	}
+
 	if pc.Proposal != nil {
-		pHash = pc.Proposal.Hash()
+		indexedMsg.ProposalHash = pc.Proposal.Hash()
 	}
 
-	// Remove proposal from the Message
-	curatedMessage := Message{
-		Code:      message.Code,
-		Address:   message.Address,
-		Signature: message.Signature,
-	}
+	setMessageBytes(&indexedMsg.Message, 
+		RoundChange{
+			View:                roundChange.View,
+			PreparedCertificate: PreparedCertificate{
+				Proposal:                nil, // Removed
+				PrepareOrCommitMessages: pc.PrepareOrCommitMessages,
+			},
+	})
 
-	curatedPC := &PreparedCertificate{
-		Proposal:                nil, // Removed
-		PrepareOrCommitMessages: pc.PrepareOrCommitMessages,
-	}
-
-	curatedRoundChange := RoundChange{
-		View:                roundChange.View,
-		PreparedCertificate: *curatedPC,
-	}
-
-	setMessageBytes(&curatedMessage, curatedRoundChange)
-
-	return &IndexedRoundChangeMessage{
-		ProposalHash: pHash,
-		Message:      curatedMessage,
-	}
+	return &indexedMsg
 }
 
 func (c *RoundChangeCertificate) indexedMessages() []*IndexedRoundChangeMessage {

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -249,6 +249,9 @@ func TestRoundChangeCertificateRLPEncoding(t *testing.T) {
 	original.RoundChangeMessages[0].prepare = nil
 	original.RoundChangeMessages[1].prepare = nil
 	original.RoundChangeMessages[2].prepare = nil
+	result.RoundChangeMessages[0].roundChange = nil
+	result.RoundChangeMessages[1].roundChange = nil
+	result.RoundChangeMessages[2].roundChange = nil
 	if !reflect.DeepEqual(original, result) {
 		t.Fatalf("RLP Encode/Decode mismatch. Got %v, expected %v", result, original)
 	}
@@ -275,6 +278,10 @@ func TestPreprepareRLPEncoding(t *testing.T) {
 	o.RoundChangeMessages[0].prepare = nil
 	o.RoundChangeMessages[1].prepare = nil
 	o.RoundChangeMessages[2].prepare = nil
+	r := result.RoundChangeCertificate
+	r.RoundChangeMessages[0].roundChange = nil
+	r.RoundChangeMessages[1].roundChange = nil
+	r.RoundChangeMessages[2].roundChange = nil
 
 	// decoded Blocks don't equal Original ones so we need to check equality differently
 	assertEqual(t, "RLP Encode/Decode mismatch: View", result.View, original.View)

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -271,6 +271,11 @@ func TestPreprepareRLPEncoding(t *testing.T) {
 		t.Fatalf("Error %v", err)
 	}
 
+	o := original.RoundChangeCertificate
+	o.RoundChangeMessages[0].prepare = nil
+	o.RoundChangeMessages[1].prepare = nil
+	o.RoundChangeMessages[2].prepare = nil
+
 	// decoded Blocks don't equal Original ones so we need to check equality differently
 	assertEqual(t, "RLP Encode/Decode mismatch: View", result.View, original.View)
 	assertEqual(t, "RLP Encode/Decode mismatch: RoundChangeCertificate", result.RoundChangeCertificate, original.RoundChangeCertificate)

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -140,6 +140,8 @@ func dummyRoundChangeMessage() *Message {
 	// existent slices.
 	msg.Signature = []byte{}
 	msg.Code = MsgRoundChange
+	roundChange := RoundChange{}
+	setMessageBytes(msg, roundChange)
 	return msg
 }
 

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -134,9 +134,18 @@ func dummyMessage(code uint64) *Message {
 	return msg
 }
 
+func dummyRoundChangeMessage() *Message {
+	msg := NewPrepareMessage(dummySubject(), common.HexToAddress("AABB"))
+	// Set empty rather than nil signature since this is how rlp decodes non
+	// existent slices.
+	msg.Signature = []byte{}
+	msg.Code = MsgRoundChange
+	return msg
+}
+
 func dummyRoundChangeCertificate() *RoundChangeCertificate {
 	return &RoundChangeCertificate{
-		RoundChangeMessages: []Message{*dummyMessage(42), *dummyMessage(32), *dummyMessage(15)},
+		RoundChangeMessages: []Message{*dummyRoundChangeMessage(), *dummyRoundChangeMessage(), *dummyRoundChangeMessage()},
 	}
 }
 

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -140,7 +140,16 @@ func dummyRoundChangeMessage() *Message {
 	// existent slices.
 	msg.Signature = []byte{}
 	msg.Code = MsgRoundChange
-	roundChange := RoundChange{}
+	roundChange := &RoundChange{
+		View: &View{
+			Round:    common.Big1,
+			Sequence: common.Big2,
+		},
+		PreparedCertificate: PreparedCertificate{
+			PrepareOrCommitMessages: []Message{},
+			Proposal:                dummyBlock(2),
+		},
+	}
 	setMessageBytes(msg, roundChange)
 	return msg
 }

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -246,10 +246,9 @@ func TestRoundChangeCertificateRLPEncoding(t *testing.T) {
 		t.Fatalf("RLP Encode/Decode mismatch at first internal Msg bytes. %v ----- %v", o1.Msg, r1.Msg)
 	}
 
-	if !reflect.DeepEqual(o1, r1) {
-		t.Fatalf("RLP Encode/Decode mismatch at first RoundChangeMessage")
-	}
-
+	original.RoundChangeMessages[0].prepare = nil
+	original.RoundChangeMessages[1].prepare = nil
+	original.RoundChangeMessages[2].prepare = nil
 	if !reflect.DeepEqual(original, result) {
 		t.Fatalf("RLP Encode/Decode mismatch. Got %v, expected %v", result, original)
 	}

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -242,6 +242,10 @@ func TestRoundChangeCertificateRLPEncoding(t *testing.T) {
 		t.Fatalf("RLP Encode/Decode mismatch at first Signature")
 	}
 
+	if !reflect.DeepEqual(o1.Msg, r1.Msg) {
+		t.Fatalf("RLP Encode/Decode mismatch at first internal Msg bytes. %v ----- %v", o1.Msg, r1.Msg)
+	}
+
 	if !reflect.DeepEqual(o1, r1) {
 		t.Fatalf("RLP Encode/Decode mismatch at first RoundChangeMessage")
 	}

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/rlp"
 	"golang.org/x/crypto/sha3"
+	"gotest.tools/assert"
 )
 
 // testHasher is the helper tool for transaction/receipt list hashing.
@@ -220,6 +221,29 @@ func TestRoundChangeCertificateRLPEncoding(t *testing.T) {
 
 	if err = rlp.DecodeBytes(rawVal, &result); err != nil {
 		t.Fatalf("Error %v", err)
+	}
+
+	assert.Equal(t, len(original.RoundChangeMessages), len(original.RoundChangeMessages))
+	o1 := original.RoundChangeMessages[0]
+	r1 := result.RoundChangeMessages[0]
+	if !reflect.DeepEqual(o1.Code, r1.Code) {
+		t.Fatalf("RLP Encode/Decode mismatch at first Code")
+	}
+
+	if !reflect.DeepEqual(o1.Code, r1.Code) {
+		t.Fatalf("RLP Encode/Decode mismatch at first Code")
+	}
+
+	if !reflect.DeepEqual(o1.Address, r1.Address) {
+		t.Fatalf("RLP Encode/Decode mismatch at first Address")
+	}
+
+	if !reflect.DeepEqual(o1.Signature, r1.Signature) {
+		t.Fatalf("RLP Encode/Decode mismatch at first Signature")
+	}
+
+	if !reflect.DeepEqual(o1, r1) {
+		t.Fatalf("RLP Encode/Decode mismatch at first RoundChangeMessage")
 	}
 
 	if !reflect.DeepEqual(original, result) {

--- a/eth/protocols/eth/handler.go
+++ b/eth/protocols/eth/handler.go
@@ -162,7 +162,7 @@ func nodeInfo(chain *core.BlockChain, network uint64) *NodeInfo {
 func Handle(backend Backend, peer *Peer) error {
 	for {
 		if err := handleMessage(backend, peer); err != nil {
-			peer.Log().Warn("Message handling failed in `eth`", "err", err)
+			peer.Log().Debug("Message handling failed in `eth`", "err", err)
 			return err
 		}
 	}

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -43,7 +43,7 @@ const ProtocolName = "eth"
 var ProtocolVersions = []uint{ETH66, ETH65}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
-const maxMessageSize = 10 * 1024 * 1024 * 10 // Celo increase for istanbul round change certificates
+const maxMessageSize = 10 * 1024 * 1024
 
 const (
 	// Protocol messages in eth/64 (celo65)

--- a/params/version.go
+++ b/params/version.go
@@ -27,7 +27,7 @@ import (
 const (
 	VersionMajor = 1        // Major version component of the current release
 	VersionMinor = 5        // Minor version component of the current release
-	VersionPatch = 7        // Patch version component of the current release
+	VersionPatch = 8        // Patch version component of the current release
 	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
### Description

This PR modifies `RoundChangeCertificate` encoding so that we don't serialize `N` times the proposal, instead we do that only once.

### Other changes


### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Change is not backward compatible, requires 2/3 of validators to use the new version at that same time