### PR TITLE
Reduce Preprepare size

### DIFF
--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -29,6 +29,7 @@ import (
 	"github.com/celo-org/celo-blockchain/core/types"
 	"github.com/celo-org/celo-blockchain/crypto"
 	blscrypto "github.com/celo-org/celo-blockchain/crypto/bls"
+	"github.com/celo-org/celo-blockchain/log"
 	"github.com/celo-org/celo-blockchain/p2p/enode"
 	"github.com/celo-org/celo-blockchain/rlp"
 )
@@ -127,6 +128,10 @@ func (v *View) Cmp(y *View) int {
 }
 
 // ## RoundChangeCertificate ##############################################################
+// To considerably reduce the bandwidth used by the RoundChangeCertificate type (which often
+// contains repeated Proposal from different RoundChange messages), we break it apart during
+// RLP encoding and then build it back during decoding. Proposals are sent just once, and
+// Messages referencing them will use their Hash instead.
 
 type RoundChangeCertificate struct {
 	RoundChangeMessages []Message
@@ -134,6 +139,134 @@ type RoundChangeCertificate struct {
 
 func (b *RoundChangeCertificate) IsEmpty() bool {
 	return len(b.RoundChangeMessages) == 0
+}
+
+// EncodeRLP serializes b into the Ethereum RLP format.
+func (c *RoundChangeCertificate) EncodeRLP(w io.Writer) error {
+	proposals, messages, err := c.asValues()
+	if err != nil {
+		return err
+	}
+	log.Debug("Round change certificate proposals", "count", len(proposals))
+	return rlp.Encode(w, []interface{}{proposals, messages})
+}
+
+// DecodeRLP implements rlp.Decoder, and load the consensus fields from a RLP stream.
+func (c *RoundChangeCertificate) DecodeRLP(s *rlp.Stream) error {
+	var decodestr struct {
+		Proposals       []*types.Block
+		IndexedMessages []IndexedRoundChangeMessage
+	}
+
+	if err := s.Decode(&decodestr); err != nil {
+		return err
+	}
+	return c.setValues(decodestr.Proposals, decodestr.IndexedMessages)
+}
+
+// setValues recreates the RoundChange messages from the props (Proposal set/index) and the
+// list of IndexedRoundChangeMessage, which is supposed to be the same as the RoundChange
+// Messages but with the proposals just referenced to the Proposals set.
+func (c *RoundChangeCertificate) setValues(props []*types.Block, iMess []IndexedRoundChangeMessage) error {
+	// create a Proposal index from the list
+	propIndex := make(map[common.Hash]Proposal)
+	for _, prop := range props {
+		propIndex[prop.Hash()] = prop
+	}
+	// Recreate Messages one by one
+	mess := make([]Message, len(iMess))
+	for i, im := range iMess {
+		mess[i] = Message{
+			Code:      im.Message.Code,
+			Address:   im.Message.Address,
+			Signature: im.Message.Signature,
+		}
+
+		// Add the proposal to the message if it had one
+		roundChange, err := im.Message.TryRoundChange()
+		if err != nil {
+			return err
+		}
+
+		if proposal, ok := propIndex[im.ProposalHash]; ok {
+			roundChange.PreparedCertificate.Proposal = proposal
+		}
+
+		setMessageBytes(&mess[i], roundChange)
+		mess[i].roundChange = roundChange
+	}
+	c.RoundChangeMessages = mess
+	return nil
+}
+
+type IndexedRoundChangeMessage struct {
+	ProposalHash common.Hash
+	Message      Message // PreparedCertificate.Proposal = nil if any
+}
+
+// asValues presents the RoundChangeCertificate as values for RLP Serialization.
+// This is done using a list of proposals, and the RoundChange messages using
+// hash references instead of the full proposal objects, to reduce bandwidth.
+func (c *RoundChangeCertificate) asValues() ([]*types.Block, []*IndexedRoundChangeMessage, error) {
+	var err error
+
+	messages := make([]*IndexedRoundChangeMessage, len(c.RoundChangeMessages))
+	proposalsMap := make(map[common.Hash]*types.Block)
+
+	for i, message := range c.RoundChangeMessages {
+		var proposal *types.Block
+		proposal, messages[i], err = extractProposal(&message)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if proposal != nil {
+			// we don't use the height since we know they MUST be the same
+			proposalsMap[proposal.Hash()] = proposal
+		}
+	}
+
+	// Iterate values. RLP does not support maps
+	proposals := make([]*types.Block, len(proposalsMap))
+	var i = 0
+	for _, p := range proposalsMap {
+		proposals[i] = p
+		i++
+	}
+	return proposals, messages, nil
+}
+
+func extractProposal(message *Message) (*types.Block, *IndexedRoundChangeMessage, error) {
+	roundChange, err := message.TryRoundChange()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pc := roundChange.PreparedCertificate
+
+	// Assume message.Code = MsgRoundChange
+	indexedMsg := IndexedRoundChangeMessage{
+		Message: Message{
+			Code:      message.Code,
+			Address:   message.Address,
+			Signature: message.Signature,
+		},
+	}
+
+	if pc.Proposal != nil {
+		indexedMsg.ProposalHash = pc.Proposal.Hash()
+	}
+
+	curatedPC := EmptyPreparedCertificate()
+	curatedPC.PrepareOrCommitMessages = pc.PrepareOrCommitMessages
+
+	setMessageBytes(&indexedMsg.Message,
+		&RoundChange{
+			View:                roundChange.View,
+			PreparedCertificate: curatedPC,
+		})
+
+	return pc.Proposal.(*types.Block), &indexedMsg, nil
 }
 
 // ## Preprepare ##############################################################
@@ -537,7 +670,7 @@ type Message struct {
 func setMessageBytes(msg *Message, innerMessage interface{}) {
 	bytes, err := rlp.EncodeToBytes(innerMessage)
 	if err != nil {
-		panic(fmt.Sprintf("attempt to serialise inner message of type %T failed", innerMessage))
+		panic(fmt.Sprintf("attempt to serialise inner message of type %T failed. %s", innerMessage, err))
 	}
 	msg.Msg = bytes
 }
@@ -552,20 +685,8 @@ func (m *Message) Sign(signingFn func(data []byte) ([]byte, error)) error {
 	return err
 }
 
-func (m *Message) DecodeRLP(stream *rlp.Stream) error {
-	type decodable Message
-	var d decodable
-	err := stream.Decode(&d)
-	if err != nil {
-		return err
-	}
-	*m = Message(d)
-
-	if len(m.Msg) == 0 && len(m.Signature) == 0 {
-		// Empty validator handshake message
-		return nil
-	}
-
+func (m *Message) DecodeMessage() error {
+	var err error
 	switch m.Code {
 	case MsgPreprepare:
 		var p *Preprepare
@@ -613,7 +734,23 @@ func (m *Message) DecodeRLP(stream *rlp.Stream) error {
 		err = fmt.Errorf("unrecognised message code %d", m.Code)
 	}
 	return err
+}
 
+func (m *Message) DecodeRLP(stream *rlp.Stream) error {
+	type decodable Message
+	var d decodable
+	err := stream.Decode(&d)
+	if err != nil {
+		return err
+	}
+	*m = Message(d)
+
+	if len(m.Msg) == 0 && len(m.Signature) == 0 {
+		// Empty validator handshake message
+		return nil
+	}
+
+	return m.DecodeMessage()
 }
 
 // FromPayload decodes b into a Message instance it will set one of the private
@@ -679,6 +816,20 @@ func (m *Message) Preprepare() *Preprepare {
 // Prepare returns prepare if this is a prepare message.
 func (m *Message) Prepare() *Subject {
 	return m.prepare
+}
+
+// Prepare returns round change if this is a round change message.
+func (m *Message) TryRoundChange() (*RoundChange, error) {
+	if m.roundChange != nil {
+		return m.roundChange, nil
+	}
+	if m.Code != MsgRoundChange {
+		return nil, fmt.Errorf("expected round change message, received code: %d", m.Code)
+	}
+	if err := m.DecodeMessage(); err != nil {
+		return nil, err
+	}
+	return m.roundChange, nil
 }
 
 // Prepare returns round change if this is a round change message.


### PR DESCRIPTION
Change serialization of the RoundChangeCertificate to reduce message size for the Preprepare phase.

Ensure no duplicate Proposals are serialized inside of a RoundChangeCertificate RLP serialization.
