### PR TITLE
Add manual force re-send and gossip of consensus messages

### DIFF
--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -310,3 +310,13 @@ func (api *API) GetLookbackWindow(number *rpc.BlockNumber) (uint64, error) {
 func (api *API) ResendPreprepare() error {
 	return api.istanbul.core.ResendPreprepare()
 }
+
+// GossipPrepares gossips the prepare messages
+func (api *API) GossipPrepares() error {
+	return api.istanbul.core.GossipPrepares()
+}
+
+// GossipCommits gossips the commit messages
+func (api *API) GossipCommits() error {
+	return api.istanbul.core.GossipCommits()
+}

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -305,3 +305,8 @@ func (api *API) GetLookbackWindow(number *rpc.BlockNumber) (uint64, error) {
 
 	return api.istanbul.LookbackWindow(header, state), nil
 }
+
+// ResendPreprepare sends again the preprepare message
+func (api *API) ResendPreprepare() error {
+	return api.istanbul.core.ResendPreprepare()
+}

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -292,7 +292,7 @@ func (c *core) GossipCommits() error {
 	commits := c.current.Commits().Values()
 	logger.Debug("Gossipping commits", "len", len(commits))
 	for _, commit := range commits {
-		c.broadcast(commit)
+		c.gossip(commit)
 		// let the bandwidth breathe a little
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -346,7 +346,7 @@ func (c *core) gossipTo(msg *istanbul.Message, addresses []common.Address) {
 		logger.Error("Tried to gossip unsigned istanbul message", "m", msg)
 		return
 	}
-
+	logger.Trace("Gossipping message", "msg.Address", msg.Address.Hex(), "msg.Code", msg.Code)
 	// Convert to payload
 	payload, err := msg.Payload()
 	if err != nil {

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -332,6 +332,35 @@ func (c *core) finalizeMessage(msg *istanbul.Message) ([]byte, error) {
 	return payload, nil
 }
 
+// gossip broadcasts an already existing & signed message.
+func (c *core) gossip(msg *istanbul.Message) {
+	c.gossipTo(msg, istanbul.MapValidatorsToAddresses(c.current.ValidatorSet().List()))
+}
+
+// gossipTo broadcasts an already existing & signed message to the specified addresses.
+func (c *core) gossipTo(msg *istanbul.Message, addresses []common.Address) {
+	logger := c.newLogger("func", "gossipTo")
+
+	if len(msg.Signature) == 0 {
+		// should use broadcast() instead
+		logger.Error("Tried to gossip unsigned istanbul message", "m", msg)
+		return
+	}
+
+	// Convert to payload
+	payload, err := msg.Payload()
+	if err != nil {
+		logger.Error("Failed to convert message to payload", "m", msg, "err", err)
+		return
+	}
+
+	// Send payload to the specified addresses
+	if err := c.backend.Multicast(addresses, payload, istanbul.ConsensusMsg, true); err != nil {
+		logger.Error("Failed to send message", "m", msg, "err", err)
+		return
+	}
+}
+
 // Send message to all current validators
 func (c *core) broadcast(msg *istanbul.Message) {
 	c.sendMsgTo(msg, istanbul.MapValidatorsToAddresses(c.current.ValidatorSet().List()))

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -212,7 +212,7 @@ func (c *core) GossipPrepares() error {
 	prepares := c.current.Prepares().Values()
 	logger.Debug("Gossipping prepares", "len", len(prepares))
 	for _, prepare := range prepares {
-		c.broadcast(prepare)
+		c.gossip(prepare)
 		// let the bandwidth breathe a little
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"errors"
 	"reflect"
 	"time"
 
@@ -198,5 +199,22 @@ func (c *core) verifyPrepare(prepare *istanbul.Subject) error {
 		return errInconsistentSubject
 	}
 
+	return nil
+}
+
+// GossipPrepares gossips to other validators all the prepares received in the current round.
+func (c *core) GossipPrepares() error {
+	logger := c.newLogger("func", "gossipPrepares")
+	st := c.current.State()
+	if st != StatePreprepared && st != StatePrepared && st != StateCommitted {
+		return errors.New("Cant gossip prepares if not in preprepared, prepared, or committed state")
+	}
+	prepares := c.current.Prepares().Values()
+	logger.Debug("Gossipping prepares", "len", len(prepares))
+	for _, prepare := range prepares {
+		c.broadcast(prepare)
+		// let the bandwidth breathe a little
+		time.Sleep(10 * time.Millisecond)
+	}
 	return nil
 }

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -40,6 +40,7 @@ func (c *core) sendPreprepare(request *istanbul.Request, roundChangeCertificate 
 	}
 }
 
+// ResendPreprepare sends again the preprepare message.
 func (c *core) ResendPreprepare() error {
 	logger := c.newLogger("func", "resendPreprepare")
 	if !c.isProposer() {

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"errors"
 	"time"
 
 	"github.com/celo-org/celo-blockchain/common"
@@ -37,6 +38,21 @@ func (c *core) sendPreprepare(request *istanbul.Request, roundChangeCertificate 
 		logger.Debug("Sending preprepare", "m", m)
 		c.broadcast(m)
 	}
+}
+
+func (c *core) ResendPreprepare() error {
+	logger := c.newLogger("func", "resendPreprepare")
+	if !c.isProposer() {
+		return errors.New("Cant resend preprepare if not proposer")
+	}
+	st := c.current.State()
+	if st != StatePreprepared && st != StatePrepared && st != StateCommitted {
+		return errors.New("Cant resend preprepare if not in preprepared, prepared, or committed state")
+	}
+	m := istanbul.NewPreprepareMessage(c.current.Preprepare(), c.address)
+	logger.Debug("Re-Sending preprepare", "m", m)
+	c.broadcast(m)
+	return nil
 }
 
 func (c *core) handlePreprepare(msg *istanbul.Message) error {

--- a/consensus/istanbul/core/types.go
+++ b/consensus/istanbul/core/types.go
@@ -39,6 +39,9 @@ type Engine interface {
 	ParentCommits() MessageSet
 	// ForceRoundChange will force round change to the current desiredRound + 1
 	ForceRoundChange()
+
+	// ResendPreprepare sends again the preprepare message.
+	ResendPreprepare() error
 }
 
 // State represents the IBFT state

--- a/consensus/istanbul/core/types.go
+++ b/consensus/istanbul/core/types.go
@@ -42,6 +42,10 @@ type Engine interface {
 
 	// ResendPreprepare sends again the preprepare message.
 	ResendPreprepare() error
+	// GossipPrepares gossips to other validators all the prepares received in the current round.
+	GossipPrepares() error
+	// GossipCommits gossips to other validators all the commits received in the current round.
+	GossipCommits() error
 }
 
 // State represents the IBFT state

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -733,6 +733,16 @@ web3._extend({
 			call: 'istanbul_resendPreprepare',
 			params: 0,
 		}),
+		new web3._extend.Method({
+			name: 'gossipPrepares',
+			call: 'istanbul_gossipPrepares',
+			params: 0,
+		}),
+		new web3._extend.Method({
+			name: 'gossipCommits',
+			call: 'istanbul_gossipCommits',
+			params: 0,
+		}),
 		new web3._extend.Property({
 			name: 'valEnodeTableInfo',
 			getter: 'istanbul_getValEnodeTable',

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -728,6 +728,11 @@ web3._extend({
 			call: 'istanbul_stopValidating',
 			params: 0,
 		}),
+		new web3._extend.Method({
+			name: 'resendPreprepare',
+			call: 'istanbul_resendPreprepare',
+			params: 0,
+		}),
 		new web3._extend.Property({
 			name: 'valEnodeTableInfo',
 			getter: 'istanbul_getValEnodeTable',


### PR DESCRIPTION
Adds the api methods `gossipPrepares`, `gossipCommits` and `resendPreprepare`.