### PR TITLE
Remove android CI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -594,11 +594,11 @@ workflows:
           requires:
             - go-modules
             - prepare-system-contracts
-      - android
+              #- android
       - ios
       - publish-mobile-client:
           requires:
-            - android
+            #- android
             - ios
             # Makes sure tests are all green before publishing
             # Though these are not using the mobile built binaries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,6 +463,10 @@ jobs:
           name: Check imports to ensure we are using github.com/celo-org/celo-blockchain
           command: ./scripts/check_imports.sh
 
+          # This build started failing on all branches unrelated to any change in this repo.
+          # The below link links to a build on master that failed, the previous build of the
+          # same commit 24 days prior succeed.
+          # https://app.circleci.com/pipelines/github/celo-org/celo-blockchain/8386/workflows/6d117662-83e7-4e8b-8d0c-d6891d6af94c/jobs/87995
           # android:
           # docker:
           #  - image: us.gcr.io/celo-testnet/android:v3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,20 +463,20 @@ jobs:
           name: Check imports to ensure we are using github.com/celo-org/celo-blockchain
           command: ./scripts/check_imports.sh
 
-  android:
-    docker:
-      - image: us.gcr.io/celo-testnet/android:v3
-    working_directory: ~/repos/geth
-    steps:
-      - *shallow-checkout
-      - *restore-go-mod-cache
-      - run:
-          name: Compile android client
-          command: make android
-      - persist_to_workspace:
-          root: ~/repos
-          paths:
-            - geth/build/bin/geth.aar
+          # android:
+          # docker:
+          #  - image: us.gcr.io/celo-testnet/android:v3
+          # working_directory: ~/repos/geth
+          # steps:
+          #  - *shallow-checkout
+          # - *restore-go-mod-cache
+          # - run:
+          #  name: Compile android client
+          # command: make android
+          # - persist_to_workspace:
+          # root: ~/repos
+          # paths:
+          #  - geth/build/bin/geth.aar
 
   ios:
     macos:


### PR DESCRIPTION
### Description

Starting with commit ba64ac2823be9cd80b5472967df7df1b6a50a918 the android test began failing, despite changing nothing related to the android build. Seemingly the failure is due to an infrastructure change outside of the main codebase. This PR comments out the android build CI test as a temporary deprioritization.

### Tested

All other CI tests.

### Backwards compatibility

Only changes the CI config file.
