### PR TITLE
Ensure CI publish-mobile-client checks out repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,6 +516,7 @@ jobs:
       - image: circleci/node:10
     working_directory: ~/repos/geth
     steps:
+      - *shallow-checkout
       - attach_workspace:
           at: ~/repos
       - run: ./scripts/publish-mobile-client.sh ${CIRCLE_SHA1} ${NPM_TOKEN_FOR_CELO_CLIENT}


### PR DESCRIPTION
Previously we were not checking out the repo for this job and that was causing it to fail
because it could not access the script. This adds a shallow checkout which should
ensure that the script is acessible.