### PR TITLE
Add missing tx.type field in the json marshal of a tx receipt

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2030,6 +2030,7 @@ func generateReceiptResponse(receipt *types.Receipt, signer types.Signer, tx *ty
 		"contractAddress":   nil,
 		"logs":              receipt.Logs,
 		"logsBloom":         receipt.Bloom,
+		"type":              hexutil.Uint(receipt.Type),
 	}
 
 	// Assign receipt status or post state.


### PR DESCRIPTION
The tx.type field was not added to the marshaled json struct when requested via rpc.