### PR TITLE
Fix tracer block context

### DIFF
--- a/core/sys_context.go
+++ b/core/sys_context.go
@@ -14,6 +14,7 @@ import (
 
 // SysContractCallCtx acts as a cache holding information obtained through
 // system contract calls to be used during block processing.
+// Note: This struct should be a read only one to be safe for concurrent use
 type SysContractCallCtx struct {
 	whitelistedCurrencies map[common.Address]struct{}
 	// The gas required for a non celo (cUSD, cEUR, ...) transfer.


### PR DESCRIPTION
### Description

The tracer was not using the same block context for every tx (it was generating a new context for every tx)

### Related issues

- Fixes #1983 

### Backwards compatibility

Yes