### PR TITLE
Add missing tx.type field in the json marshal of a tx receipt (#1985)

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2030,6 +2030,7 @@ func generateReceiptResponse(receipt *types.Receipt, signer types.Signer, tx *ty
 		"contractAddress":   nil,
 		"logs":              receipt.Logs,
 		"logsBloom":         receipt.Bloom,
+		"type":              hexutil.Uint(receipt.Type),
 	}
 
 	// Assign receipt status or post state.


### PR DESCRIPTION
Cherry pick from 1.7.1 hotfix ( 86eb9876d3473806a7ca47da80ac9c6d59a1d5e9 )