### PR TITLE
ci: Set `E2E_TESTS_FORCE_USE_MYCELO` in e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,6 +262,7 @@ end-to-end-test: &end-to-end-test
         no_output_timeout: 15m
         command: |
           export PATH=${PATH}:~/repos/golang/go/bin
+          export E2E_TESTS_FORCE_USE_MYCELO=true
           cd celo-monorepo/packages/celotool
           ./${TEST_NAME} local ~/repos/geth
     # Note, all e2e tests call 'make all' in ~/repos/geth, this causes most code


### PR DESCRIPTION
### Description

Currently `E2E_TESTS_FORCE_USE_MYCELO` is set via the CircleCI project settings. Those settings are not forwarded to CI running for PRs from forked repositories. This leads to problems like in this [PR](https://github.com/celo-org/celo-blockchain/pull/1986) ([build](https://app.circleci.com/pipelines/github/celo-org/celo-blockchain/8617/workflows/60656f24-0e27-4801-aa0f-beda72c64dec/jobs/91074)).

Instead, we define the variable directly in the CI config.

I created this PR from my fork, so this should test it.