### PR TITLE
build: Remove `wnode` from xgo archive

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -1342,7 +1342,6 @@ func xgoAllToolsArchiveFiles(target string, dir string) []string {
 		executableXgoPath("evm", target, dir),
 		executableXgoPath("geth", target, dir),
 		executableXgoPath("rlpdump", target, dir),
-		executableXgoPath("wnode", target, dir),
 		executableXgoPath("clef", target, dir),
 		executableXgoPath("blspopchecker", target, dir),
 	}


### PR DESCRIPTION
### Description

`wnode` is not build anymore, so let's not try to include it in the xgo archive.
