### PR TITLE
BLS verification in background thread

### DIFF
--- a/consensus/istanbul/announce/manager.go
+++ b/consensus/istanbul/announce/manager.go
@@ -245,13 +245,7 @@ func (m *Manager) answerQueryEnodeMsg(address common.Address, node *enode.Node, 
 			return errNodeMissingEnodeCertificate
 		}
 
-		payload, err := enodeCertMsg.Msg.Payload()
-		if err != nil {
-			logger.Warn("Error getting payload of enode certificate message", "err", err)
-			return err
-		}
-
-		if err := m.network.Multicast([]common.Address{address}, payload, istanbul.EnodeCertificateMsg, false); err != nil {
+		if err := m.network.Multicast([]common.Address{address}, enodeCertMsg.Msg, istanbul.EnodeCertificateMsg, false); err != nil {
 			return err
 		}
 	}

--- a/consensus/istanbul/announce/network.go
+++ b/consensus/istanbul/announce/network.go
@@ -1,6 +1,9 @@
 package announce
 
-import "github.com/celo-org/celo-blockchain/common"
+import (
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/consensus/istanbul"
+)
 
 // Network manages the communication needed for the announce protocol to work.
 type Network interface {
@@ -10,5 +13,5 @@ type Network interface {
 	RetrieveValidatorConnSet() (map[common.Address]bool, error)
 	// Multicast will send the eth message (with the message's payload and msgCode field set to the params
 	// payload and ethMsgCode respectively) to the nodes with the signing address in the destAddresses param.
-	Multicast(destAddresses []common.Address, payload []byte, ethMsgCode uint64, sendToSelf bool) error
+	Multicast(destAddresses []common.Address, msg *istanbul.Message, ethMsgCode uint64, sendToSelf bool) error
 }

--- a/consensus/istanbul/announce/version_sharer.go
+++ b/consensus/istanbul/announce/version_sharer.go
@@ -108,13 +108,7 @@ func (a *avs) ShareVersion(version uint) error {
 			destAddresses = valConnArray
 		}
 
-		payload, err := enodeCertMsg.Msg.Payload()
-		if err != nil {
-			a.logger.Error("Error getting payload of enode certificate message", "err", err)
-			return err
-		}
-
-		if err := a.network.Multicast(destAddresses, payload, istanbul.EnodeCertificateMsg, false); err != nil {
+		if err := a.network.Multicast(destAddresses, enodeCertMsg.Msg, istanbul.EnodeCertificateMsg, false); err != nil {
 			return err
 		}
 	}

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -162,7 +162,7 @@ func (c *core) handleCheckedCommitForPreviousSequence(msg *istanbul.Message, com
 	if validator == nil {
 		return errInvalidValidatorAddress
 	}
-	if err := c.verifyCommittedSeal(commit, validator); err != nil {
+	if err := commit.ValidComittedSeal(); err != nil {
 		return errInvalidCommittedSeal
 	}
 	if headBlock.Number().Uint64() > 0 {

--- a/consensus/istanbul/core/types.go
+++ b/consensus/istanbul/core/types.go
@@ -46,6 +46,9 @@ type Engine interface {
 	GossipPrepares() error
 	// GossipCommits gossips to other validators all the commits received in the current round.
 	GossipCommits() error
+
+	// DecodeMessage decodes an istanbul message
+	DecodeMessage(payload []byte) (*istanbul.Message, istanbul.Validator, error)
 }
 
 // State represents the IBFT state

--- a/consensus/istanbul/proxy/forward_message.go
+++ b/consensus/istanbul/proxy/forward_message.go
@@ -82,12 +82,12 @@ func (p *proxyEngine) handleForwardMsg(peer consensus.Peer, payload []byte) (boo
 		return true, errUnauthorizedMessageFromProxiedValidator
 	}
 
-	fwdMsg := istMsg.ForwardMessage()
-	logger.Trace("Forwarding a message", "msg code", fwdMsg.Code)
-	if err := p.backend.Multicast(fwdMsg.DestAddresses, fwdMsg.Msg, fwdMsg.Code, false); err != nil {
-		logger.Error("Error in multicasting a forwarded message", "error", err)
-		return true, err
-	}
+	// fwdMsg := istMsg.ForwardMessage()
+	// logger.Trace("Forwarding a message", "msg code", fwdMsg.Code)
+	// if err := p.backend.Multicast(fwdMsg.DestAddresses, fwdMsg.Msg, fwdMsg.Code, false); err != nil {
+	// 	logger.Error("Error in multicasting a forwarded message", "error", err)
+	// 	return true, err
+	// }
 
 	return true, nil
 }

--- a/consensus/istanbul/proxy/proxied_validator_engine.go
+++ b/consensus/istanbul/proxy/proxied_validator_engine.go
@@ -48,7 +48,7 @@ type BackendForProxiedValidatorEngine interface {
 	// Multicast sends a message to it's connected nodes filtered on the 'addresses' parameter (where each address
 	// is associated with those node's signing key)
 	// If sendToSelf is set to true, then the function will send an event to self via a message event
-	Multicast(addresses []common.Address, payload []byte, ethMsgCode uint64, sendToSelf bool) error
+	Multicast(addresses []common.Address, msg *istanbul.Message, ethMsgCode uint64, sendToSelf bool) error
 
 	// Unicast will asynchronously send a celo message to peer
 	Unicast(peer consensus.Peer, payload []byte, ethMsgCode uint64)

--- a/consensus/istanbul/proxy/proxy_engine.go
+++ b/consensus/istanbul/proxy/proxy_engine.go
@@ -38,7 +38,7 @@ type BackendForProxyEngine interface {
 	// Multicast sends a message to it's connected nodes filtered on the 'addresses' parameter (where each address
 	// is associated with those node's signing key)
 	// If sendToSelf is set to true, then the function will send an event to self via a message event
-	Multicast(addresses []common.Address, payload []byte, ethMsgCode uint64, sendToSelf bool) error
+	Multicast(addresses []common.Address, msg *istanbul.Message, ethMsgCode uint64, sendToSelf bool) error
 
 	// Unicast will asynchronously send a celo message to peer
 	Unicast(peer consensus.Peer, payload []byte, ethMsgCode uint64)

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -38,10 +38,10 @@ func init() {
 	// This statement is commented out but left here since its very useful for
 	// debugging problems and its non trivial to construct.
 	//
-	// log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
+	log.Root().SetHandler(log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stdout, log.TerminalFormat(true))))
 
 	// This disables all logging which in general we want, because there is a lot
-	log.Root().SetHandler(log.DiscardHandler())
+	// log.Root().SetHandler(log.DiscardHandler())
 }
 
 // This test starts a network submits a transaction and waits for the whole


### PR DESCRIPTION
Added functions to CommittedSubject to perform bls verification in background thread. In order to maintain the result of the verification moved to passing around deserialized istanbul.Message instances instead of the payload bytes. Ran into problems when handling proxy fwd messages (there is compile error).

This is proving overly complex because of the tangled nature of the istanbul code.

Suggestion would be to clean the code (refactor)and then attempt this change.