### PR TITLE
Auto apply triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -2,7 +2,7 @@
 name: Simple Task
 about: Simple Actionable Task
 title: ''
-labels: blockchain
+labels: triage
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/design_task.md
+++ b/.github/ISSUE_TEMPLATE/design_task.md
@@ -2,7 +2,7 @@
 name: Research/Design Task
 about: Research of design task
 title: ''
-labels: blockchain, needs-research
+labels: triage, needs-research
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -2,7 +2,7 @@
 name: Request a feature
 about: Report a missing feature - e.g. as a step before submitting a PR
 title: ''
-labels: 'type:feature'
+labels: triage, 'type:feature'
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -2,7 +2,7 @@
 name: Issue
 about: Feature/Need/Problem complete template
 title: ''
-labels: blockchain, needs-research
+labels: triage, needs-research
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Ask a question
 about: Something is unclear
 title: ''
-labels: 'type:docs'
+labels: triage, 'type:docs'
 assignees: ''
 ---
 


### PR DESCRIPTION
The `triage` label is automatically applied to all incoming issues so that we can use workflow automation.

### Description

Github allows some workflow automation based on labels. This label is automatically applied to all created issues so that we could implement the triage process. It removes the `blockchain` label as its usage seems to be inconsistent and doesn't carry any additional meaning.

### Other changes

No.