### PR TITLE
Update error msg when contracts are not made yet

### DIFF
--- a/test/node.go
+++ b/test/node.go
@@ -365,7 +365,7 @@ func GenerateGenesis(accounts *env.AccountsConfig, gc *genesis.Config, contracts
 		if err != nil {
 			panic(fmt.Sprintf("failed to get abs path for %s, error: %v", contractsBuildPath, err))
 		}
-		return nil, fmt.Errorf("Could not find dir %s, try running 'make compiled-system-contracts' and then re-running the test", abs)
+		return nil, fmt.Errorf("Could not find dir %s, try running 'make prepare-system-contracts' and then re-running the test", abs)
 
 	}
 	return genesis.GenerateGenesis(accounts, gc, contractsBuildPath)


### PR DESCRIPTION
There is no `compiled-system-contracts` make target, but `make prepare-system-contracts` creates the necessary files.