### PR TITLE
testing akeyless workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,6 +279,34 @@ jobs:
       - run: go mod download
       - *save-go-mod-cache
 
+  akeyless-get-token:
+    docker:
+      - image: akeyless/ci_base
+    environment:
+      PR_COMMENT_TOKEN: /dynamic-secrets/keys/github/celo-blockchain/pull_requests=write
+    steps:
+      - checkout
+      - run:
+          name: "update akeyless cli tool"
+          command: akeyless update
+
+      - run:
+          name: "authenticate to akeyless"
+          command: akeyless auth --access-id $accessid --access-type jwt --jwt $CIRCLE_OIDC_TOKEN --json | jq '.token' -r  > ~/.vault_token
+
+      - run:
+          name: "Get PR Comment token"
+          command: TOKEN=$(cat ~/.vault_token) && echo export SECRET=$(akeyless get-dynamic-secret-value --name $PR_COMMENT_TOKEN --token $TOKEN |grep token | awk '{print $2}' | tr -d '"",' ) >> "$BASH_ENV"
+
+      - run:
+          name: "Copy $BASH_ENV to bash.env file"
+          command: cp $BASH_ENV bash.env
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - bash.env
+
   prepare-system-contracts:
     parameters:
       cache-key:
@@ -377,6 +405,11 @@ jobs:
             go run tools/parsecov/main.go -packagePrefix github.com/celo-org/celo-blockchain/ cov.out > summary
             cat summary
 
+      - attach_workspace:
+          at: .
+      - run: |
+          cat bash.env > $BASH_ENV
+
       - run:
           name: Post summary comment on PR
           command: |
@@ -436,7 +469,9 @@ jobs:
             # replaced by '\n'. Using backtics causes there to be a round of
             # backslash processing on the command before execution, so we
             # need to double the backslashes in the awk command.
-            curl -u piersy:${PR_COMMENT_TOKEN} -X ${CURL_VERB} $URL -d "{\"body\":\"`awk -v ORS='\\\\n' '1' comment`\"}" ;
+            #curl -u piersy:${PR_COMMENT_TOKEN} -X ${CURL_VERB} $URL -d "{\"body\":\"`awk -v ORS='\\\\n' '1' comment`\"}" ;
+            curl -u celo-org:${SECRET} -X ${CURL_VERB} $URL -d "{\"body\":\"`awk -v ORS='\\\\n' '1' comment`\"}" ;
+
 
   e2e-benchmarks:
     executor: golang
@@ -615,10 +650,14 @@ workflows:
           requires:
             - go-modules
             - prepare-system-contracts
+      - akeyless-get-token:
+          context:
+            - akeyless
       - istanbul-e2e-coverage:
           requires:
             - go-modules
             - prepare-system-contracts
+            - akeyless-get-token
       - e2e-benchmarks:
           requires:
             - go-modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,7 +283,7 @@ jobs:
     docker:
       - image: akeyless/ci_base
     environment:
-      PR_COMMENT_TOKEN: /dynamic-secrets/keys/github/celo-blockchain/pull_requests=write
+      PR_COMMENT_TOKEN2: /dynamic-secrets/keys/github/celo-blockchain/pull_requests=write
     steps:
       - checkout
       - run:
@@ -295,8 +295,8 @@ jobs:
           command: akeyless auth --access-id $accessid --access-type jwt --jwt $CIRCLE_OIDC_TOKEN --json | jq '.token' -r  > ~/.vault_token
 
       - run:
-          name: "Get PR Comment token"
-          command: TOKEN=$(cat ~/.vault_token) && echo export SECRET=$(akeyless get-dynamic-secret-value --name $PR_COMMENT_TOKEN --token $TOKEN |grep token | awk '{print $2}' | tr -d '"",' ) >> "$BASH_ENV"
+          name: "Get PR Comment token (and remove unnecessary information and punctuation"
+          command: TOKEN=$(cat ~/.vault_token) && echo export PR_COMMENT_TOKEN2=$(akeyless get-dynamic-secret-value --name $PR_COMMENT_TOKEN2 --token $TOKEN |grep token | awk '{print $2}' | tr -d '"",' ) >> "$BASH_ENV"
 
       - run:
           name: "Copy $BASH_ENV to bash.env file"
@@ -469,8 +469,7 @@ jobs:
             # replaced by '\n'. Using backtics causes there to be a round of
             # backslash processing on the command before execution, so we
             # need to double the backslashes in the awk command.
-            #curl -u piersy:${PR_COMMENT_TOKEN} -X ${CURL_VERB} $URL -d "{\"body\":\"`awk -v ORS='\\\\n' '1' comment`\"}" ;
-            curl -u celo-org:${SECRET} -X ${CURL_VERB} $URL -d "{\"body\":\"`awk -v ORS='\\\\n' '1' comment`\"}" ;
+            curl -u celo-org:${PR_COMMENT_TOKEN2} -X ${CURL_VERB} $URL -d "{\"body\":\"`awk -v ORS='\\\\n' '1' comment`\"}" ;
 
 
   e2e-benchmarks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,23 +283,23 @@ jobs:
     docker:
       - image: akeyless/ci_base
     environment:
-      PR_COMMENT_TOKEN2: /dynamic-secrets/keys/github/celo-blockchain/pull_requests=write
+      PR_WRITE_TOKEN_PATH: /dynamic-secrets/keys/github/celo-blockchain/pull_requests=write
     steps:
       - checkout
       - run:
-          name: "update akeyless cli tool"
+          name: "update akeyless cli tool to latest version"
           command: akeyless update
 
       - run:
-          name: "authenticate to akeyless"
+          name: "authenticate to akeyless via OIDC"
           command: akeyless auth --access-id $accessid --access-type jwt --jwt $CIRCLE_OIDC_TOKEN --json | jq '.token' -r  > ~/.vault_token
 
       - run:
-          name: "Get PR Comment token (and remove unnecessary information and punctuation"
-          command: TOKEN=$(cat ~/.vault_token) && echo export PR_COMMENT_TOKEN2=$(akeyless get-dynamic-secret-value --name $PR_COMMENT_TOKEN2 --token $TOKEN |grep token | awk '{print $2}' | tr -d '"",' ) >> "$BASH_ENV"
+          name: "Get PR Comment token (and remove unnecessary information and punctuation)"
+          command: TOKEN=$(cat ~/.vault_token) && echo export PR_COMMENT_TOKEN2=$(akeyless get-dynamic-secret-value --name $PR_WRITE_TOKEN_PATH --token $TOKEN |grep token | awk '{print $2}' | tr -d '"",' ) >> "$BASH_ENV"
 
       - run:
-          name: "Copy $BASH_ENV to bash.env file"
+          name: "Copy $BASH_ENV to bash.env file so we can persist that to workspaces"
           command: cp $BASH_ENV bash.env
 
       - persist_to_workspace:


### PR DESCRIPTION
### Description

Changes the PR_COMMENT_TOKEN used to authenticate to github, to be a github organization app token instead of a personal access token, but generated by akeyless for each run.

Now it should use the akeyless context in circle ci to access the accessid variable, which is a nonsensitive id to know which akeyless auth method to use for circle ci.  This should use oauth2 to authenticate to akeyless by the circle CI organization and project ID, and have access to generate a temporary secret that gives access to write to PRs for the the celo-blockchain  github repository.

Then using the akeyless command line utility to generate the new key, it saves it and persists it via workspaces to share with the necessary jobs.



### Tested

Testing with this PR

### Backwards compatibility

Should be fully backwards compatible, leaving piersy's PR_COMMENT_TOKEN for now so it won't break anything while testing.