### PR TITLE
fix hd wallet path based on bit44

### DIFF
--- a/mycelo/env/accounts.go
+++ b/mycelo/env/accounts.go
@@ -233,8 +233,9 @@ func (accountType *AccountType) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// path is based on https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels
 func mustDerivationPath(accountType AccountType, idx int) accounts.DerivationPath {
-	return hdwallet.MustParseDerivationPath(fmt.Sprintf("m/%d/%d", int(accountType), idx))
+	return hdwallet.MustParseDerivationPath(fmt.Sprintf("m/44'/%d'/%d'/0/%d", MyceloCT.Int(), int(accountType), idx))
 }
 
 // DeriveAccount will derive the account corresponding to (accountType, idx) using the

--- a/mycelo/env/coin_type.go
+++ b/mycelo/env/coin_type.go
@@ -1,0 +1,13 @@
+package env
+
+// CoinType represents the coin_type based on BIP-44
+// Refer to https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels
+type CoinType int
+
+// https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+// This number is not duplicated in SLIP-0044 and copied from `ChainID` in `cmd/mycelo/templates.go`
+var MyceloCT CoinType = 9099000
+
+func (c CoinType) Int() int {
+	return int(c)
+}


### PR DESCRIPTION
Rebases the original PR https://github.com/celo-org/celo-blockchain/issues/1904 on current master. Original PR description follows:

Signed-off-by: Hiroki Yasui <hiroki.yasui@datachain.jp>

### Description

This PR is for https://github.com/celo-org/celo-blockchain/issues/1903

For now, HD wallet derivation path is not based on BIP-44 in mycelo. This difference makes key synchronization among other libraries difficult. Proper path must be like `m / purpose' / coin_type' / account' / change / address_index`. This is [specification](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#path-levels).
 e.g. `"m/44'/60'/0'/0/0"` is correct, but current`"m/1/0"` is not. [mycelo code](https://github.com/celo-org/celo-blockchain/blob/1a239cbf64188d7c0bd49ce6ae2fe63faab691a1/mycelo/env/accounts.go#L236-L238
)

For example, developer account keys are generated after running geth nodes with specific mnemonic through mycelo. Then I want to deploy contracts onto celo geth nodes. However it's difficult to generate same address with mnemonic using other libraries like [@truffle/hdwallet-provider](https://www.npmjs.com/package/@truffle/hdwallet-provider
) in truffle-config.json

I made sure same addresses are generated between mycelo and @truffle/hdwallet-provider using the same MNEMONIC.

### Related issues

- Fixes #1903