### PR TITLE
More nil checking in InsertReceiptChain

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1174,7 +1174,8 @@ func (bc *BlockChain) InsertReceiptChain(blockChain types.Blocks, receiptChain [
 		// Rewind may have occurred, skip in that case.
 		if bc.CurrentHeader().Number.Cmp(head.Number()) >= 0 {
 			currentFastBlock, td := bc.CurrentFastBlock(), bc.GetTd(head.Hash(), head.NumberU64())
-			if bc.GetTd(currentFastBlock.Hash(), currentFastBlock.NumberU64()).Cmp(td) < 0 {
+			fastBlockTd := bc.GetTd(currentFastBlock.Hash(), currentFastBlock.NumberU64())
+			if fastBlockTd != nil && td != nil && fastBlockTd.Cmp(td) < 0 {
 				rawdb.WriteHeadFastBlockHash(bc.db, head.Hash())
 				bc.currentFastBlock.Store(head)
 				headFastBlockGauge.Update(int64(head.NumberU64()))


### PR DESCRIPTION
Fixes https://github.com/celo-org/celo-blockchain/issues/1920

This just applies the change suggested in the issue. It seems reasonable and passed the tests, but I don't understand which situation would cause nil return values, yet.