### PR TITLE
Add local datadir flag and migrate flags

### DIFF
--- a/cmd/uptime/report.go
+++ b/cmd/uptime/report.go
@@ -33,9 +33,9 @@ var valSetSizeFlag = cli.Int64Flag{
 var reportUptimeCommand = cli.Command{
 	Name:      "report",
 	Usage:     "Reports uptime for all validators",
-	Action:    reportUptime,
+	Action:    utils.MigrateFlags(reportUptime),
 	ArgsUsage: "",
-	Flags:     []cli.Flag{epochFlag, lookbackFlag, valSetSizeFlag},
+	Flags:     []cli.Flag{epochFlag, lookbackFlag, valSetSizeFlag, utils.DataDirFlag},
 }
 
 // getHeaderByNumber retrieves a block header from the database by number,


### PR DESCRIPTION
### Description

`--datadir` cannot be passed in as a local flag for`uptime report`. Per #1914, `./build/bin/uptime report --epoch 786 --lookback 12 --valset 110 --datadir ~/chaindata/fastsync` would fail (though note that `./build/bin/uptime --datadir ~/chaindata/fastsync report --epoch 786 --lookback 12 --valset 110` worked). This adds `--datadir` as a local flag as well and migrates the flags to global context (so that the datadir is instantiated properly).

### Tested
- Tested this locally against chaindata from a mycelo testnet

### Related issues

- Fixes #1914

### Backwards compatibility

Yes, just adds the ability to add the datadir param as a local flag (in addition to global).