### PR TITLE
Stricter `make prepare-system-contracts`

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -11,7 +11,7 @@ on:
 env:
   # Increment these to force cache rebuilding
   SYSTEM_CONTRACTS_CACHE_VERSION: 2
-  CHECKOUT_MONOREPO_CACHE_VERSION: 3
+  CHECKOUT_MONOREPO_CACHE_VERSION: 4
   GO_VERSION: '1.17.5'
   # Location where compiled system contracts are stored under the root of this
   # repo.

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ $(MONOREPO_PATH): monorepo_commit
 	@set -e; \
 	mc=`cat monorepo_commit`; \
 	echo "monorepo_commit is $${mc}"; \
-	if git show-ref --verify refs/heads/$${mc} > /dev/null 2>&1; \
+	if git ls-remote --heads --exit-code git@github.com:celo-org/celo-monorepo.git $${mc} > /dev/null 2>&1; \
 	then \
 		echo "Expected commit hash or tag in 'monorepo_commit' instead found branch name '$${mc}'"; \
 		exit 1; \

--- a/monorepo_commit
+++ b/monorepo_commit
@@ -1,1 +1,1 @@
-gastonponti/core-contracts.v8-fix
+f9c26529aac16e226d054fcdf51183e6efb28af8


### PR DESCRIPTION
* Only allow tags or commit hashes to be specified in `monorepo_commit`
* Keep monorepo checkouts in a different dir per specified commit to allow fast switching

Closes https://github.com/celo-org/celo-blockchain/issues/1956