### PR TITLE
Overwrite developer genesis block period with flag value

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1836,7 +1836,18 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if err := ks.Unlock(developer, passphrase); err != nil {
 			Fatalf("Failed to unlock developer account: %v", err)
 		}
-		log.Info("Using developer account", "address", developer.Address)
+
+		// These must be set in order for dev mode to work out of the box with the developer account.
+		if cfg.Miner.Validator == (common.Address{}) {
+			log.Info("Setting developer account as validator", "address", developer.Address)
+			cfg.Miner.Validator = developer.Address
+		}
+		if cfg.TxFeeRecipient == (common.Address{}) {
+			log.Info("Setting developer account as txFeeRecipient", "address", developer.Address)
+			cfg.TxFeeRecipient = developer.Address
+		}
+
+		log.Info("Using developer account as validator & txFeeRecipient", "address", developer.Address)
 
 		// Create a new developer genesis block or reuse existing one
 		cfg.Genesis = core.DeveloperGenesisBlock(ctx.GlobalUint64(DeveloperPeriodFlag.Name))

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -150,6 +150,7 @@ var (
 	DeveloperPeriodFlag = cli.IntFlag{
 		Name:  "dev.period",
 		Usage: "Block period to use in developer mode (0 = mine only if transaction pending)",
+		Value: 1,
 	}
 	IdentityFlag = cli.StringFlag{
 		Name:  "identity",
@@ -1838,7 +1839,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		log.Info("Using developer account", "address", developer.Address)
 
 		// Create a new developer genesis block or reuse existing one
-		cfg.Genesis = core.DeveloperGenesisBlock()
+		cfg.Genesis = core.DeveloperGenesisBlock(ctx.GlobalUint64(DeveloperPeriodFlag.Name))
 		if ctx.GlobalIsSet(DataDirFlag.Name) {
 			// Check if we have an already initialized chain and fall back to
 			// that if so. Otherwise we need to generate a new genesis spec.

--- a/console/console_test.go
+++ b/console/console_test.go
@@ -98,7 +98,7 @@ func newTester(t *testing.T, confOverride func(*ethconfig.Config)) *tester {
 		t.Fatalf("failed to create node: %v", err)
 	}
 	ethConf := &eth.Config{
-		Genesis:        core.DeveloperGenesisBlock(),
+		Genesis:        core.DeveloperGenesisBlock(1),
 		TxFeeRecipient: common.HexToAddress(testAddress),
 		Miner: miner.Config{
 			Validator: common.HexToAddress(testAddress),

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -380,9 +380,10 @@ func DefaultAlfajoresGenesisBlock() *Genesis {
 }
 
 // DeveloperGenesisBlock returns the 'geth --dev' genesis block.
-func DeveloperGenesisBlock() *Genesis {
+func DeveloperGenesisBlock(period uint64) *Genesis {
 	// Override the default period to the user requested one
 	config := *params.DeveloperChainConfig
+	config.Istanbul.BlockPeriod = period
 	devAlloc := &GenesisAlloc{}
 	devAlloc.UnmarshalJSON([]byte(devAllocJSON))
 	// Assemble and return the genesis with the precompiles and faucet pre-funded

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -183,8 +183,10 @@ func TestRegistryInGenesis(t *testing.T) {
 		genesis func() *Genesis
 	}{
 		{
-			name:    "dev",
-			genesis: DeveloperGenesisBlock,
+			name: "dev",
+			genesis: func() *Genesis {
+				return DeveloperGenesisBlock(1)
+			},
 		},
 		{
 			name:    "alfajores",

--- a/docs/docs/_getting-started/dev-mode.md
+++ b/docs/docs/_getting-started/dev-mode.md
@@ -13,20 +13,19 @@ Starting geth in dev mode does the following:
 -   Sets the gas price to 0
 -   Uses the Clique PoA consensus engine with which allows blocks to be mined as-needed without excessive CPU and memory consumption
 -   By default produces a block per second
-    -   To instead produce blocks on-demand when transactions are waiting to be mined, set `--dev.period 0`
+    -   To instead produce blocks on-demand when transactions are waiting to be mined, set `--dev.period 0`)
 
 ## Start Geth in Dev Mode
 
-Note: this command currently does not work as intended in ephemeral mode and must be run with a data dictionary that contains a keystore file with the hard-coded developer account `0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95`. The easiest way of doing this is to:
+You can specify a data directory to maintain state between runs using the `--datadir` option, otherwise, databases are ephemeral and in-memory:
 
-1. Run the command with the desired `--datadir` (and `--dev.period` if a specific block period is desired): `geth --datadir test-chain-dir --dev.period 5`.
-    This will create the required genesis file in `test-chain-dir` and import the hard-coded developer account `0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95`
+```shell
+geth --dev
+```
 
-2. Then run: `geth --dev --miner.validator 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 --datadir test-chain-dir`
-    Note that this will use the block period configured in the first step.
+Optionally specify `--dev.period` if a block period other than 1 per second is desired.
 
-3. Re-run with the same state by repeating step 2. To start the chain without previous state, delete the datadir and start from step 1.
-
+Whether run ephemerally or with a persistent data directory, this uses the hard-coded developer account `0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95` to configure the validator and tx fee recipient. Note that currently dev mode does not function properly when setting the validator and tx fee recipient params to accounts other than the hard-coded developer account.
 
 ### Example with Remix
 
@@ -34,7 +33,7 @@ For this guide, start geth in dev mode as described above, and enable [RPC](../_
 
 ```shell
 geth --dev --datadir test-chain-dir
-geth --dev --datadir test-chain-dir --miner.validator 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 --http --http.corsdomain "https://remix.ethereum.org,http://remix.ethereum.org"
+geth --dev --datadir test-chain-dir --http --http.corsdomain "https://remix.ethereum.org,http://remix.ethereum.org"
 ```
 
 Connect to the IPC console on the node from another terminal window:

--- a/docs/docs/_getting-started/dev-mode.md
+++ b/docs/docs/_getting-started/dev-mode.md
@@ -8,7 +8,7 @@ Geth has a development mode that sets up a single node Ethereum test network wit
 Starting geth in dev mode does the following:
 
 -   Initializes the data directory with a testing genesis block
-  -   Sets default block period to 1 second
+    - Sets default block period to 1 second
 -   Sets max peers to 0
 -   Turns off discovery by other nodes
 -   Sets the gas price to 0

--- a/docs/docs/_getting-started/dev-mode.md
+++ b/docs/docs/_getting-started/dev-mode.md
@@ -8,12 +8,12 @@ Geth has a development mode that sets up a single node Ethereum test network wit
 Starting geth in dev mode does the following:
 
 -   Initializes the data directory with a testing genesis block
-    - Sets default block period to 1 second
 -   Sets max peers to 0
 -   Turns off discovery by other nodes
 -   Sets the gas price to 0
 -   Uses the Clique PoA consensus engine with which allows blocks to be mined as-needed without excessive CPU and memory consumption
--   Uses on-demand block generation, producing blocks when transactions are waiting to be mined
+-   By default produces a block per second
+    -   To instead produce blocks on-demand when transactions are waiting to be mined, set `--dev.period 0`
 
 ## Start Geth in Dev Mode
 

--- a/docs/docs/_getting-started/dev-mode.md
+++ b/docs/docs/_getting-started/dev-mode.md
@@ -13,7 +13,7 @@ Starting geth in dev mode does the following:
 -   Sets the gas price to 0
 -   Uses the Clique PoA consensus engine with which allows blocks to be mined as-needed without excessive CPU and memory consumption
 -   By default produces a block per second
-    -   To instead produce blocks on-demand when transactions are waiting to be mined, set `--dev.period 0`)
+    -   To instead produce blocks on-demand when transactions are waiting to be mined, set `--dev.period 0`
 
 ## Start Geth in Dev Mode
 

--- a/docs/docs/_getting-started/dev-mode.md
+++ b/docs/docs/_getting-started/dev-mode.md
@@ -8,6 +8,7 @@ Geth has a development mode that sets up a single node Ethereum test network wit
 Starting geth in dev mode does the following:
 
 -   Initializes the data directory with a testing genesis block
+  -   Sets default block period to 1 second
 -   Sets max peers to 0
 -   Turns off discovery by other nodes
 -   Sets the gas price to 0
@@ -16,16 +17,24 @@ Starting geth in dev mode does the following:
 
 ## Start Geth in Dev Mode
 
-You can specify a data directory to maintain state between runs using the `--datadir` option, otherwise, databases are ephemeral and in-memory:
+Note: this command currently does not work as intended in ephemeral mode and must be run with a data dictionary that contains a keystore file with the hard-coded developer account `0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95`. The easiest way of doing this is to:
+
+1. Run the command with the desired `--datadir` (and `--dev.period` if a specific block period is desired): `geth --datadir test-chain-dir --dev.period 5`.
+    This will create the required genesis file in `test-chain-dir` and import the hard-coded developer account `0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95`
+
+2. Then run: `geth --dev --miner.validator 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 --datadir test-chain-dir`
+    Note that this will use the block period configured in the first step.
+
+3. Re-run with the same state by repeating step 2. To start the chain without previous state, delete the datadir and start from step 1.
+
+
+### Example with Remix
+
+For this guide, start geth in dev mode as described above, and enable [RPC](../_rpc/server.md) so you can connect other applications to geth. For this guide, we use Remix, the web-based Ethereum IDE, so also allow its domains to accept cross-origin requests.
 
 ```shell
-mkdir test-chain-dir
-```
-
-For this guide, start geth in dev mode, and enable [RPC](../_rpc/server.md) so you can connect other applications to geth. For this guide, we use Remix, the web-based Ethereum IDE, so also allow its domains to accept cross-origin requests.
-
-```shell
-geth --datadir test-chain-dir --rpc --dev --rpccorsdomain "https://remix.ethereum.org,http://remix.ethereum.org"
+geth --dev --datadir test-chain-dir
+geth --dev --datadir test-chain-dir --miner.validator 0x47e172f6cfb6c7d01c1574fa3e2be7cc73269d95 --http --http.corsdomain "https://remix.ethereum.org,http://remix.ethereum.org"
 ```
 
 Connect to the IPC console on the node from another terminal window:
@@ -56,6 +65,6 @@ And check the balance of the account:
 
 If you want to test your dapps with a realistic block time use the `--dev.period` option when you start dev mode with the `--dev.period 14` argument.
 
-## Connect Remix to Geth
+#### Connect Remix to Geth
 
 With geth now running, open <https://remix.ethereum.org>. Compile the contract as normal, but when you deploy and run a contract, select _Web3 Provider_ from the _Environment_ dropdown, and add "http://127.0.0.1:8545" to the popup box. Click _Deploy_, and interact with the contract. You should see contract creation, mining, and transaction activity.

--- a/docs/docs/_getting-started/dev-mode.md
+++ b/docs/docs/_getting-started/dev-mode.md
@@ -66,4 +66,4 @@ If you want to test your dapps with a realistic block time use the `--dev.period
 
 #### Connect Remix to Geth
 
-With geth now running, open <https://remix.ethereum.org>. Compile the contract as normal, but when you deploy and run a contract, select _Web3 Provider_ from the _Environment_ dropdown, and add "http://127.0.0.1:8545" to the popup box. Click _Deploy_, and interact with the contract. You should see contract creation, mining, and transaction activity.
+With geth now running, open <https://remix.ethereum.org>. Compile the contract as normal, but when you deploy and run a contract, select _Custom -- External Http Provider_ from the _Environment_ dropdown, and add "http://127.0.0.1:8545" to the popup box. Click _Deploy_, and interact with the contract. You should see contract creation, mining, and transaction activity.

--- a/docs/docs/_interface/Command-Line-Options.md
+++ b/docs/docs/_interface/Command-Line-Options.md
@@ -68,7 +68,7 @@ LIGHT CLIENT OPTIONS:
 
 DEVELOPER CHAIN OPTIONS:
   --dev                               Ephemeral proof-of-authority network with a pre-funded developer account, mining enabled
-  --dev.period value                  Block period to use in developer mode (0 = mine only if transaction pending) (default: 0)
+  --dev.period value                  Block period to use in developer mode (0 = mine only if transaction pending) (default: 1)
 
 ETHASH OPTIONS:
   --ethash.cachedir value             Directory to store the ethash verification caches (default = inside the datadir)

--- a/miner/miner_test.go
+++ b/miner/miner_test.go
@@ -263,7 +263,7 @@ func createMiner(t *testing.T) (*Miner, *event.TypeMux) {
 	// Create chainConfig
 	memdb := memorydb.New()
 	chainDB := rawdb.NewDatabase(memdb)
-	genesis := core.DeveloperGenesisBlock()
+	genesis := core.DeveloperGenesisBlock(1)
 	chainConfig, _, err := core.SetupGenesisBlock(chainDB, genesis)
 	if err != nil {
 		t.Fatalf("can't create new chain config: %v", err)


### PR DESCRIPTION
### Description
- Overwrites the developer block period flag (`--dev.period`), which wasn't happening before.
- Ensures that the validator & txFeeRecipient vals are set in the config for dev mode, which should (mostly) fix `--dev` mode
  - Although this is a bit messy (in that we are re-setting this value after it has been set above), I think it strikes a balance of making dev mode work & not cluttering the rest of the code too much.
- Updates developer docs in `dev-mode.md` & parameter details to reflect the status quo

Note that the `geth --dev` command is still somewhat broken in terms of account configuration. For now, it runs as expected when using the hard-coded dev account (both in "ephemeral" mode & with a persistent data directory) but doesn't work properly for "general" accounts/data directories. (I didn't think it was worth investing time into making it work more generally under those circumstances, given that mycelo also exists & has more functionality anyways).

### Tested
- tested dev mode locally
- tested out the `dev-mode.md` instructions & deployment with remix

### Related issues

- Fixes #2007

### Backwards compatibility
- Backwards compatible
- Note that though the docs said that the default was 0 (on-demand), this wasn't actually the case before (default was hard-coded as 1).
