### PR TITLE
Split roundstate saving in two

### DIFF
--- a/consensus/istanbul/core/roundstate.go
+++ b/consensus/istanbul/core/roundstate.go
@@ -409,18 +409,30 @@ func (rs *roundStateImpl) TransitionToPrepared(quorumSize int) error {
 }
 
 func (rs *roundStateImpl) AddCommit(msg *istanbul.Message) error {
+	// IMPORTANT: due to how in the roundstate_save_decorator
+	// & roundstate_db we are breaking encapsulation of this type,
+	// this method CANNOT and SHOULD NOT modify ANYTHING OTHER than
+	// the 'commits' message set.
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 	return rs.commits.Add(msg)
 }
 
 func (rs *roundStateImpl) AddPrepare(msg *istanbul.Message) error {
+	// IMPORTANT: due to how in the roundstate_save_decorator
+	// & roundstate_db we are breaking encapsulation of this type,
+	// this method CANNOT and SHOULD NOT modify ANYTHING OTHER than
+	// the 'prepares' message set.
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 	return rs.prepares.Add(msg)
 }
 
 func (rs *roundStateImpl) AddParentCommit(msg *istanbul.Message) error {
+	// IMPORTANT: due to how in the roundstate_save_decorator
+	// & roundstate_db we are breaking encapsulation of this type,
+	// this method CANNOT and SHOULD NOT modify ANYTHING OTHER than
+	// the 'parentCommits' message set.
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 	return rs.parentCommits.Add(msg)

--- a/consensus/istanbul/core/roundstate_db_test.go
+++ b/consensus/istanbul/core/roundstate_db_test.go
@@ -51,8 +51,8 @@ func TestRSDBRoundStateDB(t *testing.T) {
 		view := newView(2, 1)
 		rs := newRoundState(view, valSet, valSet.GetByIndex(0))
 		rs.AddPrepare(mockViewMsg(view, istanbul.MsgPrepare, valSet.GetByIndex(0).Address()))
-		rs.AddCommit(mockViewMsg(view, istanbul.MsgPrepare, valSet.GetByIndex(0).Address()))
-		rs.AddParentCommit(mockViewMsg(view, istanbul.MsgPrepare, valSet.GetByIndex(0).Address()))
+		rs.AddCommit(mockViewMsg(view, istanbul.MsgCommit, valSet.GetByIndex(0).Address()))
+		rs.AddParentCommit(mockViewMsg(view, istanbul.MsgCommit, valSet.GetByIndex(0).Address()))
 		return rs
 	}
 

--- a/consensus/istanbul/core/roundstate_save_decorator.go
+++ b/consensus/istanbul/core/roundstate_save_decorator.go
@@ -45,6 +45,14 @@ func (rsp *rsSaveDecorator) persistOnNoError(err error) error {
 	return rsp.db.UpdateLastRoundState(rsp.rs)
 }
 
+func (rsp *rsSaveDecorator) persistRcvdOnNoError(err error) error {
+	if err != nil {
+		return err
+	}
+
+	return rsp.db.UpdateLastRcvd(rsp.rs)
+}
+
 // mutation functions
 func (rsp *rsSaveDecorator) StartNewRound(nextRound *big.Int, validatorSet istanbul.ValidatorSet, nextProposer istanbul.Validator) error {
 	return rsp.persistOnNoError(rsp.rs.StartNewRound(nextRound, validatorSet, nextProposer))
@@ -66,13 +74,13 @@ func (rsp *rsSaveDecorator) TransitionToPrepared(quorumSize int) error {
 	return rsp.persistOnNoError(rsp.rs.TransitionToPrepared(quorumSize))
 }
 func (rsp *rsSaveDecorator) AddCommit(msg *istanbul.Message) error {
-	return rsp.persistOnNoError(rsp.rs.AddCommit(msg))
+	return rsp.persistRcvdOnNoError(rsp.rs.AddCommit(msg))
 }
 func (rsp *rsSaveDecorator) AddPrepare(msg *istanbul.Message) error {
-	return rsp.persistOnNoError(rsp.rs.AddPrepare(msg))
+	return rsp.persistRcvdOnNoError(rsp.rs.AddPrepare(msg))
 }
 func (rsp *rsSaveDecorator) AddParentCommit(msg *istanbul.Message) error {
-	return rsp.persistOnNoError(rsp.rs.AddParentCommit(msg))
+	return rsp.persistRcvdOnNoError(rsp.rs.AddParentCommit(msg))
 }
 func (rsp *rsSaveDecorator) SetPendingRequest(pendingRequest *istanbul.Request) error {
 	return rsp.persistOnNoError(rsp.rs.SetPendingRequest(pendingRequest))

--- a/consensus/istanbul/core/testutils_test.go
+++ b/consensus/istanbul/core/testutils_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
+	"github.com/stretchr/testify/assert"
 )
 
 func newView(seq, round uint64) *istanbul.View {
@@ -52,15 +53,30 @@ func assertEqualRoundState(t *testing.T, have, want RoundState) {
 		}
 	}
 
+	testEqualMessageSet := func(name string, have, want MessageSet) {
+		wantValues := want.Values()
+		haveValues := have.Values()
+		if len(haveValues) != len(wantValues) {
+			t.Errorf("RoundState.%s size mismatch: have %v, want %v", name, have, want)
+			return
+		}
+		for i := range wantValues {
+			wantValues[i] = wantValues[i].Copy()
+			haveValues[i] = haveValues[i].Copy()
+		}
+		assert.ElementsMatch(t, wantValues, haveValues,
+			"RoundState.%s mismatch (values w/o order): have %v, want %v", name, haveValues, wantValues)
+	}
+
 	testEqual("State", have.State(), want.State())
 	testEqual("Round", have.Round(), want.Round())
 	testEqual("DesiredRound", have.DesiredRound(), want.DesiredRound())
 	testEqual("Sequence", have.Sequence(), want.Sequence())
 	testEqual("ValidatorSet", have.ValidatorSet(), want.ValidatorSet())
 	testEqual("Proposer", have.Proposer(), want.Proposer())
-	testEqual("ParentCommits", have.ParentCommits(), want.ParentCommits())
-	testEqual("Commits", have.Commits(), want.Commits())
-	testEqual("Prepares", have.Prepares(), want.Prepares())
+	testEqualMessageSet("ParentCommits", have.ParentCommits(), want.ParentCommits())
+	testEqualMessageSet("Commits", have.Commits(), want.Commits())
+	testEqualMessageSet("Prepares", have.Prepares(), want.Prepares())
 
 	if have.PendingRequest() == nil || want.PendingRequest() == nil {
 		testEqual("PendingRequest", have.PendingRequest(), want.PendingRequest())


### PR DESCRIPTION
Split the roundstate saving, allowing consensus message processing to be a bit faster.