### PR TITLE
Add baseFeePerGas to headers sent via EthSubscribe

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -874,6 +874,10 @@ func (fb *filterBackend) ServiceFilter(ctx context.Context, ms *bloombits.Matche
 	panic("not supported")
 }
 
+func (fb *filterBackend) RealGasPriceMinimumForHeader(ctx context.Context, currencyAddress *common.Address, header *types.Header) (*big.Int, error) {
+	return nil, fmt.Errorf("filterBackend does not implement RealGasPriceMinimumForHeader")
+}
+
 func nullSubscription() event.Subscription {
 	return event.NewSubscription(func(quit <-chan struct{}) error {
 		<-quit

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -45,6 +45,7 @@ type Backend interface {
 
 	BloomStatus() (uint64, uint64)
 	ServiceFilter(ctx context.Context, session *bloombits.MatcherSession)
+	RealGasPriceMinimumForHeader(ctx context.Context, currencyAddress *common.Address, header *types.Header) (*big.Int, error)
 }
 
 // Filter can be used to retrieve and filter logs.

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -156,6 +156,10 @@ func (b *testBackend) ServiceFilter(ctx context.Context, session *bloombits.Matc
 	}()
 }
 
+func (b *testBackend) RealGasPriceMinimumForHeader(ctx context.Context, currencyAddress *common.Address, header *types.Header) (*big.Int, error) {
+	return nil, fmt.Errorf("testBackend does not implement RealGasPriceMinimumForHeader")
+}
+
 // TestBlockSubscription tests if a block subscription returns block hashes for posted chain events.
 // It creates multiple subscriptions:
 // - one at the start and should receive all posted chain events and a second (blockHashes)

--- a/mycelo/cluster/node.go
+++ b/mycelo/cluster/node.go
@@ -40,6 +40,11 @@ func (nc *NodeConfig) RPCPort() int64 {
 	return int64(8545 + nc.Number)
 }
 
+// RPCPort is the rpc port this node will use
+func (nc *NodeConfig) WebsocketPort() int64 {
+	return int64(9545 + nc.Number)
+}
+
 // NodePort is the node port this node will use
 func (nc *NodeConfig) NodePort() int64 {
 	return int64(30303 + nc.Number)
@@ -165,6 +170,10 @@ func (n *Node) Run(ctx context.Context) error {
 		"--http.addr", "127.0.0.1",
 		"--http.port", strconv.FormatInt(n.RPCPort(), 10),
 		"--http.api", "eth,net,web3,debug,admin,personal,istanbul,txpool",
+		"--ws",
+		"--ws.addr", "127.0.0.1",
+		"--ws.port", strconv.FormatInt(n.WebsocketPort(), 10),
+		"--ws.api", "eth,net,web3,debug,admin,personal,istanbul,txpool",
 		// "--nodiscover", "--nousb ",
 		"--unlock", addressToUnlock,
 		"--password", n.pwdFile(),


### PR DESCRIPTION
### Description

Adding the `baseFeePerGas` to blocks returned by `EthSubscribe` makes the results more consistent with the data returned on Ethereum and via other RPC-Endpoints on Celo. And it is useful!

Once we add the `baseFeePerGas` to the header, this implementation is not needed anymore. So this change is only temporary.

I did not check for `RPCEthCompatibility` since this is not done for `baseFeePerGas` in the normal JSON-RPC responses, either.

### Other changes

* Enabled websockets for mycelo

### Tested

Tested against mycelo with the following code

```json
{
  "name": "subs",
  "version": "1.0.0",
  "main": "index.js",
  "license": "MIT",
  "dependencies": {
    "web3": "^1.9.0",
    "web3-providers-http": "^1.9.0"
  }
}
```
```js
const Web3WsProvider = require('web3-providers-ws');
var provider = new Web3WsProvider('ws://localhost:9545');

const Web3 = require('web3');
const web3 = new Web3(provider)

async function wrapper(){
    const subs = web3.eth.subscribe('newBlockHeaders', function(error, result) {
      if (!error)
          console.log(result);
      else
          console.log(error);
    });
}

wrapper()
```

### Related issues

- Fixes https://github.com/celo-org/celo-blockchain-planning/issues/59

### Backwards compatibility

Adding a field to the response should not break sanely implemented consumers. IMO it is acceptable to consider this backwards compatible, although it is not true in a strict sense.