### PR TITLE
ci: Fix lint job

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -112,7 +112,7 @@ jobs:
 
   lint:
     name: Lint code
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     needs: go-modules
 
     steps:
@@ -125,10 +125,7 @@ jobs:
         check-latest: false
         cache: true
     - name: Run linter
-      uses: golangci/golangci-lint-action@v3
-      with:
-        skip-pkg-cache: true
-        only-new-issues: true
+      run: make lint
 
   unit-tests:
     name: Unit tests

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -81,7 +81,7 @@ jobs:
 
   go-modules:
     name: Setup go
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repo
@@ -96,7 +96,7 @@ jobs:
   check-imports:
     name: Check imports
     needs: go-modules
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout repo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters:
     - misspell
     # - staticcheck
     - unconvert
-    - unused
+    # - unused
 
     # - gosec
     # - errcheck


### PR DESCRIPTION
- Switches CI to use the committed version of `golangci-lint`
- Use smaller runners for small jobs
- Disable `unused` lint for now
  - Has been enabled upstream later: https://github.com/ethereum/go-ethereum/pull/24783

