### PR TITLE
ci: Remove `go-modules` job

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -79,23 +79,8 @@ jobs:
         name: system-contracts
         path: 'celo-monorepo/${{ env.CONTRACTS_BUILD_PATH }}'
 
-  go-modules:
-    name: Setup go
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v3
-    - name: Setup go
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        check-latest: false
-        cache: true
-
   check-imports:
     name: Check imports
-    needs: go-modules
     runs-on: ubuntu-latest
 
     steps:
@@ -113,7 +98,6 @@ jobs:
   lint:
     name: Lint code
     runs-on: ubuntu-latest
-    needs: go-modules
 
     steps:
     - name: Checkout repo
@@ -130,9 +114,7 @@ jobs:
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest-4-cores
-    needs:
-    - go-modules
-    - prepare-system-contracts
+    needs: prepare-system-contracts
 
     steps:
     - name: Checkout repo
@@ -182,9 +164,7 @@ jobs:
     name: Data race detector
     if: ${{ github.ref == 'refs/heads/master' || contains(github.ref, 'release') }}
     runs-on: ubuntu-latest-4-cores
-    needs:
-    - go-modules
-    - prepare-system-contracts
+    needs: prepare-system-contracts
 
     steps:
     - name: Checkout repo
@@ -219,8 +199,6 @@ jobs:
   build-and-store-binaries:
     name: Build and store binaries
     runs-on: ubuntu-latest-4-cores
-    needs:
-      - go-modules
 
     steps:
     - name: Checkout repo
@@ -243,13 +221,10 @@ jobs:
   istanbul-e2e-coverage:
     name: Istanbul consensus coverage
     runs-on: ubuntu-latest-4-cores
+    needs: prepare-system-contracts
     # Needed to publish the summary PR comment
     permissions:
       pull-requests: write
-
-    needs:
-    - go-modules
-    - prepare-system-contracts
 
     steps:
     - name: Checkout repo
@@ -292,9 +267,7 @@ jobs:
   lightest-sync-test:
     name: Lightest sync test
     runs-on: ubuntu-latest-4-cores
-
-    needs:
-    - build-and-store-binaries
+    needs: build-and-store-binaries
 
     steps:
     - name: Checkout repo
@@ -320,10 +293,7 @@ jobs:
   e2e-benchmarks:
     name: End-to-end benchmarks
     runs-on: ubuntu-latest-4-cores
-
-    needs:
-    - go-modules
-    - prepare-system-contracts
+    needs: prepare-system-contracts
 
     steps:
     - name: Checkout repo
@@ -354,12 +324,9 @@ jobs:
   end-to-end-blockchain-parameters-test:
     name: End-to-end blockchain parameters test
     runs-on: ubuntu-latest-4-cores
+    needs: prepare-system-contracts
     env:
       NODE_VERSION: 12
-
-    needs:
-    - go-modules
-    - prepare-system-contracts
 
     steps:
     - name: Checkout repo
@@ -400,12 +367,9 @@ jobs:
   end-to-end-governance-test:
     name: End-to-end governance test
     runs-on: ubuntu-latest-4-cores
+    needs: prepare-system-contracts
     env:
       NODE_VERSION: 12
-
-    needs:
-    - go-modules
-    - prepare-system-contracts
 
     steps:
     - name: Checkout repo
@@ -447,12 +411,9 @@ jobs:
   end-to-end-sync-test:
     name: End-to-end sync test
     runs-on: ubuntu-latest-4-cores
+    needs: prepare-system-contracts
     env:
       NODE_VERSION: 12
-
-    needs:
-    - go-modules
-    - prepare-system-contracts
 
     steps:
     - name: Checkout repo
@@ -493,12 +454,9 @@ jobs:
   end-to-end-slashing-test:
     name: End-to-end slashing test
     runs-on: ubuntu-latest-4-cores
+    needs: prepare-system-contracts
     env:
       NODE_VERSION: 12
-
-    needs:
-    - go-modules
-    - prepare-system-contracts
 
     steps:
     - name: Checkout repo
@@ -539,12 +497,9 @@ jobs:
   end-to-end-transfers-test:
     name: End-to-end transfers test
     runs-on: ubuntu-latest-4-cores
+    needs: prepare-system-contracts
     env:
       NODE_VERSION: 12
-
-    needs:
-    - go-modules
-    - prepare-system-contracts
 
     steps:
     - name: Checkout repo
@@ -585,12 +540,9 @@ jobs:
   end-to-end-validator-order-test:
     name: End-to-end validator order test
     runs-on: ubuntu-latest-4-cores
+    needs: prepare-system-contracts
     env:
       NODE_VERSION: 12
-
-    needs:
-    - go-modules
-    - prepare-system-contracts
 
     steps:
     - name: Checkout repo
@@ -631,12 +583,9 @@ jobs:
   end-to-end-cip35-eth-compatibility-test:
     name: End-to-end CIP35-eth compatibility test
     runs-on: ubuntu-latest-4-cores
+    needs: prepare-system-contracts
     env:
       NODE_VERSION: 12
-
-    needs:
-    - go-modules
-    - prepare-system-contracts
 
     steps:
     - name: Checkout repo
@@ -677,12 +626,9 @@ jobs:
   end-to-end-replica-test:
     name: End-to-end replica test
     runs-on: ubuntu-latest-4-cores
+    needs: prepare-system-contracts
     env:
       NODE_VERSION: 12
-
-    needs:
-    - go-modules
-    - prepare-system-contracts
 
     steps:
     - name: Checkout repo

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -48,6 +48,7 @@ const (
 
 	ErrorJson = 10
 	ErrorIO   = 11
+	Test      = 12
 
 	stdinSelector = "stdin"
 )


### PR DESCRIPTION
This job was just installing and caching go, something that will only be useful in the case of updating the go version. As this does not happen often, this commit optimises the common case by removing the job.

@carterqw2 Is there another use of this job?