### PR TITLE
eth/protocols: Explain reason for protocol change

### DIFF
--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -137,6 +137,11 @@ func handleGetBlockBodies67(backend Backend, msg Decoder, peer *Peer) error {
 	return peer.ReplyBlockBodiesRLP(query.RequestId, response)
 }
 
+// In Celo the return value of the `GetBlockBodies` query has been changed to include both the block hash
+// and the block bodies. This is necessary because received block bodies can not be matched to the header
+// directly, as there is body data (i.e. `Randomness` and `EpochSnarkData`) which is not represented in the
+// header. That means that theat the block fetcher cannot find the corresponding header for given blockdata
+// without executing the block contents. This is avoided by passing the block hash with the body data.
 func answerGetBlockBodiesQuery(backend Backend, query GetBlockBodiesPacket, peer *Peer) ([]rlp.RawValue, error) {
 	// Gather blocks until the fetch or network limits is reached
 	var (


### PR DESCRIPTION
### Description

Document the reason for returning block data and block hash in the eth protocol.