### PR TITLE
Add test cases for native and precompile transfers and tracing

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -68,7 +68,7 @@ func celoPrecompileAddress(index byte) common.Address {
 var (
 	celoPrecompiledContractsAddressOffset = byte(0xff)
 
-	TransferAddress              = celoPrecompileAddress(2)
+	transferAddress              = celoPrecompileAddress(2)
 	fractionMulExpAddress        = celoPrecompileAddress(3)
 	proofOfPossessionAddress     = celoPrecompileAddress(4)
 	getValidatorAddress          = celoPrecompileAddress(5)
@@ -114,7 +114,7 @@ var PrecompiledContractsByzantium = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{8}): &bn256PairingByzantium{},
 
 	// Celo Precompiled Contracts
-	TransferAddress:              &transfer{},
+	transferAddress:              &transfer{},
 	fractionMulExpAddress:        &fractionMulExp{},
 	proofOfPossessionAddress:     &proofOfPossession{},
 	getValidatorAddress:          &getValidator{},
@@ -140,7 +140,7 @@ var PrecompiledContractsIstanbul = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 
 	// Celo Precompiled Contracts
-	TransferAddress:              &transfer{},
+	transferAddress:              &transfer{},
 	fractionMulExpAddress:        &fractionMulExp{},
 	proofOfPossessionAddress:     &proofOfPossession{},
 	getValidatorAddress:          &getValidator{},
@@ -166,7 +166,7 @@ var PrecompiledContractsDonut = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 
 	// Celo Precompiled Contracts
-	TransferAddress:              &transfer{},
+	transferAddress:              &transfer{},
 	fractionMulExpAddress:        &fractionMulExp{},
 	proofOfPossessionAddress:     &proofOfPossession{},
 	getValidatorAddress:          &getValidator{},
@@ -213,7 +213,7 @@ var PrecompiledContractsE = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 
 	// Celo Precompiled Contracts
-	TransferAddress:              &transfer{},
+	transferAddress:              &transfer{},
 	fractionMulExpAddress:        &fractionMulExp{},
 	proofOfPossessionAddress:     &proofOfPossession{},
 	getValidatorAddress:          &getValidator{},

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -698,7 +698,7 @@ func (c *transfer) Run(input []byte, caller common.Address, evm *EVM) ([]byte, e
 	//   to:    32 bytes representing the address of the recipient
 	//   value: 32 bytes, a 256 bit integer representing the amount of Celo Gold to transfer
 	// 3 arguments x 32 bytes each = 96 bytes total input
-	if (evm.chainRules.IsGFork && len(input) != 96) || len(input) <= 96 {
+	if (evm.chainRules.IsGFork && len(input) != 96) || len(input) < 96 {
 		return nil, ErrInputLength
 	}
 

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -68,7 +68,7 @@ func celoPrecompileAddress(index byte) common.Address {
 var (
 	celoPrecompiledContractsAddressOffset = byte(0xff)
 
-	transferAddress              = celoPrecompileAddress(2)
+	TransferAddress              = celoPrecompileAddress(2)
 	fractionMulExpAddress        = celoPrecompileAddress(3)
 	proofOfPossessionAddress     = celoPrecompileAddress(4)
 	getValidatorAddress          = celoPrecompileAddress(5)
@@ -114,7 +114,7 @@ var PrecompiledContractsByzantium = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{8}): &bn256PairingByzantium{},
 
 	// Celo Precompiled Contracts
-	transferAddress:              &transfer{},
+	TransferAddress:              &transfer{},
 	fractionMulExpAddress:        &fractionMulExp{},
 	proofOfPossessionAddress:     &proofOfPossession{},
 	getValidatorAddress:          &getValidator{},
@@ -140,7 +140,7 @@ var PrecompiledContractsIstanbul = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 
 	// Celo Precompiled Contracts
-	transferAddress:              &transfer{},
+	TransferAddress:              &transfer{},
 	fractionMulExpAddress:        &fractionMulExp{},
 	proofOfPossessionAddress:     &proofOfPossession{},
 	getValidatorAddress:          &getValidator{},
@@ -166,7 +166,7 @@ var PrecompiledContractsDonut = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 
 	// Celo Precompiled Contracts
-	transferAddress:              &transfer{},
+	TransferAddress:              &transfer{},
 	fractionMulExpAddress:        &fractionMulExp{},
 	proofOfPossessionAddress:     &proofOfPossession{},
 	getValidatorAddress:          &getValidator{},
@@ -213,7 +213,7 @@ var PrecompiledContractsE = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 
 	// Celo Precompiled Contracts
-	transferAddress:              &transfer{},
+	TransferAddress:              &transfer{},
 	fractionMulExpAddress:        &fractionMulExp{},
 	proofOfPossessionAddress:     &proofOfPossession{},
 	getValidatorAddress:          &getValidator{},

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -186,7 +186,7 @@ var allPrecompiles = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{18}):         &bls12381MapG2{},
 
 	// Celo Precompiled Contracts
-	TransferAddress:              &transfer{},
+	transferAddress:              &transfer{},
 	fractionMulExpAddress:        &fractionMulExp{},
 	proofOfPossessionAddress:     &proofOfPossession{},
 	getValidatorAddress:          &getValidator{},

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -186,7 +186,7 @@ var allPrecompiles = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{18}):         &bls12381MapG2{},
 
 	// Celo Precompiled Contracts
-	transferAddress:              &transfer{},
+	TransferAddress:              &transfer{},
 	fractionMulExpAddress:        &fractionMulExp{},
 	proofOfPossessionAddress:     &proofOfPossession{},
 	getValidatorAddress:          &getValidator{},

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -56,6 +56,10 @@ func TestSendCelo(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// This test starts a network, submits a GoldToken.transfer tx, waits for the whole
+// network to process the transaction, and traces that tx.
+// This tests that CELO transfers made via the transfer precompile work e2e
+// and can be useful for debugging these traces.
 func TestTraceSendCeloViaGoldToken(t *testing.T) {
 	ac := test.AccountConfig(3, 2)
 	gc, ec, err := test.BuildConfig(ac)

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -670,11 +670,10 @@ func TestCallTraceTransactionPrecompileTransfer(t *testing.T) {
 		t.Fatalf("failed to pack args: %v", err)
 	}
 
-	transferPrecompile := vm.TransferAddress
 	gas := params.TxGas * 2
 	api := NewAPI(newTestBackend(t, 1, genesis, func(i int, b *core.BlockGen) {
-		// Transfer via transferPrecompile by sending tx from GoldToken addr
-		tx, _ := types.SignTx(types.NewTransaction(uint64(i), transferPrecompile, big.NewInt(0), gas, big.NewInt(3), nil, nil, nil, data), signer, goldToken.key)
+		// Transfer via transfer precompile by sending tx from GoldToken addr
+		tx, _ := types.SignTx(types.NewTransaction(uint64(i), vm.TransferAddress, big.NewInt(0), gas, big.NewInt(3), nil, nil, nil, data), signer, goldToken.key)
 		b.AddTx(tx)
 		target = tx.Hash()
 	}))
@@ -696,7 +695,7 @@ func TestCallTraceTransactionPrecompileTransfer(t *testing.T) {
 		// Outer transaction call
 		Type:   "CALL",
 		From:   goldToken.addr,
-		To:     transferPrecompile,
+		To:     vm.TransferAddress,
 		Input:  data,
 		Output: data,
 		Gas:    newRPCUint64(20112),

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -627,10 +627,10 @@ func TestCallTraceTransactionPrecompileTransfer(t *testing.T) {
 		registryProxyAddr: { // Registry Proxy
 			Code: testutil.RegistryProxyOpcodes,
 			Storage: map[common.Hash]common.Hash{
-				common.HexToHash("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"): common.HexToHash("0xce11"),                                                             // Registry Implementation
-				common.HexToHash("0x91646b8507bf2e54d7c3de9155442ba111546b81af1cbdd1f68eeb6926b98d58"): common.HexToHash("0xd023"),                                                             // Governance Proxy
-				common.HexToHash("0x773cc8652456781771d48fb3d560d7ba3d6d1882654492b68beec583d2c590aa"): goldToken.addr.Hash(),                                                                  // GoldToken Implementation
-				common.HexToHash("0x2131a4338f6fb8d4507e234a7c72af8efefbbf2f1817ed570bce33eb6667feb9"): common.HexToHash("0x000000000000000000000000000000000000000000000000000000000000d007"), // Reserve Implementation
+				common.HexToHash("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"): common.HexToHash("0xce11"), // Registry Implementation
+				common.HexToHash("0x91646b8507bf2e54d7c3de9155442ba111546b81af1cbdd1f68eeb6926b98d58"): common.HexToHash("0xd023"), // Governance Proxy
+				common.HexToHash("0x773cc8652456781771d48fb3d560d7ba3d6d1882654492b68beec583d2c590aa"): goldToken.addr.Hash(),      // GoldToken Implementation
+				common.HexToHash("0x2131a4338f6fb8d4507e234a7c72af8efefbbf2f1817ed570bce33eb6667feb9"): common.HexToHash("0xd007"), // Reserve Implementation
 			},
 			Balance: big.NewInt(0),
 		},
@@ -669,11 +669,11 @@ func TestCallTraceTransactionPrecompileTransfer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to pack args: %v", err)
 	}
-
+	transferPrecompile := common.HexToAddress("0xfd")
 	gas := params.TxGas * 2
 	api := NewAPI(newTestBackend(t, 1, genesis, func(i int, b *core.BlockGen) {
 		// Transfer via transfer precompile by sending tx from GoldToken addr
-		tx, _ := types.SignTx(types.NewTransaction(uint64(i), vm.TransferAddress, big.NewInt(0), gas, big.NewInt(3), nil, nil, nil, data), signer, goldToken.key)
+		tx, _ := types.SignTx(types.NewTransaction(uint64(i), transferPrecompile, big.NewInt(0), gas, big.NewInt(3), nil, nil, nil, data), signer, goldToken.key)
 		b.AddTx(tx)
 		target = tx.Hash()
 	}))
@@ -695,7 +695,7 @@ func TestCallTraceTransactionPrecompileTransfer(t *testing.T) {
 		// Outer transaction call
 		Type:   "CALL",
 		From:   goldToken.addr,
-		To:     vm.TransferAddress,
+		To:     transferPrecompile,
 		Input:  data,
 		Output: data,
 		Gas:    newRPCUint64(20112),

--- a/test/account.go
+++ b/test/account.go
@@ -45,7 +45,7 @@ func (a *Account) SendCelo(ctx context.Context, recipient common.Address, value 
 	}
 
 	signer := types.MakeSigner(a.ChainConfig, new(big.Int).SetUint64(num))
-	tx, err := ValueTransferTransaction(
+	tx, err := BuildSignedTransaction(
 		node.WsClient,
 		a.Key,
 		a.Address,
@@ -150,7 +150,7 @@ func (a *Account) SendCeloViaGoldToken(ctx context.Context, recipient common.Add
 	if err != nil {
 		return nil, err
 	}
-	tx, err := ValueTransferTransaction(
+	tx, err := BuildSignedTransaction(
 		node.WsClient,
 		a.Key,
 		a.Address,

--- a/test/account.go
+++ b/test/account.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/celo-blockchain/mycelo/contract"
 	"github.com/celo-org/celo-blockchain/mycelo/env"
 	"github.com/celo-org/celo-blockchain/params"
 )
@@ -51,7 +52,9 @@ func (a *Account) SendCelo(ctx context.Context, recipient common.Address, value 
 		recipient,
 		*a.Nonce,
 		big.NewInt(value),
-		signer)
+		signer,
+		nil,
+	)
 
 	if err != nil {
 		return nil, err
@@ -116,6 +119,56 @@ func (a *Account) SendCeloTracked(ctx context.Context, recipient common.Address,
 		return nil, err
 	}
 	return node.Tracker.GetProcessedTx(tx.Hash()), nil
+}
+
+// SendCelo submits a transaction to `node` that invokes the equivalent of
+// GoldToken.transfer(recipient, value), sent from the calling account.
+// The submitted transaction is returned.
+func (a *Account) SendCeloViaGoldToken(ctx context.Context, recipient common.Address, value int64, node *Node) (*types.Transaction, error) {
+	var err error
+	// Lazy set nonce
+	if a.Nonce == nil {
+		a.Nonce = new(uint64)
+		*a.Nonce, err = node.WsClient.PendingNonceAt(ctx, a.Address)
+		if err != nil {
+			return nil, err
+		}
+	}
+	num, err := node.WsClient.BlockNumber(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	signer := types.MakeSigner(a.ChainConfig, new(big.Int).SetUint64(num))
+	goldTokenName := "GoldToken"
+	goldTokenProxyAddr, err := env.ProxyAddressFor(goldTokenName)
+	if err != nil {
+		return nil, err
+	}
+	goldTokenABI := contract.AbiFor(goldTokenName)
+	data, err := goldTokenABI.Pack("transfer", recipient, big.NewInt(value))
+	if err != nil {
+		return nil, err
+	}
+	tx, err := ValueTransferTransaction(
+		node.WsClient,
+		a.Key,
+		a.Address,
+		goldTokenProxyAddr,
+		*a.Nonce,
+		big.NewInt(0),
+		signer,
+		data,
+	)
+	if err != nil {
+		return nil, err
+	}
+	err = node.WsClient.SendTransaction(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	*a.Nonce++
+	return tx, nil
 }
 
 // Accounts converts a slice of env.Account objects to Account objects.

--- a/test/node.go
+++ b/test/node.go
@@ -477,10 +477,8 @@ func (n Network) Shutdown() []error {
 	return errors
 }
 
-// ValueTransferTransaction builds a signed transaction from the
-// sender to the recipient with the given value, nonce, and data.
-// It uses the client to suggest a gas price and to estimate the gas.
-func ValueTransferTransaction(
+// Uses the client to suggest a gas price and to estimate the gas.
+func BuildSignedTransaction(
 	client *ethclient.Client,
 	senderKey *ecdsa.PrivateKey,
 	sender,


### PR DESCRIPTION
### Description

This PR fixes a bug in transfer precompile length checking and adds a few tests for CELO transfers made via the transfer precompile (i.e. `GoldToken.transfer`). Specific test changes (and associated changes):

- e2e:
  - `TestTraceSendCeloViaGoldToken`
    - sends CELO via `GoldToken.transfer`
    - added some helper functions to the `test` package to make it easier to send transfers via `GoldToken.transfer` in future tests
    - made the function `ValueTransferTransaction` more general (making it possible to pass in tx data)
- tracers/api_test: 
  - `TestCallTraceTransactionPrecompileTransfer`: more directly invokes the transfer precompile by sending the tx from a registered GoldToken address. Does more in-depth checking of the expected traces (from `callTracer`) with some documentation (in comments) about what is happening with these transfers.
    - makes `vm.TransferAddress` public in order to use this in the test case. **Note**: if it's not advised to make this value public, I can hard-code the precompile address in the test case, but it wasn't evident to me why not to just make this value public.
  - `TestCallTraceTransactionNativeTransfer`: in-depth checking of expected traces (from `callTracer`) for a native CELO transfer

### Tested
Transfer precompile test cases were failing before and now pass.

### Backwards compatibility

Yes, making a private var public, adds tests, fixes backwards compatibility for transfer precompile length checking.