### PR TITLE
Update test for ethers compatibility to ethers 6

### DIFF
--- a/e2e_test/ethersjs-api-check/package-lock.json
+++ b/e2e_test/ethersjs-api-check/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@adraffy/ens-normalize": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
+      "integrity": "sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ=="
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -12,386 +17,15 @@
         "@jridgewell/trace-mapping": "0.3.9"
       }
     },
-    "@ethersproject/abi": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
-      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
-      "requires": {
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "@ethersproject/abstract-provider": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
-      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/networks": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/web": "^5.7.0"
-      }
-    },
-    "@ethersproject/abstract-signer": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
-      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0"
-      }
-    },
-    "@ethersproject/address": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
-      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0"
-      }
-    },
-    "@ethersproject/base64": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
-      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0"
-      }
-    },
-    "@ethersproject/basex": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
-      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0"
-      }
-    },
-    "@ethersproject/bignumber": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
-      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "bn.js": "^5.2.1"
-      }
-    },
-    "@ethersproject/bytes": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
-      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
-      "requires": {
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "@ethersproject/constants": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
-      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.7.0"
-      }
-    },
-    "@ethersproject/contracts": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
-      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
-      "requires": {
-        "@ethersproject/abi": "^5.7.0",
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0"
-      }
-    },
-    "@ethersproject/hash": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
-      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "@ethersproject/hdnode": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
-      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/basex": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/pbkdf2": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/wordlists": "^5.7.0"
-      }
-    },
-    "@ethersproject/json-wallets": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
-      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
-      "requires": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hdnode": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/pbkdf2": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
-      }
-    },
-    "@ethersproject/keccak256": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
-      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "js-sha3": "0.8.0"
-      }
-    },
-    "@ethersproject/logger": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
-    },
-    "@ethersproject/networks": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.0.tgz",
-      "integrity": "sha512-MG6oHSQHd4ebvJrleEQQ4HhVu8Ichr0RDYEfHzsVAVjHNM+w36x9wp9r+hf1JstMXtseXDtkiVoARAG6M959AA==",
-      "requires": {
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "@ethersproject/pbkdf2": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
-      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0"
-      }
-    },
-    "@ethersproject/properties": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
-      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
-      "requires": {
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "@ethersproject/providers": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.0.tgz",
-      "integrity": "sha512-+TTrrINMzZ0aXtlwO/95uhAggKm4USLm1PbeCBR/3XZ7+Oey+3pMyddzZEyRhizHpy1HXV0FRWRMI1O3EGYibA==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/basex": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/networks": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/web": "^5.7.0",
-        "bech32": "1.1.4",
-        "ws": "7.4.6"
-      }
-    },
-    "@ethersproject/random": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
-      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "@ethersproject/rlp": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
-      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "@ethersproject/sha2": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
-      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "hash.js": "1.1.7"
-      }
-    },
-    "@ethersproject/signing-key": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
-      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "bn.js": "^5.2.1",
-        "elliptic": "6.5.4",
-        "hash.js": "1.1.7"
-      }
-    },
-    "@ethersproject/solidity": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "@ethersproject/strings": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
-      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "@ethersproject/transactions": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
-      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
-      "requires": {
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0"
-      }
-    },
-    "@ethersproject/units": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-      "requires": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "@ethersproject/wallet": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
-      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
-      "requires": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/hdnode": "^5.7.0",
-        "@ethersproject/json-wallets": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/wordlists": "^5.7.0"
-      }
-    },
-    "@ethersproject/web": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.0.tgz",
-      "integrity": "sha512-ApHcbbj+muRASVDSCl/tgxaH2LBkRMEYfLOLVa0COipx0+nlu0QKet7U2lEg0vdkh8XRSLf2nd1f1Uk9SrVSGA==",
-      "requires": {
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "@ethersproject/wordlists": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
-      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
-      "requires": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
     "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA=="
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.9",
@@ -401,6 +35,16 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
     },
     "@tsconfig/node10": {
       "version": "1.0.9",
@@ -423,9 +67,9 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "@types/chai": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
-      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
+      "integrity": "sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==",
       "dev": true
     },
     "@types/mocha": {
@@ -435,21 +79,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.17.tgz",
-      "integrity": "sha512-0UyfUnt02zIuqp7yC8RYtDkp/vo8bFaQ13KkSEvUAohPOAlnVNbj5Fi3fgPSuwzakS+EvvnnZ4x9y7i6ASaSPQ==",
-      "dev": true
-    },
-    "@ungap/promise-all-settled": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
-      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "version": "18.16.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.6.tgz",
+      "integrity": "sha512-N7KINmeB8IN3vRR8dhgHEp+YpWvGFcpDoh5XZ8jB5a00AdFKCKEyyGTOPTddUf4JqU1ZKTVxkOxakDvchNVI2Q==",
       "dev": true
     },
     "acorn": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -457,9 +95,9 @@
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz",
+      "integrity": "sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA=="
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -483,9 +121,9 @@
       }
     },
     "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -515,21 +153,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "bn.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -550,11 +178,6 @@
         "fill-range": "^7.0.1"
       }
     },
-    "brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
-    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -568,14 +191,14 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -686,40 +309,18 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
       }
     },
     "diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true
-    },
-    "elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "requires": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        }
-      }
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -740,40 +341,16 @@
       "dev": true
     },
     "ethers": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.0.tgz",
-      "integrity": "sha512-5Xhzp2ZQRi0Em+0OkOcRHxPzCfoBfgtOQA+RUylSkuHbhTEaQklnYi2hsWbRgs3ztJsXVXd9VKBcO1ScWL8YfA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.3.0.tgz",
+      "integrity": "sha512-CKFYvTne1YT4S1glTiu7TgGsj0t6c6GAD7evrIk8zbeUb6nK8dcUPAiAWM8uDX/1NmRTvLM9+1Vnn49hwKtEzw==",
       "requires": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.0",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.0",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.0",
-        "@ethersproject/wordlists": "5.7.0"
+        "@adraffy/ens-normalize": "1.9.0",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "aes-js": "4.0.0-beta.3",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
       }
     },
     "fill-range": {
@@ -866,30 +443,11 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
-    "hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
-    },
-    "hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -904,7 +462,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -954,11 +513,6 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -988,9 +542,9 @@
       }
     },
     "loupe": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dev": true,
       "requires": {
         "get-func-name": "^2.0.0"
@@ -1000,16 +554,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
     },
     "minimatch": {
       "version": "5.0.1",
@@ -1032,12 +576,11 @@
       }
     },
     "mocha": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
-      "integrity": "sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
+      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
       "dev": true,
       "requires": {
-        "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.3",
@@ -1059,6 +602,14 @@
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        }
       }
     },
     "ms": {
@@ -1160,11 +711,6 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
-    "scrypt-js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
-    },
     "serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -1236,14 +782,12 @@
         "make-error": "^1.1.1",
         "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-        }
       }
+    },
+    "tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "type-detect": {
       "version": "4.0.8",
@@ -1252,9 +796,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true
     },
     "v8-compile-cache-lib": {
@@ -1286,9 +830,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/e2e_test/ethersjs-api-check/package.json
+++ b/e2e_test/ethersjs-api-check/package.json
@@ -14,10 +14,10 @@
     "@types/node": "^18.7.16",
     "chai": "^4.3.6",
     "mocha": "^10.0.0",
-    "typescript": "^4.8.3"
+    "typescript": "^5.0.4"
   },
   "dependencies": {
-    "ethers": "^5.7.0",
+    "ethers": "^6.3.0",
     "ts-node": "^10.9.1"
   }
 }

--- a/e2e_test/ethersjs-api-check/test/test.ts
+++ b/e2e_test/ethersjs-api-check/test/test.ts
@@ -10,16 +10,16 @@ import 'mocha';
 describe('ethers.js compatibility tests with state', () => {
 
 	it('provider.getBlock works (block has gasLimit set)', async () => {
-		let provider = new ethers.providers.JsonRpcProvider(process.env.npm_config_networkaddr);
+		let provider = new ethers.JsonRpcProvider(process.env.npm_config_networkaddr);
 		let block = await provider.getBlock(process.env.npm_config_blocknum as string);
 
 		// These assertions trigger on undefined or null
 		assert.notEqual(block, null);
-		assert.notEqual(block.gasLimit, null);
+		assert.notEqual(block!.gasLimit, null);
 	});
 
 	it('EIP-1559 transactions supported (can get feeData)', async () => {
-		let provider = new ethers.providers.JsonRpcProvider(process.env.npm_config_networkaddr);
+		let provider = new ethers.JsonRpcProvider(process.env.npm_config_networkaddr);
 
 		// The fee data is the construct used to determine if EIP-1559 transactions are supported, if it contains max
 		let feeData = await provider.getFeeData();
@@ -31,23 +31,23 @@ describe('ethers.js compatibility tests with state', () => {
 		assert.notEqual(feeData.maxPriorityFeePerGas, null);
 		// We check the other 2 fields for completeness, they should also be set.
 		assert.notEqual(feeData.gasPrice, null);
-		assert.notEqual(feeData.lastBaseFeePerGas, null);
+		// assert.notEqual(feeData.lastBaseFeePerGas, null);
 	});
 
 	it('block has gasLimit', async () => {
-		let provider = new ethers.providers.JsonRpcProvider(process.env.npm_config_networkaddr);
+		let provider = new ethers.JsonRpcProvider(process.env.npm_config_networkaddr);
 		const fullBlock = await provider.send(
 			'eth_getBlockByNumber',
-			[ethers.utils.hexValue(process.env.npm_config_blocknum as string), true]
+			[ethers.toQuantity(process.env.npm_config_blocknum as string), true]
 		)
 		assert.isTrue(fullBlock.hasOwnProperty('gasLimit'))
 	});
 
 	it('block has baseFeePerGas', async () => {
-		let provider = new ethers.providers.JsonRpcProvider(process.env.npm_config_networkaddr);
+		let provider = new ethers.JsonRpcProvider(process.env.npm_config_networkaddr);
 		const fullBlock = await provider.send(
 			'eth_getBlockByNumber',
-			[ethers.utils.hexValue(process.env.npm_config_blocknum as string), true]
+			[ethers.toQuantity(process.env.npm_config_blocknum as string), true]
 		)
 		assert.isTrue(fullBlock.hasOwnProperty('baseFeePerGas'))
 	});
@@ -57,7 +57,7 @@ describe('ethers.js compatibility tests with state', () => {
 describe('ethers.js compatibility tests with no state', () => {
 
 	it('provider.getBlock throws exception (no gasLimit)', async () => {
-		let provider = new ethers.providers.JsonRpcProvider(process.env.npm_config_networkaddr);
+		let provider = new ethers.JsonRpcProvider(process.env.npm_config_networkaddr);
 		try {
 			await provider.getBlock(process.env.npm_config_blocknum as string);
 		} catch (e) {
@@ -67,19 +67,19 @@ describe('ethers.js compatibility tests with no state', () => {
 	});
 
 	it('block has no gasLimit', async () => {
-		let provider = new ethers.providers.JsonRpcProvider(process.env.npm_config_networkaddr);
+		let provider = new ethers.JsonRpcProvider(process.env.npm_config_networkaddr);
 		const fullBlock = await provider.send(
 			'eth_getBlockByNumber',
-			[ethers.utils.hexValue(process.env.npm_config_blocknum as string), true]
+			[ethers.toQuantity(process.env.npm_config_blocknum as string), true]
 		)
 		assert.isFalse(fullBlock.hasOwnProperty('gasLimit'))
 	});
 
 	it('block has no baseFeePerGas', async () => {
-		let provider = new ethers.providers.JsonRpcProvider(process.env.npm_config_networkaddr);
+		let provider = new ethers.JsonRpcProvider(process.env.npm_config_networkaddr);
 		const fullBlock = await provider.send(
 			'eth_getBlockByNumber',
-			[ethers.utils.hexValue(process.env.npm_config_blocknum as string), true]
+			[ethers.toQuantity(process.env.npm_config_blocknum as string), true]
 		)
 		assert.isFalse(fullBlock.hasOwnProperty('baseFeePerGas'))
 	});


### PR DESCRIPTION
### Description

Ethers 6 requires the `difficulty` field in blocks returned via JSON-RPC. To verify compatibility, we need to update our ethers compatibility test to a recent ethers version. That in turn requires updates of typescript (easy since it is local to the test.

The tests run fine with our current node version in CI ([node 12](https://github.com/celo-org/celo-blockchain/blob/7d8fd1b8c8bf35c809f7328854af9554ae894c64/.github/workflows/config.yml#L30)). However, node 12 is not officially supported with ethers 6:
```
npm WARN notsup Unsupported engine for ethers@6.3.0: wanted: {"node":">=14.0.0"} (current: {"node":"12.22.12","npm":"6.14.16"})
npm WARN notsup Not compatible with your version of node/npm: ethers@6.3.0
npm WARN notsup Unsupported engine for mocha@10.2.0: wanted: {"node":">= 14.0.0"} (current: {"node":"12.22.12","npm":"6.14.16"})
npm WARN notsup Not compatible with your version of node/npm: mocha@10.2.0
npm WARN ethersjs-api-check@1.0.0 No repository field.
```

I also get an error locally when running with node 12, but not with node 14. I'm not sure if that is a real problem or I am just messing something up by switching between node versions.
```
/Users/karl/celo-blockchain/e2e_test/ethersjs-api-check/node_modules/ethers/lib.commonjs/abi/abi-coder.js:112
    #getCoder(param) {
             ^

SyntaxError: Unexpected token '('
```

### Other changes

- [x] Update typescript in ethers compatibility test
- [ ] Update node version?

### Related issues

- The fix without test is available as a separate PR: https://github.com/celo-org/celo-blockchain/pull/2082
