### PR TITLE
Add difficulty to JSON-RPC blocks

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -763,6 +763,8 @@ func addEthCompatibilityFields(ctx context.Context, block map[string]interface{}
 	} else {
 		block["baseFeePerGas"] = (*hexutil.Big)(baseFee)
 	}
+
+	block["difficulty"] = 0
 }
 
 // GetUncleByBlockNumberAndIndex returns the uncle block for the given block hash and index. When fullTx is true


### PR DESCRIPTION
### Description

For compatibilty with ethers 6, which fails with `Error: invalid value for value.difficulty`, otherwise.

### Tested

The regression test is included in https://github.com/celo-org/celo-blockchain/pull/2081. This PR is provided separately, in case the other PR takes long to merge due to a potentially required node version update for recent ethers versions (node>=14).

### Related issues

- Fixes https://github.com/celo-org/celo-monorepo/discussions/9922#discussioncomment-5818085

### Backwards compatibility

Adding a field to the JSON object should be harmless for reasonably implemented users. I also don't know a way to fix the problem in an even safer way.