### PR TITLE
tests: Add missing newline to "inputs:" printf

### DIFF
--- a/contracts/testutil/basic_tests.go
+++ b/contracts/testutil/basic_tests.go
@@ -59,7 +59,7 @@ func TestReturnsDefaultOnFailingRunner(t *testing.T, defaultValue interface{}, f
 		fnValue := reflect.ValueOf(fn)
 
 		argsValues := vmRunnerArguments(FailingVmRunner{}, args...)
-		fmt.Printf("inputs: %v", argsValues)
+		fmt.Printf("inputs: %v\n", argsValues)
 		outs := fnValue.Call(argsValues)
 
 		retValue := outs[0].Interface()


### PR DESCRIPTION
If this is missing, the test runner output gets messed up, breaking tools like gotestsum and making it harder to read the test output.
