### PR TITLE
Enable CI on `feature-split`

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - master
+      - feature-split
 
   pull_request:
     branches:
       - master
+      - feature-split
 
 concurrency: 
   group: ${{ github.head_ref }}


### PR DESCRIPTION
This runs CI on both
- PRs that target `feature-split`
- new commits to `feature-split`