### PR TITLE
Hex-encode difficulty in RPC

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -764,7 +764,7 @@ func addEthCompatibilityFields(ctx context.Context, block map[string]interface{}
 		block["baseFeePerGas"] = (*hexutil.Big)(baseFee)
 	}
 
-	block["difficulty"] = 0
+	block["difficulty"] = "0x0"
 }
 
 // GetUncleByBlockNumberAndIndex returns the uncle block for the given block hash and index. When fullTx is true


### PR DESCRIPTION
We add the value to a map, so our usual struct encoding steps do not apply and we have to explicitly ensure that it is hex encoded (as should be the case for all [quantities returned in JSON RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding)).

We missed this because the RPC is only e2e tested using Ethers and that
consumed the plain number without complaint.