### PR TITLE
Apply `go1.18.10 fmt ./...`

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -88,7 +88,7 @@ func Transition(ctx *cli.Context) error {
 	log.Root().SetHandler(glogger)
 
 	// TODO this command is broken: vmContext and vmRunner can not be created as required
-	log.Crit("Command does not work as expected. Requires Bug Fixing")
+	// log.Crit("Command does not work as expected. Requires Bug Fixing")
 
 	var (
 		err     error

--- a/crypto/bls12377/arithmetic_decl.go
+++ b/crypto/bls12377/arithmetic_decl.go
@@ -1,3 +1,4 @@
+//go:build amd64 && !generic
 // +build amd64,!generic
 
 package bls12377

--- a/crypto/bls12377/arithmetic_fallback.go
+++ b/crypto/bls12377/arithmetic_fallback.go
@@ -1,3 +1,4 @@
+//go:build !amd64 || generic
 // +build !amd64 generic
 
 // Native go field arithmetic code is generated with 'goff'

--- a/crypto/bls12381/arithmetic_decl.go
+++ b/crypto/bls12381/arithmetic_decl.go
@@ -1,4 +1,4 @@
-//go:build (amd64 && !generic)
+//go:build amd64 && !generic
 // +build amd64,!generic
 
 package bls12381

--- a/crypto/bls12381/arithmetic_fallback.go
+++ b/crypto/bls12381/arithmetic_fallback.go
@@ -1,3 +1,4 @@
+//go:build !amd64 || generic
 // +build !amd64 generic
 
 // Copyright 2020 ConsenSys Software Inc.

--- a/crypto/bls12381/fp_fallback.go
+++ b/crypto/bls12381/fp_fallback.go
@@ -1,3 +1,4 @@
+//go:build !amd64 || generic
 // +build !amd64 generic
 
 // Copyright 2020 ConsenSys Software Inc.

--- a/mycelo/contract/gen_abis.go
+++ b/mycelo/contract/gen_abis.go
@@ -2110,7 +2110,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// Attestations ABI
+  ]`) // Attestations ABI
 	abis["Attestations"] = mustParseABI(`[
     {
       "inputs": [
@@ -3550,7 +3550,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// BlockchainParameters ABI
+  ]`) // BlockchainParameters ABI
 	abis["BlockchainParameters"] = mustParseABI(`[
     {
       "inputs": [
@@ -4293,7 +4293,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// DoubleSigningSlasher ABI
+  ]`) // DoubleSigningSlasher ABI
 	abis["DoubleSigningSlasher"] = mustParseABI(`[
     {
       "inputs": [
@@ -5039,7 +5039,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// DowntimeSlasher ABI
+  ]`) // DowntimeSlasher ABI
 	abis["DowntimeSlasher"] = mustParseABI(`[
     {
       "inputs": [
@@ -6021,7 +6021,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// Election ABI
+  ]`) // Election ABI
 	abis["Election"] = mustParseABI(`[
     {
       "inputs": [
@@ -7710,7 +7710,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// EpochRewards ABI
+  ]`) // EpochRewards ABI
 	abis["EpochRewards"] = mustParseABI(`[
     {
       "inputs": [
@@ -8855,7 +8855,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// Escrow ABI
+  ]`) // Escrow ABI
 	abis["Escrow"] = mustParseABI(`[
     {
       "inputs": [
@@ -9643,7 +9643,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// Exchange ABI
+  ]`) // Exchange ABI
 	abis["Exchange"] = mustParseABI(`[
     {
       "inputs": [
@@ -10363,7 +10363,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// ExchangeBRL ABI
+  ]`) // ExchangeBRL ABI
 	abis["ExchangeBRL"] = mustParseABI(`[
     {
       "inputs": [
@@ -11083,7 +11083,7 @@ func init() {
       "stateMutability": "pure",
       "type": "function"
     }
-  ]`)// ExchangeEUR ABI
+  ]`) // ExchangeEUR ABI
 	abis["ExchangeEUR"] = mustParseABI(`[
     {
       "inputs": [
@@ -11803,7 +11803,7 @@ func init() {
       "stateMutability": "pure",
       "type": "function"
     }
-  ]`)// FederatedAttestations ABI
+  ]`) // FederatedAttestations ABI
 	abis["FederatedAttestations"] = mustParseABI(`[
     {
       "inputs": [
@@ -12509,7 +12509,7 @@ func init() {
       "stateMutability": "pure",
       "type": "function"
     }
-  ]`)// FeeCurrencyWhitelist ABI
+  ]`) // FeeCurrencyWhitelist ABI
 	abis["FeeCurrencyWhitelist"] = mustParseABI(`[
     {
       "inputs": [
@@ -12671,7 +12671,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// Freezer ABI
+  ]`) // Freezer ABI
 	abis["Freezer"] = mustParseABI(`[
     {
       "inputs": [
@@ -12833,7 +12833,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// GasPriceMinimum ABI
+  ]`) // GasPriceMinimum ABI
 	abis["GasPriceMinimum"] = mustParseABI(`[
     {
       "inputs": [
@@ -13268,7 +13268,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// GoldToken ABI
+  ]`) // GoldToken ABI
 	abis["GoldToken"] = mustParseABI(`[
     {
       "inputs": [
@@ -13835,7 +13835,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// Governance ABI
+  ]`) // Governance ABI
 	abis["Governance"] = mustParseABI(`[
     {
       "inputs": [
@@ -16263,7 +16263,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// GovernanceApproverMultiSig ABI
+  ]`) // GovernanceApproverMultiSig ABI
 	abis["GovernanceApproverMultiSig"] = mustParseABI(`[
     {
       "inputs": [
@@ -16923,7 +16923,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// GovernanceSlasher ABI
+  ]`) // GovernanceSlasher ABI
 	abis["GovernanceSlasher"] = mustParseABI(`[
     {
       "inputs": [
@@ -17198,7 +17198,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// GrandaMento ABI
+  ]`) // GrandaMento ABI
 	abis["GrandaMento"] = mustParseABI(`[
     {
       "inputs": [
@@ -17998,7 +17998,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// LockedGold ABI
+  ]`) // LockedGold ABI
 	abis["LockedGold"] = mustParseABI(`[
     {
       "inputs": [
@@ -18776,7 +18776,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// OdisPayments ABI
+  ]`) // OdisPayments ABI
 	abis["OdisPayments"] = mustParseABI(`[
     {
       "inputs": [
@@ -18992,7 +18992,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// Proxy ABI
+  ]`) // Proxy ABI
 	abis["Proxy"] = mustParseABI(`[
     {
       "inputs": [],
@@ -19111,7 +19111,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// Random ABI
+  ]`) // Random ABI
 	abis["Random"] = mustParseABI(`[
     {
       "inputs": [
@@ -19740,7 +19740,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// Registry ABI
+  ]`) // Registry ABI
 	abis["Registry"] = mustParseABI(`[
     {
       "inputs": [
@@ -20027,7 +20027,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// Reserve ABI
+  ]`) // Reserve ABI
 	abis["Reserve"] = mustParseABI(`[
     {
       "inputs": [
@@ -21293,7 +21293,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// ReserveSpenderMultiSig ABI
+  ]`) // ReserveSpenderMultiSig ABI
 	abis["ReserveSpenderMultiSig"] = mustParseABI(`[
     {
       "inputs": [
@@ -21953,7 +21953,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// SortedOracles ABI
+  ]`) // SortedOracles ABI
 	abis["SortedOracles"] = mustParseABI(`[
     {
       "inputs": [
@@ -22676,7 +22676,7 @@ func init() {
       "stateMutability": "view",
       "type": "function"
     }
-  ]`)// StableToken ABI
+  ]`) // StableToken ABI
 	abis["StableToken"] = mustParseABI(`[
     {
       "inputs": [
@@ -23846,7 +23846,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// StableTokenBRL ABI
+  ]`) // StableTokenBRL ABI
 	abis["StableTokenBRL"] = mustParseABI(`[
     {
       "inputs": [
@@ -25016,7 +25016,7 @@ func init() {
       "stateMutability": "pure",
       "type": "function"
     }
-  ]`)// StableTokenEUR ABI
+  ]`) // StableTokenEUR ABI
 	abis["StableTokenEUR"] = mustParseABI(`[
     {
       "inputs": [
@@ -26186,7 +26186,7 @@ func init() {
       "stateMutability": "pure",
       "type": "function"
     }
-  ]`)// TransferWhitelist ABI
+  ]`) // TransferWhitelist ABI
 	abis["TransferWhitelist"] = mustParseABI(`[
     {
       "inputs": [
@@ -26495,7 +26495,7 @@ func init() {
       "stateMutability": "nonpayable",
       "type": "function"
     }
-  ]`)// Validators ABI
+  ]`) // Validators ABI
 	abis["Validators"] = mustParseABI(`[
     {
       "inputs": [


### PR DESCRIPTION
Having all code formatted by the same tools helps with consistency and reduced diffs. Why go 1.18?
* Geth v1.10.9 shows no formatting differences when that version is used for formatting
* Later versions do
* Geth v1.10.9 uses go1.15 in its go mod. But that go version is so old that using it causes a large amount of additional errors during compilation and I want to avoid using different versions for compilation and formatting.
* Formatting with go 1.18 and 1.15 yields the same results (at least for geth and celo-blockchain)

Problems not solved which would be solved by moving to golint1.51.1 and go1.19 formatting (which have to go together):
* Linting fails locally
* Linting in CI did not catch that our formatting diverged from the gofmt output

Replaces https://github.com/celo-org/celo-blockchain/pull/2098 until we use a more recent geth version as a base. 