### PR TITLE
Bring back ethereum hardfork flags

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -564,7 +564,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 		return nil, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
 	head := b.blockchain.CurrentHeader()
-	if !b.blockchain.Config().IsEspresso(head.Number) {
+	if !b.blockchain.Config().IsLondon(head.Number) {
 		// If there's no basefee, then it must be a non-1559 execution
 		if call.GasPrice == nil {
 			call.GasPrice = new(big.Int)

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -255,7 +255,7 @@ func Transition(ctx *cli.Context) error {
 		return NewError(ErrorJson, fmt.Errorf("failed signing transactions: %v", err))
 	}
 	// Sanity check, to not `panic` in state_transition
-	if chainConfig.IsEspresso(big.NewInt(int64(prestate.Env.Number))) {
+	if chainConfig.IsLondon(big.NewInt(int64(prestate.Env.Number))) {
 		if prestate.Env.BaseFee == nil {
 			return NewError(ErrorVMConfig, errors.New("EIP-1559 config but missing 'currentBaseFee' in env section"))
 		}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -306,8 +306,8 @@ func (st *StateTransition) preCheck() error {
 		// 		st.msg.From().Hex(), codeHash)
 		// }
 	}
-	// Make sure that transaction gasFeeCap is greater than the baseFee (post espresso)
-	if st.evm.ChainConfig().IsEspresso(st.evm.Context.BlockNumber) {
+	// Make sure that transaction gasFeeCap is greater than the baseFee (post london)
+	if st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber) {
 		// Skip the checks if gas fields are zero and baseFee was explicitly disabled (eth_call)
 		if !st.evm.Config.NoBaseFee || st.gasFeeCap.BitLen() > 0 || st.gasTipCap.BitLen() > 0 {
 			if l := st.gasFeeCap.BitLen(); l > 256 {
@@ -407,7 +407,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 
 	// Set up the initial access list.
-	if rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber); rules.IsEspresso {
+	if rules := st.evm.ChainConfig().Rules(st.evm.Context.BlockNumber); rules.IsBerlin {
 		st.state.PrepareAccessList(msg.From(), msg.To(), vm.ActivePrecompiles(rules), msg.AccessList())
 	}
 	var (

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1279,7 +1279,7 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 	// because of another transaction (e.g. higher gas price).
 	if reset != nil {
 		pool.demoteUnexecutables()
-		if reset.newHead != nil && pool.chainconfig.IsEspresso(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
+		if reset.newHead != nil && pool.chainconfig.IsLondon(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
 			pool.priced.SetBaseFee(pool.ctx())
 		} else {
 			// Prevent the price heap from growing indefinitely

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -464,7 +464,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 	// We add this to the access list _before_ taking a snapshot. Even if the creation fails,
 	// the access-list change should not be rolled back
-	if evm.chainRules.IsEspresso {
+	if evm.chainRules.IsBerlin {
 		evm.StateDB.AddAddressToAccessList(address)
 	}
 	// Ensure there's no existing contract already at the designated address
@@ -507,7 +507,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	}
 
 	// Reject code starting with 0xEF if EIP-3541 is enabled.
-	if err == nil && len(ret) >= 1 && ret[0] == 0xEF && evm.chainRules.IsEspresso {
+	if err == nil && len(ret) >= 1 && ret[0] == 0xEF && evm.chainRules.IsLondon {
 		err = ErrInvalidCode
 	}
 

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -111,7 +111,7 @@ func Execute(code, input []byte, cfg *Config) ([]byte, *state.StateDB, error) {
 		vmenv   = NewEnv(cfg)
 		sender  = vm.AccountRef(cfg.Origin)
 	)
-	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsEspresso {
+	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsBerlin {
 		cfg.State.PrepareAccessList(cfg.Origin, &address, vm.ActivePrecompiles(rules), nil)
 	}
 	cfg.State.CreateAccount(address)
@@ -143,8 +143,7 @@ func Create(input []byte, cfg *Config) ([]byte, common.Address, uint64, error) {
 		vmenv  = NewEnv(cfg)
 		sender = vm.AccountRef(cfg.Origin)
 	)
-
-	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsEspresso {
+	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsBerlin {
 		cfg.State.PrepareAccessList(cfg.Origin, nil, vm.ActivePrecompiles(rules), nil)
 	}
 	// Call the code with the given configuration.
@@ -170,7 +169,7 @@ func Call(address common.Address, input []byte, cfg *Config) ([]byte, uint64, er
 	sender := cfg.State.GetOrNewStateObject(cfg.Origin)
 	statedb := cfg.State
 
-	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsEspresso {
+	if rules := cfg.ChainConfig.Rules(vmenv.Context.BlockNumber); rules.IsBerlin {
 		statedb.PrepareAccessList(cfg.Origin, &address, vm.ActivePrecompiles(rules), nil)
 	}
 	// Call the code with the given configuration.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1609,7 +1609,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 
 	fields := generateReceiptResponse(receipt, signer, tx, blockHash, blockNumber, index)
 	// Assign the effective gas price paid
-	if !s.b.ChainConfig().IsEspresso(bigblock) {
+	if !s.b.ChainConfig().IsLondon(bigblock) {
 		fields["effectiveGasPrice"] = hexutil.Uint64(tx.GasPrice().Uint64())
 	} else {
 		// var gasPrice *big.Int = new(big.Int)

--- a/params/config.go
+++ b/params/config.go
@@ -379,13 +379,6 @@ func (c *ChainConfig) IsLondon(num *big.Int) bool {
 	return isForked(c.EspressoBlock, num)
 }
 
-// IsCatalyst returns whether num is either equal to the Merge fork block or greater.
-// TODO(paul): what to do about that?
-func (c *ChainConfig) IsCatalyst(num *big.Int) bool {
-	// return isForked(c.CatalystBlock, num)
-	return false
-}
-
 // IsChurrito returns whether num represents a block number after the Churrito fork
 func (c *ChainConfig) IsChurrito(num *big.Int) bool {
 	return isForked(c.ChurritoBlock, num)

--- a/params/config.go
+++ b/params/config.go
@@ -367,6 +367,25 @@ func (c *ChainConfig) IsIstanbul(num *big.Int) bool {
 	return isForked(c.IstanbulBlock, num)
 }
 
+// IsBerlin returns whether num is either equal to the Berlin fork block or greater.
+// Celo change: This is used to keep code close to upstream, but uses Espresso activation block
+func (c *ChainConfig) IsBerlin(num *big.Int) bool {
+	return isForked(c.EspressoBlock, num)
+}
+
+// IsLondon returns whether num is either equal to the London fork block or greater.
+// Celo change: This is used to keep code close to upstream, but uses Espresso activation block
+func (c *ChainConfig) IsLondon(num *big.Int) bool {
+	return isForked(c.EspressoBlock, num)
+}
+
+// IsCatalyst returns whether num is either equal to the Merge fork block or greater.
+// TODO(paul): what to do about that?
+func (c *ChainConfig) IsCatalyst(num *big.Int) bool {
+	// return isForked(c.CatalystBlock, num)
+	return false
+}
+
 // IsChurrito returns whether num represents a block number after the Churrito fork
 func (c *ChainConfig) IsChurrito(num *big.Int) bool {
 	return isForked(c.ChurritoBlock, num)
@@ -571,8 +590,8 @@ type Rules struct {
 	ChainID                                                 *big.Int
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
-	// IsBerlin, IsLondon, IsCatalyst                          bool
-	IsChurrito, IsDonut, IsEspresso, IsGFork bool
+	IsBerlin, IsLondon                                      bool
+	IsChurrito, IsDonut, IsEspresso, IsGFork                bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -591,13 +610,12 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsConstantinople: c.IsConstantinople(num),
 		IsPetersburg:     c.IsPetersburg(num),
 		IsIstanbul:       c.IsIstanbul(num),
-		// IsBerlin:         c.IsBerlin(num),
-		// IsLondon:         c.IsLondon(num),
-		// IsCatalyst:       c.IsCatalyst(num),
-		IsChurrito: c.IsChurrito(num),
-		IsDonut:    c.IsDonut(num),
-		IsEspresso: c.IsEspresso(num),
-		IsGFork:    c.IsGFork(num),
+		IsBerlin:         c.IsBerlin(num),
+		IsLondon:         c.IsLondon(num),
+		IsChurrito:       c.IsChurrito(num),
+		IsDonut:          c.IsDonut(num),
+		IsEspresso:       c.IsEspresso(num),
+		IsGFork:          c.IsGFork(num),
 	}
 }
 


### PR DESCRIPTION
This links the `berlin` and `london` hardfork flags to the espresso hardfork. Using them removes abiguity in the code and reduces the diff to upstream.
