### PR TITLE
mycelo: enable GFork by default

### DIFF
--- a/mycelo/genesis/genesis.go
+++ b/mycelo/genesis/genesis.go
@@ -28,6 +28,7 @@ func CreateCommonGenesisConfig(chainID *big.Int, adminAccountAddress common.Addr
 		ChurritoBlock: common.Big0,
 		DonutBlock:    common.Big0,
 		EspressoBlock: common.Big0,
+		GForkBlock:    common.Big0,
 	}
 
 	// Make admin account manager of Governance & Reserve


### PR DESCRIPTION
We always want to run and test the latest hard fork by default.