### PR TITLE
Enable G fork by default in `TestChainConfig`

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -148,7 +148,7 @@ var (
 		ChurritoBlock: big.NewInt(0),
 		DonutBlock:    big.NewInt(0),
 		EspressoBlock: big.NewInt(0),
-		GForkBlock:    nil,
+		GForkBlock:    big.NewInt(0),
 
 		Istanbul: &IstanbulConfig{
 			Epoch:          30000,


### PR DESCRIPTION
### Description

Enable the G hardfork in the tests by default.