### PR TITLE
Fix CI runs on `master`

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -10,7 +10,7 @@ on:
       - master
 
 concurrency: 
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
### Description

CI runs on master fail because the `github.head_ref` is only set for PRs, not normal commits.

It is solved by using a fallback as recommended in https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value

![Screenshot 2023-06-26 at 16 43 30](https://github.com/celo-org/celo-blockchain/assets/90851/98f06419-0a50-4dd2-9f9a-b0cb8f0fdc20)
