### PR TITLE
fix: defer usage

### DIFF
--- a/p2p/discover/v4_udp_test.go
+++ b/p2p/discover/v4_udp_test.go
@@ -571,6 +571,8 @@ func startLocalhostV4(t *testing.T, cfg Config) *UDPv4 {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer socket.Close()
+	
 	realaddr := socket.LocalAddr().(*net.UDPAddr)
 	ln.SetStaticIP(realaddr.IP)
 	ln.SetFallbackUDP(realaddr.Port)

--- a/p2p/discover/v5_udp_test.go
+++ b/p2p/discover/v5_udp_test.go
@@ -90,6 +90,8 @@ func startLocalhostV5(t *testing.T, cfg Config) *UDPv5 {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer socket.Close()
+	
 	realaddr := socket.LocalAddr().(*net.UDPAddr)
 	ln.SetStaticIP(realaddr.IP)
 	ln.Set(enr.UDP(realaddr.Port))

--- a/p2p/server.go
+++ b/p2p/server.go
@@ -660,6 +660,8 @@ func (srv *Server) setupDiscovery() error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
+	
 	realaddr := conn.LocalAddr().(*net.UDPAddr)
 	srv.log.Debug("UDP listener up", "addr", realaddr)
 	if srv.NAT != nil {


### PR DESCRIPTION
### Description
there is more connections in celo that they don't use defer 
now I add them and we can make sure all connections, sockets and ports will closed when a node going shutdown.
