### PR TITLE
Add eth compat flag to deprecated section

### DIFF
--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -231,6 +231,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.LegacyGraphQLListenAddrFlag,
 			utils.LegacyGraphQLPortFlag,
 			utils.LightGatewayFeeFlag,
+			utils.DisableRPCETHCompatibility,
 		},
 	},
 	{


### PR DESCRIPTION
### Description

But the `--disablerpcethcompatibility` under the deprecated options section:
```
ALIASED (deprecated) OPTIONS:
[...]
  --graphql.port value                GraphQL server listening port (deprecated, graphql can only be enabled on the HTTP-RPC server endpoint, use --graphql) (default: 8545)
  --light.gatewayfee value            Minimum value of gateway fee to serve a light client transaction (default: 0)
  --disablerpcethcompatibility        If set, blocks returned from the RPC api will not contain the 'gasLimit' and 'baseFeePerGas' fields, which were added to the RPC block representation in order to improve compatibility with ethereum tooling. Note these fields do not currently exist on the internal block representation so they should be disregarded for the purposes of hashing or signing