### PR TITLE
Add `--rpc.gaspricemultiplier` option

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -192,6 +192,7 @@ var (
 		utils.IPCPathFlag,
 		utils.InsecureUnlockAllowedFlag,
 		utils.RPCGlobalGasInflationRateFlag,
+		utils.RPCGlobalGasPriceMultiplierFlag,
 		utils.RPCGlobalGasCapFlag,
 		utils.RPCGlobalTxFeeCapFlag,
 	}

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -139,6 +139,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.GraphQLCORSDomainFlag,
 			utils.GraphQLVirtualHostsFlag,
 			utils.RPCGlobalGasInflationRateFlag,
+			utils.RPCGlobalGasPriceMultiplierFlag,
 			utils.RPCGlobalGasCapFlag,
 			utils.RPCGlobalTxFeeCapFlag,
 			utils.JSpathFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math"
+	"math/big"
 	"path/filepath"
 	godebug "runtime/debug"
 	"strconv"
@@ -444,6 +445,11 @@ var (
 		Name:  "rpc.gasinflationrate",
 		Usage: "Multiplier applied to the gasEstimation rpc call (1 = gasEstimation, 1.3 = gasEstimation + 30%, etc. Defaults to 1.3)",
 		Value: ethconfig.Defaults.RPCGasInflationRate,
+	}
+	RPCGlobalGasPriceMultiplierFlag = cli.Float64Flag{
+		Name:  "rpc.gaspricemultiplier",
+		Usage: "Multiplier applied to the gasPrice rpc call (1 = gasPrice, 1.3 = gasPrice + 30%, etc. Defaults to 2.0)",
+		Value: 2.0,
 	}
 	RPCGlobalGasCapFlag = cli.Uint64Flag{
 		Name:  "rpc.gascap",
@@ -1745,6 +1751,15 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 
 	if ctx.GlobalIsSet(RPCGlobalGasInflationRateFlag.Name) {
 		cfg.RPCGasInflationRate = ctx.GlobalFloat64(RPCGlobalGasInflationRateFlag.Name)
+	}
+	if ctx.GlobalIsSet(RPCGlobalGasPriceMultiplierFlag.Name) {
+		floatMutliplier := ctx.GlobalFloat64(RPCGlobalGasPriceMultiplierFlag.Name)
+		if floatMutliplier < 1.0 {
+			log.Warn("Too low RPCGasPriceMultiplier, setting to 1.0", "provided value", floatMutliplier)
+			floatMutliplier = 1.0
+		}
+
+		cfg.RPCGasPriceMultiplier = big.NewInt(int64(floatMutliplier * 100))
 	}
 	if cfg.RPCGasInflationRate < 1 {
 		Fatalf("The inflation rate shouldn't be less than 1: %f", cfg.RPCGasInflationRate)

--- a/contracts/gasprice_minimum/gasprice_minimum.go
+++ b/contracts/gasprice_minimum/gasprice_minimum.go
@@ -35,7 +35,6 @@ import (
 
 var (
 	FallbackGasPriceMinimum *big.Int = big.NewInt(0) // gas price minimum to return if unable to fetch from contract
-	suggestionMultiplier    *big.Int = big.NewInt(5) // The multiplier that we apply to the minimum when suggesting gas price
 )
 
 const (
@@ -62,9 +61,12 @@ func GetGasTipCapSuggestion(vmRunner vm.EVMRunner, currencyAddress *common.Addre
 
 // GetGasPriceSuggestion suggests a gas price the suggestionMultiplier times higher than the GPM in the appropriate currency.
 // TODO: Switch to using a caching GPM manager under high load.
-func GetGasPriceSuggestion(vmRunner vm.EVMRunner, currency *common.Address) (*big.Int, error) {
+func GetGasPriceSuggestion(vmRunner vm.EVMRunner, currency *common.Address, multiplier *big.Int) (*big.Int, error) {
 	gasPriceMinimum, err := GetGasPriceMinimum(vmRunner, currency)
-	return new(big.Int).Mul(gasPriceMinimum, suggestionMultiplier), err
+
+	gasPriceWithMultiplier := new(big.Int).Mul(gasPriceMinimum, multiplier)
+	res := new(big.Int).Div(gasPriceWithMultiplier, big.NewInt(100))
+	return res, err
 }
 
 func GetGasPriceMinimum(vmRunner vm.EVMRunner, currency *common.Address) (*big.Int, error) {

--- a/contracts/gasprice_minimum/gasprice_minimum_test.go
+++ b/contracts/gasprice_minimum/gasprice_minimum_test.go
@@ -15,7 +15,7 @@ func TestGetGasPriceSuggestion(t *testing.T) {
 	celoAddress := common.HexToAddress("0x076")
 	gpmAddress := common.HexToAddress("0x090")
 
-	t.Run("should return gas price minimum multiplied by 5", func(t *testing.T) {
+	t.Run("should return gas price minimum multiplied with factor", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 
 		runner := testutil.NewMockEVMRunner()
@@ -29,10 +29,17 @@ func TestGetGasPriceSuggestion(t *testing.T) {
 		runner.RegisterContract(gpmAddress, contract)
 		registry.AddContract(config.GasPriceMinimumRegistryId, gpmAddress)
 
-		suggestedGpm, err := GetGasPriceSuggestion(runner, nil)
+		suggestedGpm, err := GetGasPriceSuggestion(runner, nil, big.NewInt(500))
 		g.Expect(err).NotTo(HaveOccurred())
-
 		g.Expect(suggestedGpm.Uint64()).To(Equal(uint64(777777 * 5)))
+
+		suggestedGpm, err = GetGasPriceSuggestion(runner, nil, big.NewInt(100))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(suggestedGpm.Uint64()).To(Equal(uint64(777777)))
+
+		suggestedGpm, err = GetGasPriceSuggestion(runner, nil, big.NewInt(110))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(suggestedGpm.Uint64()).To(Equal(uint64(855554)))
 
 	})
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -330,7 +330,7 @@ func (b *EthAPIBackend) SuggestPrice(ctx context.Context, currencyAddress *commo
 	if err != nil {
 		return nil, err
 	}
-	return gpm.GetGasPriceSuggestion(vmRunner, currencyAddress)
+	return gpm.GetGasPriceSuggestion(vmRunner, currencyAddress, b.eth.config.RPCGasPriceMultiplier)
 }
 
 func (b *EthAPIBackend) GetBlockGasLimit(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) uint64 {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -139,6 +139,10 @@ type Config struct {
 	// RPCGasInflationRate is a global multiplier applied to the gas estimations
 	RPCGasInflationRate float64
 
+	// RPCGasPriceMultiplier is a global multiplier applied to the gas price
+	// It's a percent value, e.g. 120 means a multiplication factor of 1.2
+	RPCGasPriceMultiplier *big.Int
+
 	// RPCGasCap is the global gas cap for eth-call variants.
 	RPCGasCap uint64
 

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -57,6 +57,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		Istanbul                istanbul.Config
 		DocRoot                 string `toml:"-"`
 		RPCGasInflationRate     float64
+		RPCGasPriceMultiplier   *big.Int
 		RPCGasCap               uint64
 		RPCTxFeeCap             float64
 		RPCEthCompatibility     bool
@@ -106,6 +107,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.Istanbul = c.Istanbul
 	enc.DocRoot = c.DocRoot
 	enc.RPCGasInflationRate = c.RPCGasInflationRate
+	enc.RPCGasPriceMultiplier = c.RPCGasPriceMultiplier
 	enc.RPCGasCap = c.RPCGasCap
 	enc.RPCTxFeeCap = c.RPCTxFeeCap
 	enc.RPCEthCompatibility = c.RPCEthCompatibility
@@ -159,6 +161,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		Istanbul                *istanbul.Config
 		DocRoot                 *string `toml:"-"`
 		RPCGasInflationRate     *float64
+		RPCGasPriceMultiplier   *big.Int
 		RPCGasCap               *uint64
 		RPCTxFeeCap             *float64
 		RPCEthCompatibility     *bool
@@ -290,6 +293,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.RPCGasInflationRate != nil {
 		c.RPCGasInflationRate = *dec.RPCGasInflationRate
+	}
+	if dec.RPCGasPriceMultiplier != nil {
+		c.RPCGasPriceMultiplier = dec.RPCGasPriceMultiplier
 	}
 	if dec.RPCGasCap != nil {
 		c.RPCGasCap = *dec.RPCGasCap

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -273,7 +273,7 @@ func (b *LesApiBackend) SuggestPrice(ctx context.Context, currencyAddress *commo
 	if err != nil {
 		return nil, err
 	}
-	return gpm.GetGasPriceSuggestion(vmRunner, currencyAddress)
+	return gpm.GetGasPriceSuggestion(vmRunner, currencyAddress, b.eth.config.RPCGasPriceMultiplier)
 }
 
 func (b *LesApiBackend) GetIntrinsicGasForAlternativeFeeCurrency(ctx context.Context) uint64 {

--- a/test/node.go
+++ b/test/node.go
@@ -59,12 +59,13 @@ var (
 	}
 
 	BaseEthConfig = &eth.Config{
-		SyncMode:            downloader.FullSync,
-		MinSyncPeers:        1,
-		DatabaseCache:       256,
-		DatabaseHandles:     256,
-		TxPool:              core.DefaultTxPoolConfig,
-		RPCEthCompatibility: true,
+		SyncMode:              downloader.FullSync,
+		MinSyncPeers:          1,
+		DatabaseCache:         256,
+		DatabaseHandles:       256,
+		TxPool:                core.DefaultTxPoolConfig,
+		RPCEthCompatibility:   true,
+		RPCGasPriceMultiplier: big.NewInt(100),
 		Istanbul: istanbul.Config{
 			Validator: true,
 			// Set announce gossip period to 1 minute, if not set this results


### PR DESCRIPTION
This add command line option to adjust the
multiplier in the gas price suggestion RPC
endpoint.

Example:
```
geth --rpc.gaspricemultiplier 1.456
```

Resolves #2136

Further improvements are tracked in #2153 
