### PR TITLE
Handle failing fee conversion

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -549,11 +549,12 @@ type TxWithMinerFee struct {
 	tx       *Transaction
 	minerFee *big.Int // in CELO
 }
+type ToCELOFn func(amount *big.Int, feeCurrency *common.Address) *big.Int
 
 // NewTxWithMinerFee creates a wrapped transaction, calculating the effective
 // miner gasTipCap if a base fee is provided. The MinerFee is converted to CELO.
 // Returns error in case of a negative effective miner gasTipCap.
-func NewTxWithMinerFee(tx *Transaction, baseFeeFn func(feeCurrency *common.Address) *big.Int, toCELO func(amount *big.Int, feeCurrency *common.Address) *big.Int) (*TxWithMinerFee, error) {
+func NewTxWithMinerFee(tx *Transaction, baseFeeFn func(feeCurrency *common.Address) *big.Int, toCELO ToCELOFn) (*TxWithMinerFee, error) {
 	minerFee, err := tx.EffectiveGasTip(baseFeeFn(tx.FeeCurrency()))
 	if err != nil {
 		return nil, err
@@ -596,11 +597,11 @@ func (s *TxByPriceAndTime) Pop() interface{} {
 // transactions in a profit-maximizing sorted order, while supporting removing
 // entire batches of transactions for non-executable accounts.
 type TransactionsByPriceAndNonce struct {
-	txs       map[common.Address]Transactions                             // Per account nonce-sorted list of transactions
-	heads     TxByPriceAndTime                                            // Next transaction for each unique account (price heap)
-	signer    Signer                                                      // Signer for the set of transactions
-	baseFeeFn func(feeCurrency *common.Address) *big.Int                  // Function to get the basefee for the specified feecurrency.
-	toCELO    func(amount *big.Int, feeCurrency *common.Address) *big.Int // Current exchange rate to CELO
+	txs       map[common.Address]Transactions            // Per account nonce-sorted list of transactions
+	heads     TxByPriceAndTime                           // Next transaction for each unique account (price heap)
+	signer    Signer                                     // Signer for the set of transactions
+	baseFeeFn func(feeCurrency *common.Address) *big.Int // Function to get the basefee for the specified feecurrency.
+	toCELO    ToCELOFn                                   // Current exchange rate to CELO
 }
 
 // NewTransactionsByPriceAndNonce creates a transaction set that can retrieve
@@ -609,7 +610,7 @@ type TransactionsByPriceAndNonce struct {
 // Note, the input map is reowned so the caller should not interact any more with
 // if after providing it to the constructor.
 // Note: txCmpFunc should handle the basefee
-func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transactions, baseFeeFn func(feeCurrency *common.Address) *big.Int, toCELO func(amount *big.Int, feeCurrency *common.Address) *big.Int) *TransactionsByPriceAndNonce {
+func NewTransactionsByPriceAndNonce(signer Signer, txs map[common.Address]Transactions, baseFeeFn func(feeCurrency *common.Address) *big.Int, toCELO ToCELOFn) *TransactionsByPriceAndNonce {
 	// Initialize a price and received time based heap with the head transactions
 	heads := make(TxByPriceAndTime, 0, len(txs))
 	for from, accTxs := range txs {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -549,7 +549,7 @@ type TxWithMinerFee struct {
 	tx       *Transaction
 	minerFee *big.Int // in CELO
 }
-type ToCELOFn func(amount *big.Int, feeCurrency *common.Address) *big.Int
+type ToCELOFn func(amount *big.Int, feeCurrency *common.Address) (*big.Int, error)
 
 // NewTxWithMinerFee creates a wrapped transaction, calculating the effective
 // miner gasTipCap if a base fee is provided. The MinerFee is converted to CELO.
@@ -559,9 +559,14 @@ func NewTxWithMinerFee(tx *Transaction, baseFeeFn func(feeCurrency *common.Addre
 	if err != nil {
 		return nil, err
 	}
+	minerFeeInCelo, err := toCELO(minerFee, tx.FeeCurrency())
+	if err != nil {
+		log.Error("NewTxWithMinerFee: Could not convert fees for tx", "tx", tx, "err", err)
+		return nil, err
+	}
 	return &TxWithMinerFee{
 		tx:       tx,
-		minerFee: toCELO(minerFee, tx.FeeCurrency()),
+		minerFee: minerFeeInCelo,
 	}, nil
 }
 

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -397,8 +397,8 @@ func TestTxEthCompatible(t *testing.T) {
 }
 
 // toCELO converter assuming that feeCurrency is always nil
-func toCELOMockFn(amount *big.Int, feeCurrency *common.Address) *big.Int {
-	return amount
+func toCELOMockFn(amount *big.Int, feeCurrency *common.Address) (*big.Int, error) {
+	return amount, nil
 }
 
 func TestTransactionPriceNonceSortLegacy(t *testing.T) {

--- a/miner/block.go
+++ b/miner/block.go
@@ -387,7 +387,7 @@ func (b *blockState) finalizeAndAssemble(w *worker) (*types.Block, error) {
 }
 
 // totalFees computes total consumed fees in CELO. Block transactions and receipts have to have the same order.
-func totalFees(block *types.Block, receipts []*types.Receipt, baseFeeFn func(*common.Address) *big.Int, toCELO func(*big.Int, *common.Address) *big.Int, espresso bool) *big.Float {
+func totalFees(block *types.Block, receipts []*types.Receipt, baseFeeFn func(*common.Address) *big.Int, toCELO types.ToCELOFn, espresso bool) *big.Float {
 	feesWei := new(big.Int)
 	for i, tx := range block.Transactions() {
 		var basefee *big.Int
@@ -402,7 +402,7 @@ func totalFees(block *types.Block, receipts []*types.Receipt, baseFeeFn func(*co
 
 // createConversionFunctions creates a function to convert any currency to Celo and a function to get the gas price minimum for that currency.
 // Both functions internally cache their results.
-func createConversionFunctions(sysCtx *core.SysContractCallCtx, chain *core.BlockChain, header *types.Header, state *state.StateDB) (func(feeCurrency *common.Address) *big.Int, func(amount *big.Int, feeCurrency *common.Address) *big.Int) {
+func createConversionFunctions(sysCtx *core.SysContractCallCtx, chain *core.BlockChain, header *types.Header, state *state.StateDB) (func(feeCurrency *common.Address) *big.Int, types.ToCELOFn) {
 	vmRunner := chain.NewEVMRunner(header, state)
 	currencyManager := currency.NewManager(vmRunner)
 


### PR DESCRIPTION
https://github.com/celo-org/celo-blockchain/issues/2134 leads us to
believe that there are failures happening in production. This change
* Handles error cases by skipping processing of respective txs instead
  of segfaulting
* Logs tx information in these cases to better understand why this is
  happening

Skipping transactions where conversion is not possible is analogous to
handling other cases of bad transactions. But since the linked issue
only happens for some nodes, I am not sure if this is the right thing to
do or if we should intentionally panic in that case to avoid harder to
debug consensus failures due to having different nodes process a
different set of transactions.

I would not recommend merging this PR before Gingerbread unless we are very confident that we are doing the right thing.

Very basic error logging for the problematic case has already been merged in https://github.com/celo-org/celo-blockchain/pull/2157.