### PR TITLE
Use UncleHash instead of Difficulty in EncodeRLP check

### DIFF
--- a/core/types/block_compatibility.go
+++ b/core/types/block_compatibility.go
@@ -86,12 +86,12 @@ func (h *Header) DecodeRLP(s *rlp.Stream) error {
 }
 
 func (h *Header) EncodeRLP(w io.Writer) error {
-	if h.Difficulty == nil {
+	if (h.UncleHash == common.Hash{}) {
 		// Before gingerbread hardfork Celo did not include all of
 		// Ethereum's header fields. In that case we must omit the new
 		// fields from the header when encoding as RLP to maintain the same encoding and hashes.
-		// `Difficulty` is a safe way to check, since it is always nil before
-		// gingerbread and always 0 after.
+		// `UncleHash` is a safe way to check, since it is the zero hash before
+		// gingerbread and non-zero after.
 		rlpFields := []interface{}{
 			h.ParentHash,
 			h.Coinbase,


### PR DESCRIPTION
### Description

Checking Difficulty breaks Rosetta since it seems that the Difficulty is 0x0 instead of nil.

### Tested
Tests passed locally and fixed the block hash issue seen in Rosetta.
(Will wait until CI is green but if we run into issues will add back the `|| Difficulty == nil` condition)
