### PR TITLE
Mycelo election's validators max, at least env validators

### DIFF
--- a/mycelo/genesis/genesis_state.go
+++ b/mycelo/genesis/genesis_state.go
@@ -635,10 +635,14 @@ func (ctx *deployContext) deployValidators() error {
 
 func (ctx *deployContext) deployElection() error {
 	return ctx.deployCoreContract("contracts", "Election", func(contract *contract.EVMBackend) error {
+		maxValidators := ctx.genesisConfig.Election.MaxElectableValidators
+		if uint64(ctx.accounts.NumValidators) > maxValidators {
+			maxValidators = uint64(ctx.accounts.NumValidators)
+		}
 		return contract.SimpleCall("initialize",
 			env.MustProxyAddressFor("Registry"),
 			newBigInt(ctx.genesisConfig.Election.MinElectableValidators),
-			newBigInt(ctx.genesisConfig.Election.MaxElectableValidators),
+			newBigInt(maxValidators),
 			ctx.genesisConfig.Election.MaxVotesPerAccount,
 			ctx.genesisConfig.Election.ElectabilityThreshold.BigInt(),
 		)


### PR DESCRIPTION
### Description

Allow mycelo to have more than 100 validators. Keep it as max(100, numValidatorsFromEnv) which is useful for adding validators elected via test, for smaller testnets
