### PR TITLE
Remove per-peer rlp.Encode calls of istanbul messages

### DIFF
--- a/consensus/consensustest/mockprotocol.go
+++ b/consensus/consensustest/mockprotocol.go
@@ -96,11 +96,11 @@ func NewMockPeer(node *enode.Node, purposes p2p.PurposeFlag) *MockPeer {
 	return mockPeer
 }
 
-func (mp *MockPeer) Send(msgCode uint64, data []byte) error {
+func (mp *MockPeer) EncodeAndSend(msgCode uint64, data []byte) error {
 	return nil
 }
 
-func (mp *MockPeer) SendDoubleEncoded(msgCode uint64, data []byte) error {
+func (mp *MockPeer) Send(msgCode uint64, data []byte) error {
 	return nil
 }
 

--- a/consensus/consensustest/mockprotocol.go
+++ b/consensus/consensustest/mockprotocol.go
@@ -96,7 +96,11 @@ func NewMockPeer(node *enode.Node, purposes p2p.PurposeFlag) *MockPeer {
 	return mockPeer
 }
 
-func (mp *MockPeer) Send(msgCode uint64, data interface{}) error {
+func (mp *MockPeer) Send(msgCode uint64, data []byte) error {
+	return nil
+}
+
+func (mp *MockPeer) SendDoubleEncoded(msgCode uint64, data []byte) error {
 	return nil
 }
 

--- a/consensus/istanbul/announce/vc_gossiper.go
+++ b/consensus/istanbul/announce/vc_gossiper.go
@@ -64,5 +64,5 @@ func (vg *vcGossiper) SendAllFrom(vcDb *VersionCertificateDB, peer consensus.Pee
 		return err
 	}
 
-	return peer.Send(istanbul.VersionCertificatesMsg, payload)
+	return peer.EncodeAndSend(istanbul.VersionCertificatesMsg, payload)
 }

--- a/consensus/istanbul/backend/handler.go
+++ b/consensus/istanbul/backend/handler.go
@@ -426,7 +426,7 @@ func (sb *Backend) Handshake(peer consensus.Peer) (bool, error) {
 		}
 		// No need to use sb.AsyncSendCeloMsg, since this is already
 		// being called within a goroutine.
-		err = peer.Send(istanbul.ValidatorHandshakeMsg, msgBytes)
+		err = peer.EncodeAndSend(istanbul.ValidatorHandshakeMsg, msgBytes)
 		if err != nil {
 			errCh <- err
 			return

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -32,11 +32,11 @@ type MockPeer struct {
 	NodeOverride *enode.Node
 }
 
-func (p *MockPeer) Send(msgcode uint64, data []byte) error {
+func (p *MockPeer) EncodeAndSend(msgcode uint64, data []byte) error {
 	return nil
 }
 
-func (p *MockPeer) SendDoubleEncoded(msgcode uint64, data []byte) error {
+func (p *MockPeer) Send(msgcode uint64, data []byte) error {
 	return nil
 }
 

--- a/consensus/istanbul/backend/handler_test.go
+++ b/consensus/istanbul/backend/handler_test.go
@@ -32,7 +32,11 @@ type MockPeer struct {
 	NodeOverride *enode.Node
 }
 
-func (p *MockPeer) Send(msgcode uint64, data interface{}) error {
+func (p *MockPeer) Send(msgcode uint64, data []byte) error {
+	return nil
+}
+
+func (p *MockPeer) SendDoubleEncoded(msgcode uint64, data []byte) error {
 	return nil
 }
 

--- a/consensus/istanbul/backend/message_senders.go
+++ b/consensus/istanbul/backend/message_senders.go
@@ -110,7 +110,7 @@ func (sb *Backend) Gossip(payload []byte, ethMsgCode uint64) error {
 // sendMsg will asynchronously send the the Celo messages to all the peers in the destPeers param.
 func (sb *Backend) asyncMulticast(destPeers map[enode.ID]consensus.Peer, payload []byte, ethMsgCode uint64) error {
 	logger := sb.logger.New("func", "AsyncMulticastCeloMsg", "msgCode", ethMsgCode)
-	payload2, err := rlp.EncodeToBytes(payload)
+	reencodedPayload, err := rlp.EncodeToBytes(payload)
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func (sb *Backend) asyncMulticast(destPeers map[enode.ID]consensus.Peer, payload
 		peer := peer // Create new instance of peer for the goroutine
 		go func() {
 			logger.Trace("Sending istanbul message(s) to peer", "peer", peer, "node", peer.Node())
-			if err := peer.SendDoubleEncoded(ethMsgCode, payload2); err != nil {
+			if err := peer.SendDoubleEncoded(ethMsgCode, reencodedPayload); err != nil {
 				logger.Warn("Error in sending message", "peer", peer, "ethMsgCode", ethMsgCode, "err", err)
 			}
 		}()

--- a/consensus/istanbul/backend/message_senders.go
+++ b/consensus/istanbul/backend/message_senders.go
@@ -118,7 +118,7 @@ func (sb *Backend) asyncMulticast(destPeers map[enode.ID]consensus.Peer, payload
 		peer := peer // Create new instance of peer for the goroutine
 		go func() {
 			logger.Trace("Sending istanbul message(s) to peer", "peer", peer, "node", peer.Node())
-			if err := peer.SendDoubleEncoded(ethMsgCode, reencodedPayload); err != nil {
+			if err := peer.Send(ethMsgCode, reencodedPayload); err != nil {
 				logger.Warn("Error in sending message", "peer", peer, "ethMsgCode", ethMsgCode, "err", err)
 			}
 		}()

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -20,7 +20,6 @@ import (
 	"math/big"
 
 	"github.com/celo-org/celo-blockchain/common"
-	"github.com/celo-org/celo-blockchain/common/hexutil"
 	"github.com/celo-org/celo-blockchain/consensus/istanbul"
 	"github.com/celo-org/celo-blockchain/log"
 )
@@ -173,7 +172,6 @@ func (c *core) handleMsg(payload []byte) error {
 
 	// Decode message and check its signature
 	msg := new(istanbul.Message)
-	logger.Debug("Got new message", "payload", hexutil.Encode(payload))
 	if err := msg.FromPayload(payload, c.validateFn); err != nil {
 		logger.Debug("Failed to decode message from payload", "err", err)
 		return err

--- a/consensus/istanbul/proxy/val_enodes_share.go
+++ b/consensus/istanbul/proxy/val_enodes_share.go
@@ -90,7 +90,7 @@ func (pv *proxiedValidatorEngine) sendValEnodesShareMsg(proxyPeer consensus.Peer
 	}
 
 	logger.Trace("Sending Istanbul Validator Enodes Share payload to proxy peer", "proxyPeer", proxyPeer)
-	if err := proxyPeer.Send(istanbul.ValEnodesShareMsg, payload); err != nil {
+	if err := proxyPeer.EncodeAndSend(istanbul.ValEnodesShareMsg, payload); err != nil {
 		logger.Error("Error sending Istanbul ValEnodesShare Message to proxy", "err", err)
 		return err
 	}

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -44,11 +44,13 @@ type P2PServer interface {
 
 // Peer defines the interface for a p2p.peer
 type Peer interface {
-	// Send sends the message to this peer
+	// EncodeAndSend sends the message to this peer. data should be encoded
+	// only once with rlp encoding.
+	EncodeAndSend(msgcode uint64, data []byte) error
+	// Send sends the message to this peer. Since current istanbul protocol
+	// has messages encoded twice, data should be twice encoded
+	// with rlp encoding.
 	Send(msgcode uint64, data []byte) error
-	// SendDoubleEncoded sends the message to this peer.
-	// message payload should be twice encoded in rlp encoding.
-	SendDoubleEncoded(msgcode uint64, data []byte) error
 	// Node returns the peer's enode
 	Node() *enode.Node
 	// Version returns the peer's version

--- a/consensus/protocol.go
+++ b/consensus/protocol.go
@@ -45,7 +45,10 @@ type P2PServer interface {
 // Peer defines the interface for a p2p.peer
 type Peer interface {
 	// Send sends the message to this peer
-	Send(msgcode uint64, data interface{}) error
+	Send(msgcode uint64, data []byte) error
+	// SendDoubleEncoded sends the message to this peer.
+	// message payload should be twice encoded in rlp encoding.
+	SendDoubleEncoded(msgcode uint64, data []byte) error
 	// Node returns the peer's enode
 	Node() *enode.Node
 	// Version returns the peer's version

--- a/eth/protocols/eth/celo_peer.go
+++ b/eth/protocols/eth/celo_peer.go
@@ -21,13 +21,6 @@ func (p *Peer) EncodeAndSend(msgcode uint64, data []byte) error {
 // has messages encoded twice, data should be twice encoded
 // with rlp encoding.
 func (p *Peer) Send(msgcode uint64, data []byte) error {
-	// Istanbul was encoding messages before sending it to the peer,
-	// then the peer itself would re-encode them before writing it into the
-	// output stream. This made it so that sending a message to 100 peers (validators),
-	// would encode the message a first time, then one hundred times more. With this
-	// change (making the double encode explicit here) we ensure the peer already
-	// receives the message in double encoded form, reducing the amount of rlp.encode
-	// calls from 101 to 2.
 	return p.rw.WriteMsg(p2p.Msg{Code: msgcode, Size: uint32(len(data)), Payload: bytes.NewReader(data)})
 
 }

--- a/eth/protocols/eth/celo_peer.go
+++ b/eth/protocols/eth/celo_peer.go
@@ -1,0 +1,24 @@
+package eth
+
+import (
+	"bytes"
+
+	"github.com/celo-org/celo-blockchain/p2p"
+	"github.com/celo-org/celo-blockchain/rlp"
+)
+
+// Send writes an RLP-encoded message with the given code.
+// data should encode as an RLP list.
+func (p *Peer) Send(msgcode uint64, data []byte) error {
+	raw, err := rlp.EncodeToBytes(data)
+	if err != nil {
+		return err
+	}
+	return p.SendDoubleEncoded(msgcode, raw)
+}
+
+// SendDoubleEncoded sends an rlp encoded (twice) message with the given code.
+func (p *Peer) SendDoubleEncoded(msgcode uint64, data []byte) error {
+	return p.rw.WriteMsg(p2p.Msg{Code: msgcode, Size: uint32(len(data)), Payload: bytes.NewReader(data)})
+
+}

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -173,12 +173,6 @@ func (p *Peer) markTransaction(hash common.Hash) {
 	p.knownTxs.Add(hash)
 }
 
-// Send writes an RLP-encoded message with the given code.
-// data should encode as an RLP list.
-func (p *Peer) Send(msgcode uint64, data interface{}) error {
-	return p2p.Send(p.rw, msgcode, data)
-}
-
 // SendTransactions sends transactions to the peer and includes the hashes
 // in its transaction hash set for future reference.
 //


### PR DESCRIPTION
Istanbul consensus is currently rlp encoding messages twice, and decoding them twice upon receiving one. The second encoding is done per peer, so if the same message is multicasted to 110 peers, it is encoded once, then 110 times more. This commit ensures the double encoding is done just once, reducing from 111 to 2 the calls to rlp.EncodeToBytes. A better way to handle this (but more disruptive) is completely drop the double encoding and double decoding, but would imply a protocol change.

* Also removed an expensive log line.