### PR TITLE
Remove ed25519 precompile

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -221,10 +221,10 @@ var PrecompiledContractsGingerbreadP2 = map[common.Address]CeloPrecompiledContra
 	celoPrecompileAddress(11): &getVerifiedSealBitmap{},
 
 	// New in Donut hard fork
-	celoPrecompileAddress(12): &ed25519Verify{},
 	celoPrecompileAddress(30): &getValidatorBLS{},
 
 	// Precompiles removed in Gingerbread P2 hard fork
+	// * ed25519Verify
 	// * bls12381G1Add
 	// * bls12381G1Mul
 	// * bls12381G1MultiExp


### PR DESCRIPTION
### Description

Remove the CIP-25 as part of the CIP: https://github.com/celo-org/celo-proposals/discussions/392

### Backwards compatibility

Part of the Gingerbread P2 Hard Fork
