### PR TITLE
Gingerbread Activation blocks

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -65,8 +65,8 @@ var (
 		ChurritoBlock:       big.NewInt(6774000),
 		DonutBlock:          big.NewInt(6774000),
 		EspressoBlock:       big.NewInt(11838440),
-		GingerbreadBlock:    nil,
-		GingerbreadP2Block:  nil,
+		GingerbreadBlock:    big.NewInt(21616000),
+		GingerbreadP2Block:  big.NewInt(21616000),
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -92,8 +92,8 @@ var (
 		ChurritoBlock:       big.NewInt(2719099),
 		DonutBlock:          big.NewInt(5002000),
 		EspressoBlock:       big.NewInt(9195000),
-		GingerbreadBlock:    nil,
-		GingerbreadP2Block:  nil,
+		GingerbreadBlock:    big.NewInt(18785000),
+		GingerbreadP2Block:  big.NewInt(19157000),
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,
@@ -119,8 +119,8 @@ var (
 		ChurritoBlock:       big.NewInt(4960000),
 		DonutBlock:          big.NewInt(4960000),
 		EspressoBlock:       big.NewInt(9472000),
-		GingerbreadBlock:    nil,
-		GingerbreadP2Block:  nil,
+		GingerbreadBlock:    big.NewInt(19814000),
+		GingerbreadP2Block:  big.NewInt(19814000),
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
 			ProposerPolicy: 2,

--- a/params/version.go
+++ b/params/version.go
@@ -26,7 +26,7 @@ import (
 // "1.3.0-beta", "1.3.0-beta.2", etc. and then "1.3.0-stable", "1.3.1-stable", etc.
 const (
 	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 6          // Minor version component of the current release
+	VersionMinor = 8          // Minor version component of the current release
 	VersionPatch = 0          // Patch version component of the current release
 	VersionMeta  = "unstable" // Version metadata to append to the version string
 )


### PR DESCRIPTION
### Description

Gingerbread Activation blocks:

Mainnet:
P1 & P2: `21616000` -> ~ 26/Sept/2023 17:15 UTC

Alfajores:
P1 & P2: `9814000` -> ~ 11/Sept/2023 17:30 UTC

Baklava:
P1: `18785000` -> 10/Aug/2023, 3:07:54 PM UTC
P2: `19157000` -> 01/Sept/2023, 2:08:22 PM UTC
