### PR TITLE
Fix tracing for transactions using on-chain randomness in latest block

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -204,7 +204,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, txFeeRecipien
 	return applyTransaction(msg, config, gp, statedb, header.Number, header.Hash(), tx, usedGas, vmenv, vmRunner, sysCtx)
 }
 
-func ApplyBlockRandomnessTx(block *types.Block, vmRunner *vm.EVMRunner, statedb *state.StateDB, bc *BlockChain) (error) {
+func ApplyBlockRandomnessTx(block *types.Block, vmRunner *vm.EVMRunner, statedb *state.StateDB, bc *BlockChain) error {
 	if !random.IsRunning(*vmRunner) {
 		return nil
 	}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -83,18 +83,9 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 		}
 	}
 
-	if random.IsRunning(vmRunner) {
-		author, err := p.bc.Engine().Author(header)
-		if err != nil {
-			return nil, nil, 0, err
-		}
-
-		err = random.RevealAndCommit(vmRunner, block.Randomness().Revealed, block.Randomness().Committed, author)
-		if err != nil {
-			return nil, nil, 0, err
-		}
-		// always true (EIP158)
-		statedb.IntermediateRoot(true)
+	err := ApplyBlockRandomnessTx(block, &vmRunner, statedb, p.bc)
+	if err != nil {
+		return nil, nil, 0, err
 	}
 
 	var (
@@ -211,4 +202,22 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, txFeeRecipien
 	blockContext := NewEVMBlockContext(header, bc, txFeeRecipient)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, config, cfg)
 	return applyTransaction(msg, config, gp, statedb, header.Number, header.Hash(), tx, usedGas, vmenv, vmRunner, sysCtx)
+}
+
+func ApplyBlockRandomnessTx(block *types.Block, vmRunner *vm.EVMRunner, statedb *state.StateDB, bc *BlockChain) (error) {
+	if !random.IsRunning(*vmRunner) {
+		return nil
+	}
+	author, err := bc.Engine().Author(block.Header())
+	if err != nil {
+		return err
+	}
+
+	err = random.RevealAndCommit(*vmRunner, block.Randomness().Revealed, block.Randomness().Committed, author)
+	if err != nil {
+		return err
+	}
+	// always true (EIP158)
+	statedb.IntermediateRoot(true)
+	return nil
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -477,8 +477,8 @@ func (b *EthAPIBackend) StartMining() error {
 	return b.eth.StartMining()
 }
 
-func (b *EthAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive, preferDisk bool, afterNextRandomCommit bool) (*state.StateDB, error) {
-	return b.eth.celoStateAtBlock(block, reexec, base, checkLive, preferDisk, afterNextRandomCommit)
+func (b *EthAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive, preferDisk bool, commitRandomness bool) (*state.StateDB, error) {
+	return b.eth.celoStateAtBlock(block, reexec, base, checkLive, preferDisk, commitRandomness)
 }
 
 func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, vm.EVMRunner, *state.StateDB, error) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -477,8 +477,8 @@ func (b *EthAPIBackend) StartMining() error {
 	return b.eth.StartMining()
 }
 
-func (b *EthAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive, preferDisk bool) (*state.StateDB, error) {
-	return b.eth.stateAtBlock(block, reexec, base, checkLive, preferDisk)
+func (b *EthAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive, preferDisk bool, afterNextRandomCommit bool) (*state.StateDB, error) {
+	return b.eth.celoStateAtBlock(block, reexec, base, checkLive, preferDisk, afterNextRandomCommit)
 }
 
 func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, vm.EVMRunner, *state.StateDB, error) {

--- a/eth/celo_state_accessor.go
+++ b/eth/celo_state_accessor.go
@@ -1,0 +1,35 @@
+package eth
+
+import (
+	"fmt"
+
+	"github.com/celo-org/celo-blockchain/core"
+	"github.com/celo-org/celo-blockchain/core/state"
+	"github.com/celo-org/celo-blockchain/core/types"
+)
+
+// Wraps `stateAtBlock` with the additional Celo-specific parameter afterNextRandomCommit.
+// This parameter executes the random commitment at the start of the next block,
+// since this is necessary for properly tracing transactions in the next block.
+func (eth *Ethereum) celoStateAtBlock(block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool, afterNextRandomCommit bool) (statedb *state.StateDB, err error) {
+	statedb, err = eth.stateAtBlock(block, reexec, base, checkLive, preferDisk)
+	if err != nil {
+		return nil, err
+	}
+
+	if !afterNextRandomCommit {
+		return statedb, nil
+	}
+	// Fetch next block's random commitment
+	nextBlockNum := block.NumberU64() + 1
+	nextBlock := eth.blockchain.GetBlockByNumber(nextBlockNum)
+	if nextBlock == nil {
+		return nil, fmt.Errorf("next block %d not found", nextBlockNum)
+	}
+	vmRunner := eth.blockchain.NewEVMRunner(nextBlock.Header(), statedb)
+	err = core.ApplyBlockRandomnessTx(nextBlock, &vmRunner, statedb, eth.blockchain)
+	if err != nil {
+		return nil, err
+	}
+	return statedb, nil
+}

--- a/eth/celo_state_accessor.go
+++ b/eth/celo_state_accessor.go
@@ -8,16 +8,16 @@ import (
 	"github.com/celo-org/celo-blockchain/core/types"
 )
 
-// Wraps `stateAtBlock` with the additional Celo-specific parameter afterNextRandomCommit.
+// Wraps `stateAtBlock` with the additional Celo-specific parameter `commitRandomness`.
 // This parameter executes the random commitment at the start of the next block,
 // since this is necessary for properly tracing transactions in the next block.
-func (eth *Ethereum) celoStateAtBlock(block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool, afterNextRandomCommit bool) (statedb *state.StateDB, err error) {
+func (eth *Ethereum) celoStateAtBlock(block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool, commitRandomness bool) (statedb *state.StateDB, err error) {
 	statedb, err = eth.stateAtBlock(block, reexec, base, checkLive, preferDisk)
 	if err != nil {
 		return nil, err
 	}
 
-	if !afterNextRandomCommit {
+	if !commitRandomness {
 		return statedb, nil
 	}
 	// Fetch next block's random commitment

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -169,7 +169,7 @@ func (eth *Ethereum) celoStateAtBlock(block *types.Block, reexec uint64, base *s
 		return nil, err
 	}
 
-	if (!afterNextRandomCommit) {
+	if !afterNextRandomCommit {
 		return statedb, nil
 	}
 	// Fetch next block's random commitment

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -159,32 +159,6 @@ func (eth *Ethereum) stateAtBlock(block *types.Block, reexec uint64, base *state
 	return statedb, nil
 }
 
-// Wraps `stateAtBlock` with the additional Celo-specific parameter afterNextRandomCommit.
-// This parameter executes the random commitment at the start of the next block,
-// since this is necessary for properly tracing transactions in the next block.
-func (eth *Ethereum) celoStateAtBlock(block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool, afterNextRandomCommit bool) (statedb *state.StateDB, err error) {
-	statedb, err = eth.stateAtBlock(block, reexec, base, checkLive, preferDisk)
-	if err != nil {
-		return nil, err
-	}
-
-	if !afterNextRandomCommit {
-		return statedb, nil
-	}
-	// Fetch next block's random commitment
-	nextBlockNum := block.NumberU64() + 1
-	nextBlock := eth.blockchain.GetBlockByNumber(nextBlockNum)
-	if nextBlock == nil {
-		return nil, fmt.Errorf("next block %d not found", nextBlockNum)
-	}
-	vmRunner := eth.blockchain.NewEVMRunner(nextBlock.Header(), statedb)
-	err = core.ApplyBlockRandomnessTx(nextBlock, &vmRunner, statedb, eth.blockchain)
-	if err != nil {
-		return nil, err
-	}
-	return statedb, nil
-}
-
 // stateAtTransaction returns the execution environment of a certain transaction.
 func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, vm.EVMRunner, *state.StateDB, error) {
 	// Short circuit if it's genesis block.

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -163,7 +163,6 @@ func (eth *Ethereum) stateAtBlock(block *types.Block, reexec uint64, base *state
 // This parameter executes the random commitment at the start of the next block,
 // since this is necessary for properly tracing transactions in the next block.
 func (eth *Ethereum) celoStateAtBlock(block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool, afterNextRandomCommit bool) (statedb *state.StateDB, err error) {
-	// TODO EN: need to revisit whether it's ok to use checkLive/preferDisk here
 	statedb, err = eth.stateAtBlock(block, reexec, base, checkLive, preferDisk)
 	if err != nil {
 		return nil, err
@@ -178,7 +177,6 @@ func (eth *Ethereum) celoStateAtBlock(block *types.Block, reexec uint64, base *s
 	if nextBlock == nil {
 		return nil, fmt.Errorf("next block %d not found", nextBlockNum)
 	}
-	// TODO EN: consider returning the vmRunner to not need to create multiple new runners
 	vmRunner := eth.blockchain.NewEVMRunner(nextBlock.Header(), statedb)
 	err = core.ApplyBlockRandomnessTx(nextBlock, &vmRunner, statedb, eth.blockchain)
 	if err != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -79,7 +79,7 @@ type Backend interface {
 	// N.B: For executing transactions on block N, the required stateRoot is block N-1,
 	// so this method should be called with the parent.
 	// On Celo, this should also include the random commitment of the current block.
-	StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive, preferDisk bool, afterNextRandomCommit bool) (*state.StateDB, error)
+	StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive, preferDisk bool, commitRandomness bool) (*state.StateDB, error)
 	StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, vm.EVMRunner, *state.StateDB, error)
 	NewEVMRunner(*types.Header, vm.StateDB) vm.EVMRunner
 }

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -275,7 +275,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 
 	// Celo addition, required for correct block randomness values when tracing.
 	// This is an optimization that prevents needing to regenerate and process
-	// all preceeding blocks for every single block when tracing on a full node;
+	// all preceding blocks for every single block when tracing on a full node;
 	// this is largely irrelevant when tracing on an archive node.
 	var baseStatedb *state.StateDB
 	if start.NumberU64() > 0 {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -383,8 +383,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 			}
 			// Prepare the statedb for tracing. Don't use the live database for
 			// tracing to avoid persisting state junks into the database.
-			// TODO EN: revisit if this should be true or false
-			statedb, err = api.backend.StateAtBlock(localctx, block, reexec, statedb, false, preferDisk, false)
+			statedb, err = api.backend.StateAtBlock(localctx, block, reexec, statedb, false, preferDisk, true)
 			if err != nil {
 				failed = err
 				break
@@ -850,7 +849,6 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 
 	var sysCtx *core.SysContractCallCtx
 	if api.backend.ChainConfig().IsEspresso(block.Number()) {
-		// TODO EN: revisit if this should be the same or not
 		parent, err := api.blockByNumber(ctx, rpc.BlockNumber(blockNumber-1))
 		if err != nil {
 			return nil, err
@@ -899,6 +897,8 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	if config != nil && config.Reexec != nil {
 		reexec = *config.Reexec
 	}
+	// Since this is applied at the end of the requested block (often "latest"),
+	// do not commit the following block's randomness
 	statedb, err := api.backend.StateAtBlock(ctx, block, reexec, nil, true, false, false)
 	if err != nil {
 		return nil, err

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -148,7 +148,7 @@ func (b *testBackend) ChainDb() ethdb.Database {
 	return b.chaindb
 }
 
-func (b *testBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool, afterNextRandomCommit bool) (*state.StateDB, error) {
+func (b *testBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool, commitRandomness bool) (*state.StateDB, error) {
 	statedb, err := b.chain.StateAt(block.Root())
 	if err != nil {
 		return nil, errStateNotFound

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -148,7 +148,7 @@ func (b *testBackend) ChainDb() ethdb.Database {
 	return b.chaindb
 }
 
-func (b *testBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool) (*state.StateDB, error) {
+func (b *testBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool, afterNextRandomCommit bool) (*state.StateDB, error) {
 	statedb, err := b.chain.StateAt(block.Root())
 	if err != nil {
 		return nil, errStateNotFound

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -449,7 +449,7 @@ func (b *LesApiBackend) CurrentHeader() *types.Header {
 	return b.eth.blockchain.CurrentHeader()
 }
 
-func (b *LesApiBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool) (*state.StateDB, error) {
+func (b *LesApiBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool, afterNextRandomCommit bool) (*state.StateDB, error) {
 	return b.eth.stateAtBlock(ctx, block, reexec)
 }
 

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -449,7 +449,7 @@ func (b *LesApiBackend) CurrentHeader() *types.Header {
 	return b.eth.blockchain.CurrentHeader()
 }
 
-func (b *LesApiBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool, afterNextRandomCommit bool) (*state.StateDB, error) {
+func (b *LesApiBackend) StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, checkLive bool, preferDisk bool, commitRandomness bool) (*state.StateDB, error) {
 	return b.eth.stateAtBlock(ctx, block, reexec)
 }
 


### PR DESCRIPTION
## Description

Fixes transaction tracing bug where the tracer did not include the block randomness for block whose transaction was being traced. For `(tx_i, block_n)`, it would fetch the state for `block_n-1` and then reexecute all txs up until `tx_i`, but would omit the random commitment at the very start of `block_n`.

This affects the following endpoints:
- `TraceTransaction`
- `TraceBlock*`
- `StandardTraceBlock*`
- `IntermediateRoots`
- `TraceChain`

Note:
- `TraceCall` performs correctly since this applies the tx _at the end_ of the requested block, so the block randomness of the next block is irrelevant.

### Implementation note
- Initially attempted to limit scope of the changes to the API (`eth/tracers/api.go`) but this results in even more messiness because the `eth/state_accessor/stateAtTransaction` function needs to have the solution duplicated
- Fixing this in the eth backend means that technically, the LES tracing API logic is wrong, but tracing with the light client fails or is incorrect as is anyways (confirmed for endpoints above)
  - Upside to this is that we can nicely separate out the celo-specific changes and make it explicit in the tracing API when randomness is included or not

*One alternative* here is just directly updating the `stateAtTransaction` function and then updating the API to use `stateAtTransaction` with the block & 0th index transaction to set up the state properly pre-tracing. I thought this was potentially a bit unclear + more likely to be accidentally overwritten in future merges but happy to reconsider!

Factors out `ApplyBlockRandomnessTx` from `core/state_processor/Process` so that it can be used by `state_accessor` as well.

## Tested
Unfortunately, testing this via an e2e/unit test is extremely involved, since tracing a simple interaction with `Random.sol` will not suffice. It appears necessary to trace a transaction where a contract interacts with `Random.sol` (tracing a non-view call), and deploying a contract manually in the test feels unnecessary.

- [x] Manual/scripted testing using foundry + mycelo -- https://github.com/celo-org/tracer-testing
 - future tracer testing can use the same repo
- [x] tested all endpoints listed above
- [  ] debugging an issue with `TraceChain` & not using the `live` database for multiple blocks 🤔  

## Backwards compatibility

This changes the behavior of the tracing API endpoints but is not expected to be a consensus-relevant breaking change.