### PR TITLE
Fix gingerbreadP2 check for light tx pool

### DIFF
--- a/light/txpool.go
+++ b/light/txpool.go
@@ -331,6 +331,7 @@ func (pool *TxPool) setNewHead(head *types.Header) {
 	pool.donut = pool.config.IsDonut(next)
 	pool.espresso = pool.config.IsEspresso(next)
 	pool.gingerbread = pool.config.IsGingerbread(next)
+	pool.gingerbreadP2 = pool.config.IsGingerbread(next)
 }
 
 // Stop stops the light transaction pool


### PR DESCRIPTION
### Description

Currently the light tx pool is missing the `pool.gingerbreadP2` property definition, causing light clients to incorrectly throw an error on receiving `0x7b` (`CeloDynamicFeeTxV2Type`) transactions.

### Tested

Manually checked that this allows `CeloDynamicFeeTxV2Type` txs to be submitted afterwards.

### Backwards compatibility

Not a consensus-level change so shouldn't require a hardfork.