### PR TITLE
Fee currencies without `credit`/`debit`

### DIFF
--- a/contracts/erc20gas/erc20gas.go
+++ b/contracts/erc20gas/erc20gas.go
@@ -52,20 +52,6 @@ func DebitFeesNative(evm *vm.EVM, address common.Address, amount *big.Int, feeCu
 		return nil
 	}
 
-	// Imitate the sender and do an approve & transfer from him
-
-	// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
-	//
-	// Solidity: function approve(address spender, uint256 amount) returns(bool)
-	// approveSelector := hexutil.MustDecode("0x095ea7b3")
-	// approveData := common.GetEncodedAbi(approveSelector, [][]byte{common.AddressToAbi(tmpAddress), common.AmountToAbi(amount)})
-
-	// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
-	//
-	// Solidity: function transferFrom(address from, address to, uint256 amount) returns(bool)
-	// transferFromSelector := hexutil.MustDecode("0x23b872dd")
-	// transferFromData := common.GetEncodedAbi(transferFromSelector, [][]byte{})
-
 	// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
 	//
 	// Solidity: function transfer(address to, uint256 amount) returns(bool)
@@ -75,12 +61,6 @@ func DebitFeesNative(evm *vm.EVM, address common.Address, amount *big.Int, feeCu
 	// create account ref
 	caller := vm.AccountRef(address)
 
-	// do EVM calls
-	// _, leftoverGas, err := evm.Call(caller, *feeCurrency, approveData, maxGasForDebitNativeTransactions, big.NewInt(0))
-	// if err != nil {
-	// 	return err
-	// }
-	// gasUsed := maxGasForDebitGasFeesTransactions - leftoverGas
 	_, leftoverGas, err := evm.Call(caller, *feeCurrency, transferData, maxGasForDebitNativeTransactions, big.NewInt(0))
 	gasUsed := maxGasForCreditNativeTransactions - leftoverGas
 	log.Trace("debitGasFees called", "feeCurrency", *feeCurrency, "gasUsed", gasUsed)
@@ -129,24 +109,6 @@ func CreditFeesNative(
 	feeCurrency *common.Address) error {
 	// create account ref
 	caller := vm.AccountRef(tmpAddress)
-
-	// totalApprove := big.NewInt(0).Add(big.NewInt(0).Add(refund, tipTxFee), baseTxFee)
-	// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
-	//
-	// Solidity: function approve(address spender, uint256 amount) returns(bool)
-	// approveSelector := hexutil.MustDecode("0x095ea7b3")
-	// approveData := common.GetEncodedAbi(approveSelector, [][]byte{common.AddressToAbi(tmpAddress), common.AmountToAbi(totalApprove)})
-
-	// _, leftoverGas, err := evm.Call(caller, *feeCurrency, approveData, maxGasForDebitNativeTransactions, big.NewInt(0))
-	// if err != nil {
-	// 	return err
-	// }
-	// gasUsed := maxGasForDebitGasFeesTransactions - leftoverGas
-	// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
-	//
-	// Solidity: function transferFrom(address from, address to, uint256 amount) returns(bool)
-	// transferFromSelector := hexutil.MustDecode("0x23b872dd")
-	// transferFromData := common.GetEncodedAbi(transferFromSelector, [][]byte{})
 
 	// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
 	//

--- a/contracts/erc20gas/erc20gas.go
+++ b/contracts/erc20gas/erc20gas.go
@@ -52,6 +52,12 @@ func DebitFeesNative(evm *vm.EVM, address common.Address, amount *big.Int, feeCu
 		return nil
 	}
 
+	// Run only primary evm.Call() with tracer
+	if evm.GetDebug() {
+		evm.SetDebug(false)
+		defer func() { evm.SetDebug(true) }()
+	}
+
 	// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
 	//
 	// Solidity: function transfer(address to, uint256 amount) returns(bool)
@@ -107,6 +113,13 @@ func CreditFeesNative(
 	gatewayFee *big.Int,
 	baseTxFee *big.Int,
 	feeCurrency *common.Address) error {
+
+	// Run only primary evm.Call() with tracer
+	if evm.GetDebug() {
+		evm.SetDebug(false)
+		defer func() { evm.SetDebug(true) }()
+	}
+
 	// create account ref
 	caller := vm.AccountRef(tmpAddress)
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -358,7 +358,7 @@ func (st *StateTransition) debitFee(from common.Address, feeCurrency *common.Add
 		st.state.SubBalance(from, effectiveFee)
 		return nil
 	} else {
-		return erc20gas.DebitFees(st.evm, from, effectiveFee, feeCurrency)
+		return erc20gas.DebitFeesNative(st.evm, from, effectiveFee, feeCurrency)
 	}
 }
 
@@ -583,7 +583,7 @@ func (st *StateTransition) distributeTxFees() error {
 		st.state.AddBalance(st.evm.Context.Coinbase, tipTxFee)
 		st.state.AddBalance(from, refund)
 	} else {
-		if err = erc20gas.CreditFees(st.evm, from, st.evm.Context.Coinbase, gatewayFeeRecipient, feeHandlerAddress, refund, tipTxFee, st.msg.GatewayFee(), baseTxFee, feeCurrency); err != nil {
+		if err = erc20gas.CreditFeesNative(st.evm, from, st.evm.Context.Coinbase, gatewayFeeRecipient, feeHandlerAddress, refund, tipTxFee, st.msg.GatewayFee(), baseTxFee, feeCurrency); err != nil {
 			log.Error("Error crediting", "from", from, "coinbase", st.evm.Context.Coinbase, "gateway", gatewayFeeRecipient, "feeHandler", feeHandlerAddress)
 			return err
 		}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -358,7 +358,7 @@ func (st *StateTransition) debitFee(from common.Address, feeCurrency *common.Add
 		st.state.SubBalance(from, effectiveFee)
 		return nil
 	} else {
-		return erc20gas.DebitFeesNative(st.evm, from, effectiveFee, feeCurrency)
+		return erc20gas.DebitFeesNew(st.evm, from, effectiveFee, feeCurrency)
 	}
 }
 
@@ -583,7 +583,7 @@ func (st *StateTransition) distributeTxFees() error {
 		st.state.AddBalance(st.evm.Context.Coinbase, tipTxFee)
 		st.state.AddBalance(from, refund)
 	} else {
-		if err = erc20gas.CreditFeesNative(st.evm, from, st.evm.Context.Coinbase, gatewayFeeRecipient, feeHandlerAddress, refund, tipTxFee, st.msg.GatewayFee(), baseTxFee, feeCurrency); err != nil {
+		if err = erc20gas.CreditFeesNew(st.evm, from, st.evm.Context.Coinbase, gatewayFeeRecipient, feeHandlerAddress, refund, tipTxFee, st.msg.GatewayFee(), baseTxFee, feeCurrency); err != nil {
 			log.Error("Error crediting", "from", from, "coinbase", st.evm.Context.Coinbase, "gateway", gatewayFeeRecipient, "feeHandler", feeHandlerAddress)
 			return err
 		}

--- a/e2e_test/e2e_transfer_test.go
+++ b/e2e_test/e2e_transfer_test.go
@@ -531,11 +531,12 @@ func TestTransferERC20(t *testing.T) {
 			require.Equal(t, feeHandlerAddress, eventTo)
 
 			fmt.Println("feendler", env.MustProxyAddressFor("FeeHandler"))
+			// fmt.Println("Gas", receipt.GasUsed)
 			fmt.Println("Logs", receipt.Logs)
 			for i := 0; i < len(receipt.Logs); i++ {
 				fmt.Println("log ", i, receipt.Logs[i])
 			}
-			// require.Error(t, err)
+			require.Error(t, err)
 		})
 	}
 }

--- a/e2e_test/e2e_transfer_test.go
+++ b/e2e_test/e2e_transfer_test.go
@@ -526,15 +526,15 @@ func TestTransferERC20(t *testing.T) {
 			watcher.Update()
 			receipt, _ := client.TransactionReceipt(ctx, tx.Hash())
 
-			require.Equal(t, 2, len(receipt.Logs))
-			eventTo := common.BytesToAddress(receipt.Logs[0].Topics[2].Bytes())
+			require.Equal(t, 4, len(receipt.Logs))
+			eventTo := common.BytesToAddress(receipt.Logs[3].Topics[2].Bytes())
 			require.Equal(t, feeHandlerAddress, eventTo)
 
-			// fmt.Println("feendler", env.MustProxyAddressFor("FeeHandler"))
-			// fmt.Println("Logs", receipt.Logs)
-			// for i := 0; i < len(receipt.Logs); i++ {
-			// 	fmt.Println("log ", i, receipt.Logs[i])
-			// }
+			fmt.Println("feendler", env.MustProxyAddressFor("FeeHandler"))
+			fmt.Println("Logs", receipt.Logs)
+			for i := 0; i < len(receipt.Logs); i++ {
+				fmt.Println("log ", i, receipt.Logs[i])
+			}
 			// require.Error(t, err)
 		})
 	}


### PR DESCRIPTION
### Description

Prototype for gas currency payments without `credit`/`debit` functions in the token contract.

Inside the EVM state transition code it is possible to send transactions from arbitrary accounts. @karlb came up with the idea to use this to use the existing `approve`/`transferFrom` functions to remove the need of `credit`/`debit` functions in fee currency token contracts.

During the implementation it became clear that it is possible to just call `transfer`, which reduces the overhead further.

There's two remaining differences from the current implementation:
- This will emit transfer events. It should be possible to discard them though.
- It doesn't temporarily reduce the total supply like we do now. It still keeps the invariant "sum(balances) == total supply" by moving the tokens to `0xce106a5` instead of letting the debited fees vanish.


⚠️ The code is a prototype, the gas limit handling is just wrong and error handling needs to be improved.