### PR TITLE
Fix underpriced check for multi currency

### DIFF
--- a/contracts/currency/currency.go
+++ b/contracts/currency/currency.go
@@ -153,6 +153,11 @@ func NewManager(vmRunner vm.EVMRunner) *CurrencyManager {
 	return newManager(GetExchangeRate, vmRunner)
 }
 
+// NewCacheOnlyManager creates a cache-full currency manager. TESTING PURPOSES ONLY
+func NewCacheOnlyManager(currencyCache map[common.Address]*Currency) *CurrencyManager {
+	return &CurrencyManager{currencyCache: currencyCache}
+}
+
 func newManager(_getExchangeRate func(vm.EVMRunner, *common.Address) (*ExchangeRate, error), vmRunner vm.EVMRunner) *CurrencyManager {
 	return &CurrencyManager{
 		vmRunner:         vmRunner,

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -696,27 +696,29 @@ func (l *txPricedList) Underpriced(tx *types.Transaction) bool {
 }
 
 func (l *txPricedList) underpricedForMulti(h *multiCurrencyPriceHeap, tx *types.Transaction) bool {
-	// Has to be underpriced for ALL heaps to be underpriced for the whole pool.
-	if !l.underpricedFor(h.nativeCurrencyHeap, tx, h.IsCheaper) {
-		// Check Len after calling underpricedFor since it might prune entries
-		if h.nativeCurrencyHeap.Len() > 0 {
+	// wellpriced returns if, after pruning, tx is above minimum price
+	// compared to the top of the heap (minimum priced tx in heap)
+	wellpriced := func(heap *priceHeap) bool {
+		l.prune(heap)
+		return heap.Len() > 0 && !h.IsCheaper(tx, heap.list[0])
+	}
+
+	// If tx is wellpriced for at least one heap, then it is not underpriced
+	if wellpriced(h.nativeCurrencyHeap) {
+		return false
+	}
+	for _, sh := range h.currencyHeaps {
+		if wellpriced(sh) {
 			return false
 		}
 	}
-	for _, sh := range h.currencyHeaps {
-		if !l.underpricedFor(sh, tx, h.IsCheaper) {
-			// Check Len after calling underpricedFor since it might prune entries
-			if sh.Len() > 0 {
-				return false
-			}
-		}
-	}
+	// While this impl. is returning true when all heaps are empty (h.Len() == 0), that border
+	// case is managed on invokation of this fn.
 	return true
 }
 
-// underpricedFor checks whether a transaction is cheaper than (or as cheap as) the
-// lowest priced (remote) transaction in the given heap.
-func (l *txPricedList) underpricedFor(h *priceHeap, tx *types.Transaction, isCheaper func(tx1, tx2 *types.Transaction) bool) bool {
+// prune discards from the top of the heap txs that are no longer in the pool
+func (l *txPricedList) prune(h *priceHeap) {
 	// Discard stale price points if found at the heap start
 	for len(h.list) > 0 {
 		head := h.list[0]
@@ -727,13 +729,6 @@ func (l *txPricedList) underpricedFor(h *priceHeap, tx *types.Transaction, isChe
 		}
 		break
 	}
-	// Check if the transaction is underpriced or not
-	if len(h.list) == 0 {
-		return false // There is no remote transaction at all.
-	}
-	// If the remote transaction is even cheaper than the
-	// cheapest one tracked locally, reject it.
-	return isCheaper(tx, h.list[0])
 }
 
 // Discard finds a number of most underpriced transactions, removes them from the

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -698,11 +698,17 @@ func (l *txPricedList) Underpriced(tx *types.Transaction) bool {
 func (l *txPricedList) underpricedForMulti(h *multiCurrencyPriceHeap, tx *types.Transaction) bool {
 	// Has to be underpriced for ALL heaps to be underpriced for the whole pool.
 	if !l.underpricedFor(h.nativeCurrencyHeap, tx, h.IsCheaper) {
-		return false
+		// Check Len after calling underpricedFor since it might prune entries
+		if h.nativeCurrencyHeap.Len() > 0 {
+			return false
+		}
 	}
 	for _, sh := range h.currencyHeaps {
 		if !l.underpricedFor(sh, tx, h.IsCheaper) {
-			return false
+			// Check Len after calling underpricedFor since it might prune entries
+			if sh.Len() > 0 {
+				return false
+			}
 		}
 	}
 	return true

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -697,13 +697,15 @@ func (l *txPricedList) Underpriced(tx *types.Transaction) bool {
 
 func (l *txPricedList) underpricedForMulti(h *multiCurrencyPriceHeap, tx *types.Transaction) bool {
 	// Has to be underpriced for ALL heaps to be underpriced for the whole pool.
-	underpriced := l.underpricedFor(h.nativeCurrencyHeap, tx, h.IsCheaper)
+	if !l.underpricedFor(h.nativeCurrencyHeap, tx, h.IsCheaper) {
+		return false
+	}
 	for _, sh := range h.currencyHeaps {
 		if !l.underpricedFor(sh, tx, h.IsCheaper) {
-			underpriced = false
+			return false
 		}
 	}
-	return underpriced
+	return true
 }
 
 // underpricedFor checks whether a transaction is cheaper than (or as cheap as) the

--- a/core/tx_multicurrency_priceheap.go
+++ b/core/tx_multicurrency_priceheap.go
@@ -19,6 +19,9 @@ func (cc CurrencyCmpFn) GasTipCapCmp(tx, other *types.Transaction) int {
 	return cc(tx.GasTipCap(), tx.FeeCurrency(), other.GasTipCap(), other.FeeCurrency())
 }
 
+// EffectiveGasTipCmp returns the same comparison result as Transaction.EffectiveGasTipCmp
+// but taking into account the exchange rate comparison of the CurrencyCmpFn.
+// Each baseFee is expressed in each tx's currency.
 func (cc CurrencyCmpFn) EffectiveGasTipCmp(tx, other *types.Transaction, baseFeeA, baseFeeB *big.Int) int {
 	if baseFeeA == nil && baseFeeB == nil {
 		return cc.GasTipCapCmp(tx, other)
@@ -30,6 +33,9 @@ func (cc CurrencyCmpFn) GasFeeCapCmp(a, b *types.Transaction) int {
 	return cc(a.GasFeeCap(), a.FeeCurrency(), b.GasFeeCap(), b.FeeCurrency())
 }
 
+// Cmp returns the same comparison as the priceHeap comparison but taking into account
+// the exchange rate comparison of the CurrencyCmpFn.
+// Each baseFee is expressed in each tx's currency.
 func (cc CurrencyCmpFn) Cmp(a, b *types.Transaction, baseFeeA, baseFeeB *big.Int) int {
 	if baseFeeA != nil || baseFeeB != nil {
 		// Compare effective tips if baseFee is specified

--- a/core/tx_multicurrency_priceheap.go
+++ b/core/tx_multicurrency_priceheap.go
@@ -37,7 +37,7 @@ func (cc CurrencyCmpFn) GasFeeCapCmp(a, b *types.Transaction) int {
 // the exchange rate comparison of the CurrencyCmpFn.
 // Each baseFee is expressed in each tx's currency.
 func (cc CurrencyCmpFn) Cmp(a, b *types.Transaction, baseFeeA, baseFeeB *big.Int) int {
-	if baseFeeA != nil || baseFeeB != nil {
+	if baseFeeA != nil && baseFeeB != nil {
 		// Compare effective tips if baseFee is specified
 		if c := cc.EffectiveGasTipCmp(a, b, baseFeeA, baseFeeB); c != 0 {
 			return c
@@ -70,9 +70,9 @@ func newMultiCurrencyPriceHeap(currencyCmp CurrencyCmpFn, gpm GasPriceMinimums) 
 
 		// inner state
 
-		nativeCurrencyHeap: &priceHeap{
-			baseFee: gpm.GetNativeGPM(),
-		},
+		nativeCurrencyHeap: &priceHeap{}, // Not initializing the basefee
+		// since it gets updated as soon as the node starts, and
+		// tx pool tests (upstream) assume baseFee == nil
 		currencyHeaps: make(map[common.Address]*priceHeap),
 	}
 }

--- a/core/tx_multicurrency_priceheap.go
+++ b/core/tx_multicurrency_priceheap.go
@@ -10,11 +10,6 @@ import (
 
 type CurrencyCmpFn func(*big.Int, *common.Address, *big.Int, *common.Address) int
 
-// IsCheaper returns true if tx1 is cheaper (or equal) than tx2 (GasPrice with currency comparison)
-func (cc CurrencyCmpFn) IsCheaper(tx1, tx2 *types.Transaction) bool {
-	return cc.Cmp(tx1, tx2, nil, nil) <= 0
-}
-
 func (cc CurrencyCmpFn) GasTipCapCmp(tx, other *types.Transaction) int {
 	return cc(tx.GasTipCap(), tx.FeeCurrency(), other.GasTipCap(), other.FeeCurrency())
 }
@@ -128,7 +123,7 @@ func (h *multiCurrencyPriceHeap) cheapestTx() *types.Transaction {
 	txs := h.cheapestTxs()
 	var cheapestTx *types.Transaction
 	for _, tx := range txs {
-		if cheapestTx == nil || h.currencyCmp.IsCheaper(tx, cheapestTx) {
+		if cheapestTx == nil || h.IsCheaper(tx, cheapestTx) {
 			cheapestTx = tx
 		}
 	}

--- a/core/tx_multicurrency_priceheap.go
+++ b/core/tx_multicurrency_priceheap.go
@@ -18,9 +18,6 @@ func (cc CurrencyCmpFn) GasTipCapCmp(tx, other *types.Transaction) int {
 // but taking into account the exchange rate comparison of the CurrencyCmpFn.
 // Each baseFee is expressed in each tx's currency.
 func (cc CurrencyCmpFn) EffectiveGasTipCmp(tx, other *types.Transaction, baseFeeA, baseFeeB *big.Int) int {
-	if baseFeeA == nil && baseFeeB == nil {
-		return cc.GasTipCapCmp(tx, other)
-	}
 	return cc(tx.EffectiveGasTipValue(baseFeeA), tx.FeeCurrency(), other.EffectiveGasTipValue(baseFeeB), other.FeeCurrency())
 }
 

--- a/core/tx_multicurrency_priceheap_test.go
+++ b/core/tx_multicurrency_priceheap_test.go
@@ -447,7 +447,85 @@ func TestMulticurrencyUnderpriced(t *testing.T) {
 			},
 		},
 		{
-			name: "Many txs from Many currencies",
+			name: "Mixed existing transactions",
+			existingTxs: []addTx{
+				{tx(3), false},
+				{txC(5, &curr1), false},
+			},
+			cases: []testCase{
+				{
+					desc:     "Accepted native",
+					newTx:    tx(4),
+					expected: false,
+				},
+				{
+					desc:     "Underpriced native",
+					newTx:    tx(3),
+					expected: true,
+				},
+				{
+					desc:     "Accepted cheapest curr1",
+					newTx:    txC(5, &curr1),
+					expected: false,
+				},
+				{
+					desc:     "Underpriced curr1",
+					newTx:    txC(3, &curr1),
+					expected: true,
+				},
+				{
+					desc:     "Accepted cheapest curr3",
+					newTx:    txC(2, &curr3),
+					expected: false,
+				},
+				{
+					desc:     "Underpriced curr3",
+					newTx:    txC(1, &curr3),
+					expected: true,
+				},
+			},
+		},
+		{
+			name: "Multiple existing transactions",
+			existingTxs: []addTx{
+				{tx(3), false},
+				{tx(5), false},
+			},
+			cases: []testCase{
+				{
+					desc:     "Accepted native",
+					newTx:    tx(4),
+					expected: false,
+				},
+				{
+					desc:     "Underpriced native",
+					newTx:    tx(3),
+					expected: true,
+				},
+				{
+					desc:     "Accepted cheapest curr1",
+					newTx:    txC(5, &curr1),
+					expected: false,
+				},
+				{
+					desc:     "Underpriced curr1",
+					newTx:    txC(3, &curr1),
+					expected: true,
+				},
+				{
+					desc:     "Accepted cheapest curr3",
+					newTx:    txC(2, &curr3),
+					expected: false,
+				},
+				{
+					desc:     "Underpriced curr3",
+					newTx:    txC(1, &curr3),
+					expected: true,
+				},
+			},
+		},
+		{
+			name: "Many txs from many currencies",
 			existingTxs: []addTx{
 				{txC(3, nil), false}, // Cheapest native currency: 3
 				{txC(6, nil), false},

--- a/core/tx_multicurrency_priceheap_test.go
+++ b/core/tx_multicurrency_priceheap_test.go
@@ -382,22 +382,26 @@ func TestMulticurrencyUnderpriced(t *testing.T) {
 	curr1 := common.HexToAddress("aaaa1")
 	rate1, _ := currency.NewExchangeRate(common.Big1, common.Big1)
 	curr2 := common.HexToAddress("aaaa2")
-
-	rate2, _ := currency.NewExchangeRate(common.Big1, common.Big1)
+	rate2, _ := currency.NewExchangeRate(common.Big1, common.Big2)
+	curr3 := common.HexToAddress("aaaa3")
+	rate3, _ := currency.NewExchangeRate(common.Big1, common.Big3)
 	all.Add(txC(5, &curr1), false)
-	all.Add(txC(2, nil), false)
-	all.Add(txC(4, &curr2), false)
+	all.Add(txC(3, nil), false)
+	all.Add(txC(1, &curr2), false)
+	all.Add(txC(2, &curr2), false)
 	all.Add(txC(6, nil), false)
+	all.Add(txC(1, &curr3), false)
 
 	currCache := map[common.Address]*currency.Currency{
 		curr1: currency.NewCurrency(curr1, *rate1),
 		curr2: currency.NewCurrency(curr2, *rate2),
+		curr3: currency.NewCurrency(curr3, *rate3),
 	}
 	cm := currency.NewCacheOnlyManager(currCache)
 	ctx := txPoolContext{
 		&SysContractCallCtx{
-			whitelistedCurrencies: map[common.Address]struct{}{curr1: {}, curr2: {}},
-			gasPriceMinimums:      map[common.Address]*big.Int{curr1: nil, curr2: nil},
+			whitelistedCurrencies: map[common.Address]struct{}{curr1: {}, curr2: {}, curr3: {}},
+			gasPriceMinimums:      map[common.Address]*big.Int{curr1: nil, curr2: nil, curr3: nil},
 		},
 		cm,
 		nil,

--- a/core/tx_multicurrency_priceheap_test.go
+++ b/core/tx_multicurrency_priceheap_test.go
@@ -335,7 +335,34 @@ func TestClear(t *testing.T) {
 	assert.Nil(t, m.Pop())
 }
 
+func TestIsCheaper_FwdFields(t *testing.T) {
+	// Tests that the CurrencyCmpFn receives the
+	// proper fields for comparison in a gas fee cap cmp
+	curr1 := common.BigToAddress(big.NewInt(123))
+	price1 := big.NewInt(100)
+	curr2 := common.BigToAddress(big.NewInt(123))
+	price2 := big.NewInt(200)
+	tx1 := types.NewTx(&types.LegacyTx{
+		GasPrice:    price1,
+		FeeCurrency: &curr1,
+	})
+	tx2 := types.NewTx(&types.LegacyTx{
+		GasPrice:    price2,
+		FeeCurrency: &curr2,
+	})
+	var cmp CurrencyCmpFn = func(p1 *big.Int, c1 *common.Address, p2 *big.Int, c2 *common.Address) int {
+		assert.Equal(t, price1, p1)
+		assert.Equal(t, price2, p2)
+		assert.Equal(t, curr1, *c1)
+		assert.Equal(t, curr2, *c2)
+		return -1
+	}
+	assert.True(t, cmp.Cmp(tx1, tx2, nil, nil) == -1)
+}
+
 func TestIsCheaper(t *testing.T) {
+	// Tests that the result of the currency comparison function is
+	// properly being returned in the tx comparison function
 	tx1 := types.NewTx(&types.LegacyTx{})
 	tx2 := types.NewTx(&types.LegacyTx{})
 	var cheaper CurrencyCmpFn = func(p1 *big.Int, c1 *common.Address, p2 *big.Int, c2 *common.Address) int {

--- a/core/tx_multicurrency_priceheap_test.go
+++ b/core/tx_multicurrency_priceheap_test.go
@@ -307,7 +307,7 @@ func TestIsCheaper_FwdFields(t *testing.T) {
 		assert.Equal(t, curr2, *c2)
 		return -1
 	}
-	assert.True(t, cmp.IsCheaper(tx1, tx2))
+	assert.True(t, cmp.Cmp(tx1, tx2, nil, nil) <= 0)
 }
 
 func TestIsCheaper(t *testing.T) {
@@ -322,9 +322,9 @@ func TestIsCheaper(t *testing.T) {
 	var notCheaper CurrencyCmpFn = func(p1 *big.Int, c1 *common.Address, p2 *big.Int, c2 *common.Address) int {
 		return 1
 	}
-	assert.True(t, cheaper.IsCheaper(tx1, tx2))
-	assert.True(t, equal.IsCheaper(tx1, tx2))
-	assert.False(t, notCheaper.IsCheaper(tx1, tx2))
+	assert.True(t, cheaper.Cmp(tx1, tx2, nil, nil) <= 0)
+	assert.True(t, equal.Cmp(tx1, tx2, nil, nil) <= 0)
+	assert.False(t, notCheaper.Cmp(tx1, tx2, nil, nil) <= 0)
 }
 
 // TestMulticurrencyUnderpriced tests that the underpriced method from pricedList functions

--- a/core/tx_multicurrency_priceheap_test.go
+++ b/core/tx_multicurrency_priceheap_test.go
@@ -321,6 +321,6 @@ func TestIsCheaper(t *testing.T) {
 		return 1
 	}
 	assert.True(t, cheaper.IsCheaper(tx1, tx2))
-	assert.False(t, equal.IsCheaper(tx1, tx2))
+	assert.True(t, equal.IsCheaper(tx1, tx2))
 	assert.False(t, notCheaper.IsCheaper(tx1, tx2))
 }

--- a/core/tx_multicurrency_priceheap_test.go
+++ b/core/tx_multicurrency_priceheap_test.go
@@ -127,7 +127,7 @@ func TestMultiPushPop(t *testing.T) {
 	}
 	m := newMultiCurrencyPriceHeap(cmp, gpm)
 	m.UpdateFeesAndCurrencies(cmp, gpm)
-	m.Push(txC(100, c1)) // 100 * 10 - 10 * 10 = 900 (substracting basefee x currencyValue)
+	m.Push(txC(100, c1)) // 100 * 10 - 10 * 10 = 900 (subtracting basefee x currencyValue)
 	m.Push(txC(250, c1)) // 2500 - 10 * 10 = 2400
 	m.Push(txC(50, c1))  // 500 - 100 = 400
 	m.Push(txC(200, c1)) // 2000 - 100 = 1900
@@ -210,7 +210,7 @@ func TestMultiAddInit(t *testing.T) {
 	}
 	m := newMultiCurrencyPriceHeap(cmp, gpm)
 	m.UpdateFeesAndCurrencies(cmp, gpm)
-	m.Add(txC(100, c1)) // 100 * 10 - 10 * 10 = 900 (substracting basefee x currencyValue)
+	m.Add(txC(100, c1)) // 100 * 10 - 10 * 10 = 900 (subtracting basefee x currencyValue)
 	m.Add(txC(250, c1)) // 2500 - 10 * 10 = 2400
 	m.Add(txC(50, c1))  // 500 - 100 = 400
 	m.Add(txC(200, c1)) // 2000 - 100 = 1900


### PR DESCRIPTION
Previous underprice implementation would provoke different currency comparisons, erroneously calculate the underprice flag, and ignore basefee in underprice comparisons.