### PR TITLE
Upgrade CI to go 1.19

### DIFF
--- a/.github/workflows/blockchain.yml
+++ b/.github/workflows/blockchain.yml
@@ -18,7 +18,7 @@ env:
   # Increment these to force cache rebuilding
   SYSTEM_CONTRACTS_CACHE_VERSION: 4
   CHECKOUT_MONOREPO_CACHE_VERSION: 8
-  GO_VERSION: '1.18'
+  GO_VERSION: '1.19'
   # Location where compiled system contracts are stored under the root of this
   # repo.
   SYSTEM_CONTRACTS_PATH: "compiled-system-contracts"


### PR DESCRIPTION
### Description

Follow-up for https://github.com/celo-org/celo-blockchain/pull/2189, upgrade CI as well.
