### PR TITLE
Add chain_head_gasprice gauge metric. Fix e2e tests

### DIFF
--- a/.github/workflows/blockchain.yml
+++ b/.github/workflows/blockchain.yml
@@ -39,7 +39,7 @@ jobs:
     #   options: --user root
     runs-on: ["8-cpu","self-hosted","blockchain"]
     env:
-      NODE_VERSION: 18
+      NODE_VERSION: 18.18
       CONTRACTS_BUILD_PATH: packages/protocol/build
 
     steps:
@@ -431,12 +431,6 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
         cache: yarn
         cache-dependency-path: celo-monorepo/yarn.lock
-
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 30
-      with:
-        limit-access-to-actor: true
 
     - name: Run e2e test
       run: |

--- a/.github/workflows/blockchain.yml
+++ b/.github/workflows/blockchain.yml
@@ -22,6 +22,8 @@ env:
   # Location where compiled system contracts are stored under the root of this
   # repo.
   SYSTEM_CONTRACTS_PATH: "compiled-system-contracts"
+  # Used for celo-monorepo
+  NODE_VERSION: 18.18
 
 defaults:
   run:
@@ -39,7 +41,6 @@ jobs:
     #   options: --user root
     runs-on: ["8-cpu","self-hosted","blockchain"]
     env:
-      NODE_VERSION: 18.18
       CONTRACTS_BUILD_PATH: packages/protocol/build
 
     steps:
@@ -391,8 +392,6 @@ jobs:
     name: End-to-end blockchain parameters test
     runs-on: ["8-cpu","self-hosted","blockchain"]
     timeout-minutes: 30
-    env:
-      NODE_VERSION: 18
 
     needs:
     - go-modules
@@ -442,8 +441,6 @@ jobs:
     name: End-to-end governance test
     runs-on: ["8-cpu","self-hosted","blockchain"]
     timeout-minutes: 30
-    env:
-      NODE_VERSION: 18
 
     needs:
     - go-modules
@@ -493,8 +490,6 @@ jobs:
     name: End-to-end sync test
     runs-on: ["8-cpu","self-hosted","blockchain"]
     timeout-minutes: 30
-    env:
-      NODE_VERSION: 18
 
     needs:
     - go-modules
@@ -543,8 +538,6 @@ jobs:
     name: End-to-end slashing test
     runs-on: ["8-cpu","self-hosted","blockchain"]
     timeout-minutes: 30
-    env:
-      NODE_VERSION: 18
 
     needs:
     - go-modules
@@ -593,8 +586,6 @@ jobs:
     name: End-to-end transfers test
     runs-on: ["8-cpu","self-hosted","blockchain"]
     timeout-minutes: 30
-    env:
-      NODE_VERSION: 18
 
     needs:
     - go-modules
@@ -643,8 +634,6 @@ jobs:
     name: End-to-end validator order test
     runs-on: ["8-cpu","self-hosted","blockchain"]
     timeout-minutes: 30
-    env:
-      NODE_VERSION: 18
 
     needs:
     - go-modules
@@ -693,8 +682,6 @@ jobs:
     name: End-to-end CIP35-eth compatibility test
     runs-on: ["8-cpu","self-hosted","blockchain"]
     timeout-minutes: 30
-    env:
-      NODE_VERSION: 18
 
     needs:
     - go-modules
@@ -743,8 +730,6 @@ jobs:
     name: End-to-end replica test
     runs-on: ["8-cpu","self-hosted","blockchain"]
     timeout-minutes: 30
-    env:
-      NODE_VERSION: 18
 
     needs:
     - go-modules

--- a/.github/workflows/blockchain.yml
+++ b/.github/workflows/blockchain.yml
@@ -431,6 +431,13 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
         cache: yarn
         cache-dependency-path: celo-monorepo/yarn.lock
+
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 30
+      with:
+        limit-access-to-actor: true
+
     - name: Run e2e test
       run: |
         export E2E_TESTS_FORCE_USE_MYCELO=true

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -50,9 +50,10 @@ import (
 )
 
 var (
-	headBlockGauge     = metrics.NewRegisteredGauge("chain/head/block", nil)
-	headHeaderGauge    = metrics.NewRegisteredGauge("chain/head/header", nil)
-	headFastBlockGauge = metrics.NewRegisteredGauge("chain/head/receipt", nil)
+	headBlockGauge       = metrics.NewRegisteredGauge("chain/head/block", nil)
+	headHeaderGauge      = metrics.NewRegisteredGauge("chain/head/header", nil)
+	headFastBlockGauge   = metrics.NewRegisteredGauge("chain/head/receipt", nil)
+	headBlockGasPriceMin = metrics.NewRegisteredGauge("chain/head/gasprice", nil)
 
 	accountReadTimer   = metrics.NewRegisteredTimer("chain/account/reads", nil)
 	accountHashTimer   = metrics.NewRegisteredTimer("chain/account/hashes", nil)
@@ -476,6 +477,8 @@ func (bc *BlockChain) loadLastState() error {
 	}
 	log.Debug(fmt.Sprintf("Loading Last State: %v", currentHeader.Number))
 	bc.hc.SetCurrentHeader(currentHeader)
+	// Update the head block gas price minimum
+	headBlockGasPriceMin.Update(currentHeader.BaseFee.Int64())
 
 	// Restore the last known head fast block
 	bc.currentFastBlock.Store(currentBlock)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -478,7 +478,9 @@ func (bc *BlockChain) loadLastState() error {
 	log.Debug(fmt.Sprintf("Loading Last State: %v", currentHeader.Number))
 	bc.hc.SetCurrentHeader(currentHeader)
 	// Update the head block gas price minimum
-	headBlockGasPriceMin.Update(currentHeader.BaseFee.Int64())
+	if (currentHeader.BaseFee != nil) {
+		headBlockGasPriceMin.Update(currentHeader.BaseFee.Int64())
+	}
 
 	// Restore the last known head fast block
 	bc.currentFastBlock.Store(currentBlock)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -50,10 +50,10 @@ import (
 )
 
 var (
-	headBlockGauge       = metrics.NewRegisteredGauge("chain/head/block", nil)
-	headHeaderGauge      = metrics.NewRegisteredGauge("chain/head/header", nil)
-	headFastBlockGauge   = metrics.NewRegisteredGauge("chain/head/receipt", nil)
-	headBlockGasPriceMin = metrics.NewRegisteredGauge("chain/head/gasprice", nil)
+	headBlockGauge     = metrics.NewRegisteredGauge("chain/head/block", nil)
+	headHeaderGauge    = metrics.NewRegisteredGauge("chain/head/header", nil)
+	headFastBlockGauge = metrics.NewRegisteredGauge("chain/head/receipt", nil)
+	headBlockBaseFee   = metrics.NewRegisteredGauge("chain/head/basefee", nil)
 
 	accountReadTimer   = metrics.NewRegisteredTimer("chain/account/reads", nil)
 	accountHashTimer   = metrics.NewRegisteredTimer("chain/account/hashes", nil)
@@ -477,9 +477,9 @@ func (bc *BlockChain) loadLastState() error {
 	}
 	log.Debug(fmt.Sprintf("Loading Last State: %v", currentHeader.Number))
 	bc.hc.SetCurrentHeader(currentHeader)
-	// Update the head block gas price minimum (after EIP-1559)
+	// Update the head block basefee gauge metric (after EIP-1559)
 	if currentHeader.BaseFee != nil {
-		headBlockGasPriceMin.Update(currentHeader.BaseFee.Int64())
+		headBlockBaseFee.Update(currentHeader.BaseFee.Int64())
 	}
 
 	// Restore the last known head fast block

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -477,8 +477,8 @@ func (bc *BlockChain) loadLastState() error {
 	}
 	log.Debug(fmt.Sprintf("Loading Last State: %v", currentHeader.Number))
 	bc.hc.SetCurrentHeader(currentHeader)
-	// Update the head block gas price minimum
-	if (currentHeader.BaseFee != nil) {
+	// Update the head block gas price minimum (after EIP-1559)
+	if currentHeader.BaseFee != nil {
 		headBlockGasPriceMin.Update(currentHeader.BaseFee.Int64())
 	}
 


### PR DESCRIPTION
### Description

Add chain_head_gasprice gauge metric. This metric represents the baseFee (gasPriceMinimum) for last block.

### Other Changes

Pinned Node version to 18.18. Node 18.19 breaks the tests ([changelog](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#2023-11-29-version-18190-hydrogen-lts-targos))
