### PR TITLE
CI: Fix forkdiff build

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
 env:
-  GO_VERSION: '1.17.5'
+  GO_VERSION: '1.18'
   CELO_BLOCKCHAIN_PATH: 'celo-blockchain'
   GO_ETHEREUM_PATH: 'go-ethereum'
 


### PR DESCRIPTION
### Description

In https://github.com/celo-org/celo-blockchain/actions/runs/7260906287/job/19781026224 the forkdiff job fails because of an old go version. This upgrade to version to fix the build.