### PR TITLE
Using glibc for amd64 and muslc for arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt update && \
       *) echo "Unsupported platform: $platform" && exit 1 ;; \
     esac
 
-# Pull Geth into a second stage deploy alpine container
+# Using debian:bookworm-slim as the base image for the final
 FROM debian:bookworm-slim
 ARG COMMIT_SHA
 


### PR DESCRIPTION
### Description

As pointed by @carterqw2 (🙏 ), [celo-bls-go is not compatible with musl for amd64](https://github.com/celo-org/celo-bls-go/blob/master/bls/bls_linux.go#L1).

This PR aims to use glibc for amd64 image, and musl for arm64 images.