### PR TITLE
Using debian:trixie as base image

### DIFF
--- a/.github/workflows/mycelo-docker-image.yaml
+++ b/.github/workflows/mycelo-docker-image.yaml
@@ -33,7 +33,6 @@ jobs:
           tags: mycelo:latest
           load: true
           build-args: GETH_COMMIT={{ github.sha }}
-          trivy: true
       - name: Check docker images
         run: docker images
       - name: Generate genesis.json using mycelo image

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,13 @@ RUN apt update && \
       *) echo "Unsupported platform: $platform" && exit 1 ;; \
     esac
 
-# Using debian:bookworm-slim as the base image for the final
-FROM debian:bookworm-slim
+# Using debian:trixie-slim as the base image for the final
+FROM debian:trixie-slim
 ARG COMMIT_SHA
 
+# Install dependecies and update packages to reduce CVEs
 RUN apt update &&\
+    apt upgrade -y &&\
     apt install -y ca-certificates wget &&\
     rm -rf /var/cache/apt &&\
     rm -rf /var/lib/apt/lists/* &&\

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -9,10 +9,11 @@ ADD . /go-ethereum
 RUN cd /go-ethereum && make all-musl
 
 # Pull all binaries into a second stage deploy alpine container
-FROM debian:bookworm
+FROM debian:trixie-slim
 ARG COMMIT_SHA
 
 RUN apt update &&\
+    apt upgrade -y &&\
     apt install -y ca-certificates wget &&\
     rm -rf /var/cache/apt &&\
     rm -rf /var/lib/apt/lists/* &&\


### PR DESCRIPTION
### Description

Using new debian release codename trixie (testing debian release branch) to compare the affected CVEs using this base image compared to bookworm (stable release branch)