### PR TITLE
renovate: Ungroup GH actions updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,12 +10,6 @@
       "matchManagers": ["gomod", "dockerfile", "docker-compose"],
       "matchPackagePatterns": ["*"],
       "separateMajorMinor": false
-    },
-    {
-      "groupName": "github-actions",
-      "matchManagers": ["github-actions"],
-      "matchPackagePatterns": ["*"],
-      "separateMajorMinor": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
### Description

As seen in https://github.com/celo-org/celo-blockchain/pull/2221 , those upgrades introduce some problem in CI and it's hard to find out exactly what.

Let's go back to ungrouping those updates for the time now.