### PR TITLE
Hardcode pre gingerbread block gas limits for existing chains #2

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -752,10 +752,11 @@ func addEthCompatibilityFields(ctx context.Context, response map[string]interfac
 		var gasLimit uint64
 		var err error
 
-		// For mainnet, alfajores and baklava we have a set of hardcoded values derived from historical state that we can use.
-		v := params.PreGingerbreadNetworkGasLimits[b.ChainConfig().ChainID.Uint64()]
-		if v != nil {
-			gasLimit = v.Limit(header.Number)
+		// For mainnet, alfajores and baklava we have a set of hardcoded values derived from historical state that we can
+		// use, note ChainID might be unset, so we need to account for that.
+		chainId := b.ChainConfig().ChainID
+		if chainId != nil && params.PreGingerbreadNetworkGasLimits[chainId.Uint64()] != nil {
+			gasLimit = params.PreGingerbreadNetworkGasLimits[chainId.Uint64()].Limit(header.Number)
 		} else {
 			// If no hardcoded limits are available for this network then we will try to look up the gas limit in the state.
 			hash := header.Hash()

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1152,7 +1152,6 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		"miner":            head.Coinbase,
 		"extraData":        hexutil.Bytes(head.Extra),
 		"size":             hexutil.Uint64(head.Size()),
-		"gasLimit":         hexutil.Uint64(head.GasLimit),
 		"gasUsed":          hexutil.Uint64(head.GasUsed),
 		"timestamp":        hexutil.Uint64(head.Time),
 		"transactionsRoot": head.TxHash,
@@ -1166,6 +1165,11 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		result["sha3Uncles"] = head.UncleHash
 		result["uncles"] = []interface{}{}
 		result["mixHash"] = head.MixDigest
+	}
+
+	// Before the gingerbread hardfork gas limit was not part of the block header.
+	if head.GasLimit > 0 {
+		result["gasLimit"] = hexutil.Uint64(head.GasLimit)
 	}
 
 	if head.BaseFee != nil {

--- a/params/config.go
+++ b/params/config.go
@@ -176,6 +176,51 @@ var (
 			},
 		)
 	TestRules = TestChainConfig.Rules(new(big.Int))
+
+	mainnetGasLimits = &GasLimits{
+		changes: []LimitChange{
+			{big.NewInt(0), 20e6},
+			{big.NewInt(3317), 10e6},
+			{big.NewInt(3251772), 13e6},
+			{big.NewInt(6137285), 20e6},
+			{big.NewInt(13562578), 50e6},
+			{big.NewInt(14137511), 13e6},
+			{big.NewInt(21355415), 32e6},
+		},
+	}
+
+	alfajoresGasLimits = &GasLimits{
+		changes: []LimitChange{
+			{big.NewInt(0), 20e6},
+			{big.NewInt(912), 10e6},
+			{big.NewInt(1392355), 130e6},
+			{big.NewInt(1507905), 13e6},
+			{big.NewInt(4581182), 20e6},
+			{big.NewInt(11143973), 35e6},
+		},
+	}
+
+	baklavaGasLimits = &GasLimits{
+		changes: []LimitChange{
+			{big.NewInt(0), 20e6},
+			{big.NewInt(1230), 10e6},
+			{big.NewInt(1713181), 130e6},
+			{big.NewInt(1945003), 13e6},
+			{big.NewInt(15158971), 20e6},
+		},
+	}
+
+	// This is a hardcoded set of gas limit changes derived from historical
+	// state. They allow non archive nodes to return the gas limit for blocks
+	// before gingerbread (where we added gas limit to the block header).
+	// Additionally they ensure that archive nodes return the correct value at
+	// the beginning of the chain, before the blockchain parameters contract
+	// was deployed and activated.
+	PreGingerbreadNetworkGasLimits = map[uint64]*GasLimits{
+		MainnetNetworkId:   mainnetGasLimits,
+		AlfajoresNetworkId: alfajoresGasLimits,
+		BaklavaNetworkId:   baklavaGasLimits,
+	}
 )
 
 // TrustedCheckpoint represents a set of post-processed trie roots (CHT and

--- a/params/gas_limts.go
+++ b/params/gas_limts.go
@@ -1,0 +1,25 @@
+package params
+
+import "math/big"
+
+type GasLimits struct {
+	// changes holds all gas limit changes, it is assumed that the first change ocurrs at block 0.
+	changes []LimitChange
+}
+
+type LimitChange struct {
+	block    *big.Int
+	gasLimit uint64
+}
+
+func (g *GasLimits) Limit(block *big.Int) uint64 {
+	// Grab the gas limit at block 0
+	curr := g.changes[0].gasLimit
+	for _, c := range g.changes[1:] {
+		if block.Cmp(c.block) < 0 {
+			return curr
+		}
+		curr = c.gasLimit
+	}
+	return curr
+}


### PR DESCRIPTION
Note that this duplicates #2216 because we force reverted master after #2216 was merged.

### Description

Ensures that for mainnet, alfajores and baklava, nodes will return the correct block gas limit up to the gingerbread fork even if they are not archive nodes when running in eth compatibility mode (I.E. `--disablerpcethcompatibility` is not set). More detail can be found here:
* #2214

### Other changes

A small re-factor of GetBlockByNumber and GetBlockByHash to reduce the depth of nesting.

### Tested

CI is passing

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

This change is not backwards compatible with the previous implementations on mainnet, alfajores or baklava which would have returned a zero gas limit for a block if there was no state for that block.
