### PR TITLE
renovate: ignore non-security npm updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
     {
       "enabled": false,
       "groupName": "everything",
-      "matchManagers": ["gomod", "dockerfile", "docker-compose"],
+      "matchManagers": ["gomod", "dockerfile", "docker-compose", "npm"],
       "matchPackagePatterns": ["*"],
       "separateMajorMinor": false
     }


### PR DESCRIPTION
Those updates take a lot of time of time to merge and provide little actual benefit. So lets disable non-security updates.