### PR TITLE
update reusable workflow to version 2.0, to add scanning for gha-cred…

### DIFF
--- a/.github/workflows/build-sign-commit-images.yaml
+++ b/.github/workflows/build-sign-commit-images.yaml
@@ -16,14 +16,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Login at GCP Artifact Registry
-        # v1.14.2 is main at Oct 26, 2023
-        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@v1.14.2
+        # v2.0 is main at feb 1 2023
+        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@v2.0
         with:
           workload-id-provider: 'projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-blockchain-dev/providers/github-by-repos'
           service-account: 'celo-blockchain-dev@devopsre.iam.gserviceaccount.com'
           docker-gcp-registries: us-west1-docker.pkg.dev
       - name: Build and push container
-        uses: celo-org/reusable-workflows/.github/actions/build-container@v1.14.2
+        uses: celo-org/reusable-workflows/.github/actions/build-container@v2.0
         with:
           platforms: linux/amd64,linux/arm64
           registry: us-west1-docker.pkg.dev/devopsre/dev-images/geth
@@ -44,13 +44,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Login at GCP Artifact Registry
-        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@v1.14.2
+        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@v2.0
         with:
           workload-id-provider: 'projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-blockchain/providers/github-by-repos'
           service-account: 'celo-blockchain@devopsre.iam.gserviceaccount.com'
           docker-gcp-registries: us-west1-docker.pkg.dev
       - name: Build and push container
-        uses: celo-org/reusable-workflows/.github/actions/build-container@v1.14.2
+        uses: celo-org/reusable-workflows/.github/actions/build-container@v2.0
         with:
           platforms: linux/amd64,linux/arm64
           registry: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/geth
@@ -71,13 +71,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Login at GCP Artifact Registry
-        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@v1.14.2
+        uses: celo-org/reusable-workflows/.github/actions/auth-gcp-artifact-registry@v2.0
         with:
           workload-id-provider: 'projects/1094498259535/locations/global/workloadIdentityPools/gh-celo-blockchain/providers/github-by-repos'
           service-account: 'celo-blockchain@devopsre.iam.gserviceaccount.com'
           docker-gcp-registries: us-west1-docker.pkg.dev
       - name: Build and push container
-        uses: celo-org/reusable-workflows/.github/actions/build-container@v1.14.2
+        uses: celo-org/reusable-workflows/.github/actions/build-container@v2.0
         with:
           platforms: linux/amd64,linux/arm64
           registry: us-west1-docker.pkg.dev/devopsre/celo-blockchain-public/geth-all

--- a/.github/workflows/build-sign-release-images.yaml
+++ b/.github/workflows/build-sign-release-images.yaml
@@ -53,8 +53,8 @@ jobs:
           echo "MAJOR_MINOR=${semver[0]}.${semver[1]}" >> $GITHUB_OUTPUT
 
   build-container-geth-dev:
-    # v1.14.2 is main at Jan 19th 2024
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.2
+    # v2.0 is main at Feb 2 2024
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.0
     if: startsWith(github.ref, 'refs/heads/release')
     needs:
       - replace-branch-name
@@ -69,7 +69,7 @@ jobs:
       trivy: true
 
   build-container-geth-all-dev:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.0
     if: startsWith(github.ref, 'refs/heads/release')
     needs:
       - replace-branch-name
@@ -84,7 +84,7 @@ jobs:
       trivy: true
 
   build-container-geth-devopsre:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.0
     if: startsWith(github.ref, 'refs/tags/v') && false
     needs:
       - replace-tag-v
@@ -99,7 +99,7 @@ jobs:
       trivy: true
 
   build-container-geth-all-devopsre:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.0
     if: startsWith(github.ref, 'refs/tags/v') && false
     needs:
       - replace-tag-v
@@ -114,7 +114,7 @@ jobs:
       trivy: true
 
   build-container-geth-celo-org:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.0
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - replace-tag-v
@@ -129,7 +129,7 @@ jobs:
       trivy: true
 
   build-container-geth-all-celo-org:
-    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v1.14.2
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd.yaml@v2.0
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - replace-tag-v


### PR DESCRIPTION
…entials inside of containers

### Description

Updating to version 2.0 of reusableo workflows.  This contains a feature that scans for workload identity credentials inside the container and will fail the build if its there, along with an error message of how to resolve the problem (adding gha-creds-*.json to proper ignore files such as .gitignore and .dockerignore

### Other changes

None
### Tested

Tested in other repositories to make sure it will cause the build to fail if it finds a file matching the regex 'gha-creds-.*.json'

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

Should be fully backwards compatible.