### PR TITLE
ci: Fix release tag regex

### DIFF
--- a/.github/workflows/build-sign-release-images.yaml
+++ b/.github/workflows/build-sign-release-images.yaml
@@ -6,7 +6,7 @@ on:
       # Matches i.e: release/1.9.x
       - 'release/[0-9]+.[0-9]+.x'
     tags:        
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+(?:-\S+(?:\.\d+)*)*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The release build wasn't triggered for the latest RC: https://github.com/celo-org/celo-blockchain/releases/tag/v1.8.1-rc.1

Not also matches tags including `beta` or `rc` suffixes.

