### PR TITLE
Test celo transaction replacement

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,3 +69,6 @@ issues:
     - path: cmd/faucet/
       linters:
         - deadcode
+    - path: core/tx_pool_test.go
+      linters:
+        - goconst

--- a/common/types.go
+++ b/common/types.go
@@ -442,3 +442,16 @@ func (ma *MixedcaseAddress) ValidChecksum() bool {
 func (ma *MixedcaseAddress) Original() string {
 	return ma.original
 }
+
+func AreSameAddress(a, b *Address) bool {
+	// both are nil or point to the same address
+	if a == b {
+		return true
+	}
+	// if only one is nil
+	if a == nil || b == nil {
+		return false
+	}
+	// if they point to the same
+	return *a == *b
+}

--- a/contracts/abis/abi_str.go
+++ b/contracts/abis/abi_str.go
@@ -119,7 +119,7 @@ const ERC20Str = `[
 }]`
 
 // This is taken from celo-monorepo/packages/protocol/build/<env>/contracts/FeeCurrency.json
-const FeeCurrencyStr = `[
+const FeeCurrencyWhitelistStr = `[
 	{
 		"constant": true,
 		"inputs": [],
@@ -749,4 +749,44 @@ const ValidatorsStr = `[
 		"stateMutability": "view",
 		"type": "function"
 	}
+]`
+
+const FeeCurrencyStr = `[
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "who",
+				"type": "address"
+			}
+		],
+		"name": "balanceOf",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"inputs": [
+		{
+			"internalType": "address",
+			"name": "from",
+			"type": "address"
+		},
+		{
+			"internalType": "uint256",
+			"name": "value",
+			"type": "uint256"
+		}
+		],
+		"name": "debitGasFees",
+		"outputs": [],
+		"stateMutability": "nonpayable",
+		"type": "function"
+  }
 ]`

--- a/contracts/abis/parsed_abi.go
+++ b/contracts/abis/parsed_abi.go
@@ -14,7 +14,7 @@ var (
 	BlockchainParameters *abi.ABI = mustParseAbi("BlockchainParameters", BlockchainParametersStr)
 	SortedOracles        *abi.ABI = mustParseAbi("SortedOracles", SortedOraclesStr)
 	ERC20                *abi.ABI = mustParseAbi("ERC20", ERC20Str)
-	FeeCurrency          *abi.ABI = mustParseAbi("FeeCurrency", FeeCurrencyStr)
+	FeeCurrencyWhitelist *abi.ABI = mustParseAbi("FeeCurrencyWhitelist", FeeCurrencyWhitelistStr)
 	Elections            *abi.ABI = mustParseAbi("Elections", ElectionsStr)
 	EpochRewards         *abi.ABI = mustParseAbi("EpochRewards", EpochRewardsStr)
 	Freezer              *abi.ABI = mustParseAbi("Freezer", FreezerStr)
@@ -22,6 +22,7 @@ var (
 	GoldToken            *abi.ABI = mustParseAbi("GoldToken", GoldTokenStr)
 	Random               *abi.ABI = mustParseAbi("Random", RandomStr)
 	Validators           *abi.ABI = mustParseAbi("Validators", ValidatorsStr)
+	FeeCurrency          *abi.ABI = mustParseAbi("FeeCurrency", FeeCurrencyStr)
 )
 
 func mustParseAbi(name, abiStr string) *abi.ABI {
@@ -35,7 +36,7 @@ func mustParseAbi(name, abiStr string) *abi.ABI {
 var byRegistryId = map[common.Hash]*abi.ABI{
 	config.BlockchainParametersRegistryId: BlockchainParameters,
 	config.SortedOraclesRegistryId:        SortedOracles,
-	config.FeeCurrencyWhitelistRegistryId: FeeCurrency,
+	config.FeeCurrencyWhitelistRegistryId: FeeCurrencyWhitelist,
 	config.ElectionRegistryId:             Elections,
 	config.EpochRewardsRegistryId:         EpochRewards,
 	config.FreezerRegistryId:              Freezer,

--- a/contracts/currency/currency.go
+++ b/contracts/currency/currency.go
@@ -37,7 +37,7 @@ const (
 
 var (
 	medianRateMethod   = contracts.NewRegisteredContractMethod(config.SortedOraclesRegistryId, abis.SortedOracles, "medianRate", maxGasForMedianRate)
-	getWhitelistMethod = contracts.NewRegisteredContractMethod(config.FeeCurrencyWhitelistRegistryId, abis.FeeCurrency, "getWhitelist", maxGasForGetWhiteList)
+	getWhitelistMethod = contracts.NewRegisteredContractMethod(config.FeeCurrencyWhitelistRegistryId, abis.FeeCurrencyWhitelist, "getWhitelist", maxGasForGetWhiteList)
 	getBalanceMethod   = contracts.NewMethod(abis.ERC20, "balanceOf", maxGasToReadErc20Balance)
 )
 

--- a/contracts/testutil/blockchain_parameters.go
+++ b/contracts/testutil/blockchain_parameters.go
@@ -53,8 +53,7 @@ func NewWhitelistMock() *WhitelistMock {
 }
 
 func (bp *WhitelistMock) GetWhitelist() []common.Address {
-	ok := common.HexToAddress("02")
-	return []common.Address{ok}
+	return []common.Address{common.HexToAddress("02"), common.HexToAddress("05")}
 }
 
 type TokenMock struct {

--- a/contracts/testutil/blockchain_parameters.go
+++ b/contracts/testutil/blockchain_parameters.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"math/big"
 
+	"github.com/celo-org/celo-blockchain/common"
 	"github.com/celo-org/celo-blockchain/contracts/abis"
 	"github.com/celo-org/celo-blockchain/contracts/config"
 )
@@ -37,4 +38,37 @@ func (bp *BlockchainParametersMock) GetUptimeLookbackWindow() *big.Int {
 }
 func (bp *BlockchainParametersMock) IntrinsicGasForAlternativeFeeCurrency() *big.Int {
 	return bp.IntrinsicGasForAlternativeFeeCurrencyValue
+}
+
+type WhitelistMock struct {
+	ContractMock
+}
+
+func NewWhitelistMock() *WhitelistMock {
+	mock := &WhitelistMock{}
+
+	contract := NewContractMock(abis.FeeCurrency, mock)
+	mock.ContractMock = contract
+	return mock
+}
+
+func (bp *WhitelistMock) GetWhitelist() []common.Address {
+	ok := common.HexToAddress("02")
+	return []common.Address{ok}
+}
+
+type TokenMock struct {
+	ContractMock
+}
+
+func NewTokenMock() *TokenMock {
+	mock := &TokenMock{}
+
+	contract := NewContractMock(abis.ERC20, mock)
+	mock.ContractMock = contract
+	return mock
+}
+
+func (bp *TokenMock) BalanceOf(addr common.Address) *big.Int {
+	return big.NewInt(1_000_000_000_000_000)
 }

--- a/contracts/testutil/celo.go
+++ b/contracts/testutil/celo.go
@@ -9,6 +9,8 @@ type CeloMock struct {
 	Runner               *MockEVMRunner
 	Registry             *RegistryMock
 	BlockchainParameters *BlockchainParametersMock
+	Whitelist            *WhitelistMock
+	Token                *TokenMock
 }
 
 func NewCeloMock() CeloMock {
@@ -16,12 +18,19 @@ func NewCeloMock() CeloMock {
 		Runner:               NewMockEVMRunner(),
 		Registry:             NewRegistryMock(),
 		BlockchainParameters: NewBlockchainParametersMock(),
+		Whitelist:            NewWhitelistMock(),
+		Token:                NewTokenMock(),
 	}
 
 	celo.Runner.RegisterContract(config.RegistrySmartContractAddress, celo.Registry)
 
 	celo.Registry.AddContract(config.BlockchainParametersRegistryId, common.HexToAddress("0x01"))
 	celo.Runner.RegisterContract(common.HexToAddress("0x01"), celo.BlockchainParameters)
+
+	celo.Registry.AddContract(config.FeeCurrencyWhitelistRegistryId, common.HexToAddress("0x03"))
+	celo.Runner.RegisterContract(common.HexToAddress("0x03"), celo.Whitelist)
+
+	celo.Runner.RegisterContract(common.HexToAddress("0x02"), celo.Token)
 
 	return celo
 }

--- a/contracts/testutil/celo.go
+++ b/contracts/testutil/celo.go
@@ -31,6 +31,7 @@ func NewCeloMock() CeloMock {
 	celo.Runner.RegisterContract(common.HexToAddress("0x03"), celo.Whitelist)
 
 	celo.Runner.RegisterContract(common.HexToAddress("0x02"), celo.Token)
+	celo.Runner.RegisterContract(common.HexToAddress("0x05"), celo.Token)
 
 	return celo
 }

--- a/contracts/testutil/celo.go
+++ b/contracts/testutil/celo.go
@@ -9,8 +9,8 @@ type CeloMock struct {
 	Runner               *MockEVMRunner
 	Registry             *RegistryMock
 	BlockchainParameters *BlockchainParametersMock
-	Whitelist            *WhitelistMock
-	Token                *TokenMock
+	FeeCurrencyWhitelist *FeeCurrencyWhitelistMock
+	ERC20Token           *ERC20TokenMock
 }
 
 func NewCeloMock() CeloMock {
@@ -18,8 +18,8 @@ func NewCeloMock() CeloMock {
 		Runner:               NewMockEVMRunner(),
 		Registry:             NewRegistryMock(),
 		BlockchainParameters: NewBlockchainParametersMock(),
-		Whitelist:            NewWhitelistMock(),
-		Token:                NewTokenMock(),
+		FeeCurrencyWhitelist: NewWhitelistMock(),
+		ERC20Token:           NewTokenMock(),
 	}
 
 	celo.Runner.RegisterContract(config.RegistrySmartContractAddress, celo.Registry)
@@ -28,10 +28,10 @@ func NewCeloMock() CeloMock {
 	celo.Runner.RegisterContract(common.HexToAddress("0x01"), celo.BlockchainParameters)
 
 	celo.Registry.AddContract(config.FeeCurrencyWhitelistRegistryId, common.HexToAddress("0x03"))
-	celo.Runner.RegisterContract(common.HexToAddress("0x03"), celo.Whitelist)
+	celo.Runner.RegisterContract(common.HexToAddress("0x03"), celo.FeeCurrencyWhitelist)
 
-	celo.Runner.RegisterContract(common.HexToAddress("0x02"), celo.Token)
-	celo.Runner.RegisterContract(common.HexToAddress("0x05"), celo.Token)
+	celo.Runner.RegisterContract(common.HexToAddress("0x02"), celo.ERC20Token)
+	celo.Runner.RegisterContract(common.HexToAddress("0x05"), celo.ERC20Token)
 
 	return celo
 }

--- a/contracts/testutil/contract_mocks.go
+++ b/contracts/testutil/contract_mocks.go
@@ -40,34 +40,34 @@ func (bp *BlockchainParametersMock) IntrinsicGasForAlternativeFeeCurrency() *big
 	return bp.IntrinsicGasForAlternativeFeeCurrencyValue
 }
 
-type WhitelistMock struct {
+type FeeCurrencyWhitelistMock struct {
 	ContractMock
 }
 
-func NewWhitelistMock() *WhitelistMock {
-	mock := &WhitelistMock{}
+func NewWhitelistMock() *FeeCurrencyWhitelistMock {
+	mock := &FeeCurrencyWhitelistMock{}
 
 	contract := NewContractMock(abis.FeeCurrency, mock)
 	mock.ContractMock = contract
 	return mock
 }
 
-func (bp *WhitelistMock) GetWhitelist() []common.Address {
+func (bp *FeeCurrencyWhitelistMock) GetWhitelist() []common.Address {
 	return []common.Address{common.HexToAddress("02"), common.HexToAddress("05")}
 }
 
-type TokenMock struct {
+type ERC20TokenMock struct {
 	ContractMock
 }
 
-func NewTokenMock() *TokenMock {
-	mock := &TokenMock{}
+func NewTokenMock() *ERC20TokenMock {
+	mock := &ERC20TokenMock{}
 
 	contract := NewContractMock(abis.ERC20, mock)
 	mock.ContractMock = contract
 	return mock
 }
 
-func (bp *TokenMock) BalanceOf(addr common.Address) *big.Int {
+func (bp *ERC20TokenMock) BalanceOf(addr common.Address) *big.Int {
 	return big.NewInt(1_000_000_000_000_000)
 }

--- a/contracts/testutil/contract_mocks.go
+++ b/contracts/testutil/contract_mocks.go
@@ -47,7 +47,7 @@ type FeeCurrencyWhitelistMock struct {
 func NewWhitelistMock() *FeeCurrencyWhitelistMock {
 	mock := &FeeCurrencyWhitelistMock{}
 
-	contract := NewContractMock(abis.FeeCurrency, mock)
+	contract := NewContractMock(abis.FeeCurrencyWhitelist, mock)
 	mock.ContractMock = contract
 	return mock
 }
@@ -63,11 +63,15 @@ type ERC20TokenMock struct {
 func NewTokenMock() *ERC20TokenMock {
 	mock := &ERC20TokenMock{}
 
-	contract := NewContractMock(abis.ERC20, mock)
+	contract := NewContractMock(abis.FeeCurrency, mock)
 	mock.ContractMock = contract
 	return mock
 }
 
 func (bp *ERC20TokenMock) BalanceOf(addr common.Address) *big.Int {
 	return big.NewInt(1_000_000_000_000_000)
+}
+
+func (bp *ERC20TokenMock) DebitGasFees(from common.Address, value *big.Int) {
+	// Does not return anything
 }

--- a/core/tx_list.go
+++ b/core/tx_list.go
@@ -316,7 +316,7 @@ func (l *txList) Add(tx *types.Transaction, priceBump uint64) (bool, *types.Tran
 		var newGasFeeCap, newGasTipCap *big.Int
 
 		// Short circuit conversion if both are the same currency
-		if old.FeeCurrency() == tx.FeeCurrency() {
+		if common.AreSameAddress(old.FeeCurrency(), tx.FeeCurrency()) {
 			if old.GasFeeCapCmp(tx) >= 0 || old.GasTipCapCmp(tx) >= 0 {
 				return false, nil
 			}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -176,9 +176,6 @@ func setupTxPool() (*TxPool, *ecdsa.PrivateKey) {
 }
 
 func setupTxPoolWithConfig(config *params.ChainConfig) (*TxPool, *ecdsa.PrivateKey) {
-	// statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
-	// blockchain := &testBlockChain{10000000, statedb, new(event.Feed)}
-
 	blockchain := newTestBlockchain()
 	key, _ := crypto.GenerateKey()
 	pool := NewTxPool(testTxPoolConfig, config, blockchain)
@@ -2384,6 +2381,116 @@ func TestTransactionReplacementDynamicFee(t *testing.T) {
 		// 10. Check events match expected (3 new executable txs during pending, 0 during queue)
 		tx = dynamicFeeTx(nonce, 100000, big.NewInt(feeCapThreshold), big.NewInt(tipThreshold), key)
 		if err := pool.addRemoteSync(tx); err != nil {
+			t.Fatalf("failed to replace original cheap %s transaction: %v", stage, err)
+		}
+		// 11. Check events match expected (3 new executable txs during pending, 0 during queue)
+		count = 2
+		if stage == "queued" {
+			count = 0
+		}
+		if err := validateEvents(events, count); err != nil {
+			t.Fatalf("replacement %s event firing failed: %v", stage, err)
+		}
+	}
+
+	if err := validateTxPoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+}
+
+// Tests that the pool rejects replacement celo dynamic fee transactions that don't
+// meet the minimum price bump required.
+func TestTransactionReplacementCeloDynamicFee(t *testing.T) {
+	t.Parallel()
+
+	// Create the pool to test the pricing enforcement with
+	pool, key := setupTxPoolWithConfig(eip1559Config)
+	defer pool.Stop()
+	testAddBalance(pool, crypto.PubkeyToAddress(key.PublicKey), big.NewInt(1000000000))
+
+	// Keep track of transaction events to ensure all executables get announced
+	events := make(chan NewTxsEvent, 32)
+	sub := pool.txFeed.Subscribe(events)
+	defer sub.Unsubscribe()
+
+	// Add pending transactions, ensuring the minimum price bump is enforced for replacement (for ultra low prices too)
+	gasFeeCap := int64(100)
+	feeCapThreshold := (gasFeeCap * (100 + int64(testTxPoolConfig.PriceBump))) / 100
+	gasTipCap := int64(60)
+	tipThreshold := (gasTipCap * (100 + int64(testTxPoolConfig.PriceBump))) / 100
+
+	// Run the following identical checks for both the pending and queue pools:
+	//	1.  Send initial tx => accept
+	//	2.  Don't bump tip or fee cap => discard
+	//	3.  Bump both more than min => accept
+	//	4.  Check events match expected (2 new executable txs during pending, 0 during queue)
+	//	5.  Send new tx with larger tip and gasFeeCap => accept
+	//	6.  Bump tip max allowed so it's still underpriced => discard
+	//	7.  Bump fee cap max allowed so it's still underpriced => discard
+	//	8.  Bump tip min for acceptance => discard
+	//	9.  Bump feecap min for acceptance => discard
+	//	10. Bump feecap and tip min for acceptance => accept
+	//	11. Check events match expected (2 new executable txs during pending, 0 during queue)
+	stages := []string{"pending", "queued"}
+	for _, stage := range stages {
+		// Since state is empty, 0 nonce txs are "executable" and can go
+		// into pending immediately. 2 nonce txs are "happed
+		nonce := uint64(0)
+		if stage == "queued" {
+			nonce = 2
+		}
+
+		// 1.  Send initial tx => accept
+		tx := celoDynamicFeeTxV2(nonce, 100000, big.NewInt(2), big.NewInt(1), key)
+		if err := pool.addRemoteSync(tx); err != nil {
+			t.Fatalf("failed to add original cheap %s transaction: %v", stage, err)
+		}
+		// 2.  Don't bump tip or feecap => discard
+		tx = celoDynamicFeeTxV2(nonce, 100001, big.NewInt(2), big.NewInt(1), key)
+		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
+			t.Fatalf("original cheap %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
+		}
+		// 3.  Bump both more than min => accept
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(3), big.NewInt(2), key)
+		if err := pool.AddRemote(tx); err != nil {
+			t.Fatalf("failed to replace original cheap %s transaction: %v", stage, err)
+		}
+		// 4.  Check events match expected (2 new executable txs during pending, 0 during queue)
+		count := 2
+		if stage == "queued" {
+			count = 0
+		}
+		if err := validateEvents(events, count); err != nil {
+			t.Fatalf("cheap %s replacement event firing failed: %v", stage, err)
+		}
+		// 5.  Send new tx with larger tip and feeCap => accept
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(gasTipCap), key)
+		if err := pool.addRemoteSync(tx); err != nil {
+			t.Fatalf("failed to add original proper %s transaction: %v", stage, err)
+		}
+		// 6.  Bump tip max allowed so it's still underpriced => discard
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(tipThreshold-1), key)
+		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
+			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
+		}
+		// 7.  Bump fee cap max allowed so it's still underpriced => discard
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold-1), big.NewInt(gasTipCap), key)
+		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
+			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
+		}
+		// 8.  Bump tip min for acceptance => accept
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(tipThreshold), key)
+		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
+			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
+		}
+		// 9.  Bump fee cap min for acceptance => accept
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold), big.NewInt(gasTipCap), key)
+		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
+			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
+		}
+		// 10. Check events match expected (3 new executable txs during pending, 0 during queue)
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold), big.NewInt(tipThreshold), key)
+		if err := pool.AddRemote(tx); err != nil {
 			t.Fatalf("failed to replace original cheap %s transaction: %v", stage, err)
 		}
 		// 11. Check events match expected (3 new executable txs during pending, 0 during queue)

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -51,6 +51,8 @@ var (
 
 	// eip1559Config is a chain config with EIP-1559 enabled at block 0.
 	eip1559Config *params.ChainConfig
+
+	defaultFeeCurrency = common.HexToAddress("02")
 )
 
 func init() {
@@ -154,8 +156,7 @@ func dynamicFeeTx(nonce uint64, gaslimit uint64, gasFee *big.Int, tip *big.Int, 
 	return tx
 }
 
-func celoDynamicFeeTxV2(nonce uint64, gaslimit uint64, gasFee *big.Int, tip *big.Int, key *ecdsa.PrivateKey) *types.Transaction {
-	feeCurrency := common.HexToAddress("02")
+func celoDynamicFeeTxV2(nonce uint64, gaslimit uint64, gasFee *big.Int, tip *big.Int, key *ecdsa.PrivateKey, feeCurrency common.Address) *types.Transaction {
 	tx, _ := types.SignNewTx(key, types.LatestSignerForChainID(params.TestChainConfig.ChainID), &types.CeloDynamicFeeTxV2{
 		ChainID:     params.TestChainConfig.ChainID,
 		Nonce:       nonce,
@@ -2441,17 +2442,17 @@ func TestTransactionReplacementCeloDynamicFee(t *testing.T) {
 		}
 
 		// 1.  Send initial tx => accept
-		tx := celoDynamicFeeTxV2(nonce, 100000, big.NewInt(2), big.NewInt(1), key)
+		tx := celoDynamicFeeTxV2(nonce, 100000, big.NewInt(2), big.NewInt(1), key, defaultFeeCurrency)
 		if err := pool.addRemoteSync(tx); err != nil {
 			t.Fatalf("failed to add original cheap %s transaction: %v", stage, err)
 		}
 		// 2.  Don't bump tip or feecap => discard
-		tx = celoDynamicFeeTxV2(nonce, 100001, big.NewInt(2), big.NewInt(1), key)
+		tx = celoDynamicFeeTxV2(nonce, 100001, big.NewInt(2), big.NewInt(1), key, defaultFeeCurrency)
 		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
 			t.Fatalf("original cheap %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
 		}
 		// 3.  Bump both more than min => accept
-		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(3), big.NewInt(2), key)
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(3), big.NewInt(2), key, defaultFeeCurrency)
 		if err := pool.AddRemote(tx); err != nil {
 			t.Fatalf("failed to replace original cheap %s transaction: %v", stage, err)
 		}
@@ -2464,32 +2465,144 @@ func TestTransactionReplacementCeloDynamicFee(t *testing.T) {
 			t.Fatalf("cheap %s replacement event firing failed: %v", stage, err)
 		}
 		// 5.  Send new tx with larger tip and feeCap => accept
-		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(gasTipCap), key)
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(gasTipCap), key, defaultFeeCurrency)
 		if err := pool.addRemoteSync(tx); err != nil {
 			t.Fatalf("failed to add original proper %s transaction: %v", stage, err)
 		}
 		// 6.  Bump tip max allowed so it's still underpriced => discard
-		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(tipThreshold-1), key)
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(tipThreshold-1), key, defaultFeeCurrency)
 		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
 			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
 		}
 		// 7.  Bump fee cap max allowed so it's still underpriced => discard
-		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold-1), big.NewInt(gasTipCap), key)
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold-1), big.NewInt(gasTipCap), key, defaultFeeCurrency)
 		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
 			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
 		}
 		// 8.  Bump tip min for acceptance => accept
-		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(tipThreshold), key)
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(tipThreshold), key, defaultFeeCurrency)
 		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
 			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
 		}
 		// 9.  Bump fee cap min for acceptance => accept
-		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold), big.NewInt(gasTipCap), key)
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold), big.NewInt(gasTipCap), key, defaultFeeCurrency)
 		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
 			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
 		}
 		// 10. Check events match expected (3 new executable txs during pending, 0 during queue)
-		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold), big.NewInt(tipThreshold), key)
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold), big.NewInt(tipThreshold), key, defaultFeeCurrency)
+		if err := pool.AddRemote(tx); err != nil {
+			t.Fatalf("failed to replace original cheap %s transaction: %v", stage, err)
+		}
+		// 11. Check events match expected (3 new executable txs during pending, 0 during queue)
+		count = 2
+		if stage == "queued" {
+			count = 0
+		}
+		if err := validateEvents(events, count); err != nil {
+			t.Fatalf("replacement %s event firing failed: %v", stage, err)
+		}
+	}
+
+	if err := validateTxPoolInternals(pool); err != nil {
+		t.Fatalf("pool internal state corrupted: %v", err)
+	}
+}
+
+// Tests that the pool rejects replacement celo dynamic fee transactions that don't
+// meet the minimum price bump required.
+func TestTransactionReplacementCeloDynamicFeeDifferentCurrencies(t *testing.T) {
+	t.Parallel()
+
+	// Create the pool to test the pricing enforcement with
+	pool, key := setupTxPoolWithConfig(eip1559Config)
+	defer pool.Stop()
+	testAddBalance(pool, crypto.PubkeyToAddress(key.PublicKey), big.NewInt(1000000000))
+
+	// Keep track of transaction events to ensure all executables get announced
+	events := make(chan NewTxsEvent, 32)
+	sub := pool.txFeed.Subscribe(events)
+	defer sub.Unsubscribe()
+
+	// Add pending transactions, ensuring the minimum price bump is enforced for replacement (for ultra low prices too)
+	gasFeeCap := int64(100)
+	feeCapThreshold := (gasFeeCap * (100 + int64(testTxPoolConfig.PriceBump))) / 100
+	gasTipCap := int64(60)
+	tipThreshold := (gasTipCap * (100 + int64(testTxPoolConfig.PriceBump))) / 100
+
+	secondFeeCurrency := common.HexToAddress("05")
+
+	// Run the following identical checks for both the pending and queue pools:
+	//	1.  Send initial tx => accept
+	//	2.  Don't bump tip or fee cap => discard
+	//	3.  Bump both more than min => accept
+	//	4.  Check events match expected (2 new executable txs during pending, 0 during queue)
+	//	5.  Send new tx with larger tip and gasFeeCap => accept
+	//	6.  Bump tip max allowed so it's still underpriced => discard
+	//	7.  Bump fee cap max allowed so it's still underpriced => discard
+	//	8.  Bump tip min for acceptance => discard
+	//	9.  Bump feecap min for acceptance => discard
+	//	10. Bump feecap and tip min for acceptance => accept
+	//	11. Check events match expected (2 new executable txs during pending, 0 during queue)
+	stages := []string{"pending", "queued"}
+	for _, stage := range stages {
+		// Since state is empty, 0 nonce txs are "executable" and can go
+		// into pending immediately. 2 nonce txs are "happed
+		nonce := uint64(0)
+		if stage == "queued" {
+			nonce = 2
+		}
+
+		// 1.  Send initial tx => accept
+		tx := celoDynamicFeeTxV2(nonce, 100000, big.NewInt(20), big.NewInt(10), key, defaultFeeCurrency)
+		if err := pool.addRemoteSync(tx); err != nil {
+			t.Fatalf("failed to add original cheap %s transaction: %v", stage, err)
+		}
+		// 2.  Don't bump tip or feecap => discard
+		tx = celoDynamicFeeTxV2(nonce, 100001, big.NewInt(20), big.NewInt(10), key, secondFeeCurrency)
+		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
+			t.Fatalf("original cheap %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
+		}
+		// 3.  Bump both more than min => accept
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(30), big.NewInt(20), key, secondFeeCurrency)
+		if err := pool.AddRemote(tx); err != nil {
+			t.Fatalf("failed to replace original cheap %s transaction: %v", stage, err)
+		}
+		// 4.  Check events match expected (2 new executable txs during pending, 0 during queue)
+		count := 2
+		if stage == "queued" {
+			count = 0
+		}
+		if err := validateEvents(events, count); err != nil {
+			t.Fatalf("cheap %s replacement event firing failed: %v", stage, err)
+		}
+		// 5.  Send new tx with larger tip and feeCap => accept
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(gasTipCap), key, secondFeeCurrency)
+		if err := pool.addRemoteSync(tx); err != nil {
+			t.Fatalf("failed to add original proper %s transaction: %v", stage, err)
+		}
+		// 6.  Bump tip max allowed so it's still underpriced => discard
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(tipThreshold-1), key, secondFeeCurrency)
+		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
+			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
+		}
+		// 7.  Bump fee cap max allowed so it's still underpriced => discard
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold-1), big.NewInt(gasTipCap), key, secondFeeCurrency)
+		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
+			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
+		}
+		// 8.  Bump tip min for acceptance => accept
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(gasFeeCap), big.NewInt(tipThreshold), key, secondFeeCurrency)
+		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
+			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
+		}
+		// 9.  Bump fee cap min for acceptance => accept
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold), big.NewInt(gasTipCap), key, secondFeeCurrency)
+		if err := pool.AddRemote(tx); err != ErrReplaceUnderpriced {
+			t.Fatalf("original proper %s transaction replacement error mismatch: have %v, want %v", stage, err, ErrReplaceUnderpriced)
+		}
+		// 10. Check events match expected (3 new executable txs during pending, 0 during queue)
+		tx = celoDynamicFeeTxV2(nonce, 100000, big.NewInt(feeCapThreshold), big.NewInt(tipThreshold), key, secondFeeCurrency)
 		if err := pool.AddRemote(tx); err != nil {
 			t.Fatalf("failed to replace original cheap %s transaction: %v", stage, err)
 		}


### PR DESCRIPTION
This PR adds tests for replacing celo transactions in the txpool.

Adding this required extending the mocked contracts. It also found two issues:
1. A comparison of fee currencies only checked the pointers, not the underlying addresses.
2. There is the problem of rounding errors happening when calculating the required replacement fee values. For example if a 10% increase is required and a fee of 2 wei is offered by the old transaction, the calculation also rounded the new required fee down to 2 (2 * 110 / 100). I solved this by removing the division by 100. This might cause overflow, but I believe that this won't cause problems in reality as the fee amounts will never be this high. But please have a special look at this during the review.