### PR TITLE
Validate debitGasFees execution in tx pool

### DIFF
--- a/contracts/testutil/fail_runner.go
+++ b/contracts/testutil/fail_runner.go
@@ -22,6 +22,10 @@ func (fvm FailingVmRunner) ExecuteFrom(sender, recipient common.Address, input [
 	return nil, ErrFailingRunner
 }
 
+func (fvm FailingVmRunner) ExecuteAndDiscardChanges(recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error) {
+	return nil, ErrFailingRunner
+}
+
 func (fvm FailingVmRunner) Query(recipient common.Address, input []byte, gas uint64) (ret []byte, err error) {
 	return nil, ErrFailingRunner
 }

--- a/contracts/testutil/runner.go
+++ b/contracts/testutil/runner.go
@@ -50,6 +50,10 @@ func (ev *MockEVMRunner) ExecuteFrom(sender, recipient common.Address, input []b
 	return ev.Execute(recipient, input, gas, value)
 }
 
+func (ev *MockEVMRunner) ExecuteAndDiscardChanges(recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error) {
+	return ev.Execute(recipient, input, gas, value)
+}
+
 func (ev *MockEVMRunner) Query(recipient common.Address, input []byte, gas uint64) (ret []byte, err error) {
 	mock, ok := ev.contracts[recipient]
 	if !ok {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1718,7 +1718,7 @@ func (pool *TxPool) demoteUnexecutables() {
 // ValidateTransactorBalanceCoversTx validates transactor has enough funds to cover transaction cost, the rules are consistent with state_transition.
 //
 // For native token(CELO) as feeCurrency:
-//   - it ensures balance >= GasFeeCap * gas + value + gatewayFee (2)
+//   - it ensures balance >= GasFeeCap * gas + value
 //
 // For non-native tokens(cUSD, cEUR, ...) as feeCurrency:
 //   - It executes a static call on debitGasFees, implicitly ensuring balance >= GasFeeCap * gas and that `from` is not on the token's block list
@@ -1726,13 +1726,10 @@ func ValidateTransactorBalanceCoversTx(tx *types.Transaction, from common.Addres
 	if tx.FeeCurrency() == nil {
 		balance := currentState.GetBalance(from)
 
-		// cost = GasFeeCap * gas + value + gatewayFee, as in (2)
+		// cost = GasFeeCap * gas + value
 		cost := new(big.Int).SetUint64(tx.Gas())
 		cost.Mul(cost, tx.GasFeeCap())
 		cost.Add(cost, tx.Value())
-		if tx.GatewayFeeRecipient() != nil {
-			cost.Add(cost, tx.GatewayFee())
-		}
 
 		if balance.Cmp(cost) < 0 {
 			log.Debug("ValidateTransactorBalanceCoversTx: insufficient CELO funds",

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -104,6 +104,9 @@ type EVMRunner interface {
 	// originally used the transaction's sender instead of the zero address.
 	ExecuteFrom(sender, recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error)
 
+	// Execute input after creating a snapshot and revert to that snapshot afterwards.
+	ExecuteAndDiscardChanges(recipient common.Address, input []byte, gas uint64, value *big.Int) (ret []byte, err error)
+
 	// Query performs a read operation over the runner's state
 	// It can be seen as a message (input,value) from sender to recipient that returns `ret`
 	Query(recipient common.Address, input []byte, gas uint64) (ret []byte, err error)


### PR DESCRIPTION
### Description

Txs must not fail during `debitGasFees` execution during the state transition, so we must remove problematic txs during the tx pool validation. We do this by executing `debitGasFees` inside the tx pool validation and discarding the resulting state changes. This is not overly efficient, but still better than the alternatives that have been considered so far.

### Other changes

* Added `ExecuteAndDiscardChanges` to `vm.EVMRunner`. I would have liked to avoid this change, but `StaticCall` does not allow (even temporary) changes and I didn't see a better way.
* extracted `debitGasFeesSelector` and `creditGasFeesSelector` and updated comment to show how to generate the selector with `cast` instead of python.
* removed old check for sufficient ERC20 balance, since that is implicitly checked by executing `debitGasFees` and I want to avoid duplicate work
* no espresso hardfork check for fee currencies in `ValidateTransactorBalanceCoversTx`, since we don't need to support older forks in the tx pool

### Tested

Manually by sending txs via Viem to a local mycelo. Adding a unit test would be desirable.

I'm haven't tested that the state revert works as expected and am also not sure about the performance impact.

### Backwards compatibility

At the time of writing, we don't have any fee currencies on mainnet that can fail in `debitGasFees`. The error message for fee currencies without sufficient balance will change with this PR. The new error will contain the revert message from the token's `debitGasFees`.