### PR TITLE
feat (internal/ethapi): implement eth_getBlockReceipts

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -331,6 +331,15 @@ func (ec *Client) TransactionReceipt(ctx context.Context, txHash common.Hash) (*
 	return r, err
 }
 
+func (ec *Client) BlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error) {
+	var r []*types.Receipt
+	err := ec.c.CallContext(ctx, &r, "eth_getBlockReceipts", blockNrOrHash)
+	if err == nil && r == nil {
+		return nil, ethereum.NotFound
+	}
+	return r, err
+}
+
 type rpcProgress struct {
 	StartingBlock hexutil.Uint64
 	CurrentBlock  hexutil.Uint64

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -453,6 +453,11 @@ web3._extend({
 			outputFormatter: web3._extend.formatters.outputTransactionReceiptFormatter
 		}),
 		new web3._extend.Method({
+			name: 'getBlockReceipts',
+			call: 'eth_getBlockReceipts',
+			params: 1,
+		}),
+		new web3._extend.Method({
 			name: 'getRawTransaction',
 			call: 'eth_getRawTransactionByHash',
 			params: 1


### PR DESCRIPTION
### Description

Addition of a new ETH RPC method `eth_getBlockReceipts`.

https://github.com/ethereum/execution-apis/pull/438

Standardized and implemented in several eth clients e.g. geth, nethermind, nimbus, besu e.t.c.

### Other changes

None.

### Tested

[`internal/ethapi/api.go`](https://app.codecov.io/gh/celo-org/celo-blockchain/blob/master/internal%2Fethapi%2Fapi.go) is not covered by any tests.

To be tested on a devnet/testnet with existing chaindata.

### Related issues

 #2187

### Backwards compatibility

Backwards compatible.
