### PR TITLE
fix(eth/tracers): wrong balance on prestate tracer

### DIFF
--- a/eth/tracers/js/internal/tracers/prestate_tracer.js
+++ b/eth/tracers/js/internal/tracers/prestate_tracer.js
@@ -61,7 +61,7 @@
 		var toBal   = bigInt(this.prestate[toHex(ctx.to)].balance.slice(2), 16);
 
 		this.prestate[toHex(ctx.to)].balance   = '0x'+toBal.subtract(ctx.value).toString(16);
-		this.prestate[toHex(ctx.from)].balance = '0x'+fromBal.add(ctx.value).add((ctx.gasUsed + ctx.intrinsicGas) * ctx.gasPrice).toString(16);
+		this.prestate[toHex(ctx.from)].balance = '0x'+fromBal.add(ctx.value).add(ctx.gasUsed * ctx.gasPrice).toString(16);
 
 		// Decrement the caller's nonce, and remove empty create targets
 		this.prestate[toHex(ctx.from)].nonce--;


### PR DESCRIPTION
### Description

Fix the wrong balance on prestate_tracer.js

go-ethereum fix: [prestate_tracer](https://github.com/ethereum/go-ethereum/blob/14cc967d1964d3366252193cadd4bfcb4c927ac1/eth/tracers/js/internal/tracers/prestate_tracer_legacy.js#L65)
