### PR TITLE
Fix effective gas price calculation

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2135,7 +2135,7 @@ func generateReceiptResponse(ctx context.Context, backend Backend, receipt *type
 		fields["from"], _ = types.Sender(signer, tx)
 		fields["to"] = tx.To()
 		// Assign the effective gas price paid
-		if backend.ChainConfig().IsLondon(new(big.Int).SetUint64(blockNumber)) {
+		if !backend.ChainConfig().IsLondon(new(big.Int).SetUint64(blockNumber)) {
 			fields["effectiveGasPrice"] = hexutil.Uint64(tx.GasPrice().Uint64())
 		} else {
 			// var gasPrice *big.Int = new(big.Int)


### PR DESCRIPTION
6351612d67d4cf5e18708a0536f0cb43afa19e43 introduced the bug by accidentally losing the negation in `if
!s.b.ChainConfig().IsLondon(bigblock)`. This results in wrong `effectiveGasPrice` values to be returned from the RPC. The actually transferred fees are correct.