### PR TITLE
cip66 fixes

### DIFF
--- a/core/types/celo_denominated_tx.go
+++ b/core/types/celo_denominated_tx.go
@@ -39,14 +39,15 @@ func (tx *CeloDenominatedTx) copy() TxData {
 		Gas:         tx.Gas,
 		FeeCurrency: copyAddressPtr(tx.FeeCurrency),
 		// These are copied below.
-		AccessList: make(AccessList, len(tx.AccessList)),
-		Value:      new(big.Int),
-		ChainID:    new(big.Int),
-		GasTipCap:  new(big.Int),
-		GasFeeCap:  new(big.Int),
-		V:          new(big.Int),
-		R:          new(big.Int),
-		S:          new(big.Int),
+		AccessList:          make(AccessList, len(tx.AccessList)),
+		Value:               new(big.Int),
+		ChainID:             new(big.Int),
+		GasTipCap:           new(big.Int),
+		GasFeeCap:           new(big.Int),
+		MaxFeeInFeeCurrency: new(big.Int),
+		V:                   new(big.Int),
+		R:                   new(big.Int),
+		S:                   new(big.Int),
 	}
 	copy(cpy.AccessList, tx.AccessList)
 	if tx.Value != nil {
@@ -60,6 +61,9 @@ func (tx *CeloDenominatedTx) copy() TxData {
 	}
 	if tx.GasFeeCap != nil {
 		cpy.GasFeeCap.Set(tx.GasFeeCap)
+	}
+	if tx.MaxFeeInFeeCurrency != nil {
+		cpy.MaxFeeInFeeCurrency.Set(tx.MaxFeeInFeeCurrency)
 	}
 	if tx.V != nil {
 		cpy.V.Set(tx.V)

--- a/core/types/celo_denominated_tx.go
+++ b/core/types/celo_denominated_tx.go
@@ -17,11 +17,11 @@ type CeloDenominatedTx struct {
 	GasTipCap           *big.Int
 	GasFeeCap           *big.Int
 	Gas                 uint64
-	FeeCurrency         *common.Address `rlp:"nil"` // nil means native currency
 	To                  *common.Address `rlp:"nil"` // nil means contract creation
 	Value               *big.Int
 	Data                []byte
 	AccessList          AccessList
+	FeeCurrency         *common.Address `rlp:"nil"` // nil means native currency
 	MaxFeeInFeeCurrency *big.Int
 
 	// Signature values


### PR DESCRIPTION
### Description

Fixes two issues with the current cip66 implementation, firstly `FeeCurrency` was in the wrong position in the struct and secondly the `copy` method was not copying `MaxFeeInFeeCurrency`


### Tested
Manually: Serialized a transaction and inspected it with rlpdump

```
0x7af8ce82a4ec01843b9aca00850342770c0083030d409443d72ff17701b2da814620735c39c620ce0ea4a180b844a9059cbb000000000000000000000000bd8be21f6883569ad7d15cc55c87137fcef308c300000000000000000000000000000000000000000000000001605eba271024d6c094765de816845861e75a25fca122bb6898b8b1282a8501a13b860080a02a015905a494549d8a1da26ce769309963e43f407936bbce1ea8276072b08416a072fd12d24c44bc79648bd88f4d8c158f2f0778694557868b3dc7d80e3aa6b539
```
