### PR TITLE
fix relative paths for images and links in docs/docs/_clef/Setup.md

### DIFF
--- a/docs/docs/_clef/Setup.md
+++ b/docs/docs/_clef/Setup.md
@@ -41,7 +41,7 @@ There are two ways that this can be achieved: integrated via Qubes or integrated
 Qubes provdes a facility for inter-qubes communication via `qrexec`. A qube can request to make a cross-qube RPC request 
 to another qube. The OS then asks the user if the call is permitted. 
 
-![Example](qrexec-example.png)
+![Example](qubes/qrexec-example.png)
 
 A policy-file can be created to allow such interaction. On the `target` domain, a service is invoked which can read the
 `stdin` from the `client` qube. 
@@ -50,11 +50,11 @@ This is how [Split GPG](https://www.qubes-os.org/doc/split-gpg/) is implemented.
 
 ##### Server
 
-![Clef via qrexec](clef_qubes_qrexec.png)
+![Clef via qrexec](qubes/clef_qubes_qrexec.png)
 
 On the `target` qubes, we need to define the rpc service.
 
-[qubes.Clefsign](qubes.Clefsign):
+[qubes.Clefsign](qubes/qubes.Clefsign):
 
 ```bash
 #!/bin/bash
@@ -98,7 +98,7 @@ with minimal requirements.
 On the `client` qube, we need to create a listener which will receive the request from the Dapp, and proxy it. 
 
 
-[qubes-client.py](qubes-client.py):
+[qubes-client.py](qubes/qubes-client.py):
 
 ```python
 
@@ -141,11 +141,11 @@ $ cat newaccnt.json| qrexec-client-vm debian-work qubes.Clefsign
 
 This should pop up first a dialog to allow the IPC call:
 
-![one](qubes_newaccount-1.png)
+![one](qubes/qubes_newaccount-1.png)
 
 Followed by a GTK-dialog to approve the operation
 
-![two](qubes_newaccount-2.png)
+![two](qubes/qubes_newaccount-2.png)
 
 To test the full flow, we use the client wrapper. Start it on the `client` qube:
 ```
@@ -183,7 +183,7 @@ However, it comes with a couple of drawbacks:
 The second way to set up Clef on a qubes system is to allow networking, and have Clef listen to a port which is accessible
 form other qubes. 
 
-![Clef via http](clef_qubes_http.png)
+![Clef via http](qubes/clef_qubes_http.png)
 
 
 


### PR DESCRIPTION
### Description

Fixed the relative paths for images and links in [docs/docs/_clef/Setup.md](https://github.com/celo-org/celo-blockchain/blob/master/docs/docs/_clef/Setup.md).


### Tested

Manually verified that all updated links correctly point to the files.
