### PR TITLE
Test concurrent feecurrency tx handling in tx pool

### DIFF
--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -36,7 +36,9 @@ func (c *core) Start() error {
 		return err
 	}
 
+	c.currentMu.Lock()
 	c.current = roundState
+	c.currentMu.Unlock()
 	c.roundChangeSetV2 = newRoundChangeSetV2(c.current.ValidatorSet())
 
 	// Reset the Round Change timer for the current round to timeout.

--- a/e2e_test/e2e_test.go
+++ b/e2e_test/e2e_test.go
@@ -1087,7 +1087,7 @@ func TestManyFeeCurrencyTransactions(t *testing.T) {
 					tx, err := accounts[nodeIndex].SendValueWithDynamicFee(ctx, accounts[nodeIndex].Address, 1, feeCurrency, baseFee.Add(baseFee, tip), tip, network[nodeIndex], 71000)
 					require.NoError(t, err)
 					txs = append(txs, tx)
-					time.Sleep(10 * time.Millisecond)
+					time.Sleep(16 * time.Millisecond)
 				}
 			}
 			txsChan <- txs

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -546,7 +546,7 @@ func (ec *Client) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
 	return (*big.Int)(&hex), nil
 }
 
-// SuggestGasPrice retrieves the currently suggested gas price to allow a timely
+// SuggestGasPriceInCurrency retrieves the currently suggested gas price to allow a timely
 // execution of a transaction.
 func (ec *Client) SuggestGasPriceInCurrency(ctx context.Context, feeCurrency *common.Address) (*big.Int, error) {
 	var hex hexutil.Big
@@ -561,6 +561,16 @@ func (ec *Client) SuggestGasPriceInCurrency(ctx context.Context, feeCurrency *co
 func (ec *Client) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
 	var hex hexutil.Big
 	if err := ec.c.CallContext(ctx, &hex, "eth_maxPriorityFeePerGas"); err != nil {
+		return nil, err
+	}
+	return (*big.Int)(&hex), nil
+}
+
+// SuggestGasTipCapInCurrency retrieves the currently suggested gas tip cap after 1559 to
+// allow a timely execution of a transaction.
+func (ec *Client) SuggestGasTipCapInCurrency(ctx context.Context, feeCurrency *common.Address) (*big.Int, error) {
+	var hex hexutil.Big
+	if err := ec.c.CallContext(ctx, &hex, "eth_maxPriorityFeePerGas", feeCurrency); err != nil {
 		return nil, err
 	}
 	return (*big.Int)(&hex), nil

--- a/test/account.go
+++ b/test/account.go
@@ -70,12 +70,13 @@ func (a *Account) SendCelo(ctx context.Context, recipient common.Address, value 
 // SendCeloWithDynamicFee submits a value transfer transaction via the provided Node to send
 // celo to the recipient. The submitted transaction is returned.
 func (a *Account) SendCeloWithDynamicFee(ctx context.Context, recipient common.Address, value int64, gasFeeCap *big.Int, gasTipCap *big.Int, node *Node) (*types.Transaction, error) {
-	return a.SendValueWithDynamicFee(ctx, recipient, value, nil, gasFeeCap, gasTipCap, node)
+	return a.SendValueWithDynamicFee(ctx, recipient, value, nil, gasFeeCap, gasTipCap, node, 0)
 }
 
-// SendValueWithDynamicFee submits a value transfer transaction via the provided Node to send
-// celo to the recipient. The submitted transaction is returned.
-func (a *Account) SendValueWithDynamicFee(ctx context.Context, recipient common.Address, value int64, feeCurrency *common.Address, gasFeeCap, gasTipCap *big.Int, node *Node) (*types.Transaction, error) {
+// SendValueWithDynamicFee submits a value transfer transaction via the provided Node to send celo to the recipient. The
+// submitted transaction is returned. Note that gasLimit is optional and if 0 is provided the estimate gas will be
+// called to determine the gas limit.
+func (a *Account) SendValueWithDynamicFee(ctx context.Context, recipient common.Address, value int64, feeCurrency *common.Address, gasFeeCap, gasTipCap *big.Int, node *Node, gasLimit uint64) (*types.Transaction, error) {
 	var err error
 	// Lazy set nonce
 	if a.Nonce == nil {
@@ -101,7 +102,8 @@ func (a *Account) SendValueWithDynamicFee(ctx context.Context, recipient common.
 		feeCurrency,
 		gasFeeCap,
 		gasTipCap,
-		signer)
+		signer,
+		gasLimit)
 
 	if err != nil {
 		return nil, err

--- a/test/node.go
+++ b/test/node.go
@@ -665,14 +665,18 @@ func ValueTransferTransactionWithDynamicFee(
 	gasFeeCap *big.Int,
 	gasTipCap *big.Int,
 	signer types.Signer,
+	gasLimit uint64,
 ) (*types.Transaction, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 	defer cancel()
 
-	msg := ethereum.CallMsg{From: sender, To: &recipient, Value: value, FeeCurrency: feeCurrency}
-	gasLimit, err := client.EstimateGas(ctx, msg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to estimate gas needed: %v", err)
+	if gasLimit == 0 {
+		msg := ethereum.CallMsg{From: sender, To: &recipient, Value: value, FeeCurrency: feeCurrency}
+		var err error
+		gasLimit, err = client.EstimateGas(ctx, msg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to estimate gas needed: %v", err)
+		}
 	}
 	// Create the transaction and sign it
 	rawTx := types.NewTx(&types.CeloDynamicFeeTx{


### PR DESCRIPTION
Adds a test to verify that the tx pool is executing concurrent fee currency checks safely.

I created this to see if I could reproduce https://github.com/celo-org/celo-blockchain/issues/2318 but I was unable to reproduce that issue. It did however uncover a different race condition, which was that `core.current` was being set in one goroutine and accessed from others without synchronisation. This was easy to fix by just locking around the point where it is set.

