### PR TITLE
config: Add L2 migration config for testnets

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -97,7 +97,7 @@ var (
 		GingerbreadBlock:    big.NewInt(18785000),
 		GingerbreadP2Block:  big.NewInt(19157000),
 		HForkBlock:          nil, // TBD
-		L2MigrationBlock:    big.NewInt(27109999),
+		L2MigrationBlock:    big.NewInt(27110000),
 
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,

--- a/params/config.go
+++ b/params/config.go
@@ -127,7 +127,7 @@ var (
 		GingerbreadBlock:    big.NewInt(19814000),
 		GingerbreadP2Block:  big.NewInt(19814000),
 		HForkBlock:          nil, // TBD
-		L2MigrationBlock:    big.NewInt(26383999),
+		L2MigrationBlock:    big.NewInt(26384000),
 
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,

--- a/params/config.go
+++ b/params/config.go
@@ -97,6 +97,7 @@ var (
 		GingerbreadBlock:    big.NewInt(18785000),
 		GingerbreadP2Block:  big.NewInt(19157000),
 		HForkBlock:          nil, // TBD
+		L2MigrationBlock:    big.NewInt(27109999),
 
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,
@@ -126,6 +127,7 @@ var (
 		GingerbreadBlock:    big.NewInt(19814000),
 		GingerbreadP2Block:  big.NewInt(19814000),
 		HForkBlock:          nil, // TBD
+		L2MigrationBlock:    big.NewInt(26383999),
 
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,


### PR DESCRIPTION
Adds the L2 migration config for Alfajores and Baklava testnets.