### PR TITLE
Remove Baklava L2 migration config

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -97,7 +97,7 @@ var (
 		GingerbreadBlock:    big.NewInt(18785000),
 		GingerbreadP2Block:  big.NewInt(19157000),
 		HForkBlock:          nil, // TBD
-		L2MigrationBlock:    big.NewInt(27110000),
+		L2MigrationBlock:    nil,
 
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,


### PR DESCRIPTION
### Description

We need to reschedule the Baklava L2 migration. Until that, we have to remove the activation block from the client
