### PR TITLE
Fix Typographical Errors

### DIFF
--- a/accounts/abi/bind/auth.go
+++ b/accounts/abi/bind/auth.go
@@ -57,7 +57,7 @@ func NewTransactor(keyin io.Reader, passphrase string) (*TransactOpts, error) {
 }
 
 // NewKeyStoreTransactor is a utility method to easily create a transaction signer from
-// an decrypted key from a keystore.
+// a decrypted key from a keystore.
 //
 // Deprecated: Use NewKeyStoreTransactorWithChainID instead.
 func NewKeyStoreTransactor(keystore *keystore.KeyStore, account accounts.Account) (*TransactOpts, error) {
@@ -118,7 +118,7 @@ func NewTransactorWithChainID(keyin io.Reader, passphrase string, chainID *big.I
 }
 
 // NewKeyStoreTransactorWithChainID is a utility method to easily create a transaction signer from
-// an decrypted key from a keystore.
+// a decrypted key from a keystore.
 func NewKeyStoreTransactorWithChainID(keystore *keystore.KeyStore, account accounts.Account, chainID *big.Int) (*TransactOpts, error) {
 	if chainID == nil {
 		return nil, ErrNoChainID

--- a/accounts/abi/event.go
+++ b/accounts/abi/event.go
@@ -29,7 +29,7 @@ import (
 // don't get the signature canonical representation as the first LOG topic.
 type Event struct {
 	// Name is the event name used for internal representation. It's derived from
-	// the raw name and a suffix will be added in the case of a event overload.
+	// the raw name and a suffix will be added in the case of an event overload.
 	//
 	// e.g.
 	// These are two events that have the same name:

--- a/accounts/abi/type_test.go
+++ b/accounts/abi/type_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
-// typeWithoutStringer is a alias for the Type type which simply doesn't implement
+// typeWithoutStringer is an alias for the Type type which simply doesn't implement
 // the stringer interface to allow printing type details in the tests below.
 type typeWithoutStringer Type
 

--- a/rpc/testservice_test.go
+++ b/rpc/testservice_test.go
@@ -159,7 +159,7 @@ func (s *notificationTestService) SomeSubscription(ctx context.Context, n, val i
 		return nil, ErrNotificationsUnsupported
 	}
 
-	// By explicitly creating an subscription we make sure that the subscription id is send
+	// By explicitly creating a subscription we make sure that the subscription id is send
 	// back to the client before the first subscription.Notify is called. Otherwise the
 	// events might be send before the response for the *_subscribe method.
 	subscription := notifier.CreateSubscription()

--- a/trie/sync.go
+++ b/trie/sync.go
@@ -270,14 +270,14 @@ func (s *Sync) Process(result SyncResult) error {
 	if s.nodeReqs[result.Hash] == nil && s.codeReqs[result.Hash] == nil {
 		return ErrNotRequested
 	}
-	// There is an pending code request for this data, commit directly
+	// There is a pending code request for this data, commit directly
 	var filled bool
 	if req := s.codeReqs[result.Hash]; req != nil && req.data == nil {
 		filled = true
 		req.data = result.Data
 		s.commit(req)
 	}
-	// There is an pending node request for this data, fill it.
+	// There is a pending node request for this data, fill it.
 	if req := s.nodeReqs[result.Hash]; req != nil && req.data == nil {
 		filled = true
 		// Decode the node data content and update the request


### PR DESCRIPTION
This pull request addresses multiple typographical errors in the following files:

- `auth.go`: Fixed the phrase "an decrypted" to "a decrypted" for grammatical correctness.
- `event.go`: Corrected "a event" to "an event" in the event overload comment.
- `type_test.go`: Fixed "alias" spelling inconsistency in the comment for `typeWithoutStringer`.
- `testservice_test.go`: Corrected "an subscription" to "a subscription" in the comment.
- `sync.go`: Fixed "an pending" to "a pending" in the comment regarding requests.
