### PR TITLE
Add deep copy of Difficulty field in types.CopyHeader

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -341,7 +341,7 @@ func CopyHeader(h *Header) *Header {
 		TxHash:      h.TxHash,
 		ReceiptHash: h.ReceiptHash,
 		Bloom:       h.Bloom,
-		Difficulty:  h.Difficulty,
+		Difficulty:  new(big.Int),
 		Number:      new(big.Int),
 		GasLimit:    h.GasLimit,
 		GasUsed:     h.GasUsed,
@@ -350,6 +350,9 @@ func CopyHeader(h *Header) *Header {
 		Nonce:       h.Nonce,
 	}
 
+	if h.Difficulty != nil {
+		cpy.Difficulty.Set(h.Difficulty)
+	}
 	if h.Number != nil {
 		cpy.Number.Set(h.Number)
 	}


### PR DESCRIPTION
### Description

Add a deep copy of the `Difficulty` field in `types.CopyHeader` function.

Resolves: https://github.com/celo-org/celo-blockchain/issues/2309

