### PR TITLE
Add Mainnet L2 migration block

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -67,7 +67,8 @@ var (
 		EspressoBlock:       big.NewInt(11838440),
 		GingerbreadBlock:    big.NewInt(21616000),
 		GingerbreadP2Block:  big.NewInt(21616000),
-		HForkBlock:          nil, // TBD
+		HForkBlock:          nil,
+		L2MigrationBlock:    big.NewInt(31056500),
 
 		Istanbul: &IstanbulConfig{
 			Epoch:          17280,


### PR DESCRIPTION
### Description

See https://forum.celo.org/t/returning-home-to-ethereum-the-launch-of-celo-l2-mainnet/10466

Part of https://github.com/celo-org/celo-blockchain-planning/issues/903
