### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -1879,13 +1879,6 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 	return nil
 }
 
-func max(a uint64, b uint64) uint64 {
-	if a < b {
-		return b
-	}
-	return a
-}
-
 func computePivot(height uint64, epochSize uint64) uint64 {
 	if height <= fsMinFullBlocks {
 		return 0

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -57,13 +57,6 @@ const (
 	maxQueuedBlockAnns = 4
 )
 
-// max is a helper function which returns the larger of the two given integers.
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
 
 // Peer is a collection of relevant information we have about a `eth` peer.
 type Peer struct {

--- a/les/downloader/downloader.go
+++ b/les/downloader/downloader.go
@@ -1879,13 +1879,6 @@ func (d *Downloader) importBlockResults(results []*fetchResult) error {
 	return nil
 }
 
-func max(a uint64, b uint64) uint64 {
-	if a < b {
-		return b
-	}
-	return a
-}
-
 func computePivot(height uint64, epochSize uint64) uint64 {
 	if height <= fsMinFullBlocks {
 		return 0

--- a/p2p/discover/common.go
+++ b/p2p/discover/common.go
@@ -74,10 +74,3 @@ type ReadPacket struct {
 	Data []byte
 	Addr *net.UDPAddr
 }
-
-func min(x, y int) int {
-	if x > y {
-		return y
-	}
-	return x
-}


### PR DESCRIPTION
### Description

Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._
