### PR TITLE
Fix typos: "vector" and "synchronisation" spelling corrections

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -159,7 +159,7 @@ func (api *PrivateAdminAPI) ExportChain(file string, first *uint64, last *uint64
 		last = &head
 	}
 	if _, err := os.Stat(file); err == nil {
-		// File already exists. Allowing overwrite could be a DoS vecotor,
+		// File already exists. Allowing overwrite could be a DoS vector,
 		// since the 'file' may point to arbitrary paths on the drive
 		return false, errors.New("location would overwrite an existing file")
 	}

--- a/eth/downloader/doc.go
+++ b/eth/downloader/doc.go
@@ -1,7 +1,7 @@
 /*
 Package downloader handles downloading data from other nodes for sync. Sync
 refers to the process of catching up with other nodes, once caught up nodes
-use a different process to maintain their syncronisation.
+use a different process to maintain their synchronisation.
 
 # There are a few different modes for syncing
 


### PR DESCRIPTION
### Description

This PR fixes two minor typos:
- Corrects "vecotor" to "vector" in eth/api.go comment
- Corrects "syncronisation" to "synchronisation" in eth/downloader/doc.go comment

These changes are purely cosmetic and do not affect any functionality.
